### PR TITLE
sensor/stmemsc: Align stmemsc i/f to v2.3

### DIFF
--- a/sensor/stmemsc/CMakeLists.txt
+++ b/sensor/stmemsc/CMakeLists.txt
@@ -79,6 +79,7 @@ set(stmems_pids
   lsm6dsv16x
   lsm6dsv
   lsm9ds1
+  sths34pf80
   stts22h
   stts751
   )

--- a/sensor/stmemsc/README
+++ b/sensor/stmemsc/README
@@ -6,7 +6,7 @@ Origin:
    https://www.st.com/en/embedded-software/c-driver-mems.html
 
 Status:
-   version v2.02
+   version v2.3
 
 Purpose:
    ST Microelectronics standard C platform-independent drivers for MEMS
@@ -47,6 +47,86 @@ Description:
        .mdelay = (stmdev_mdelay_ptr) platform_mdelay,
    };
 
+   Driver versions in this package:
+
+     - a3g4250d_STdC         v1.1.0
+     - ais25ba_STdC          v1.1.0
+     - ais2dw12_STdC         v1.1.0
+     - ais2ih_STdC           v1.1.0
+     - ais328dq_STdC         v1.1.0
+     - ais3624dq_STdC        v1.1.0
+     - asm330lhb_STdC        v1.0.0
+     - asm330lhh_STdC        v2.1.0
+     - asm330lhhx_STdC       v1.1.1
+     - h3lis100dl_STdC       v1.1.0
+     - h3lis331dl_STdC       v1.1.0
+     - hts221_STdC           v1.1.0
+     - i3g4250d_STdC         v1.1.0
+     - iis2dh_STdC           v1.1.0
+     - iis2dlpc_STdC         v1.1.0
+     - iis2iclx_STdC         v1.1.0
+     - iis2mdc_STdC          v1.1.0
+     - iis328dq_STdC         v1.1.0
+     - iis3dhhc_STdC         v1.1.0
+     - iis3dwb_STdC          v1.1.1
+     - ilps22qs_STdC         v2.1.1
+     - ilps28qsw_STdC        v1.0.1
+     - ism303dac_STdC        v1.1.0
+     - ism330dhcx_STdC       v1.1.0
+     - ism330dlc_STdC        v1.1.0
+     - ism330is_STdC         v2.1.0
+     - l20g20is_STdC         v1.1.0
+     - l3gd20h_STdC          v1.1.0
+     - lis25ba_STdC          v1.1.0
+     - lis2de12_STdC         v1.1.0
+     - lis2dh12_STdC         v1.1.0
+     - lis2dh_STdC           v1.1.0
+     - lis2ds12_STdC         v1.1.0
+     - lis2dtw12_STdC        v1.1.0
+     - lis2du12_STdC         v1.1.3
+     - lis2dux12_STdC        v1.1.4
+     - lis2duxs12_STdC       v1.1.5
+     - lis2dw12_STdC         v1.1.0
+     - lis2hh12_STdC         v1.1.0
+     - lis2mdl_STdC          v1.1.0
+     - lis331dlh_STdC        v1.1.0
+     - lis3de_STdC           v1.1.0
+     - lis3dh_STdC           v1.1.0
+     - lis3dhh_STdC          v1.1.0
+     - lis3dsh_STdC          v1.1.0
+     - lis3mdl_STdC          v1.1.0
+     - lps22ch_STdC          v1.1.0
+     - lps22df_STdC          v1.1.0
+     - lps22hb_STdC          v1.1.0
+     - lps22hh_STdC          v1.1.0
+     - lps25hb_STdC          v1.1.0
+     - lps27hhtw_STdC        v1.1.0
+     - lps27hhw_STdC         v1.1.0
+     - lps28dfw_STdC         v1.1.0
+     - lps33hw_STdC          v1.1.0
+     - lps33k_STdC           v1.1.0
+     - lps33w_STdC           v1.1.0
+     - lsm303agr_STdC        v1.1.0
+     - lsm303ah_STdC         v1.1.0
+     - lsm6ds3_STdC          v1.1.1
+     - lsm6ds3tr-c_STdC      v1.1.0
+     - lsm6dsl_STdC          v1.1.0
+     - lsm6dsm_STdC          v1.1.0
+     - lsm6dso16is_STdC      v2.1.1
+     - lsm6dso32_STdC        v1.1.0
+     - lsm6dso32x_STdC       v1.1.0
+     - lsm6dso_STdC          v2.1.0
+     - lsm6dsox_STdC         v2.0.1
+     - lsm6dsr_STdC          v1.1.0
+     - lsm6dsrx_STdC         v1.1.0
+     - lsm6dsv16bx_STdC      v2.1.2
+     - lsm6dsv16x_STdC       v2.2.1
+     - lsm6dsv_STdC          v1.2.1
+     - lsm9ds1_STdC          v1.1.0
+     - sths34pf80_STdC       v1.0.0
+     - stts22h_STdC          v1.1.0
+     - stts751_STdC          v1.1.0
+
 Dependencies:
     None.
 
@@ -54,7 +134,7 @@ URL:
    https://www.st.com/en/embedded-software/c-driver-mems.html
 
 commit:
-   version v2.02
+   version v2.3
 
 Maintained-by:
    ST Microelectronics

--- a/sensor/stmemsc/iis3dwb_STdC/driver/iis3dwb_reg.c
+++ b/sensor/stmemsc/iis3dwb_STdC/driver/iis3dwb_reg.c
@@ -555,6 +555,49 @@ int32_t iis3dwb_temp_flag_data_ready_get(stmdev_ctx_t *ctx,
 }
 
 /**
+  * @brief  Enables the accelerometer user offset correction block, can be enabled 
+  * by setting the USR_OFF_ON_OUT bit of the CTRL7_C register.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of USR_OFF_ON_OUT in reg CTRL7_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_usr_offset_block_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  iis3dwb_ctrl7_c_t ctrl7_c;
+
+  int32_t ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL7_C, (uint8_t *)&ctrl7_c, 1);
+
+  if (ret == 0)
+  {
+    ctrl7_c.usr_off_on_out = val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_CTRL7_C, (uint8_t *)&ctrl7_c, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables the accelerometer user offset correction block, can be enabled 
+  * by setting the USR_OFF_ON_OUT bit of the CTRL7_C register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of USR_OFF_ON_OUT in reg CTRL7_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_usr_offset_block_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  iis3dwb_ctrl7_c_t ctrl7_c;
+
+  const int32_t ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL7_C, (uint8_t *)&ctrl7_c, 1);
+  *val = ctrl7_c.usr_off_on_out;
+
+  return ret;
+}
+
+/**
   * @brief  Accelerometer X-axis user offset correction expressed in two’s
   *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
   *         The value must be in the range [-127 127].[set]

--- a/sensor/stmemsc/iis3dwb_STdC/driver/iis3dwb_reg.h
+++ b/sensor/stmemsc/iis3dwb_STdC/driver/iis3dwb_reg.h
@@ -410,6 +410,19 @@ typedef struct
   uint8_t xl_axis_sel              : 2;
 #endif /* DRV_BYTE_ORDER */
 } iis3dwb_ctrl6_c_t;
+#define IIS3DWB_CTRL7_C                      0x16U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used_01               : 1;
+  uint8_t usr_off_on_out            : 1;
+  uint8_t not_used_02               : 6;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used_02               : 6;
+  uint8_t usr_off_on_out            : 1;
+  uint8_t not_used_01               : 1;
+#endif /* DRV_BYTE_ORDER */
+} iis3dwb_ctrl7_c_t;
 
 #define IIS3DWB_CTRL8_XL                     0x17U
 typedef struct
@@ -695,6 +708,7 @@ typedef union
   iis3dwb_ctrl4_c_t                       ctrl4_c;
   iis3dwb_ctrl5_c_t                       ctrl5_c;
   iis3dwb_ctrl6_c_t                       ctrl6_c;
+  iis3dwb_ctrl7_c_t                       ctrl7_c;
   iis3dwb_ctrl8_xl_t                      ctrl8_xl;
   iis3dwb_ctrl10_c_t                      ctrl10_c;
   iis3dwb_all_int_src_t                   all_int_src;
@@ -816,6 +830,9 @@ int32_t iis3dwb_xl_flag_data_ready_get(stmdev_ctx_t *ctx,
 
 int32_t iis3dwb_temp_flag_data_ready_get(stmdev_ctx_t *ctx,
                                          uint8_t *val);
+
+int32_t iis3dwb_usr_offset_block_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dwb_usr_offset_block_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 int32_t iis3dwb_xl_usr_offset_x_set(stmdev_ctx_t *ctx, uint8_t *buff);
 int32_t iis3dwb_xl_usr_offset_x_get(stmdev_ctx_t *ctx, uint8_t *buff);

--- a/sensor/stmemsc/ilps22qs_STdC/driver/ilps22qs_reg.c
+++ b/sensor/stmemsc/ilps22qs_STdC/driver/ilps22qs_reg.c
@@ -119,6 +119,11 @@ float_t ilps22qs_from_lsb_to_celsius(int16_t lsb)
   return ((float_t)lsb / 100.0f);
 }
 
+float_t ilps22qs_from_lsb_to_mv(int32_t lsb)
+{
+  return ((float_t)lsb) / 438000.0f;
+}
+
 /**
   * @}
   *
@@ -782,6 +787,8 @@ int32_t ilps22qs_ah_qvar_data_get(stmdev_ctx_t *ctx,
   data->raw = (data->raw * 256) + (int32_t) buff[0];
   data->raw = (data->raw * 256);
   data->lsb = (data->raw / 256); /* shift 8bit left */
+
+  data->mv = ilps22qs_from_lsb_to_mv(data->lsb);
 
   return ret;
 }

--- a/sensor/stmemsc/ilps22qs_STdC/driver/ilps22qs_reg.h
+++ b/sensor/stmemsc/ilps22qs_STdC/driver/ilps22qs_reg.h
@@ -486,6 +486,8 @@ extern float_t ilps22qs_from_fs4000_to_hPa(int32_t lsb);
 
 extern float_t ilps22qs_from_lsb_to_celsius(int16_t lsb);
 
+extern float_t ilps22qs_from_lsb_to_mv(int32_t lsb);
+
 typedef struct
 {
   uint8_t whoami;
@@ -616,6 +618,7 @@ int32_t ilps22qs_data_get(stmdev_ctx_t *ctx, ilps22qs_md_t *md,
                           ilps22qs_data_t *data);
 typedef struct
 {
+  float_t mv; /* value converted in mV */
   int32_t lsb; /* 24 bit properly right aligned */
   int32_t raw; /* 32 bit signed-left algned  format left  */
 } ilps22qs_ah_qvar_data_t;

--- a/sensor/stmemsc/ilps28qsw_STdC/driver/ilps28qsw_reg.c
+++ b/sensor/stmemsc/ilps28qsw_STdC/driver/ilps28qsw_reg.c
@@ -120,6 +120,11 @@ float_t ilps28qsw_from_lsb_to_celsius(int16_t lsb)
   return ((float_t)lsb / 100.0f);
 }
 
+float_t ilps28qsw_from_lsb_to_mv(int32_t lsb)
+{
+  return ((float_t)lsb) / 426000.0f;
+}
+
 /**
   * @}
   *
@@ -755,6 +760,8 @@ int32_t ilps28qsw_ah_qvar_data_get(stmdev_ctx_t *ctx,
   data->raw = (data->raw * 256) + (int32_t) buff[0];
   data->raw = (data->raw * 256);
   data->lsb = (data->raw / 256); /* shift 8bit left */
+
+  data->mv = ilps28qsw_from_lsb_to_mv(data->lsb);
 
   return ret;
 }

--- a/sensor/stmemsc/ilps28qsw_STdC/driver/ilps28qsw_reg.h
+++ b/sensor/stmemsc/ilps28qsw_STdC/driver/ilps28qsw_reg.h
@@ -478,6 +478,8 @@ extern float_t ilps28qsw_from_fs4000_to_hPa(int32_t lsb);
 
 extern float_t ilps28qsw_from_lsb_to_celsius(int16_t lsb);
 
+extern float_t ilps28qsw_from_lsb_to_mv(int32_t lsb);
+
 typedef struct
 {
   uint8_t whoami;
@@ -602,6 +604,7 @@ int32_t ilps28qsw_data_get(stmdev_ctx_t *ctx, ilps28qsw_md_t *md,
                            ilps28qsw_data_t *data);
 typedef struct
 {
+  float_t mv; /* value converted in mV */
   int32_t lsb; /* 24 bit properly right aligned */
   int32_t raw; /* 32 bit signed-left algned  format left  */
 } ilps28qsw_ah_qvar_data_t;

--- a/sensor/stmemsc/ism330is_STdC/driver/ism330is_reg.h
+++ b/sensor/stmemsc/ism330is_STdC/driver/ism330is_reg.h
@@ -1029,7 +1029,7 @@ typedef struct
 #endif /* DRV_BYTE_ORDER */
 } ism330is_slv0_subadd_t;
 
-#define ISM330IS_SLAVE0_CONFIG                   0x17U
+#define ISM330IS_SLV0_CONFIG                   0x17U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1065,7 +1065,7 @@ typedef struct
 #endif /* DRV_BYTE_ORDER */
 } ism330is_slv1_subadd_t;
 
-#define ISM330IS_SLAVE1_CONFIG                   0x1AU
+#define ISM330IS_SLV1_CONFIG                   0x1AU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1099,7 +1099,7 @@ typedef struct
 #endif /* DRV_BYTE_ORDER */
 } ism330is_slv2_subadd_t;
 
-#define ISM330IS_SLAVE2_CONFIG                   0x1DU
+#define ISM330IS_SLV2_CONFIG                   0x1DU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1133,7 +1133,7 @@ typedef struct
 #endif /* DRV_BYTE_ORDER */
 } ism330is_slv3_subadd_t;
 
-#define ISM330IS_SLAVE3_CONFIG                   0x20U
+#define ISM330IS_SLV3_CONFIG                   0x20U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -2602,29 +2602,7 @@ int32_t ism330is_acceleration_raw_get(stmdev_ctx_t *ctx, int16_t *val);
 int32_t ism330is_odr_cal_reg_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t ism330is_odr_cal_reg_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef struct
-{
-  ism330is_sensor_hub_1_t   sh_byte_1;
-  ism330is_sensor_hub_2_t   sh_byte_2;
-  ism330is_sensor_hub_3_t   sh_byte_3;
-  ism330is_sensor_hub_4_t   sh_byte_4;
-  ism330is_sensor_hub_5_t   sh_byte_5;
-  ism330is_sensor_hub_6_t   sh_byte_6;
-  ism330is_sensor_hub_7_t   sh_byte_7;
-  ism330is_sensor_hub_8_t   sh_byte_8;
-  ism330is_sensor_hub_9_t   sh_byte_9;
-  ism330is_sensor_hub_10_t  sh_byte_10;
-  ism330is_sensor_hub_11_t  sh_byte_11;
-  ism330is_sensor_hub_12_t  sh_byte_12;
-  ism330is_sensor_hub_13_t  sh_byte_13;
-  ism330is_sensor_hub_14_t  sh_byte_14;
-  ism330is_sensor_hub_15_t  sh_byte_15;
-  ism330is_sensor_hub_16_t  sh_byte_16;
-  ism330is_sensor_hub_17_t  sh_byte_17;
-  ism330is_sensor_hub_18_t  sh_byte_18;
-} ism330is_emb_sh_read_t;
-int32_t ism330is_sh_read_data_raw_get(stmdev_ctx_t *ctx,
-                                      ism330is_emb_sh_read_t *val,
+int32_t ism330is_sh_read_data_raw_get(stmdev_ctx_t *ctx, uint8_t *val,
                                       uint8_t len);
 
 typedef enum
@@ -2699,14 +2677,11 @@ typedef struct
   uint8_t   slv_subadd;
   uint8_t   slv_len;
 } ism330is_sh_cfg_read_t;
-int32_t ism330is_sh_slv0_cfg_read(stmdev_ctx_t *ctx,
-                                  ism330is_sh_cfg_read_t *val);
-int32_t ism330is_sh_slv1_cfg_read(stmdev_ctx_t *ctx,
-                                  ism330is_sh_cfg_read_t *val);
-int32_t ism330is_sh_slv2_cfg_read(stmdev_ctx_t *ctx,
-                                  ism330is_sh_cfg_read_t *val);
-int32_t ism330is_sh_slv3_cfg_read(stmdev_ctx_t *ctx,
-                                  ism330is_sh_cfg_read_t *val);
+int32_t ism330is_sh_slv_cfg_read(stmdev_ctx_t *ctx, uint8_t idx,
+                                 ism330is_sh_cfg_read_t *val);
+
+int32_t ism330is_sh_status_get(stmdev_ctx_t *ctx,
+                               ism330is_status_master_t *val);
 
 int32_t ism330is_ispu_reset_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t ism330is_ispu_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
@@ -2754,8 +2729,8 @@ int32_t ism330is_ia_ispu_get(stmdev_ctx_t *ctx, uint32_t *val);
 
 int32_t ism330is_ispu_write_dummy_cfg(stmdev_ctx_t *ctx, uint8_t offset,
                                       uint8_t *val, uint8_t len);
-int32_t ism330is_ispu_ready_dummy_cfg(stmdev_ctx_t *ctx, uint8_t offset,
-                                      uint8_t *val, uint8_t len);
+int32_t ism330is_ispu_read_dummy_cfg(stmdev_ctx_t *ctx, uint8_t offset,
+                                     uint8_t *val, uint8_t len);
 
 typedef enum
 {

--- a/sensor/stmemsc/lis2du12_STdC/driver/lis2du12_reg.c
+++ b/sensor/stmemsc/lis2du12_STdC/driver/lis2du12_reg.c
@@ -430,7 +430,7 @@ int32_t lis2du12_all_sources_get(stmdev_ctx_t *ctx,
 
       val->wake_up_z = wu_src.z_wu;
       val->wake_up_y = wu_src.y_wu;
-      val->wake_up_x = wu_src.z_wu;
+      val->wake_up_x = wu_src.x_wu;
       val->sleep_state = wu_src.sleep_state;
     }
 
@@ -493,8 +493,8 @@ int32_t lis2du12_mode_get(stmdev_ctx_t *ctx, lis2du12_md_t *val)
     case LIS2DU12_OFF:
       val->odr = LIS2DU12_OFF;
       break;
-    case LIS2DU12_1Hz5_ULP:
-      val->odr = LIS2DU12_1Hz5_ULP;
+    case LIS2DU12_1Hz6_ULP:
+      val->odr = LIS2DU12_1Hz6_ULP;
       break;
     case LIS2DU12_3Hz_ULP:
       val->odr = LIS2DU12_3Hz_ULP;
@@ -1280,6 +1280,7 @@ int32_t lis2du12_wake_up_mode_set(stmdev_ctx_t *ctx, lis2du12_wkup_md_t *val)
                            (uint8_t*)&wake_up_dur, 1);
   ret += lis2du12_write_reg(ctx, LIS2DU12_MD1_CFG, (uint8_t*)&md1_cfg, 1);
   ret += lis2du12_write_reg(ctx, LIS2DU12_CTRL1, (uint8_t*)&ctrl1, 1);
+  ret += lis2du12_write_reg(ctx, LIS2DU12_CTRL4, (uint8_t *)&ctrl4, 1);
 
   return ret;
 }
@@ -1343,8 +1344,8 @@ int32_t lis2du12_wake_up_mode_get(stmdev_ctx_t *ctx, lis2du12_wkup_md_t *val)
     case LIS2DU12_SLEEP_AT_3Hz:
       val->sleep.odr = LIS2DU12_SLEEP_AT_3Hz;
       break;
-    case LIS2DU12_SLEEP_AT_1Hz5:
-      val->sleep.odr = LIS2DU12_SLEEP_AT_1Hz5;
+    case LIS2DU12_SLEEP_AT_1Hz6:
+      val->sleep.odr = LIS2DU12_SLEEP_AT_1Hz6;
       break;
     default:
       val->sleep.odr = LIS2DU12_DO_NOT_CHANGE;

--- a/sensor/stmemsc/lis2du12_STdC/driver/lis2du12_reg.h
+++ b/sensor/stmemsc/lis2du12_STdC/driver/lis2du12_reg.h
@@ -778,17 +778,17 @@ int32_t lis2du12_all_sources_get(stmdev_ctx_t *ctx,
 typedef struct {
   enum {
     LIS2DU12_OFF               = 0x00, /* in power down */
-    LIS2DU12_1Hz5_ULP          = 0x01, /* @1Hz6 (low power) */
-    LIS2DU12_3Hz_ULP           = 0x02, /* @1Hz6 (ultra low/Gy, OIS imu off) */
-    LIS2DU12_6Hz_ULP           = 0x03, /* @12Hz5 (high performance) */
-    LIS2DU12_6Hz               = 0x04, /* @12Hz5 (low power) */
-    LIS2DU12_12Hz5             = 0x05, /* @12Hz5 (ultra low/Gy, OIS imu off) */
-    LIS2DU12_25Hz              = 0x06, /* @26Hz  (high performance) */
-    LIS2DU12_50Hz              = 0x07, /* @26Hz  (low power) */
-    LIS2DU12_100Hz             = 0x08, /* @26Hz  (ultra low/Gy, OIS imu off) */
-    LIS2DU12_200Hz             = 0x09, /* @52Hz  (high performance) */
-    LIS2DU12_400Hz             = 0x0A, /* @52Hz  (low power) */
-    LIS2DU12_800Hz             = 0x0B, /* @52Hz  (ultra low/Gy, OIS imu off) */
+    LIS2DU12_1Hz6_ULP          = 0x01, /* @1Hz6(ultralow power) */
+    LIS2DU12_3Hz_ULP           = 0x02, /* @3Hz (ultralow power) */
+    LIS2DU12_6Hz_ULP           = 0x03, /* @6Hz (ultralow power) */
+    LIS2DU12_6Hz               = 0x04, /* @6Hz (normal) */
+    LIS2DU12_12Hz5             = 0x05, /* @12Hz5 (normal) */
+    LIS2DU12_25Hz              = 0x06, /* @25Hz  (normal) */
+    LIS2DU12_50Hz              = 0x07, /* @50Hz  (normal) */
+    LIS2DU12_100Hz             = 0x08, /* @100Hz (normal) */
+    LIS2DU12_200Hz             = 0x09, /* @200Hz (normal) */
+    LIS2DU12_400Hz             = 0x0A, /* @400Hz (normal) */
+    LIS2DU12_800Hz             = 0x0B, /* @800Hz (normal) */
     LIS2DU12_TRIG_PIN          = 0x0E, /* Single-shot high latency by INT2 */
     LIS2DU12_TRIG_SW           = 0x0F, /* Single-shot high latency by IF */
   } odr;
@@ -924,7 +924,7 @@ typedef struct {
       LIS2DU12_DO_NOT_CHANGE = 0,
       LIS2DU12_SLEEP_AT_6Hz  = 1,
       LIS2DU12_SLEEP_AT_3Hz  = 2,
-      LIS2DU12_SLEEP_AT_1Hz5 = 3,
+      LIS2DU12_SLEEP_AT_1Hz6 = 3,
     } odr;
   } sleep;
 } lis2du12_wkup_md_t;

--- a/sensor/stmemsc/lis2dux12_STdC/driver/lis2dux12_reg.c
+++ b/sensor/stmemsc/lis2dux12_STdC/driver/lis2dux12_reg.c
@@ -316,11 +316,81 @@ int32_t lis2dux12_mode_set(stmdev_ctx_t *ctx, lis2dux12_md_t *val)
 
   ctrl5.odr = (uint8_t)val->odr & 0xFU;
   ctrl5.fs = (uint8_t)val->fs;
-  ctrl5.bw = (uint8_t)val->bw;
+
+  /* set the bandwidth */
+  switch (val->odr) {
+    /* no anti-aliasing filter present */
+    case LIS2DUX12_OFF:
+    case LIS2DUX12_1Hz6_ULP:
+    case LIS2DUX12_3Hz_ULP:
+    case LIS2DUX12_25Hz_ULP:
+      ctrl5.bw = 0x0;
+      break;
+
+    /* low-power mode with ODR < 50 Hz */
+    case LIS2DUX12_6Hz_LP:
+      switch(val->bw) {
+        case LIS2DUX12_ODR_div_4:
+        case LIS2DUX12_ODR_div_8:
+        case LIS2DUX12_ODR_div_16:
+          return -1;
+        case LIS2DUX12_ODR_div_2:
+          ctrl5.bw = 0x3;
+          break;
+      }
+      break;
+    case LIS2DUX12_12Hz5_LP:
+      switch(val->bw) {
+        case LIS2DUX12_ODR_div_8:
+        case LIS2DUX12_ODR_div_16:
+          return -1;
+        case LIS2DUX12_ODR_div_2:
+          ctrl5.bw = 0x2;
+          break;
+        case LIS2DUX12_ODR_div_4:
+          ctrl5.bw = 0x3;
+          break;
+      }
+      break;
+    case LIS2DUX12_25Hz_LP:
+      switch(val->bw) {
+        case LIS2DUX12_ODR_div_16:
+          return -1;
+        case LIS2DUX12_ODR_div_2:
+          ctrl5.bw = 0x1;
+          break;
+        case LIS2DUX12_ODR_div_4:
+          ctrl5.bw = 0x2;
+          break;
+        case LIS2DUX12_ODR_div_8:
+          ctrl5.bw = 0x3;
+          break;
+      }
+      break;
+
+    /* standard cases */
+    case LIS2DUX12_50Hz_LP:
+    case LIS2DUX12_100Hz_LP:
+    case LIS2DUX12_200Hz_LP:
+    case LIS2DUX12_400Hz_LP:
+    case LIS2DUX12_800Hz_LP:
+    case LIS2DUX12_TRIG_PIN:
+    case LIS2DUX12_TRIG_SW:
+    case LIS2DUX12_6Hz_HP:
+    case LIS2DUX12_12Hz5_HP:
+    case LIS2DUX12_25Hz_HP:
+    case LIS2DUX12_50Hz_HP:
+    case LIS2DUX12_100Hz_HP:
+    case LIS2DUX12_200Hz_HP:
+    case LIS2DUX12_400Hz_HP:
+    case LIS2DUX12_800Hz_HP:
+      ctrl5.bw = (uint8_t)val->bw;
+      break;
+  }
 
   ret += lis2dux12_read_reg(ctx, LIS2DUX12_CTRL3, (uint8_t*)&ctrl3, 1);
 
-  ctrl3.hp_en = (((uint8_t)val->odr & 0x10U) != 0U) ? 1U : 0U;
+  ctrl3.hp_en = (((uint8_t)val->odr & 0x30U) == 0x10U) ? 1U : 0U;
 
   if (ret == 0) {
     ret = lis2dux12_write_reg(ctx, LIS2DUX12_CTRL5, (uint8_t*)&ctrl5, 1);
@@ -351,8 +421,8 @@ int32_t lis2dux12_mode_get(stmdev_ctx_t *ctx, lis2dux12_md_t *val)
     case LIS2DUX12_OFF:
       val->odr = LIS2DUX12_OFF;
       break;
-    case LIS2DUX12_1Hz5_ULP:
-      val->odr = LIS2DUX12_1Hz5_ULP;
+    case LIS2DUX12_1Hz6_ULP:
+      val->odr = LIS2DUX12_1Hz6_ULP;
       break;
     case LIS2DUX12_3Hz_ULP:
       val->odr = LIS2DUX12_3Hz_ULP;
@@ -360,29 +430,29 @@ int32_t lis2dux12_mode_get(stmdev_ctx_t *ctx, lis2dux12_md_t *val)
     case LIS2DUX12_25Hz_ULP:
       val->odr = LIS2DUX12_25Hz_ULP;
       break;
-    case LIS2DUX12_6Hz:
-      val->odr = LIS2DUX12_6Hz;
+    case LIS2DUX12_6Hz_LP:
+      val->odr = LIS2DUX12_6Hz_LP;
       break;
-    case LIS2DUX12_12Hz5:
-      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUX12_12Hz5_HP : LIS2DUX12_12Hz5;
+    case LIS2DUX12_12Hz5_LP:
+      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUX12_12Hz5_HP : LIS2DUX12_12Hz5_LP;
       break;
-    case LIS2DUX12_25Hz:
-      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUX12_25Hz_HP : LIS2DUX12_25Hz;
+    case LIS2DUX12_25Hz_LP:
+      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUX12_25Hz_HP : LIS2DUX12_25Hz_LP;
       break;
-    case LIS2DUX12_50Hz:
-      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUX12_50Hz_HP : LIS2DUX12_50Hz;
+    case LIS2DUX12_50Hz_LP:
+      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUX12_50Hz_HP : LIS2DUX12_50Hz_LP;
       break;
-    case LIS2DUX12_100Hz:
-      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUX12_100Hz_HP : LIS2DUX12_100Hz;
+    case LIS2DUX12_100Hz_LP:
+      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUX12_100Hz_HP : LIS2DUX12_100Hz_LP;
       break;
-    case LIS2DUX12_200Hz:
-      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUX12_200Hz_HP : LIS2DUX12_200Hz;
+    case LIS2DUX12_200Hz_LP:
+      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUX12_200Hz_HP : LIS2DUX12_200Hz_LP;
       break;
-    case LIS2DUX12_400Hz:
-      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUX12_400Hz_HP : LIS2DUX12_400Hz;
+    case LIS2DUX12_400Hz_LP:
+      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUX12_400Hz_HP : LIS2DUX12_400Hz_LP;
       break;
-    case LIS2DUX12_800Hz:
-      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUX12_800Hz_HP : LIS2DUX12_800Hz;
+    case LIS2DUX12_800Hz_LP:
+      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUX12_800Hz_HP : LIS2DUX12_800Hz_LP;
       break;
     case LIS2DUX12_TRIG_PIN:
       val->odr = LIS2DUX12_TRIG_PIN;
@@ -1334,7 +1404,7 @@ int32_t lis2dux12_pin_int2_route_set(stmdev_ctx_t *ctx, lis2dux12_pin_int_route_
   lis2dux12_md2_cfg_t md2_cfg;
   int32_t ret;
 
-  ret = lis2dux12_read_reg(ctx, LIS2DUX12_CTRL2, (uint8_t *)&ctrl3, 1);
+  ret = lis2dux12_read_reg(ctx, LIS2DUX12_CTRL3, (uint8_t *)&ctrl3, 1);
 
   if (ret == 0)
   {
@@ -1730,19 +1800,19 @@ int32_t lis2dux12_fifo_mode_get(stmdev_ctx_t *ctx, lis2dux12_fifo_mode_t *val)
       val->operation = LIS2DUX12_FIFO_OFF;
     }
     else {
-      val->operation = (enum operation)fifo_ctrl.fifo_mode;
+      val->operation = (lis2dux12_operation_t)fifo_ctrl.fifo_mode;
     }
     val->cfg_change_in_fifo = fifo_ctrl.cfg_chg_en;
 
     /* get fifo depth (1X/2X) */
-    val->store = (enum store)fifo_ctrl.fifo_depth;
+    val->store = (lis2dux12_store_t)fifo_ctrl.fifo_depth;
 
     /* Get xl_only_fifo */
     val->xl_only = fifo_wtm.xl_only_fifo;
 
     /* get batching info */
-    val->batch.dec_ts = (enum dec_ts)fifo_batch.dec_ts_batch;
-    val->batch.bdr_xl = (enum bdr_xl)fifo_batch.bdr_xl;
+    val->batch.dec_ts = (lis2dux12_dec_ts_t)fifo_batch.dec_ts_batch;
+    val->batch.bdr_xl = (lis2dux12_bdr_xl_t)fifo_batch.bdr_xl;
 
     /* get watermark */
     val->watermark = fifo_wtm.fth;
@@ -2432,7 +2502,7 @@ int32_t lis2dux12_sixd_config_get(stmdev_ctx_t *ctx, lis2dux12_sixd_config_t *va
 
   ret = lis2dux12_read_reg(ctx, LIS2DUX12_SIXD, (uint8_t *)&sixd, 1);
 
-  val->mode = (enum mode)sixd.d4d_en;
+  val->mode = (lis2dux12_mode_t)sixd.d4d_en;
 
   switch ((sixd.d6d_ths))
   {
@@ -2580,8 +2650,8 @@ int32_t lis2dux12_wakeup_config_get(stmdev_ctx_t *ctx, lis2dux12_wakeup_config_t
 
     val->wake_ths_weight = int_cfg.wake_ths_w;
     val->wake_ths = wup_ths.wk_ths;
-    val->wake_enable = (enum wake_enable)wup_ths.sleep_on;
-    val->inact_odr = (enum inact_odr)ctrl4.inact_odr;
+    val->wake_enable = (lis2dux12_wake_enable_t)wup_ths.sleep_on;
+    val->inact_odr = (lis2dux12_inact_odr_t)ctrl4.inact_odr;
   }
 
   return ret;
@@ -2663,7 +2733,7 @@ int32_t lis2dux12_tap_config_get(stmdev_ctx_t *ctx, lis2dux12_tap_config_t *val)
 
   if (ret == 0)
   {
-    val->axis = (enum axis)tap_cfg0.axis;
+    val->axis = (lis2dux12_axis_t)tap_cfg0.axis;
     val->inverted_peak_time = tap_cfg0.invert_t;
     val->pre_still_ths = tap_cfg1.pre_still_ths;
     val->post_still_ths = tap_cfg3.post_still_ths;
@@ -3193,6 +3263,59 @@ int32_t lis2dux12_fsm_init_get(stmdev_ctx_t *ctx, uint8_t *val)
 }
 
 /**
+  * @brief  FSM FIFO en bit.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the value of fsm_fifo_en in reg LIS2DUX12_EMB_FUNC_FIFO_EN
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2dux12_fsm_fifo_en_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2dux12_emb_func_fifo_en_t fifo_reg;
+  int32_t ret;
+
+  ret = lis2dux12_mem_bank_set(ctx, LIS2DUX12_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = lis2dux12_read_reg(ctx, LIS2DUX12_EMB_FUNC_FIFO_EN, (uint8_t *)&fifo_reg, 1);
+    fifo_reg.fsm_fifo_en = val;
+    ret += lis2dux12_write_reg(ctx, LIS2DUX12_EMB_FUNC_FIFO_EN, (uint8_t *)&fifo_reg, 1);
+  }
+
+  ret += lis2dux12_mem_bank_set(ctx, LIS2DUX12_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  FSM FIFO en bit.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the value of fsm_fifo_en in reg LIS2DUX12_EMB_FUNC_FIFO_EN
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2dux12_fsm_fifo_en_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2dux12_emb_func_fifo_en_t fifo_reg;
+  int32_t ret;
+
+  ret = lis2dux12_mem_bank_set(ctx, LIS2DUX12_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = lis2dux12_read_reg(ctx, LIS2DUX12_EMB_FUNC_FIFO_EN, (uint8_t *)&fifo_reg, 1);
+    *val = fifo_reg.fsm_fifo_en;
+  }
+
+  ret += lis2dux12_mem_bank_set(ctx, LIS2DUX12_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
   * @brief  FSM long counter timeout register (r/w). The long counter
   *         timeout value is an unsigned integer value (16-bit format).
   *         When the long counter value reached this value, the FSM
@@ -3541,6 +3664,59 @@ int32_t lis2dux12_mlc_data_rate_get(stmdev_ctx_t *ctx,
         *val = LIS2DUX12_ODR_PRGS_12Hz5;
         break;
     }
+  }
+
+  ret += lis2dux12_mem_bank_set(ctx, LIS2DUX12_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  MLC FIFO en bit.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the value of mlc_fifo_en in reg LIS2DUX12_EMB_FUNC_FIFO_EN
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2dux12_mlc_fifo_en_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2dux12_emb_func_fifo_en_t fifo_reg;
+  int32_t ret;
+
+  ret = lis2dux12_mem_bank_set(ctx, LIS2DUX12_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = lis2dux12_read_reg(ctx, LIS2DUX12_EMB_FUNC_FIFO_EN, (uint8_t *)&fifo_reg, 1);
+    fifo_reg.mlc_fifo_en = val;
+    ret += lis2dux12_write_reg(ctx, LIS2DUX12_EMB_FUNC_FIFO_EN, (uint8_t *)&fifo_reg, 1);
+  }
+
+  ret += lis2dux12_mem_bank_set(ctx, LIS2DUX12_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  MLC FIFO en bit.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the value of mlc_fifo_en in reg LIS2DUX12_EMB_FUNC_FIFO_EN
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2dux12_mlc_fifo_en_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2dux12_emb_func_fifo_en_t fifo_reg;
+  int32_t ret;
+
+  ret = lis2dux12_mem_bank_set(ctx, LIS2DUX12_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = lis2dux12_read_reg(ctx, LIS2DUX12_EMB_FUNC_FIFO_EN, (uint8_t *)&fifo_reg, 1);
+    *val = fifo_reg.mlc_fifo_en;
   }
 
   ret += lis2dux12_mem_bank_set(ctx, LIS2DUX12_MAIN_MEM_BANK);

--- a/sensor/stmemsc/lis2dux12_STdC/driver/lis2dux12_reg.h
+++ b/sensor/stmemsc/lis2dux12_STdC/driver/lis2dux12_reg.h
@@ -2079,43 +2079,49 @@ typedef enum
 int32_t lis2dux12_data_ready_mode_set(stmdev_ctx_t *ctx, lis2dux12_data_ready_mode_t val);
 int32_t lis2dux12_data_ready_mode_get(stmdev_ctx_t *ctx, lis2dux12_data_ready_mode_t *val);
 
+typedef enum {
+  LIS2DUX12_OFF               = 0x00, /* in power down */
+  LIS2DUX12_1Hz6_ULP          = 0x01, /* @1Hz6 (ultra low power) */
+  LIS2DUX12_3Hz_ULP           = 0x02, /* @3Hz (ultra low power) */
+  LIS2DUX12_25Hz_ULP          = 0x03, /* @25Hz (ultra low power) */
+  LIS2DUX12_6Hz_LP            = 0x04, /* @6Hz (low power) */
+  LIS2DUX12_12Hz5_LP          = 0x05, /* @12Hz5 (low power) */
+  LIS2DUX12_25Hz_LP           = 0x06, /* @25Hz  (low power ) */
+  LIS2DUX12_50Hz_LP           = 0x07, /* @50Hz  (low power) */
+  LIS2DUX12_100Hz_LP          = 0x08, /* @100Hz (low power) */
+  LIS2DUX12_200Hz_LP          = 0x09, /* @200Hz (low power) */
+  LIS2DUX12_400Hz_LP          = 0x0A, /* @400Hz (low power) */
+  LIS2DUX12_800Hz_LP          = 0x0B, /* @800Hz (low power) */
+  LIS2DUX12_6Hz_HP            = 0x14, /* @6Hz (high performance) */
+  LIS2DUX12_12Hz5_HP          = 0x15, /* @12Hz5 (high performance) */
+  LIS2DUX12_25Hz_HP           = 0x16, /* @25Hz  (high performance ) */
+  LIS2DUX12_50Hz_HP           = 0x17, /* @50Hz  (high performance) */
+  LIS2DUX12_100Hz_HP          = 0x18, /* @100Hz (high performance) */
+  LIS2DUX12_200Hz_HP          = 0x19, /* @200Hz (high performance) */
+  LIS2DUX12_400Hz_HP          = 0x1A, /* @400Hz (high performance) */
+  LIS2DUX12_800Hz_HP          = 0x1B, /* @800Hz (high performance) */
+  LIS2DUX12_TRIG_PIN          = 0x2E, /* Single-shot high latency by INT2 */
+  LIS2DUX12_TRIG_SW           = 0x2F, /* Single-shot high latency by IF */
+} lis2dux12_odr_t;
+
+typedef enum {
+  LIS2DUX12_2g   = 0,
+  LIS2DUX12_4g   = 1,
+  LIS2DUX12_8g   = 2,
+  LIS2DUX12_16g  = 3,
+} lis2dux12_fs_t;
+
+typedef enum {
+  LIS2DUX12_ODR_div_2   = 0,
+  LIS2DUX12_ODR_div_4   = 1,
+  LIS2DUX12_ODR_div_8   = 2,
+  LIS2DUX12_ODR_div_16  = 3,
+} lis2dux12_bw_t;
+
 typedef struct {
-  enum {
-    LIS2DUX12_OFF               = 0x00, /* in power down */
-    LIS2DUX12_1Hz5_ULP          = 0x01, /* @1Hz6 (low power) */
-    LIS2DUX12_3Hz_ULP           = 0x02, /* @3Hz (ultra low) */
-    LIS2DUX12_25Hz_ULP          = 0x03, /* @25Hz (ultra low) */
-    LIS2DUX12_6Hz               = 0x04, /* @6Hz (low power) */
-    LIS2DUX12_12Hz5             = 0x05, /* @12Hz5 (low power) */
-    LIS2DUX12_25Hz              = 0x06, /* @25Hz  (low power ) */
-    LIS2DUX12_50Hz              = 0x07, /* @50Hz  (low power) */
-    LIS2DUX12_100Hz             = 0x08, /* @100Hz (low power) */
-    LIS2DUX12_200Hz             = 0x09, /* @200Hz (low power) */
-    LIS2DUX12_400Hz             = 0x0A, /* @400Hz (low power) */
-    LIS2DUX12_800Hz             = 0x0B, /* @800Hz (low power) */
-    LIS2DUX12_TRIG_PIN          = 0x0E, /* Single-shot high latency by INT2 */
-    LIS2DUX12_TRIG_SW           = 0x0F, /* Single-shot high latency by IF */
-    LIS2DUX12_6Hz_HP            = 0x14, /* @6Hz (high performance) */
-    LIS2DUX12_12Hz5_HP          = 0x15, /* @12Hz5 (high performance) */
-    LIS2DUX12_25Hz_HP           = 0x16, /* @25Hz  (high performance ) */
-    LIS2DUX12_50Hz_HP           = 0x17, /* @50Hz  (high performance) */
-    LIS2DUX12_100Hz_HP          = 0x18, /* @100Hz (high performance) */
-    LIS2DUX12_200Hz_HP          = 0x19, /* @200Hz (high performance) */
-    LIS2DUX12_400Hz_HP          = 0x1A, /* @400Hz (high performance) */
-    LIS2DUX12_800Hz_HP          = 0x1B, /* @800Hz (high performance) */
-  } odr;
-  enum {
-    LIS2DUX12_2g   = 0,
-    LIS2DUX12_4g   = 1,
-    LIS2DUX12_8g   = 2,
-    LIS2DUX12_16g  = 3,
-  } fs;
-  enum {
-    LIS2DUX12_ODR_div_2   = 0,
-    LIS2DUX12_ODR_div_4   = 1,
-    LIS2DUX12_ODR_div_8   = 2,
-    LIS2DUX12_ODR_div_16  = 3,
-  } bw;
+  lis2dux12_odr_t odr;
+  lis2dux12_fs_t fs;
+  lis2dux12_bw_t bw;
 } lis2dux12_md_t;
 int32_t lis2dux12_mode_set(stmdev_ctx_t *ctx, lis2dux12_md_t *val);
 int32_t lis2dux12_mode_get(stmdev_ctx_t *ctx, lis2dux12_md_t *val);
@@ -2180,13 +2186,15 @@ int32_t lis2dux12_self_test_stop(stmdev_ctx_t *ctx);
 int32_t lis2dux12_enter_deep_power_down(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lis2dux12_exit_deep_power_down(stmdev_ctx_t *ctx);
 
+typedef enum {
+  LIS2DUX12_I3C_BUS_AVAIL_TIME_20US = 0x0,
+  LIS2DUX12_I3C_BUS_AVAIL_TIME_50US = 0x1,
+  LIS2DUX12_I3C_BUS_AVAIL_TIME_1MS  = 0x2,
+  LIS2DUX12_I3C_BUS_AVAIL_TIME_25MS = 0x3,
+} lis2dux12_bus_act_sel_t;
+
 typedef struct {
-  enum {
-    LIS2DUX12_I3C_BUS_AVAIL_TIME_20US = 0x0,
-    LIS2DUX12_I3C_BUS_AVAIL_TIME_50US = 0x1,
-    LIS2DUX12_I3C_BUS_AVAIL_TIME_1MS  = 0x2,
-    LIS2DUX12_I3C_BUS_AVAIL_TIME_25MS = 0x3,
-  } bus_act_sel;
+  lis2dux12_bus_act_sel_t bus_act_sel;
   uint8_t asf_on                       : 1;
   uint8_t drstdaa_en                   : 1;
 } lis2dux12_i3c_cfg_t;
@@ -2270,13 +2278,15 @@ int32_t lis2dux12_emb_pin_int2_route_set(stmdev_ctx_t *ctx,
 int32_t lis2dux12_emb_pin_int2_route_get(stmdev_ctx_t *ctx,
                                           lis2dux12_emb_pin_int_route_t *val);
 
+typedef enum
+{
+  LIS2DUX12_INT_DISABLED             = 0x0,
+  LIS2DUX12_INT_LEVEL                = 0x1,
+  LIS2DUX12_INT_LATCHED              = 0x2,
+} lis2dux12_int_cfg_t;
+
 typedef struct {
-  enum int_cfg
-  {
-    LIS2DUX12_INT_DISABLED             = 0x0,
-    LIS2DUX12_INT_LEVEL                = 0x1,
-    LIS2DUX12_INT_LATCHED              = 0x2,
-  } int_cfg;
+  lis2dux12_int_cfg_t int_cfg;
   uint8_t sleep_status_on_int          : 1;  /* route sleep_status on interrupt */
   uint8_t dis_rst_lir_all_int          : 1;  /* disable LIR reset when reading ALL_INT_SRC */
 } lis2dux12_int_config_t;
@@ -2291,43 +2301,51 @@ typedef enum
 int32_t lis2dux12_embedded_int_config_set(stmdev_ctx_t *ctx, lis2dux12_embedded_int_config_t val);
 int32_t lis2dux12_embedded_int_config_get(stmdev_ctx_t *ctx, lis2dux12_embedded_int_config_t *val);
 
+typedef enum
+{
+  LIS2DUX12_BYPASS_MODE              = 0x0,
+  LIS2DUX12_FIFO_MODE                = 0x1,
+  LIS2DUX12_STREAM_TO_FIFO_MODE      = 0x3,
+  LIS2DUX12_BYPASS_TO_STREAM_MODE    = 0x4,
+  LIS2DUX12_STREAM_MODE              = 0x6,
+  LIS2DUX12_BYPASS_TO_FIFO_MODE      = 0x7,
+  LIS2DUX12_FIFO_OFF                 = 0x8,
+} lis2dux12_operation_t;
+
+typedef enum {
+  LIS2DUX12_FIFO_1X                  = 0,
+  LIS2DUX12_FIFO_2X                  = 1,
+} lis2dux12_store_t;
+
+typedef enum
+{
+  LIS2DUX12_DEC_TS_OFF             = 0x0,
+  LIS2DUX12_DEC_TS_1               = 0x1,
+  LIS2DUX12_DEC_TS_8               = 0x2,
+  LIS2DUX12_DEC_TS_32              = 0x3,
+} lis2dux12_dec_ts_t;
+
+typedef enum
+{
+  LIS2DUX12_BDR_XL_ODR             = 0x0,
+  LIS2DUX12_BDR_XL_ODR_DIV_2       = 0x1,
+  LIS2DUX12_BDR_XL_ODR_DIV_4       = 0x2,
+  LIS2DUX12_BDR_XL_ODR_DIV_8       = 0x3,
+  LIS2DUX12_BDR_XL_ODR_DIV_16      = 0x4,
+  LIS2DUX12_BDR_XL_ODR_DIV_32      = 0x5,
+  LIS2DUX12_BDR_XL_ODR_DIV_64      = 0x6,
+  LIS2DUX12_BDR_XL_ODR_OFF         = 0x7,
+} lis2dux12_bdr_xl_t;
+
 typedef struct {
-  enum operation
-  {
-    LIS2DUX12_BYPASS_MODE              = 0x0,
-    LIS2DUX12_FIFO_MODE                = 0x1,
-    LIS2DUX12_STREAM_TO_FIFO_MODE      = 0x3,
-    LIS2DUX12_BYPASS_TO_STREAM_MODE    = 0x4,
-    LIS2DUX12_STREAM_MODE              = 0x6,
-    LIS2DUX12_BYPASS_TO_FIFO_MODE      = 0x7,
-    LIS2DUX12_FIFO_OFF                 = 0x8,
-  } operation;
-  enum store {
-    LIS2DUX12_FIFO_1X                  = 0,
-    LIS2DUX12_FIFO_2X                  = 1,
-  } store;
+  lis2dux12_operation_t operation;
+  lis2dux12_store_t store;
   uint8_t xl_only                      : 1; /* when set to 1, only XL samples (16-bit) are stored in FIFO */
   uint8_t watermark                    : 7; /* (0 disable) max 127 @16bit, even and max 256 @8bit.*/
   uint8_t cfg_change_in_fifo           : 1;
   struct {
-    enum dec_ts
-    {
-      LIS2DUX12_DEC_TS_OFF             = 0x0,
-      LIS2DUX12_DEC_TS_1               = 0x1,
-      LIS2DUX12_DEC_TS_8               = 0x2,
-      LIS2DUX12_DEC_TS_32              = 0x3,
-    } dec_ts; /* decimation for timestamp batching*/
-    enum bdr_xl
-    {
-      LIS2DUX12_BDR_XL_ODR             = 0x0,
-      LIS2DUX12_BDR_XL_ODR_DIV_2       = 0x1,
-      LIS2DUX12_BDR_XL_ODR_DIV_4       = 0x2,
-      LIS2DUX12_BDR_XL_ODR_DIV_8       = 0x3,
-      LIS2DUX12_BDR_XL_ODR_DIV_16      = 0x4,
-      LIS2DUX12_BDR_XL_ODR_DIV_32      = 0x5,
-      LIS2DUX12_BDR_XL_ODR_DIV_64      = 0x6,
-      LIS2DUX12_BDR_XL_ODR_OFF         = 0x7,
-    } bdr_xl; /* accelerometer batch data rate*/
+    lis2dux12_dec_ts_t dec_ts; /* decimation for timestamp batching*/
+    lis2dux12_bdr_xl_t bdr_xl; /* accelerometer batch data rate*/
   } batch;
 } lis2dux12_fifo_mode_t;
 int32_t lis2dux12_fifo_mode_set(stmdev_ctx_t *ctx, lis2dux12_fifo_mode_t val);
@@ -2359,15 +2377,15 @@ typedef struct {
     float_t mg[3];
     int16_t raw[3];
   }xl[2];
-  struct heat {
+  struct lis2dux12_heat {
     float_t deg_c;
     int16_t raw;
   } heat;
-  struct pedo {
+  struct lis2dux12_pedo {
     uint32_t steps;
     uint32_t timestamp;
   } pedo;
-  struct cfg_chg {
+  struct lis2dux12_cfg_chg {
     uint8_t cfg_change                 : 1; /* 1 if ODR/BDR configuration is changed */
     uint8_t odr                        : 4; /* ODR */
     uint8_t bw                         : 2; /* BW */
@@ -2425,63 +2443,75 @@ typedef enum
 int32_t lis2dux12_ff_thresholds_set(stmdev_ctx_t *ctx, lis2dux12_ff_thresholds_t val);
 int32_t lis2dux12_ff_thresholds_get(stmdev_ctx_t *ctx, lis2dux12_ff_thresholds_t *val);
 
+typedef enum
+{
+  LIS2DUX12_DEG_80 = 0x0,
+  LIS2DUX12_DEG_70 = 0x1,
+  LIS2DUX12_DEG_60 = 0x2,
+  LIS2DUX12_DEG_50 = 0x3,
+} lis2dux12_threshold_t;
+
+typedef enum
+{
+  LIS2DUX12_6D = 0x0,
+  LIS2DUX12_4D = 0x1,
+} lis2dux12_mode_t;
+
 typedef struct {
-  enum threshold
-  {
-    LIS2DUX12_DEG_80 = 0x0,
-    LIS2DUX12_DEG_70 = 0x1,
-    LIS2DUX12_DEG_60 = 0x2,
-    LIS2DUX12_DEG_50 = 0x3,
-  } threshold;
-  enum mode
-  {
-    LIS2DUX12_6D = 0x0,
-    LIS2DUX12_4D = 0x1,
-  } mode;
+  lis2dux12_threshold_t threshold;
+  lis2dux12_mode_t mode;
 } lis2dux12_sixd_config_t;
 
 int32_t lis2dux12_sixd_config_set(stmdev_ctx_t *ctx, lis2dux12_sixd_config_t val);
 int32_t lis2dux12_sixd_config_get(stmdev_ctx_t *ctx, lis2dux12_sixd_config_t *val);
 
+typedef enum
+{
+  LIS2DUX12_0_ODR  = 0x000, /* 0 ODR time */
+  LIS2DUX12_1_ODR  = 0x001, /* 1 ODR time */
+  LIS2DUX12_2_ODR  = 0x002, /* 2 ODR time */
+  LIS2DUX12_3_ODR  = 0x100, /* 3 ODR time */
+  LIS2DUX12_7_ODR  = 0x101, /* 7 ODR time */
+  LIS2DUX12_11_ODR = 0x102, /* 11 ODR time */
+  LIS2DUX12_15_ODR = 0x103, /* 15 ODR time */
+} lis2dux12_wake_dur_t;
+
+typedef enum
+{
+  LIS2DUX12_SLEEP_OFF = 0,
+  LIS2DUX12_SLEEP_ON  = 1,
+} lis2dux12_wake_enable_t;
+
+typedef enum
+{
+  LIS2DUX12_ODR_NO_CHANGE       = 0,  /* no odr change during inactivity state */
+  LIS2DUX12_ODR_1_6_HZ          = 1,  /* set odr to 1.6Hz during inactivity state */
+  LIS2DUX12_ODR_3_HZ            = 1,  /* set odr to 3Hz during inactivity state */
+  LIS2DUX12_ODR_25_HZ           = 1,  /* set odr to 25Hz during inactivity state */
+} lis2dux12_inact_odr_t;
+
 typedef struct {
-  enum wake_dur
-  {
-    LIS2DUX12_0_ODR  = 0x000, /* 0 ODR time */
-    LIS2DUX12_1_ODR  = 0x001, /* 1 ODR time */
-    LIS2DUX12_2_ODR  = 0x002, /* 2 ODR time */
-    LIS2DUX12_3_ODR  = 0x100, /* 3 ODR time */
-    LIS2DUX12_7_ODR  = 0x101, /* 7 ODR time */
-    LIS2DUX12_11_ODR = 0x102, /* 11 ODR time */
-    LIS2DUX12_15_ODR = 0x103, /* 15 ODR time */
-  } wake_dur;
+  lis2dux12_wake_dur_t wake_dur;
   uint8_t sleep_dur                    : 4;       /* 1 LSB == 512 ODR time */
   uint8_t wake_ths                     : 7;       /* wakeup threshold */
   uint8_t wake_ths_weight              : 1;       /* 0: 1LSB = FS_XL/2^6, 1: 1LSB = FS_XL/2^8 */
-  enum wake_enable
-  {
-    LIS2DUX12_SLEEP_OFF = 0,
-    LIS2DUX12_SLEEP_ON  = 1,
-  } wake_enable;
-  enum inact_odr
-  {
-    LIS2DUX12_ODR_NO_CHANGE       = 0,  /* no odr change during inactivity state */
-    LIS2DUX12_ODR_1_6_HZ          = 1,  /* set odr to 1.6Hz during inactivity state */
-    LIS2DUX12_ODR_3_HZ            = 1,  /* set odr to 3Hz during inactivity state */
-    LIS2DUX12_ODR_25_HZ           = 1,  /* set odr to 25Hz during inactivity state */
-  } inact_odr;
+  lis2dux12_wake_enable_t wake_enable;
+  lis2dux12_inact_odr_t inact_odr;
 } lis2dux12_wakeup_config_t;
 
 int32_t lis2dux12_wakeup_config_set(stmdev_ctx_t *ctx, lis2dux12_wakeup_config_t val);
 int32_t lis2dux12_wakeup_config_get(stmdev_ctx_t *ctx, lis2dux12_wakeup_config_t *val);
 
+typedef enum
+{
+  LIS2DUX12_TAP_NONE  = 0x0, /* No axis */
+  LIS2DUX12_TAP_ON_X  = 0x1, /* Detect tap on X axis */
+  LIS2DUX12_TAP_ON_Y  = 0x2, /* Detect tap on Y axis */
+  LIS2DUX12_TAP_ON_Z  = 0x3, /* Detect tap on Z axis */
+} lis2dux12_axis_t;
+
 typedef struct {
-  enum axis
-  {
-    LIS2DUX12_TAP_NONE  = 0x0, /* No axis */
-    LIS2DUX12_TAP_ON_X  = 0x1, /* Detect tap on X axis */
-    LIS2DUX12_TAP_ON_Y  = 0x2, /* Detect tap on Y axis */
-    LIS2DUX12_TAP_ON_Z  = 0x3, /* Detect tap on Z axis */
-  } axis;
+  lis2dux12_axis_t axis;
   uint8_t inverted_peak_time           : 5; /* 1 LSB == 1 sample */
   uint8_t pre_still_ths                : 4; /* 1 LSB == 62.5 mg */
   uint8_t post_still_ths               : 4; /* 1 LSB == 62.5 mg */
@@ -2546,6 +2576,9 @@ int32_t lis2dux12_fsm_data_rate_get(stmdev_ctx_t *ctx,
 int32_t lis2dux12_fsm_init_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lis2dux12_fsm_init_get(stmdev_ctx_t *ctx, uint8_t *val);
 
+int32_t lis2dux12_fsm_fifo_en_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dux12_fsm_fifo_en_get(stmdev_ctx_t *ctx, uint8_t *val);
+
 int32_t lis2dux12_long_cnt_int_value_set(stmdev_ctx_t *ctx,
                                           uint16_t val);
 int32_t lis2dux12_long_cnt_int_value_get(stmdev_ctx_t *ctx,
@@ -2587,6 +2620,9 @@ int32_t lis2dux12_mlc_data_rate_set(stmdev_ctx_t *ctx,
                                      lis2dux12_mlc_odr_val_t val);
 int32_t lis2dux12_mlc_data_rate_get(stmdev_ctx_t *ctx,
                                      lis2dux12_mlc_odr_val_t *val);
+
+int32_t lis2dux12_mlc_fifo_en_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dux12_mlc_fifo_en_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 #ifdef __cplusplus
 }

--- a/sensor/stmemsc/lis2duxs12_STdC/driver/lis2duxs12_reg.c
+++ b/sensor/stmemsc/lis2duxs12_STdC/driver/lis2duxs12_reg.c
@@ -109,6 +109,11 @@ float_t lis2duxs12_from_lsb_to_celsius(int16_t lsb)
   return ((float_t)lsb / 355.5f) + 25.0f;
 }
 
+float_t lis2duxs12_from_lsb_to_mv(int16_t lsb)
+{
+  return ((float_t)lsb) / 74.4f;
+}
+
 /**
   * @}
   *
@@ -316,11 +321,81 @@ int32_t lis2duxs12_mode_set(stmdev_ctx_t *ctx, lis2duxs12_md_t *val)
 
   ctrl5.odr = (uint8_t)val->odr & 0xFU;
   ctrl5.fs = (uint8_t)val->fs;
-  ctrl5.bw = (uint8_t)val->bw;
+
+  /* set the bandwidth */
+  switch (val->odr) {
+    /* no anti-aliasing filter present */
+    case LIS2DUXS12_OFF:
+    case LIS2DUXS12_1Hz6_ULP:
+    case LIS2DUXS12_3Hz_ULP:
+    case LIS2DUXS12_25Hz_ULP:
+      ctrl5.bw = 0x0;
+      break;
+
+    /* low-power mode with ODR < 50 Hz */
+    case LIS2DUXS12_6Hz_LP:
+      switch(val->bw) {
+        case LIS2DUXS12_ODR_div_4:
+        case LIS2DUXS12_ODR_div_8:
+        case LIS2DUXS12_ODR_div_16:
+          return -1;
+        case LIS2DUXS12_ODR_div_2:
+          ctrl5.bw = 0x3;
+          break;
+      }
+      break;
+    case LIS2DUXS12_12Hz5_LP:
+      switch(val->bw) {
+        case LIS2DUXS12_ODR_div_8:
+        case LIS2DUXS12_ODR_div_16:
+          return -1;
+        case LIS2DUXS12_ODR_div_2:
+          ctrl5.bw = 0x2;
+          break;
+        case LIS2DUXS12_ODR_div_4:
+          ctrl5.bw = 0x3;
+          break;
+      }
+      break;
+    case LIS2DUXS12_25Hz_LP:
+      switch(val->bw) {
+        case LIS2DUXS12_ODR_div_16:
+          return -1;
+        case LIS2DUXS12_ODR_div_2:
+          ctrl5.bw = 0x1;
+          break;
+        case LIS2DUXS12_ODR_div_4:
+          ctrl5.bw = 0x2;
+          break;
+        case LIS2DUXS12_ODR_div_8:
+          ctrl5.bw = 0x3;
+          break;
+      }
+      break;
+
+    /* standard cases */
+    case LIS2DUXS12_50Hz_LP:
+    case LIS2DUXS12_100Hz_LP:
+    case LIS2DUXS12_200Hz_LP:
+    case LIS2DUXS12_400Hz_LP:
+    case LIS2DUXS12_800Hz_LP:
+    case LIS2DUXS12_TRIG_PIN:
+    case LIS2DUXS12_TRIG_SW:
+    case LIS2DUXS12_6Hz_HP:
+    case LIS2DUXS12_12Hz5_HP:
+    case LIS2DUXS12_25Hz_HP:
+    case LIS2DUXS12_50Hz_HP:
+    case LIS2DUXS12_100Hz_HP:
+    case LIS2DUXS12_200Hz_HP:
+    case LIS2DUXS12_400Hz_HP:
+    case LIS2DUXS12_800Hz_HP:
+      ctrl5.bw = (uint8_t)val->bw;
+      break;
+  }
 
   ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL3, (uint8_t*)&ctrl3, 1);
 
-  ctrl3.hp_en = (((uint8_t)val->odr & 0x10U) != 0U) ? 1U : 0U;
+  ctrl3.hp_en = (((uint8_t)val->odr & 0x30U) == 0x10U) ? 1U : 0U;
 
   if (ret == 0) {
     ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_CTRL5, (uint8_t*)&ctrl5, 1);
@@ -351,8 +426,8 @@ int32_t lis2duxs12_mode_get(stmdev_ctx_t *ctx, lis2duxs12_md_t *val)
     case LIS2DUXS12_OFF:
       val->odr = LIS2DUXS12_OFF;
       break;
-    case LIS2DUXS12_1Hz5_ULP:
-      val->odr = LIS2DUXS12_1Hz5_ULP;
+    case LIS2DUXS12_1Hz6_ULP:
+      val->odr = LIS2DUXS12_1Hz6_ULP;
       break;
     case LIS2DUXS12_3Hz_ULP:
       val->odr = LIS2DUXS12_3Hz_ULP;
@@ -360,29 +435,29 @@ int32_t lis2duxs12_mode_get(stmdev_ctx_t *ctx, lis2duxs12_md_t *val)
     case LIS2DUXS12_25Hz_ULP:
       val->odr = LIS2DUXS12_25Hz_ULP;
       break;
-    case LIS2DUXS12_6Hz:
-      val->odr = LIS2DUXS12_6Hz;
+    case LIS2DUXS12_6Hz_LP:
+      val->odr = LIS2DUXS12_6Hz_LP;
       break;
-    case LIS2DUXS12_12Hz5:
-      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUXS12_12Hz5_HP : LIS2DUXS12_12Hz5;
+    case LIS2DUXS12_12Hz5_LP:
+      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUXS12_12Hz5_HP : LIS2DUXS12_12Hz5_LP;
       break;
-    case LIS2DUXS12_25Hz:
-      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUXS12_25Hz_HP : LIS2DUXS12_25Hz;
+    case LIS2DUXS12_25Hz_LP:
+      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUXS12_25Hz_HP : LIS2DUXS12_25Hz_LP;
       break;
-    case LIS2DUXS12_50Hz:
-      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUXS12_50Hz_HP : LIS2DUXS12_50Hz;
+    case LIS2DUXS12_50Hz_LP:
+      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUXS12_50Hz_HP : LIS2DUXS12_50Hz_LP;
       break;
-    case LIS2DUXS12_100Hz:
-      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUXS12_100Hz_HP : LIS2DUXS12_100Hz;
+    case LIS2DUXS12_100Hz_LP:
+      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUXS12_100Hz_HP : LIS2DUXS12_100Hz_LP;
       break;
-    case LIS2DUXS12_200Hz:
-      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUXS12_200Hz_HP : LIS2DUXS12_200Hz;
+    case LIS2DUXS12_200Hz_LP:
+      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUXS12_200Hz_HP : LIS2DUXS12_200Hz_LP;
       break;
-    case LIS2DUXS12_400Hz:
-      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUXS12_400Hz_HP : LIS2DUXS12_400Hz;
+    case LIS2DUXS12_400Hz_LP:
+      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUXS12_400Hz_HP : LIS2DUXS12_400Hz_LP;
       break;
-    case LIS2DUXS12_800Hz:
-      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUXS12_800Hz_HP : LIS2DUXS12_800Hz;
+    case LIS2DUXS12_800Hz_LP:
+      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUXS12_800Hz_HP : LIS2DUXS12_800Hz_LP;
       break;
     case LIS2DUXS12_TRIG_PIN:
       val->odr = LIS2DUXS12_TRIG_PIN;
@@ -631,9 +706,10 @@ int32_t lis2duxs12_ah_qvar_data_get(stmdev_ctx_t *ctx, lis2duxs12_md_t *md,
 
   ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_OUT_T_AH_QVAR_L, buff, 2);
 
-  data->ah_qvar = (int16_t)buff[1U];
-  data->ah_qvar = (data->ah_qvar * 256) + (int16_t) buff[0];
+  data->raw = (int16_t)buff[1U];
+  data->raw = (data->raw * 256) + (int16_t) buff[0];
 
+  data->mv = lis2duxs12_from_lsb_to_mv(data->raw);
   return ret;
 }
 
@@ -1357,7 +1433,7 @@ int32_t lis2duxs12_pin_int2_route_set(stmdev_ctx_t *ctx, lis2duxs12_pin_int_rout
   lis2duxs12_md2_cfg_t md2_cfg;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL2, (uint8_t *)&ctrl3, 1);
+  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL3, (uint8_t *)&ctrl3, 1);
 
   if (ret == 0)
   {
@@ -1753,19 +1829,19 @@ int32_t lis2duxs12_fifo_mode_get(stmdev_ctx_t *ctx, lis2duxs12_fifo_mode_t *val)
       val->operation = LIS2DUXS12_FIFO_OFF;
     }
     else {
-      val->operation = (enum operation)fifo_ctrl.fifo_mode;
+      val->operation = (lis2duxs12_operation_t)fifo_ctrl.fifo_mode;
     }
     val->cfg_change_in_fifo = fifo_ctrl.cfg_chg_en;
 
     /* get fifo depth (1X/2X) */
-    val->store = (enum store)fifo_ctrl.fifo_depth;
+    val->store = (lis2duxs12_store_t)fifo_ctrl.fifo_depth;
 
     /* Get xl_only_fifo */
     val->xl_only = fifo_wtm.xl_only_fifo;
 
     /* get batching info */
-    val->batch.dec_ts = (enum dec_ts)fifo_batch.dec_ts_batch;
-    val->batch.bdr_xl = (enum bdr_xl)fifo_batch.bdr_xl;
+    val->batch.dec_ts = (lis2duxs12_dec_ts_t)fifo_batch.dec_ts_batch;
+    val->batch.bdr_xl = (lis2duxs12_bdr_xl_t)fifo_batch.bdr_xl;
 
     /* get watermark */
     val->watermark = fifo_wtm.fth;
@@ -1864,7 +1940,8 @@ int32_t lis2duxs12_fifo_data_get(stmdev_ctx_t *ctx, lis2duxs12_md_t *md,
          if (fifo_tag.tag_sensor == (uint8_t)LIS2DUXS12_XL_TEMP_TAG) {
            data->heat.deg_c = lis2duxs12_from_lsb_to_celsius(data->heat.raw);
         } else {
-           data->ah_qvar = data->heat.raw;
+           data->ah_qvar.raw = data->heat.raw;
+           data->ah_qvar.mv = lis2duxs12_from_lsb_to_mv(data->ah_qvar.raw);
        }
       } else {
         /* A FIFO sample consists of 16-bits 3-axis XL at ODR  */
@@ -2564,7 +2641,7 @@ int32_t lis2duxs12_sixd_config_get(stmdev_ctx_t *ctx, lis2duxs12_sixd_config_t *
 
   ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_SIXD, (uint8_t *)&sixd, 1);
 
-  val->mode = (enum mode)sixd.d4d_en;
+  val->mode = (lis2duxs12_mode_t)sixd.d4d_en;
 
   switch ((sixd.d6d_ths))
   {
@@ -2712,8 +2789,8 @@ int32_t lis2duxs12_wakeup_config_get(stmdev_ctx_t *ctx, lis2duxs12_wakeup_config
 
     val->wake_ths_weight = int_cfg.wake_ths_w;
     val->wake_ths = wup_ths.wk_ths;
-    val->wake_enable = (enum wake_enable)wup_ths.sleep_on;
-    val->inact_odr = (enum inact_odr)ctrl4.inact_odr;
+    val->wake_enable = (lis2duxs12_wake_enable_t)wup_ths.sleep_on;
+    val->inact_odr = (lis2duxs12_inact_odr_t)ctrl4.inact_odr;
   }
 
   return ret;
@@ -2795,7 +2872,7 @@ int32_t lis2duxs12_tap_config_get(stmdev_ctx_t *ctx, lis2duxs12_tap_config_t *va
 
   if (ret == 0)
   {
-    val->axis = (enum axis)tap_cfg0.axis;
+    val->axis = (lis2duxs12_axis_t)tap_cfg0.axis;
     val->inverted_peak_time = tap_cfg0.invert_t;
     val->pre_still_ths = tap_cfg1.pre_still_ths;
     val->post_still_ths = tap_cfg3.post_still_ths;
@@ -3325,6 +3402,59 @@ int32_t lis2duxs12_fsm_init_get(stmdev_ctx_t *ctx, uint8_t *val)
 }
 
 /**
+  * @brief  FSM FIFO en bit.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the value of fsm_fifo_en in reg LIS2DUXS12_EMB_FUNC_FIFO_EN
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2duxs12_fsm_fifo_en_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2duxs12_emb_func_fifo_en_t fifo_reg;
+  int32_t ret;
+
+  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_FIFO_EN, (uint8_t *)&fifo_reg, 1);
+    fifo_reg.fsm_fifo_en = val;
+    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_EMB_FUNC_FIFO_EN, (uint8_t *)&fifo_reg, 1);
+  }
+
+  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  FSM FIFO en bit.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the value of fsm_fifo_en in reg LIS2DUXS12_EMB_FUNC_FIFO_EN
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2duxs12_fsm_fifo_en_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2duxs12_emb_func_fifo_en_t fifo_reg;
+  int32_t ret;
+
+  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_FIFO_EN, (uint8_t *)&fifo_reg, 1);
+    *val = fifo_reg.fsm_fifo_en;
+  }
+
+  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
   * @brief  FSM long counter timeout register (r/w). The long counter
   *         timeout value is an unsigned integer value (16-bit format).
   *         When the long counter value reached this value, the FSM
@@ -3673,6 +3803,59 @@ int32_t lis2duxs12_mlc_data_rate_get(stmdev_ctx_t *ctx,
         *val = LIS2DUXS12_ODR_PRGS_12Hz5;
         break;
     }
+  }
+
+  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  MLC FIFO en bit.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the value of mlc_fifo_en in reg LIS2DUXS12_EMB_FUNC_FIFO_EN
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2duxs12_mlc_fifo_en_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2duxs12_emb_func_fifo_en_t fifo_reg;
+  int32_t ret;
+
+  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_FIFO_EN, (uint8_t *)&fifo_reg, 1);
+    fifo_reg.mlc_fifo_en = val;
+    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_EMB_FUNC_FIFO_EN, (uint8_t *)&fifo_reg, 1);
+  }
+
+  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  MLC FIFO en bit.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the value of mlc_fifo_en in reg LIS2DUXS12_EMB_FUNC_FIFO_EN
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2duxs12_mlc_fifo_en_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2duxs12_emb_func_fifo_en_t fifo_reg;
+  int32_t ret;
+
+  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_FIFO_EN, (uint8_t *)&fifo_reg, 1);
+    *val = fifo_reg.mlc_fifo_en;
   }
 
   ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);

--- a/sensor/stmemsc/lis2duxs12_STdC/driver/lis2duxs12_reg.h
+++ b/sensor/stmemsc/lis2duxs12_STdC/driver/lis2duxs12_reg.h
@@ -2065,6 +2065,7 @@ float_t lis2duxs12_from_fs4g_to_mg(int16_t lsb);
 float_t lis2duxs12_from_fs8g_to_mg(int16_t lsb);
 float_t lis2duxs12_from_fs16g_to_mg(int16_t lsb);
 float_t lis2duxs12_from_lsb_to_celsius(int16_t lsb);
+float_t lis2duxs12_from_lsb_to_mv(int16_t lsb);
 
 int32_t lis2duxs12_device_id_get(stmdev_ctx_t *ctx, uint8_t *val);
 
@@ -2100,43 +2101,49 @@ typedef enum
 int32_t lis2duxs12_data_ready_mode_set(stmdev_ctx_t *ctx, lis2duxs12_data_ready_mode_t val);
 int32_t lis2duxs12_data_ready_mode_get(stmdev_ctx_t *ctx, lis2duxs12_data_ready_mode_t *val);
 
+typedef enum {
+  LIS2DUXS12_OFF               = 0x00, /* in power down */
+  LIS2DUXS12_1Hz6_ULP          = 0x01, /* @1Hz6 (ultra low power) */
+  LIS2DUXS12_3Hz_ULP           = 0x02, /* @3Hz (ultra low power) */
+  LIS2DUXS12_25Hz_ULP          = 0x03, /* @25Hz (ultra low power) */
+  LIS2DUXS12_6Hz_LP            = 0x04, /* @6Hz (low power) */
+  LIS2DUXS12_12Hz5_LP          = 0x05, /* @12Hz5 (low power) */
+  LIS2DUXS12_25Hz_LP           = 0x06, /* @25Hz  (low power ) */
+  LIS2DUXS12_50Hz_LP           = 0x07, /* @50Hz  (low power) */
+  LIS2DUXS12_100Hz_LP          = 0x08, /* @100Hz (low power) */
+  LIS2DUXS12_200Hz_LP          = 0x09, /* @200Hz (low power) */
+  LIS2DUXS12_400Hz_LP          = 0x0A, /* @400Hz (low power) */
+  LIS2DUXS12_800Hz_LP          = 0x0B, /* @800Hz (low power) */
+  LIS2DUXS12_6Hz_HP            = 0x14, /* @6Hz (high performance) */
+  LIS2DUXS12_12Hz5_HP          = 0x15, /* @12Hz5 (high performance) */
+  LIS2DUXS12_25Hz_HP           = 0x16, /* @25Hz  (high performance ) */
+  LIS2DUXS12_50Hz_HP           = 0x17, /* @50Hz  (high performance) */
+  LIS2DUXS12_100Hz_HP          = 0x18, /* @100Hz (high performance) */
+  LIS2DUXS12_200Hz_HP          = 0x19, /* @200Hz (high performance) */
+  LIS2DUXS12_400Hz_HP          = 0x1A, /* @400Hz (high performance) */
+  LIS2DUXS12_800Hz_HP          = 0x1B, /* @800Hz (high performance) */
+  LIS2DUXS12_TRIG_PIN          = 0x2E, /* Single-shot high latency by INT2 */
+  LIS2DUXS12_TRIG_SW           = 0x2F, /* Single-shot high latency by IF */
+} lis2duxs12_odr_t;
+
+typedef enum {
+  LIS2DUXS12_2g   = 0,
+  LIS2DUXS12_4g   = 1,
+  LIS2DUXS12_8g   = 2,
+  LIS2DUXS12_16g  = 3,
+} lis2duxs12_fs_t;
+
+typedef enum {
+  LIS2DUXS12_ODR_div_2   = 0,
+  LIS2DUXS12_ODR_div_4   = 1,
+  LIS2DUXS12_ODR_div_8   = 2,
+  LIS2DUXS12_ODR_div_16  = 3,
+} lis2duxs12_bw_t;
+
 typedef struct {
-  enum {
-    LIS2DUXS12_OFF               = 0x00, /* in power down */
-    LIS2DUXS12_1Hz5_ULP          = 0x01, /* @1Hz6 (low power) */
-    LIS2DUXS12_3Hz_ULP           = 0x02, /* @3Hz (ultra low) */
-    LIS2DUXS12_25Hz_ULP          = 0x03, /* @25Hz (ultra low) */
-    LIS2DUXS12_6Hz               = 0x04, /* @6Hz (low power) */
-    LIS2DUXS12_12Hz5             = 0x05, /* @12Hz5 (low power) */
-    LIS2DUXS12_25Hz              = 0x06, /* @25Hz  (low power ) */
-    LIS2DUXS12_50Hz              = 0x07, /* @50Hz  (low power) */
-    LIS2DUXS12_100Hz             = 0x08, /* @100Hz (low power) */
-    LIS2DUXS12_200Hz             = 0x09, /* @200Hz (low power) */
-    LIS2DUXS12_400Hz             = 0x0A, /* @400Hz (low power) */
-    LIS2DUXS12_800Hz             = 0x0B, /* @800Hz (low power) */
-    LIS2DUXS12_TRIG_PIN          = 0x0E, /* Single-shot high latency by INT2 */
-    LIS2DUXS12_TRIG_SW           = 0x0F, /* Single-shot high latency by IF */
-    LIS2DUXS12_6Hz_HP            = 0x14, /* @6Hz (high performance) */
-    LIS2DUXS12_12Hz5_HP          = 0x15, /* @12Hz5 (high performance) */
-    LIS2DUXS12_25Hz_HP           = 0x16, /* @25Hz  (high performance ) */
-    LIS2DUXS12_50Hz_HP           = 0x17, /* @50Hz  (high performance) */
-    LIS2DUXS12_100Hz_HP          = 0x18, /* @100Hz (high performance) */
-    LIS2DUXS12_200Hz_HP          = 0x19, /* @200Hz (high performance) */
-    LIS2DUXS12_400Hz_HP          = 0x1A, /* @400Hz (high performance) */
-    LIS2DUXS12_800Hz_HP          = 0x1B, /* @800Hz (high performance) */
-  } odr;
-  enum {
-    LIS2DUXS12_2g   = 0,
-    LIS2DUXS12_4g   = 1,
-    LIS2DUXS12_8g   = 2,
-    LIS2DUXS12_16g  = 3,
-  } fs;
-  enum {
-    LIS2DUXS12_ODR_div_2   = 0,
-    LIS2DUXS12_ODR_div_4   = 1,
-    LIS2DUXS12_ODR_div_8   = 2,
-    LIS2DUXS12_ODR_div_16  = 3,
-  } bw;
+  lis2duxs12_odr_t odr;
+  lis2duxs12_fs_t fs;
+  lis2duxs12_bw_t bw;
 } lis2duxs12_md_t;
 int32_t lis2duxs12_mode_set(stmdev_ctx_t *ctx, lis2duxs12_md_t *val);
 int32_t lis2duxs12_mode_get(stmdev_ctx_t *ctx, lis2duxs12_md_t *val);
@@ -2189,7 +2196,8 @@ int32_t lis2duxs12_outt_data_get(stmdev_ctx_t *ctx, lis2duxs12_md_t *md,
                                lis2duxs12_outt_data_t *data);
 
 typedef struct {
-  int16_t ah_qvar;
+  float_t mv;
+  int16_t raw;
 } lis2duxs12_ah_qvar_data_t;
 int32_t lis2duxs12_ah_qvar_data_get(stmdev_ctx_t *ctx, lis2duxs12_md_t *md,
                                lis2duxs12_ah_qvar_data_t *data);
@@ -2207,13 +2215,15 @@ int32_t lis2duxs12_self_test_stop(stmdev_ctx_t *ctx);
 int32_t lis2duxs12_enter_deep_power_down(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lis2duxs12_exit_deep_power_down(stmdev_ctx_t *ctx);
 
+typedef enum {
+  LIS2DUXS12_I3C_BUS_AVAIL_TIME_20US = 0x0,
+  LIS2DUXS12_I3C_BUS_AVAIL_TIME_50US = 0x1,
+  LIS2DUXS12_I3C_BUS_AVAIL_TIME_1MS  = 0x2,
+  LIS2DUXS12_I3C_BUS_AVAIL_TIME_25MS = 0x3,
+} lis2duxs12_bus_act_sel_t;
+
 typedef struct {
-  enum {
-    LIS2DUXS12_I3C_BUS_AVAIL_TIME_20US = 0x0,
-    LIS2DUXS12_I3C_BUS_AVAIL_TIME_50US = 0x1,
-    LIS2DUXS12_I3C_BUS_AVAIL_TIME_1MS  = 0x2,
-    LIS2DUXS12_I3C_BUS_AVAIL_TIME_25MS = 0x3,
-  } bus_act_sel;
+  lis2duxs12_bus_act_sel_t bus_act_sel;
   uint8_t asf_on                       : 1;
   uint8_t drstdaa_en                   : 1;
 } lis2duxs12_i3c_cfg_t;
@@ -2297,13 +2307,15 @@ int32_t lis2duxs12_emb_pin_int2_route_set(stmdev_ctx_t *ctx,
 int32_t lis2duxs12_emb_pin_int2_route_get(stmdev_ctx_t *ctx,
                                           lis2duxs12_emb_pin_int_route_t *val);
 
+typedef enum
+{
+  LIS2DUXS12_INT_DISABLED             = 0x0,
+  LIS2DUXS12_INT_LEVEL                = 0x1,
+  LIS2DUXS12_INT_LATCHED              = 0x2,
+} lis2duxs12_int_cfg_t;
+
 typedef struct {
-  enum int_cfg
-  {
-    LIS2DUXS12_INT_DISABLED             = 0x0,
-    LIS2DUXS12_INT_LEVEL                = 0x1,
-    LIS2DUXS12_INT_LATCHED              = 0x2,
-  } int_cfg;
+  lis2duxs12_int_cfg_t int_cfg;
   uint8_t sleep_status_on_int          : 1;  /* route sleep_status on interrupt */
   uint8_t dis_rst_lir_all_int          : 1;  /* disable LIR reset when reading ALL_INT_SRC */
 } lis2duxs12_int_config_t;
@@ -2318,43 +2330,51 @@ typedef enum
 int32_t lis2duxs12_embedded_int_config_set(stmdev_ctx_t *ctx, lis2duxs12_embedded_int_config_t val);
 int32_t lis2duxs12_embedded_int_config_get(stmdev_ctx_t *ctx, lis2duxs12_embedded_int_config_t *val);
 
+typedef enum
+{
+  LIS2DUXS12_BYPASS_MODE              = 0x0,
+  LIS2DUXS12_FIFO_MODE                = 0x1,
+  LIS2DUXS12_STREAM_TO_FIFO_MODE      = 0x3,
+  LIS2DUXS12_BYPASS_TO_STREAM_MODE    = 0x4,
+  LIS2DUXS12_STREAM_MODE              = 0x6,
+  LIS2DUXS12_BYPASS_TO_FIFO_MODE      = 0x7,
+  LIS2DUXS12_FIFO_OFF                 = 0x8,
+} lis2duxs12_operation_t;
+
+typedef enum {
+  LIS2DUXS12_FIFO_1X                  = 0,
+  LIS2DUXS12_FIFO_2X                  = 1,
+} lis2duxs12_store_t;
+
+typedef enum
+{
+  LIS2DUXS12_DEC_TS_OFF             = 0x0,
+  LIS2DUXS12_DEC_TS_1               = 0x1,
+  LIS2DUXS12_DEC_TS_8               = 0x2,
+  LIS2DUXS12_DEC_TS_32              = 0x3,
+} lis2duxs12_dec_ts_t;
+
+typedef enum
+{
+  LIS2DUXS12_BDR_XL_ODR             = 0x0,
+  LIS2DUXS12_BDR_XL_ODR_DIV_2       = 0x1,
+  LIS2DUXS12_BDR_XL_ODR_DIV_4       = 0x2,
+  LIS2DUXS12_BDR_XL_ODR_DIV_8       = 0x3,
+  LIS2DUXS12_BDR_XL_ODR_DIV_16      = 0x4,
+  LIS2DUXS12_BDR_XL_ODR_DIV_32      = 0x5,
+  LIS2DUXS12_BDR_XL_ODR_DIV_64      = 0x6,
+  LIS2DUXS12_BDR_XL_ODR_OFF         = 0x7,
+} lis2duxs12_bdr_xl_t;
+
 typedef struct {
-  enum operation
-  {
-    LIS2DUXS12_BYPASS_MODE              = 0x0,
-    LIS2DUXS12_FIFO_MODE                = 0x1,
-    LIS2DUXS12_STREAM_TO_FIFO_MODE      = 0x3,
-    LIS2DUXS12_BYPASS_TO_STREAM_MODE    = 0x4,
-    LIS2DUXS12_STREAM_MODE              = 0x6,
-    LIS2DUXS12_BYPASS_TO_FIFO_MODE      = 0x7,
-    LIS2DUXS12_FIFO_OFF                 = 0x8,
-  } operation;
-  enum store {
-    LIS2DUXS12_FIFO_1X                  = 0,
-    LIS2DUXS12_FIFO_2X                  = 1,
-  } store;
+  lis2duxs12_operation_t operation;
+  lis2duxs12_store_t store;
   uint8_t xl_only                      : 1; /* when set to 1, only XL samples (16-bit) are stored in FIFO */
   uint8_t watermark                    : 7; /* (0 disable) max 127 @16bit, even and max 256 @8bit.*/
   uint8_t cfg_change_in_fifo           : 1;
   struct {
-    enum dec_ts
-    {
-      LIS2DUXS12_DEC_TS_OFF             = 0x0,
-      LIS2DUXS12_DEC_TS_1               = 0x1,
-      LIS2DUXS12_DEC_TS_8               = 0x2,
-      LIS2DUXS12_DEC_TS_32              = 0x3,
-    } dec_ts; /* decimation for timestamp batching*/
-    enum bdr_xl
-    {
-      LIS2DUXS12_BDR_XL_ODR             = 0x0,
-      LIS2DUXS12_BDR_XL_ODR_DIV_2       = 0x1,
-      LIS2DUXS12_BDR_XL_ODR_DIV_4       = 0x2,
-      LIS2DUXS12_BDR_XL_ODR_DIV_8       = 0x3,
-      LIS2DUXS12_BDR_XL_ODR_DIV_16      = 0x4,
-      LIS2DUXS12_BDR_XL_ODR_DIV_32      = 0x5,
-      LIS2DUXS12_BDR_XL_ODR_DIV_64      = 0x6,
-      LIS2DUXS12_BDR_XL_ODR_OFF         = 0x7,
-    } bdr_xl; /* accelerometer batch data rate*/
+    lis2duxs12_dec_ts_t dec_ts; /* decimation for timestamp batching*/
+    lis2duxs12_bdr_xl_t bdr_xl; /* accelerometer batch data rate*/
   } batch;
 } lis2duxs12_fifo_mode_t;
 int32_t lis2duxs12_fifo_mode_set(stmdev_ctx_t *ctx, lis2duxs12_fifo_mode_t val);
@@ -2388,16 +2408,19 @@ typedef struct {
     float_t mg[3];
     int16_t raw[3];
   }xl[2];
-  int16_t ah_qvar;
+  struct {
+    float_t mv;
+    int16_t raw;
+  } ah_qvar;
   struct {
     float_t deg_c;
     int16_t raw;
   }heat;
-  struct pedo {
+  struct lis2duxs12_pedo {
     uint32_t steps;
     uint32_t timestamp;
   } pedo;
-  struct cfg_chg {
+  struct lis2duxs12_cfg_chg {
     uint8_t cfg_change                 : 1; /* 1 if ODR/BDR configuration is changed */
     uint8_t odr                        : 4; /* ODR */
     uint8_t bw                         : 2; /* BW */
@@ -2413,26 +2436,32 @@ int32_t lis2duxs12_fifo_data_get(stmdev_ctx_t *ctx, lis2duxs12_md_t *md,
                                  lis2duxs12_fifo_mode_t *fmd,
                                  lis2duxs12_fifo_data_t *data);
 
+typedef enum {
+  LIS2DUXS12_NOTCH_50HZ       = 0x0,
+  LIS2DUXS12_NOTCH_60HZ       = 0x1,
+} lis2duxs12_ah_qvar_notch_t;
+
+typedef enum {
+  LIS2DUXS12_520MOhm          = 0x0,
+  LIS2DUXS12_175MOhm          = 0x1,
+  LIS2DUXS12_310MOhm          = 0x2,
+  LIS2DUXS12_75MOhm           = 0x3,
+} lis2duxs12_ah_qvar_zin_t;
+
+typedef enum {
+  LIS2DUXS12_GAIN_0_5         = 0x0,
+  LIS2DUXS12_GAIN_1           = 0x1,
+  LIS2DUXS12_GAIN_2           = 0x2,
+  LIS2DUXS12_GAIN_4           = 0x3,
+} lis2duxs12_ah_qvar_gain_t;
+
 typedef struct
 {
   uint8_t ah_qvar_en                   : 1;
   uint8_t ah_qvar_notch_en             : 1;
-  enum {
-    LIS2DUXS12_NOTCH_50HZ       = 0x0,
-    LIS2DUXS12_NOTCH_60HZ       = 0x1,
-  } ah_qvar_notch;
-  enum {
-    LIS2DUXS12_520MOhm          = 0x0,
-    LIS2DUXS12_175MOhm          = 0x1,
-    LIS2DUXS12_310MOhm          = 0x2,
-    LIS2DUXS12_75MOhm           = 0x3,
-  } ah_qvar_zin;
-  enum {
-    LIS2DUXS12_GAIN_0_5         = 0x0,
-    LIS2DUXS12_GAIN_1           = 0x1,
-    LIS2DUXS12_GAIN_2           = 0x2,
-    LIS2DUXS12_GAIN_4           = 0x3,
-  } ah_qvar_gain;
+  lis2duxs12_ah_qvar_notch_t ah_qvar_notch;
+  lis2duxs12_ah_qvar_zin_t ah_qvar_zin;
+  lis2duxs12_ah_qvar_gain_t ah_qvar_gain;
 } lis2duxs12_ah_qvar_mode_t;
 int32_t lis2duxs12_ah_qvar_mode_set(stmdev_ctx_t *ctx,
                                     lis2duxs12_ah_qvar_mode_t val);
@@ -2481,63 +2510,75 @@ typedef enum
 int32_t lis2duxs12_ff_thresholds_set(stmdev_ctx_t *ctx, lis2duxs12_ff_thresholds_t val);
 int32_t lis2duxs12_ff_thresholds_get(stmdev_ctx_t *ctx, lis2duxs12_ff_thresholds_t *val);
 
+typedef enum
+{
+  LIS2DUXS12_DEG_80 = 0x0,
+  LIS2DUXS12_DEG_70 = 0x1,
+  LIS2DUXS12_DEG_60 = 0x2,
+  LIS2DUXS12_DEG_50 = 0x3,
+} lis2duxs12_threshold_t;
+
+typedef enum
+{
+  LIS2DUXS12_6D = 0x0,
+  LIS2DUXS12_4D = 0x1,
+} lis2duxs12_mode_t;
+
 typedef struct {
-  enum threshold
-  {
-    LIS2DUXS12_DEG_80 = 0x0,
-    LIS2DUXS12_DEG_70 = 0x1,
-    LIS2DUXS12_DEG_60 = 0x2,
-    LIS2DUXS12_DEG_50 = 0x3,
-  } threshold;
-  enum mode
-  {
-    LIS2DUXS12_6D = 0x0,
-    LIS2DUXS12_4D = 0x1,
-  } mode;
+  lis2duxs12_threshold_t threshold;
+  lis2duxs12_mode_t mode;
 } lis2duxs12_sixd_config_t;
 
 int32_t lis2duxs12_sixd_config_set(stmdev_ctx_t *ctx, lis2duxs12_sixd_config_t val);
 int32_t lis2duxs12_sixd_config_get(stmdev_ctx_t *ctx, lis2duxs12_sixd_config_t *val);
 
+typedef enum
+{
+  LIS2DUXS12_0_ODR  = 0x000, /* 0 ODR time */
+  LIS2DUXS12_1_ODR  = 0x001, /* 1 ODR time */
+  LIS2DUXS12_2_ODR  = 0x002, /* 2 ODR time */
+  LIS2DUXS12_3_ODR  = 0x100, /* 3 ODR time */
+  LIS2DUXS12_7_ODR  = 0x101, /* 7 ODR time */
+  LIS2DUXS12_11_ODR = 0x102, /* 11 ODR time */
+  LIS2DUXS12_15_ODR = 0x103, /* 15 ODR time */
+} lis2duxs12_wake_dur_t;
+
+typedef enum
+{
+  LIS2DUXS12_SLEEP_OFF = 0,
+  LIS2DUXS12_SLEEP_ON  = 1,
+} lis2duxs12_wake_enable_t;
+
+typedef enum
+{
+  LIS2DUXS12_ODR_NO_CHANGE       = 0,  /* no odr change during inactivity state */
+  LIS2DUXS12_ODR_1_6_HZ          = 1,  /* set odr to 1.6Hz during inactivity state */
+  LIS2DUXS12_ODR_3_HZ            = 1,  /* set odr to 3Hz during inactivity state */
+  LIS2DUXS12_ODR_25_HZ           = 1,  /* set odr to 25Hz during inactivity state */
+} lis2duxs12_inact_odr_t;
+
 typedef struct {
-  enum wake_dur
-  {
-    LIS2DUXS12_0_ODR  = 0x000, /* 0 ODR time */
-    LIS2DUXS12_1_ODR  = 0x001, /* 1 ODR time */
-    LIS2DUXS12_2_ODR  = 0x002, /* 2 ODR time */
-    LIS2DUXS12_3_ODR  = 0x100, /* 3 ODR time */
-    LIS2DUXS12_7_ODR  = 0x101, /* 7 ODR time */
-    LIS2DUXS12_11_ODR = 0x102, /* 11 ODR time */
-    LIS2DUXS12_15_ODR = 0x103, /* 15 ODR time */
-  } wake_dur;
+  lis2duxs12_wake_dur_t wake_dur;
   uint8_t sleep_dur                    : 4;       /* 1 LSB == 512 ODR time */
   uint8_t wake_ths                     : 7;       /* wakeup threshold */
   uint8_t wake_ths_weight              : 1;       /* 0: 1LSB = FS_XL/2^6, 1: 1LSB = FS_XL/2^8 */
-  enum wake_enable
-  {
-    LIS2DUXS12_SLEEP_OFF = 0,
-    LIS2DUXS12_SLEEP_ON  = 1,
-  } wake_enable;
-  enum inact_odr
-  {
-    LIS2DUXS12_ODR_NO_CHANGE       = 0,  /* no odr change during inactivity state */
-    LIS2DUXS12_ODR_1_6_HZ          = 1,  /* set odr to 1.6Hz during inactivity state */
-    LIS2DUXS12_ODR_3_HZ            = 1,  /* set odr to 3Hz during inactivity state */
-    LIS2DUXS12_ODR_25_HZ           = 1,  /* set odr to 25Hz during inactivity state */
-  } inact_odr;
+  lis2duxs12_wake_enable_t wake_enable;
+  lis2duxs12_inact_odr_t inact_odr;
 } lis2duxs12_wakeup_config_t;
 
 int32_t lis2duxs12_wakeup_config_set(stmdev_ctx_t *ctx, lis2duxs12_wakeup_config_t val);
 int32_t lis2duxs12_wakeup_config_get(stmdev_ctx_t *ctx, lis2duxs12_wakeup_config_t *val);
 
+typedef enum
+{
+  LIS2DUXS12_TAP_NONE  = 0x0, /* No axis */
+  LIS2DUXS12_TAP_ON_X  = 0x1, /* Detect tap on X axis */
+  LIS2DUXS12_TAP_ON_Y  = 0x2, /* Detect tap on Y axis */
+  LIS2DUXS12_TAP_ON_Z  = 0x3, /* Detect tap on Z axis */
+} lis2duxs12_axis_t;
+
 typedef struct {
-  enum axis
-  {
-    LIS2DUXS12_TAP_NONE  = 0x0, /* No axis */
-    LIS2DUXS12_TAP_ON_X  = 0x1, /* Detect tap on X axis */
-    LIS2DUXS12_TAP_ON_Y  = 0x2, /* Detect tap on Y axis */
-    LIS2DUXS12_TAP_ON_Z  = 0x3, /* Detect tap on Z axis */
-  } axis;
+  lis2duxs12_axis_t axis;
   uint8_t inverted_peak_time           : 5; /* 1 LSB == 1 sample */
   uint8_t pre_still_ths                : 4; /* 1 LSB == 62.5 mg */
   uint8_t post_still_ths               : 4; /* 1 LSB == 62.5 mg */
@@ -2602,6 +2643,9 @@ int32_t lis2duxs12_fsm_data_rate_get(stmdev_ctx_t *ctx,
 int32_t lis2duxs12_fsm_init_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lis2duxs12_fsm_init_get(stmdev_ctx_t *ctx, uint8_t *val);
 
+int32_t lis2duxs12_fsm_fifo_en_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2duxs12_fsm_fifo_en_get(stmdev_ctx_t *ctx, uint8_t *val);
+
 int32_t lis2duxs12_long_cnt_int_value_set(stmdev_ctx_t *ctx,
                                           uint16_t val);
 int32_t lis2duxs12_long_cnt_int_value_get(stmdev_ctx_t *ctx,
@@ -2643,6 +2687,9 @@ int32_t lis2duxs12_mlc_data_rate_set(stmdev_ctx_t *ctx,
                                      lis2duxs12_mlc_odr_val_t val);
 int32_t lis2duxs12_mlc_data_rate_get(stmdev_ctx_t *ctx,
                                      lis2duxs12_mlc_odr_val_t *val);
+
+int32_t lis2duxs12_mlc_fifo_en_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2duxs12_mlc_fifo_en_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 #ifdef __cplusplus
 }

--- a/sensor/stmemsc/lis2dw12_STdC/driver/lis2dw12_reg.c
+++ b/sensor/stmemsc/lis2dw12_STdC/driver/lis2dw12_reg.c
@@ -2934,7 +2934,7 @@ int32_t lis2dw12_6d_feed_data_get(stmdev_ctx_t *ctx,
   */
 
 /**
-  * @brief  Wake up duration event(1LSb = 1 / ODR).[set]
+  * @brief  Free fall duration event(1LSb = 1 / ODR).[set]
   *
   * @param  ctx      read / write interface definitions
   * @param  val      change the values of ff_dur in reg
@@ -2975,7 +2975,7 @@ int32_t lis2dw12_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 }
 
 /**
-  * @brief  Wake up duration event(1LSb = 1 / ODR).[get]
+  * @brief  Free fall duration event(1LSb = 1 / ODR).[get]
   *
   * @param  ctx      read / write interface definitions
   * @param  val      change the values of ff_dur in

--- a/sensor/stmemsc/lsm6ds3_STdC/driver/lsm6ds3_reg.c
+++ b/sensor/stmemsc/lsm6ds3_STdC/driver/lsm6ds3_reg.c
@@ -1166,7 +1166,7 @@ int32_t lsm6ds3_status_reg_get(stmdev_ctx_t *ctx,
 {
   int32_t ret;
 
-  ret = lsm6ds3_read_reg(ctx, LSM6DS3_STATUS_REG, (uint8_t *)&val, 1);
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_STATUS_REG, (uint8_t *)val, 1);
 
   return ret;
 }
@@ -4066,7 +4066,7 @@ int32_t lsm6ds3_fifo_watermark_set(stmdev_ctx_t *ctx, uint16_t val)
 
   if (ret == 0)
   {
-    fifo_ctrl1.fth = (uint8_t)(val & 0x00FF0U);
+    fifo_ctrl1.fth = (uint8_t)(val & 0x00FFU);
     ret = lsm6ds3_write_reg(ctx, LSM6DS3_FIFO_CTRL1,
                             (uint8_t *)&fifo_ctrl1, 1);
   }

--- a/sensor/stmemsc/lsm6dso16is_STdC/driver/lsm6dso16is_reg.c
+++ b/sensor/stmemsc/lsm6dso16is_STdC/driver/lsm6dso16is_reg.c
@@ -207,17 +207,13 @@ int32_t lsm6dso16is_odr_cal_reg_get(stmdev_ctx_t *ctx, uint8_t *val)
   */
 int32_t lsm6dso16is_mem_bank_set(stmdev_ctx_t *ctx, lsm6dso16is_mem_bank_t val)
 {
-  lsm6dso16is_func_cfg_access_t func_cfg_access;
+  lsm6dso16is_func_cfg_access_t func_cfg_access = {0x0};
   int32_t ret;
 
-  ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
-
-  if (ret == 0)
-  {
-    func_cfg_access.shub_reg_access = (val == LSM6DSO16IS_SENSOR_HUB_MEM_BANK) ? 0x1U : 0x0U;
-    func_cfg_access.ispu_reg_access = (val == LSM6DSO16IS_ISPU_MEM_BANK) ? 0x1U : 0x0U;
-    ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
-  }
+  /* no need to read it first as the only other field is a ispu reset bit */
+  func_cfg_access.shub_reg_access = (val == LSM6DSO16IS_SENSOR_HUB_MEM_BANK) ? 0x1U : 0x0U;
+  func_cfg_access.ispu_reg_access = (val == LSM6DSO16IS_ISPU_MEM_BANK) ? 0x1U : 0x0U;
+  ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
 
   return ret;
 }
@@ -348,7 +344,7 @@ int32_t lsm6dso16is_software_reset(stmdev_ctx_t *ctx)
     ret += lsm6dso16is_gy_data_rate_set(ctx, LSM6DSO16IS_GY_ODR_OFF);
 
     ctrl3_c.sw_reset = PROPERTY_ENABLE;
-    ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
 
     do {
       ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
@@ -433,8 +429,7 @@ int32_t lsm6dso16is_xl_hm_mode_set(stmdev_ctx_t *ctx, lsm6dso16is_hm_mode_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dso16is_xl_hm_mode_get(stmdev_ctx_t *ctx,
-                                   lsm6dso16is_hm_mode_t *val)
+int32_t lsm6dso16is_xl_hm_mode_get(stmdev_ctx_t *ctx, lsm6dso16is_hm_mode_t *val)
 {
   lsm6dso16is_ctrl6_c_t ctrl6_c;
   int32_t ret;
@@ -544,18 +539,15 @@ int32_t lsm6dso16is_xl_data_rate_set(stmdev_ctx_t *ctx,
   {
     if (((uint8_t)val & 0x10U) == 0x10U)
     {
-      ret += lsm6dso16is_xl_hm_mode_set(ctx,
-                                        LSM6DSO16IS_HIGH_PERFOMANCE_MODE_DISABLED);
+      ret += lsm6dso16is_xl_hm_mode_set(ctx, LSM6DSO16IS_HIGH_PERFOMANCE_MODE_DISABLED);
     }
     else
     {
-      ret += lsm6dso16is_xl_hm_mode_set(ctx,
-                                        LSM6DSO16IS_HIGH_PERFOMANCE_MODE_ENABLED);
+      ret += lsm6dso16is_xl_hm_mode_set(ctx, LSM6DSO16IS_HIGH_PERFOMANCE_MODE_ENABLED);
     }
 
     ctrl1_xl.odr_xl = ((uint8_t)val & 0xfU);
-    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_CTRL1_XL, (uint8_t *)&ctrl1_xl,
-                                 1);
+    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_CTRL1_XL, (uint8_t *)&ctrl1_xl, 1);
   }
 
   return ret;
@@ -577,10 +569,7 @@ int32_t lsm6dso16is_xl_data_rate_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_CTRL1_XL, (uint8_t *)&ctrl1_xl, 1);
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
-  }
+  ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
 
   switch ((ctrl6_c.xl_hm_mode << 4) | (ctrl1_xl.odr_xl))
   {
@@ -676,6 +665,7 @@ int32_t lsm6dso16is_xl_data_rate_get(stmdev_ctx_t *ctx,
       *val = LSM6DSO16IS_XL_ODR_OFF;
       break;
   }
+
   return ret;
 }
 
@@ -711,8 +701,7 @@ int32_t lsm6dso16is_gy_hm_mode_set(stmdev_ctx_t *ctx, lsm6dso16is_hm_mode_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dso16is_gy_hm_mode_get(stmdev_ctx_t *ctx,
-                                   lsm6dso16is_hm_mode_t *val)
+int32_t lsm6dso16is_gy_hm_mode_get(stmdev_ctx_t *ctx, lsm6dso16is_hm_mode_t *val)
 {
   lsm6dso16is_ctrl7_g_t ctrl7_g;
   int32_t ret;
@@ -827,13 +816,11 @@ int32_t lsm6dso16is_gy_data_rate_set(stmdev_ctx_t *ctx,
   {
     if (((uint8_t)val & 0x10U) == 0x10U)
     {
-      ret += lsm6dso16is_gy_hm_mode_set(ctx,
-                                        LSM6DSO16IS_HIGH_PERFOMANCE_MODE_DISABLED);
+      ret += lsm6dso16is_gy_hm_mode_set(ctx, LSM6DSO16IS_HIGH_PERFOMANCE_MODE_DISABLED);
     }
     else
     {
-      ret += lsm6dso16is_gy_hm_mode_set(ctx,
-                                        LSM6DSO16IS_HIGH_PERFOMANCE_MODE_ENABLED);
+      ret += lsm6dso16is_gy_hm_mode_set(ctx, LSM6DSO16IS_HIGH_PERFOMANCE_MODE_ENABLED);
     }
 
     ctrl2_g.odr_g = ((uint8_t)val & 0xfU);
@@ -859,10 +846,7 @@ int32_t lsm6dso16is_gy_data_rate_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_CTRL2_G, (uint8_t *)&ctrl2_g, 1);
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
-  }
+  ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
 
   switch ((ctrl7_g.g_hm_mode << 4) | (ctrl2_g.odr_g))
   {
@@ -1340,8 +1324,7 @@ int32_t lsm6dso16is_spi_mode_get(stmdev_ctx_t *ctx, lsm6dso16is_spi_mode_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dso16is_ui_i2c_mode_set(stmdev_ctx_t *ctx,
-                                    lsm6dso16is_ui_i2c_mode_t val)
+int32_t lsm6dso16is_ui_i2c_mode_set(stmdev_ctx_t *ctx, lsm6dso16is_ui_i2c_mode_t val)
 {
   lsm6dso16is_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -1365,8 +1348,7 @@ int32_t lsm6dso16is_ui_i2c_mode_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dso16is_ui_i2c_mode_get(stmdev_ctx_t *ctx,
-                                    lsm6dso16is_ui_i2c_mode_t *val)
+int32_t lsm6dso16is_ui_i2c_mode_get(stmdev_ctx_t *ctx, lsm6dso16is_ui_i2c_mode_t *val)
 {
   lsm6dso16is_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -1481,8 +1463,7 @@ int32_t lsm6dso16is_timestamp_raw_get(stmdev_ctx_t *ctx, uint32_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dso16is_all_sources_get(stmdev_ctx_t *ctx,
-                                    lsm6dso16is_all_sources_t *val)
+int32_t lsm6dso16is_all_sources_get(stmdev_ctx_t *ctx, lsm6dso16is_all_sources_t *val)
 {
   lsm6dso16is_status_reg_t status_reg;
   lsm6dso16is_status_master_mainpage_t status_sh;
@@ -1490,29 +1471,26 @@ int32_t lsm6dso16is_all_sources_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_STATUS_REG, (uint8_t *)&status_reg, 1);
-  if (ret == 0)
-  {
-    val->drdy_xl = status_reg.xlda;
-    val->drdy_gy = status_reg.gda;
-    val->drdy_temp = status_reg.tda;
-  }
+  if (ret != 0) { return ret; }
+
+  val->drdy_xl = status_reg.xlda;
+  val->drdy_gy = status_reg.gda;
+  val->drdy_temp = status_reg.tda;
 
   ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_STATUS_MASTER_MAINPAGE, (uint8_t *)&status_sh, 1);
-  if (ret == 0)
-  {
-    val->sh_endop = status_sh.sens_hub_endop;
-    val->sh_slave0_nack = status_sh.sens_hub_endop;
-    val->sh_slave1_nack = status_sh.sens_hub_endop;
-    val->sh_slave2_nack = status_sh.sens_hub_endop;
-    val->sh_slave3_nack = status_sh.sens_hub_endop;
-    val->sh_wr_once = status_sh.sens_hub_endop;
-  }
+  if (ret != 0) { return ret; }
+
+  val->sh_endop = status_sh.sens_hub_endop;
+  val->sh_slave0_nack = status_sh.sens_hub_endop;
+  val->sh_slave1_nack = status_sh.sens_hub_endop;
+  val->sh_slave2_nack = status_sh.sens_hub_endop;
+  val->sh_slave3_nack = status_sh.sens_hub_endop;
+  val->sh_wr_once = status_sh.sens_hub_endop;
 
   ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_ISPU_INT_STATUS0_MAINPAGE, (uint8_t *)&status_ispu, 4);
-  if (ret == 0)
-  {
-    val->ispu = status_ispu;
-  }
+  if (ret != 0) { return ret; }
+
+  val->ispu = status_ispu;
 
   return ret;
 }
@@ -1689,23 +1667,18 @@ int32_t lsm6dso16is_pin_int1_route_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_INT1_CTRL, (uint8_t *)&int1_ctrl, 1);
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MD1_CFG, (uint8_t *)&md1_cfg, 1);
-  }
+  ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    int1_ctrl.int1_drdy_xl = val.drdy_xl;
-    int1_ctrl.int1_drdy_g = val.drdy_gy;
-    int1_ctrl.int1_boot = val.boot;
-    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_INT1_CTRL, (uint8_t *)&int1_ctrl,
-                                 1);
+  int1_ctrl.int1_drdy_xl = val.drdy_xl;
+  int1_ctrl.int1_drdy_g = val.drdy_gy;
+  int1_ctrl.int1_boot = val.boot;
+  ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_INT1_CTRL, (uint8_t *)&int1_ctrl,
+                               1);
 
-    md1_cfg.int1_shub = val.sh_endop;
-    md1_cfg.int1_ispu = val.ispu;
-    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_MD1_CFG, (uint8_t *)&md1_cfg, 1);
-  }
+  md1_cfg.int1_shub = val.sh_endop;
+  md1_cfg.int1_ispu = val.ispu;
+  ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_MD1_CFG, (uint8_t *)&md1_cfg, 1);
 
   return ret;
 }
@@ -1726,19 +1699,14 @@ int32_t lsm6dso16is_pin_int1_route_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_INT1_CTRL, (uint8_t *)&int1_ctrl, 1);
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MD1_CFG, (uint8_t *)&md1_cfg, 1);
-  }
+  ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    val->drdy_xl = int1_ctrl.int1_drdy_xl;
-    val->drdy_gy = int1_ctrl.int1_drdy_g;
-    val->boot = int1_ctrl.int1_boot;
-    val->sh_endop = md1_cfg.int1_shub;
-    val->ispu = md1_cfg.int1_ispu;
-  }
+  val->drdy_xl = int1_ctrl.int1_drdy_xl;
+  val->drdy_gy = int1_ctrl.int1_drdy_g;
+  val->boot = int1_ctrl.int1_boot;
+  val->sh_endop = md1_cfg.int1_shub;
+  val->ispu = md1_cfg.int1_ispu;
 
   return ret;
 }
@@ -1759,24 +1727,18 @@ int32_t lsm6dso16is_pin_int2_route_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MD2_CFG, (uint8_t *)&md2_cfg, 1);
-  }
+  ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    int2_ctrl.int2_drdy_xl = val.drdy_xl;
-    int2_ctrl.int2_drdy_g = val.drdy_gy;
-    int2_ctrl.int2_drdy_temp = val.drdy_temp;
-    int2_ctrl.int2_sleep_ispu = val.ispu_sleep;
-    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_INT2_CTRL, (uint8_t *)&int2_ctrl,
-                                 1);
+  int2_ctrl.int2_drdy_xl = val.drdy_xl;
+  int2_ctrl.int2_drdy_g = val.drdy_gy;
+  int2_ctrl.int2_drdy_temp = val.drdy_temp;
+  int2_ctrl.int2_sleep_ispu = val.ispu_sleep;
+  ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
 
-    md2_cfg.int2_ispu = val.ispu;
-    md2_cfg.int2_timestamp = val.timestamp;
-    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_MD2_CFG, (uint8_t *)&md2_cfg, 1);
-  }
+  md2_cfg.int2_ispu = val.ispu;
+  md2_cfg.int2_timestamp = val.timestamp;
+  ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_MD2_CFG, (uint8_t *)&md2_cfg, 1);
 
   return ret;
 }
@@ -1797,20 +1759,15 @@ int32_t lsm6dso16is_pin_int2_route_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MD2_CFG, (uint8_t *)&md2_cfg, 1);
-  }
+  ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    val->drdy_xl = int2_ctrl.int2_drdy_xl;
-    val->drdy_gy = int2_ctrl.int2_drdy_g;
-    val->drdy_temp = int2_ctrl.int2_drdy_temp;
-    val->ispu_sleep = int2_ctrl.int2_sleep_ispu;
-    val->ispu = md2_cfg.int2_ispu;
-    val->timestamp = md2_cfg.int2_timestamp;
-  }
+  val->drdy_xl = int2_ctrl.int2_drdy_xl;
+  val->drdy_gy = int2_ctrl.int2_drdy_g;
+  val->drdy_temp = int2_ctrl.int2_drdy_temp;
+  val->ispu_sleep = int2_ctrl.int2_sleep_ispu;
+  val->ispu = md2_cfg.int2_ispu;
+  val->timestamp = md2_cfg.int2_timestamp;
 
   return ret;
 }
@@ -1952,23 +1909,14 @@ int32_t lsm6dso16is_pin_polarity_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dso16is_sh_read_data_raw_get(stmdev_ctx_t *ctx,
-                                         lsm6dso16is_emb_sh_read_t *val,
+int32_t lsm6dso16is_sh_read_data_raw_get(stmdev_ctx_t *ctx, uint8_t *val,
                                          uint8_t len)
 {
   int32_t ret;
 
   ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_SENSOR_HUB_1, (uint8_t *) val,
-                               len);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
-  }
-
+  ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_SENSOR_HUB_1, val, len);
+  ret += lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -1988,20 +1936,14 @@ int32_t lsm6dso16is_sh_slave_connected_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    master_config.aux_sens_on = (uint8_t)val & 0x3U;
-    ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
-  }
+  master_config.aux_sens_on = (uint8_t)val & 0x3U;
+  ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+
+exit:
+  ret += lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -2021,14 +1963,9 @@ int32_t lsm6dso16is_sh_slave_connected_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
-  }
+  ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+  ret += lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
+  if (ret != 0) { return ret; }
 
   switch (master_config.aux_sens_on)
   {
@@ -2052,6 +1989,7 @@ int32_t lsm6dso16is_sh_slave_connected_get(stmdev_ctx_t *ctx,
       *val = LSM6DSO16IS_SLV_0;
       break;
   }
+
   return ret;
 }
 
@@ -2069,20 +2007,14 @@ int32_t lsm6dso16is_sh_master_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    master_config.master_on = val;
-    ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
-  }
+  master_config.master_on = val;
+  ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+
+exit:
+  ret += lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -2101,17 +2033,12 @@ int32_t lsm6dso16is_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+  if (ret != 0) { return ret; }
 
   *val = master_config.master_on;
 
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
-  }
+  ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -2124,28 +2051,20 @@ int32_t lsm6dso16is_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dso16is_sh_master_interface_pull_up_set(stmdev_ctx_t *ctx,
-                                                    uint8_t val)
+int32_t lsm6dso16is_sh_master_interface_pull_up_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dso16is_master_config_t master_config;
   int32_t ret;
 
   ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    master_config.shub_pu_en = val;
-    ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  master_config.shub_pu_en = val;
+  ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
-  }
+exit:
+  ret += lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -2165,17 +2084,12 @@ int32_t lsm6dso16is_sh_master_interface_pull_up_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+  if (ret != 0) { return ret; }
 
   *val = master_config.shub_pu_en;
 
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
-  }
+  ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -2194,24 +2108,14 @@ int32_t lsm6dso16is_sh_pass_through_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MASTER_CONFIG,
-                               (uint8_t *)&master_config, 1);
-  }
+  master_config.pass_through_mode = (uint8_t)val;
+  ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
 
-  if (ret == 0)
-  {
-    master_config.pass_through_mode = (uint8_t)val;
-    ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_MASTER_CONFIG,
-                                (uint8_t *)&master_config, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
-  }
+exit:
+  ret += lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -2230,18 +2134,10 @@ int32_t lsm6dso16is_sh_pass_through_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MASTER_CONFIG,
-                               (uint8_t *)&master_config, 1);
-  }
-
-  if (ret == 0)
-  {
-    *val = master_config.pass_through_mode;
-    ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
-  }
+  *val = master_config.pass_through_mode;
+  ret += lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -2261,20 +2157,14 @@ int32_t lsm6dso16is_sh_syncro_mode_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    master_config.start_config = (uint8_t)val & 0x01U;
-    ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
-  }
+  master_config.start_config = (uint8_t)val & 0x01U;
+  ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+
+exit:
+  ret += lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -2294,14 +2184,9 @@ int32_t lsm6dso16is_sh_syncro_mode_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
-  }
+  ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+  ret += lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
+  if (ret != 0) { return ret; }
 
   switch (master_config.start_config)
   {
@@ -2317,6 +2202,7 @@ int32_t lsm6dso16is_sh_syncro_mode_get(stmdev_ctx_t *ctx,
       *val = LSM6DSO16IS_SH_TRG_XL_GY_DRDY;
       break;
   }
+
   return ret;
 }
 
@@ -2335,20 +2221,14 @@ int32_t lsm6dso16is_sh_write_mode_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    master_config.write_once = (uint8_t)val & 0x01U;
-    ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
-  }
+  master_config.write_once = (uint8_t)val & 0x01U;
+  ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+
+exit:
+  ret += lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -2368,15 +2248,9 @@ int32_t lsm6dso16is_sh_write_mode_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
-  }
-
+  ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+  ret += lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
+  if (ret != 0) { return ret; }
 
   switch (master_config.write_once)
   {
@@ -2392,6 +2266,7 @@ int32_t lsm6dso16is_sh_write_mode_get(stmdev_ctx_t *ctx,
       *val = LSM6DSO16IS_EACH_SH_CYCLE;
       break;
   }
+
   return ret;
 }
 
@@ -2409,20 +2284,14 @@ int32_t lsm6dso16is_sh_reset_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    master_config.rst_master_regs = val;
-    ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
-  }
+  master_config.rst_master_regs = val;
+  ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+
+exit:
+  ret += lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -2441,17 +2310,12 @@ int32_t lsm6dso16is_sh_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+  if (ret != 0) { return ret; }
 
   *val = master_config.rst_master_regs;
 
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
-  }
+  ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -2474,29 +2338,22 @@ int32_t lsm6dso16is_sh_cfg_write(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    reg.slave0_add = val->slv0_add;
-    reg.rw_0 = 0;
-    ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_SLV0_ADD, (uint8_t *)&reg, 1);
-  }
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_SLV0_SUBADD,
-                                &(val->slv0_subadd), 1);
-  }
+  reg.slave0_add = val->slv0_add;
+  reg.rw_0 = 0;
+  ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_SLV0_ADD, (uint8_t *)&reg, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_DATAWRITE_SLV0,
-                                &(val->slv0_data), 1);
-  }
+  ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_SLV0_SUBADD,
+                              &(val->slv0_subadd), 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
-  }
+  ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_DATAWRITE_SLV0,
+                              &(val->slv0_data), 1);
+
+exit:
+  ret += lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -2516,20 +2373,14 @@ int32_t lsm6dso16is_sh_data_rate_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_SLAVE0_CONFIG, (uint8_t *)&slv0_config, 1);
-  }
+  ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_SLV0_CONFIG, (uint8_t *)&slv0_config, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    slv0_config.shub_odr = (uint8_t)val & 0x07U;
-    ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_SLAVE0_CONFIG, (uint8_t *)&slv0_config, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
-  }
+  slv0_config.shub_odr = (uint8_t)val & 0x07U;
+  ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_SLV0_CONFIG, (uint8_t *)&slv0_config, 1);
+
+exit:
+  ret += lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -2549,14 +2400,9 @@ int32_t lsm6dso16is_sh_data_rate_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_SLAVE0_CONFIG, (uint8_t *)&slv0_config, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
-  }
+  ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_SLV0_CONFIG, (uint8_t *)&slv0_config, 1);
+  ret += lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
+  if (ret != 0) { return ret; }
 
   switch (slv0_config.shub_odr)
   {
@@ -2580,221 +2426,69 @@ int32_t lsm6dso16is_sh_data_rate_get(stmdev_ctx_t *ctx,
       *val = LSM6DSO16IS_SH_12_5Hz;
       break;
   }
-  return ret;
-}
-
-/**
-  * @brief  Configure slave 0 for perform a read.[set]
-  *
-  * @param  ctx      read / write interface definitions
-  * @param  val      Structure that contain
-  *                      - uint8_t slv1_add;    8 bit i2c device address
-  *                      - uint8_t slv1_subadd; 8 bit register device address
-  *                      - uint8_t slv1_len;    num of bit to read
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
-  *
-  */
-int32_t lsm6dso16is_sh_slv0_cfg_read(stmdev_ctx_t *ctx,
-                                     lsm6dso16is_sh_cfg_read_t *val)
-{
-  lsm6dso16is_slv0_add_t slv0_add;
-  lsm6dso16is_slv0_config_t slv0_config;
-  int32_t ret;
-
-  ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_SENSOR_HUB_MEM_BANK);
-
-  if (ret == 0)
-  {
-    slv0_add.slave0_add = val->slv_add;
-    slv0_add.rw_0 = 1;
-    ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_SLV0_ADD, (uint8_t *)&slv0_add, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_SLV0_SUBADD,
-                                &(val->slv_subadd), 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_SLAVE0_CONFIG,
-                               (uint8_t *)&slv0_config, 1);
-  }
-
-  if (ret == 0)
-  {
-    slv0_config.slave0_numop = val->slv_len;
-    ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_SLAVE0_CONFIG,
-                                (uint8_t *)&slv0_config, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
-  }
 
   return ret;
 }
 
 /**
-  * @brief  Configure slave 0 for perform a write/read.[set]
+  * @brief  Configure slave idx for perform a read.[set]
   *
   * @param  ctx      read / write interface definitions
   * @param  val      Structure that contain
-  *                      - uint8_t slv1_add;    8 bit i2c device address
-  *                      - uint8_t slv1_subadd; 8 bit register device address
-  *                      - uint8_t slv1_len;    num of bit to read
+  *                      - uint8_t slv_add;    8 bit i2c device address
+  *                      - uint8_t slv_subadd; 8 bit register device address
+  *                      - uint8_t slv_len;    num of bit to read
   * @retval             interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dso16is_sh_slv1_cfg_read(stmdev_ctx_t *ctx,
-                                     lsm6dso16is_sh_cfg_read_t *val)
+int32_t lsm6dso16is_sh_slv_cfg_read(stmdev_ctx_t *ctx, uint8_t idx,
+                                    lsm6dso16is_sh_cfg_read_t *val)
 {
-  lsm6dso16is_slv1_add_t slv1_add;
-  lsm6dso16is_slv1_config_t slv1_config;
+  lsm6dso16is_slv0_add_t slv_add;
+  lsm6dso16is_slv0_config_t slv_config;
   int32_t ret;
 
   ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_SENSOR_HUB_MEM_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    slv1_add.slave1_add = val->slv_add;
-    slv1_add.r_1 = 1;
-    ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_SLV1_ADD, (uint8_t *)&slv1_add, 1);
-  }
+  slv_add.slave0_add = val->slv_add;
+  slv_add.rw_0 = 1;
+  ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_SLV0_ADD + idx*3U,
+                             (uint8_t *)&slv_add, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_SLV1_SUBADD,
-                                &(val->slv_subadd), 1);
-  }
+  ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_SLV0_SUBADD + idx*3U,
+                             &(val->slv_subadd), 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_SLAVE1_CONFIG,
-                               (uint8_t *)&slv1_config, 1);
-  }
+  ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_SLV0_CONFIG + idx*3U,
+                            (uint8_t *)&slv_config, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    slv1_config.slave1_numop = val->slv_len;
-    ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_SLAVE1_CONFIG,
-                                (uint8_t *)&slv1_config, 1);
-  }
+  slv_config.slave0_numop = val->slv_len;
+  ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_SLV0_CONFIG + idx*3U,
+                             (uint8_t *)&slv_config, 1);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
-  }
+exit:
+  ret += lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
 
   return ret;
 }
 
 /**
-  * @brief  Configure slave 0 for perform a write/read.[set]
+  * @brief  Sensor hub source register.[get]
   *
   * @param  ctx      read / write interface definitions
-  * @param  val      Structure that contain
-  *                      - uint8_t slv2_add;    8 bit i2c device address
-  *                      - uint8_t slv2_subadd; 8 bit register device address
-  *                      - uint8_t slv2_len;    num of bit to read
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
+  * @param  val      union of registers from STATUS_MASTER to
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dso16is_sh_slv2_cfg_read(stmdev_ctx_t *ctx,
-                                     lsm6dso16is_sh_cfg_read_t *val)
+int32_t lsm6dso16is_sh_status_get(stmdev_ctx_t *ctx,
+                                  lsm6dso16is_status_master_t *val)
 {
-  lsm6dso16is_slv2_add_t slv2_add;
-  lsm6dso16is_slv2_config_t slv2_config;
   int32_t ret;
 
-  ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_SENSOR_HUB_MEM_BANK);
-
-  if (ret == 0)
-  {
-    slv2_add.slave2_add = val->slv_add;
-    slv2_add.r_2 = 1;
-    ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_SLV2_ADD, (uint8_t *)&slv2_add, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_SLV2_SUBADD,
-                                &(val->slv_subadd), 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_SLAVE2_CONFIG,
-                               (uint8_t *)&slv2_config, 1);
-  }
-
-  if (ret == 0)
-  {
-    slv2_config.slave2_numop = val->slv_len;
-    ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_SLAVE2_CONFIG,
-                                (uint8_t *)&slv2_config, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
-  }
-
-  return ret;
-}
-
-/**
-  * @brief Configure slave 0 for perform a write/read.[set]
-  *
-  * @param  ctx      read / write interface definitions
-  * @param  val      Structure that contain
-  *                      - uint8_t slv3_add;    8 bit i2c device address
-  *                      - uint8_t slv3_subadd; 8 bit register device address
-  *                      - uint8_t slv3_len;    num of bit to read
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
-  *
-  */
-int32_t lsm6dso16is_sh_slv3_cfg_read(stmdev_ctx_t *ctx,
-                                     lsm6dso16is_sh_cfg_read_t *val)
-{
-  lsm6dso16is_slv3_add_t slv3_add;
-  lsm6dso16is_slv3_config_t slv3_config;
-  int32_t ret;
-
-  ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_SENSOR_HUB_MEM_BANK);
-
-  if (ret == 0)
-  {
-    slv3_add.slave3_add = val->slv_add;
-    slv3_add.r_3 = 1;
-    ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_SLV3_ADD, (uint8_t *)&slv3_add, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_SLV3_SUBADD,
-                                &(val->slv_subadd), 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_SLAVE3_CONFIG,
-                               (uint8_t *)&slv3_config, 1);
-  }
-
-  if (ret == 0)
-  {
-    slv3_config.slave3_numop = val->slv_len;
-    ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_SLAVE3_CONFIG,
-                                (uint8_t *)&slv3_config, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
-  }
+  ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_STATUS_MASTER_MAINPAGE, (uint8_t *) val, 1);
 
   return ret;
 }
@@ -2866,8 +2560,7 @@ int32_t lsm6dso16is_ispu_clock_set(stmdev_ctx_t *ctx,
   if (ret == 0)
   {
     ctrl10_c.ispu_clk_sel = (uint8_t)val;
-    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_CTRL10_C, (uint8_t *)&ctrl10_c,
-                                 1);
+    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_CTRL10_C, (uint8_t *)&ctrl10_c, 1);
   }
 
   return ret;
@@ -3096,8 +2789,7 @@ int32_t lsm6dso16is_ispu_write_dummy_cfg(stmdev_ctx_t *ctx, uint8_t offset,
   int32_t ret;
 
   /* check if we are writing outside of the range */
-  if (LSM6DSO16IS_ISPU_DUMMY_CFG_1_L + offset + len >
-      LSM6DSO16IS_ISPU_DUMMY_CFG_4_H)
+  if (LSM6DSO16IS_ISPU_DUMMY_CFG_1_L + offset + len > LSM6DSO16IS_ISPU_DUMMY_CFG_4_H)
   {
     return -1;
   }
@@ -3117,14 +2809,13 @@ int32_t lsm6dso16is_ispu_write_dummy_cfg(stmdev_ctx_t *ctx, uint8_t offset,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dso16is_ispu_ready_dummy_cfg(stmdev_ctx_t *ctx, uint8_t offset,
-                                         uint8_t *val, uint8_t len)
+int32_t lsm6dso16is_ispu_read_dummy_cfg(stmdev_ctx_t *ctx, uint8_t offset,
+                                        uint8_t *val, uint8_t len)
 {
   int32_t ret;
 
   /* check if we are reading outside of the range */
-  if (LSM6DSO16IS_ISPU_DUMMY_CFG_1_L + offset + len >
-      LSM6DSO16IS_ISPU_DUMMY_CFG_4_H)
+  if (LSM6DSO16IS_ISPU_DUMMY_CFG_1_L + offset + len > LSM6DSO16IS_ISPU_DUMMY_CFG_4_H)
   {
     return -1;
   }
@@ -3149,22 +2840,16 @@ int32_t lsm6dso16is_ispu_boot_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_ISPU_MEM_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_ISPU_CONFIG,
-                                (uint8_t *)&ispu_config, 1);
-  }
+  ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_ISPU_CONFIG, (uint8_t *)&ispu_config, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    ispu_config.ispu_rst_n = (uint8_t)val;
-    ispu_config.clk_dis = (uint8_t)val;
-    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_CONFIG,
-                                 (uint8_t *)&ispu_config,
-                                 1);
-  }
+  ispu_config.ispu_rst_n = (uint8_t)val;
+  ispu_config.clk_dis = (uint8_t)val;
+  ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_CONFIG, (uint8_t *)&ispu_config, 1);
 
+exit:
   ret += lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
 
   return ret;
@@ -3185,12 +2870,10 @@ int32_t lsm6dso16is_ispu_boot_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_ISPU_MEM_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_ISPU_CONFIG,
-                                (uint8_t *)&ispu_config, 1);
-  }
+  ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_ISPU_CONFIG, (uint8_t *)&ispu_config, 1);
+  if (ret != 0) { goto exit; }
 
   *val = LSM6DSO16IS_ISPU_TURN_OFF;
   if (ispu_config.ispu_rst_n == 1U || ispu_config.clk_dis == 1U)
@@ -3198,6 +2881,7 @@ int32_t lsm6dso16is_ispu_boot_get(stmdev_ctx_t *ctx,
     *val = LSM6DSO16IS_ISPU_TURN_ON;
   }
 
+exit:
   ret += lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
 
   return ret;
@@ -3218,21 +2902,15 @@ int32_t lsm6dso16is_ispu_int_latched_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_ISPU_MEM_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_ISPU_CONFIG,
-                                (uint8_t *)&ispu_config, 1);
-  }
+  ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_ISPU_CONFIG, (uint8_t *)&ispu_config, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    ispu_config.latched = ((uint8_t)val & 0x1U);
-    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_CONFIG,
-                                 (uint8_t *)&ispu_config,
-                                 1);
-  }
+  ispu_config.latched = ((uint8_t)val & 0x1U);
+  ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_CONFIG, (uint8_t *)&ispu_config, 1);
 
+exit:
   ret += lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
 
   return ret;
@@ -3253,14 +2931,9 @@ int32_t lsm6dso16is_ispu_int_latched_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_ISPU_MEM_BANK);
-
-  if (ret == 0)
-  {
-    ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_ISPU_CONFIG,
-                                (uint8_t *)&ispu_config, 1);
-  }
-
+  ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_ISPU_CONFIG, (uint8_t *)&ispu_config, 1);
   ret += lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
+  if (ret != 0) { return ret; }
 
   switch ((ispu_config.latched))
   {
@@ -3276,6 +2949,7 @@ int32_t lsm6dso16is_ispu_int_latched_get(stmdev_ctx_t *ctx,
       *val = LSM6DSO16IS_ISPU_INT_PULSED;
       break;
   }
+
   return ret;
 }
 
@@ -3294,13 +2968,11 @@ int32_t lsm6dso16is_ispu_get_boot_status(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_ISPU_MEM_BANK);
-  if (ret == 0)
-  {
-    ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_ISPU_STATUS,
-                                (uint8_t *)&ispu_boot_status, 1);
-    *val = (lsm6dso16is_ispu_boot_end_t)ispu_boot_status.boot_end;
-    ret += lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
-  }
+  if (ret != 0) { return ret; }
+
+  ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_ISPU_STATUS, (uint8_t *)&ispu_boot_status, 1);
+  *val = (lsm6dso16is_ispu_boot_end_t)ispu_boot_status.boot_end;
+  ret += lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -3321,7 +2993,7 @@ static int32_t lsm6dso16is_ispu_sel_memory_addr(stmdev_ctx_t *ctx, uint16_t mem_
 }
 
 /**
-  * @brief  ISPU write memory
+  * @brief  ISPU write memory. ISPU clock is disabled inside the routine.
   *
   * @param  ctx      read / write interface definitions
   * @param  mem_sel  LSM6DSO16IS_ISPU_DATA_RAM_MEMORY, LSM6DSO16IS_ISPU_PROGRAM_RAM_MEMORY
@@ -3336,46 +3008,63 @@ int32_t lsm6dso16is_ispu_write_memory(stmdev_ctx_t *ctx,
                                       uint16_t mem_addr, uint8_t *mem_data, uint16_t len)
 {
   lsm6dso16is_ispu_mem_sel_t ispu_mem_sel;
+  lsm6dso16is_ispu_config_t ispu_cfg;
+  uint8_t clk_dis;
   int32_t ret;
   uint16_t i;
 
   ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_ISPU_MEM_BANK);
   if (ret == 0)
   {
+    /* disable ISPU clock */
+    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_ISPU_CONFIG, (uint8_t *)&ispu_cfg, 1);
+    clk_dis = ispu_cfg.clk_dis;
+    ispu_cfg.clk_dis = 1;
+    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_CONFIG, (uint8_t *)&ispu_cfg, 1);
+
     /* select memory to be written */
     ispu_mem_sel.read_mem_en = 0;
     ispu_mem_sel.mem_sel = (uint8_t)mem_sel;
-    ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_MEM_SEL, (uint8_t *)&ispu_mem_sel, 1);
+    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_MEM_SEL, (uint8_t *)&ispu_mem_sel, 1);
 
     if (mem_sel == LSM6DSO16IS_ISPU_PROGRAM_RAM_MEMORY)
     {
-      uint16_t addr_s[4] = {0U, 0U, 0U, 0U};
-      uint16_t len_s[4] = {0U, 0U, 0U, 0U};
+      uint16_t addr_s[4] = {(uint16_t)0, (uint16_t)0, (uint16_t)0, (uint16_t)0};
+      uint16_t len_s[4] = {(uint16_t)0, (uint16_t)0, (uint16_t)0, (uint16_t)0};
       uint8_t j = 0;
       uint16_t k;
 
       addr_s[0] = mem_addr;
-      for (i = 0, k = 0; i < len; i++, k++)
+      k = 0U;
+      for (i = 0U; i < len; i++)
       {
         if ((mem_addr + i == 0x2000U) || (mem_addr + i == 0x4000U) || (mem_addr + i == 0x6000U))
         {
           len_s[j++] = k;
           addr_s[j] = mem_addr + i;
-          k = 0;
+          k = 0U;
         }
+
+        k++;
       }
       len_s[j++] = k;
 
-      for (i = 0, k = 0; i < j; k+=len_s[i], i++)
+      k = 0U;
+      for (i = 0U; i < j; i++)
       {
         ret += lsm6dso16is_ispu_sel_memory_addr(ctx, addr_s[i]);
         ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_MEM_DATA, &mem_data[k], len_s[i]);
+        k+=len_s[i];
       }
     } else {
       /* select memory address */
       ret += lsm6dso16is_ispu_sel_memory_addr(ctx, mem_addr);
       ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_MEM_DATA, &mem_data[0], len);
     }
+
+    /* set ISPU clock back to previous value */
+    ispu_cfg.clk_dis = clk_dis;
+    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_CONFIG, (uint8_t *)&ispu_cfg, 1);
   }
 
   ret += lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
@@ -3384,7 +3073,7 @@ int32_t lsm6dso16is_ispu_write_memory(stmdev_ctx_t *ctx,
 }
 
 /**
-  * @brief  ISPU read memory
+  * @brief  ISPU read memory. ISPU clock is disabled inside the routine.
   *
   * @param  ctx      read / write interface definitions
   * @param  mem_sel  LSM6DSO16IS_ISPU_DATA_RAM_MEMORY, LSM6DSO16IS_ISPU_PROGRAM_RAM_MEMORY
@@ -3399,22 +3088,35 @@ int32_t lsm6dso16is_ispu_read_memory(stmdev_ctx_t *ctx,
                                      uint16_t mem_addr, uint8_t *mem_data, uint16_t len)
 {
   lsm6dso16is_ispu_mem_sel_t ispu_mem_sel;
+  lsm6dso16is_ispu_config_t ispu_cfg;
+  uint8_t clk_dis;
   int32_t ret;
   uint8_t dummy;
 
   ret = lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_ISPU_MEM_BANK);
   if (ret == 0)
   {
+    /* disable ISPU clock */
+    ret = lsm6dso16is_read_reg(ctx, LSM6DSO16IS_ISPU_CONFIG, (uint8_t *)&ispu_cfg, 1);
+    clk_dis = ispu_cfg.clk_dis;
+    ispu_cfg.clk_dis = 1;
+    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_CONFIG, (uint8_t *)&ispu_cfg, 1);
+
     /* select memory to be read */
     ispu_mem_sel.read_mem_en = 1;
     ispu_mem_sel.mem_sel = (uint8_t)mem_sel;
-    ret = lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_MEM_SEL, (uint8_t *)&ispu_mem_sel, 1);
+    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_MEM_SEL, (uint8_t *)&ispu_mem_sel, 1);
 
     /* select memory address */
     ret += lsm6dso16is_ispu_sel_memory_addr(ctx, mem_addr);
-    ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_ISPU_MEM_DATA, &dummy, 1);
 
+    /* read data */
+    ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_ISPU_MEM_DATA, &dummy, 1);
     ret += lsm6dso16is_read_reg(ctx, LSM6DSO16IS_ISPU_MEM_DATA, &mem_data[0], len);
+
+    /* set ISPU clock back to previous value */
+    ispu_cfg.clk_dis = clk_dis;
+    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_CONFIG, (uint8_t *)&ispu_cfg, 1);
   }
 
   ret += lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
@@ -3441,12 +3143,10 @@ int32_t lsm6dso16is_ispu_write_flags(stmdev_ctx_t *ctx, uint16_t data)
   {
     /* write the flags */
     flag_h.if2s = (uint8_t)(data / 256U);
-    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_IF2S_FLAG_H,
-                                 (uint8_t *)&flag_h,
+    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_IF2S_FLAG_H, (uint8_t *)&flag_h,
                                  1);
     flag_l.if2s = (uint8_t)(data & 0xffU);
-    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_IF2S_FLAG_L,
-                                 (uint8_t *)&flag_l,
+    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_IF2S_FLAG_L, (uint8_t *)&flag_l,
                                  1);
   }
 
@@ -3582,23 +3282,19 @@ int32_t lsm6dso16is_ispu_int1_ctrl_set(stmdev_ctx_t *ctx, uint32_t val)
   {
     /* write the int1_ctrl reg */
     int1_ctrl3.ispu_int1_ctrl = (uint8_t)((val >> 24) & 0xffU);
-    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_INT1_CTRL3,
-                                 (uint8_t *)&int1_ctrl3,
+    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_INT1_CTRL3, (uint8_t *)&int1_ctrl3,
                                  1);
 
     int1_ctrl2.ispu_int1_ctrl = (uint8_t)((val >> 16) & 0xffU);
-    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_INT1_CTRL2,
-                                 (uint8_t *)&int1_ctrl2,
+    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_INT1_CTRL2, (uint8_t *)&int1_ctrl2,
                                  1);
 
     int1_ctrl1.ispu_int1_ctrl = (uint8_t)((val >>  8) & 0xffU);
-    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_INT1_CTRL1,
-                                 (uint8_t *)&int1_ctrl1,
+    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_INT1_CTRL1, (uint8_t *)&int1_ctrl1,
                                  1);
 
     int1_ctrl0.ispu_int1_ctrl = (uint8_t)(val & 0xffU);
-    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_INT1_CTRL0,
-                                 (uint8_t *)&int1_ctrl0,
+    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_INT1_CTRL0, (uint8_t *)&int1_ctrl0,
                                  1);
   }
 
@@ -3658,23 +3354,19 @@ int32_t lsm6dso16is_ispu_int2_ctrl_set(stmdev_ctx_t *ctx, uint32_t val)
   {
     /* write the int2_ctrl reg */
     int2_ctrl3.ispu_int2_ctrl = (uint8_t)((val >> 24) & 0xffU);
-    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_INT2_CTRL3,
-                                 (uint8_t *)&int2_ctrl3,
+    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_INT2_CTRL3, (uint8_t *)&int2_ctrl3,
                                  1);
 
     int2_ctrl2.ispu_int2_ctrl = (uint8_t)((val >> 16) & 0xffU);
-    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_INT2_CTRL2,
-                                 (uint8_t *)&int2_ctrl2,
+    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_INT2_CTRL2, (uint8_t *)&int2_ctrl2,
                                  1);
 
     int2_ctrl1.ispu_int2_ctrl = (uint8_t)((val >>  8) & 0xffU);
-    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_INT2_CTRL1,
-                                 (uint8_t *)&int2_ctrl1,
+    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_INT2_CTRL1, (uint8_t *)&int2_ctrl1,
                                  1);
 
     int2_ctrl0.ispu_int2_ctrl = (uint8_t)(val & 0xffU);
-    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_INT2_CTRL0,
-                                 (uint8_t *)&int2_ctrl0,
+    ret += lsm6dso16is_write_reg(ctx, LSM6DSO16IS_ISPU_INT2_CTRL0, (uint8_t *)&int2_ctrl0,
                                  1);
   }
 

--- a/sensor/stmemsc/lsm6dso16is_STdC/driver/lsm6dso16is_reg.h
+++ b/sensor/stmemsc/lsm6dso16is_STdC/driver/lsm6dso16is_reg.h
@@ -1029,7 +1029,7 @@ typedef struct
 #endif /* DRV_BYTE_ORDER */
 } lsm6dso16is_slv0_subadd_t;
 
-#define LSM6DSO16IS_SLAVE0_CONFIG                   0x17U
+#define LSM6DSO16IS_SLV0_CONFIG                   0x17U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1065,7 +1065,7 @@ typedef struct
 #endif /* DRV_BYTE_ORDER */
 } lsm6dso16is_slv1_subadd_t;
 
-#define LSM6DSO16IS_SLAVE1_CONFIG                   0x1AU
+#define LSM6DSO16IS_SLV1_CONFIG                   0x1AU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1099,7 +1099,7 @@ typedef struct
 #endif /* DRV_BYTE_ORDER */
 } lsm6dso16is_slv2_subadd_t;
 
-#define LSM6DSO16IS_SLAVE2_CONFIG                   0x1DU
+#define LSM6DSO16IS_SLV2_CONFIG                   0x1DU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1133,7 +1133,7 @@ typedef struct
 #endif /* DRV_BYTE_ORDER */
 } lsm6dso16is_slv3_subadd_t;
 
-#define LSM6DSO16IS_SLAVE3_CONFIG                   0x20U
+#define LSM6DSO16IS_SLV3_CONFIG                   0x20U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -2342,8 +2342,7 @@ typedef enum
   LSM6DSO16IS_ISPU_MEM_BANK =             0x3,
 } lsm6dso16is_mem_bank_t;
 int32_t lsm6dso16is_mem_bank_set(stmdev_ctx_t *ctx, lsm6dso16is_mem_bank_t val);
-int32_t lsm6dso16is_mem_bank_get(stmdev_ctx_t *ctx,
-                                 lsm6dso16is_mem_bank_t *val);
+int32_t lsm6dso16is_mem_bank_get(stmdev_ctx_t *ctx, lsm6dso16is_mem_bank_t *val);
 
 typedef enum
 {
@@ -2368,14 +2367,10 @@ typedef enum
   LSM6DSO16IS_HIGH_PERFOMANCE_MODE_ENABLED =        0x0,
   LSM6DSO16IS_HIGH_PERFOMANCE_MODE_DISABLED =       0x1,
 } lsm6dso16is_hm_mode_t;
-int32_t lsm6dso16is_xl_hm_mode_set(stmdev_ctx_t *ctx,
-                                   lsm6dso16is_hm_mode_t val);
-int32_t lsm6dso16is_xl_hm_mode_get(stmdev_ctx_t *ctx,
-                                   lsm6dso16is_hm_mode_t *val);
-int32_t lsm6dso16is_gy_hm_mode_set(stmdev_ctx_t *ctx,
-                                   lsm6dso16is_hm_mode_t val);
-int32_t lsm6dso16is_gy_hm_mode_get(stmdev_ctx_t *ctx,
-                                   lsm6dso16is_hm_mode_t *val);
+int32_t lsm6dso16is_xl_hm_mode_set(stmdev_ctx_t *ctx, lsm6dso16is_hm_mode_t val);
+int32_t lsm6dso16is_xl_hm_mode_get(stmdev_ctx_t *ctx, lsm6dso16is_hm_mode_t *val);
+int32_t lsm6dso16is_gy_hm_mode_set(stmdev_ctx_t *ctx, lsm6dso16is_hm_mode_t val);
+int32_t lsm6dso16is_gy_hm_mode_get(stmdev_ctx_t *ctx, lsm6dso16is_hm_mode_t *val);
 
 typedef enum
 {
@@ -2506,16 +2501,14 @@ typedef enum
   LSM6DSO16IS_SPI_3_WIRE =                0x1,
 } lsm6dso16is_spi_mode_t;
 int32_t lsm6dso16is_spi_mode_set(stmdev_ctx_t *ctx, lsm6dso16is_spi_mode_t val);
-int32_t lsm6dso16is_spi_mode_get(stmdev_ctx_t *ctx,
-                                 lsm6dso16is_spi_mode_t *val);
+int32_t lsm6dso16is_spi_mode_get(stmdev_ctx_t *ctx, lsm6dso16is_spi_mode_t *val);
 
 typedef enum
 {
   LSM6DSO16IS_I2C_ENABLE =                0x0,
   LSM6DSO16IS_I2C_DISABLE =               0x1,
 } lsm6dso16is_ui_i2c_mode_t;
-int32_t lsm6dso16is_ui_i2c_mode_set(stmdev_ctx_t *ctx,
-                                    lsm6dso16is_ui_i2c_mode_t val);
+int32_t lsm6dso16is_ui_i2c_mode_set(stmdev_ctx_t *ctx, lsm6dso16is_ui_i2c_mode_t val);
 int32_t lsm6dso16is_ui_i2c_mode_get(stmdev_ctx_t *ctx,
                                     lsm6dso16is_ui_i2c_mode_t *val);
 
@@ -2609,29 +2602,7 @@ int32_t lsm6dso16is_acceleration_raw_get(stmdev_ctx_t *ctx, int16_t *val);
 int32_t lsm6dso16is_odr_cal_reg_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dso16is_odr_cal_reg_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef struct
-{
-  lsm6dso16is_sensor_hub_1_t   sh_byte_1;
-  lsm6dso16is_sensor_hub_2_t   sh_byte_2;
-  lsm6dso16is_sensor_hub_3_t   sh_byte_3;
-  lsm6dso16is_sensor_hub_4_t   sh_byte_4;
-  lsm6dso16is_sensor_hub_5_t   sh_byte_5;
-  lsm6dso16is_sensor_hub_6_t   sh_byte_6;
-  lsm6dso16is_sensor_hub_7_t   sh_byte_7;
-  lsm6dso16is_sensor_hub_8_t   sh_byte_8;
-  lsm6dso16is_sensor_hub_9_t   sh_byte_9;
-  lsm6dso16is_sensor_hub_10_t  sh_byte_10;
-  lsm6dso16is_sensor_hub_11_t  sh_byte_11;
-  lsm6dso16is_sensor_hub_12_t  sh_byte_12;
-  lsm6dso16is_sensor_hub_13_t  sh_byte_13;
-  lsm6dso16is_sensor_hub_14_t  sh_byte_14;
-  lsm6dso16is_sensor_hub_15_t  sh_byte_15;
-  lsm6dso16is_sensor_hub_16_t  sh_byte_16;
-  lsm6dso16is_sensor_hub_17_t  sh_byte_17;
-  lsm6dso16is_sensor_hub_18_t  sh_byte_18;
-} lsm6dso16is_emb_sh_read_t;
-int32_t lsm6dso16is_sh_read_data_raw_get(stmdev_ctx_t *ctx,
-                                         lsm6dso16is_emb_sh_read_t *val,
+int32_t lsm6dso16is_sh_read_data_raw_get(stmdev_ctx_t *ctx, uint8_t *val,
                                          uint8_t len);
 
 typedef enum
@@ -2706,14 +2677,11 @@ typedef struct
   uint8_t   slv_subadd;
   uint8_t   slv_len;
 } lsm6dso16is_sh_cfg_read_t;
-int32_t lsm6dso16is_sh_slv0_cfg_read(stmdev_ctx_t *ctx,
-                                     lsm6dso16is_sh_cfg_read_t *val);
-int32_t lsm6dso16is_sh_slv1_cfg_read(stmdev_ctx_t *ctx,
-                                     lsm6dso16is_sh_cfg_read_t *val);
-int32_t lsm6dso16is_sh_slv2_cfg_read(stmdev_ctx_t *ctx,
-                                     lsm6dso16is_sh_cfg_read_t *val);
-int32_t lsm6dso16is_sh_slv3_cfg_read(stmdev_ctx_t *ctx,
-                                     lsm6dso16is_sh_cfg_read_t *val);
+int32_t lsm6dso16is_sh_slv_cfg_read(stmdev_ctx_t *ctx, uint8_t idx,
+                                    lsm6dso16is_sh_cfg_read_t *val);
+
+int32_t lsm6dso16is_sh_status_get(stmdev_ctx_t *ctx,
+                                  lsm6dso16is_status_master_t *val);
 
 int32_t lsm6dso16is_ispu_reset_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dso16is_ispu_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
@@ -2755,15 +2723,14 @@ typedef enum
   LSM6DSO16IS_ISPU_BDU_ON_4B_4B =         0x3,
 } lsm6dso16is_ispu_bdu_t;
 int32_t lsm6dso16is_ispu_bdu_set(stmdev_ctx_t *ctx, lsm6dso16is_ispu_bdu_t val);
-int32_t lsm6dso16is_ispu_bdu_get(stmdev_ctx_t *ctx,
-                                 lsm6dso16is_ispu_bdu_t *val);
+int32_t lsm6dso16is_ispu_bdu_get(stmdev_ctx_t *ctx, lsm6dso16is_ispu_bdu_t *val);
 
 int32_t lsm6dso16is_ia_ispu_get(stmdev_ctx_t *ctx, uint32_t *val);
 
 int32_t lsm6dso16is_ispu_write_dummy_cfg(stmdev_ctx_t *ctx, uint8_t offset,
                                          uint8_t *val, uint8_t len);
-int32_t lsm6dso16is_ispu_ready_dummy_cfg(stmdev_ctx_t *ctx, uint8_t offset,
-                                         uint8_t *val, uint8_t len);
+int32_t lsm6dso16is_ispu_read_dummy_cfg(stmdev_ctx_t *ctx, uint8_t offset,
+                                        uint8_t *val, uint8_t len);
 
 typedef enum
 {

--- a/sensor/stmemsc/lsm6dso_STdC/driver/lsm6dso_reg.c
+++ b/sensor/stmemsc/lsm6dso_STdC/driver/lsm6dso_reg.c
@@ -258,132 +258,111 @@ int32_t lsm6dso_xl_data_rate_set(stmdev_ctx_t *ctx,
 
   /* Check the Finite State Machine data rate constraints */
   ret =  lsm6dso_fsm_enable_get(ctx, &fsm_enable);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
+  if ((fsm_enable.fsm_enable_a.fsm1_en  |
+       fsm_enable.fsm_enable_a.fsm2_en  |
+       fsm_enable.fsm_enable_a.fsm3_en  |
+       fsm_enable.fsm_enable_a.fsm4_en  |
+       fsm_enable.fsm_enable_a.fsm5_en  |
+       fsm_enable.fsm_enable_a.fsm6_en  |
+       fsm_enable.fsm_enable_a.fsm7_en  |
+       fsm_enable.fsm_enable_a.fsm8_en  |
+       fsm_enable.fsm_enable_b.fsm9_en  |
+       fsm_enable.fsm_enable_b.fsm10_en |
+       fsm_enable.fsm_enable_b.fsm11_en |
+       fsm_enable.fsm_enable_b.fsm12_en |
+       fsm_enable.fsm_enable_b.fsm13_en |
+       fsm_enable.fsm_enable_b.fsm14_en |
+       fsm_enable.fsm_enable_b.fsm15_en |
+       fsm_enable.fsm_enable_b.fsm16_en) == PROPERTY_ENABLE)
   {
-    if ((fsm_enable.fsm_enable_a.fsm1_en  |
-         fsm_enable.fsm_enable_a.fsm2_en  |
-         fsm_enable.fsm_enable_a.fsm3_en  |
-         fsm_enable.fsm_enable_a.fsm4_en  |
-         fsm_enable.fsm_enable_a.fsm5_en  |
-         fsm_enable.fsm_enable_a.fsm6_en  |
-         fsm_enable.fsm_enable_a.fsm7_en  |
-         fsm_enable.fsm_enable_a.fsm8_en  |
-         fsm_enable.fsm_enable_b.fsm9_en  |
-         fsm_enable.fsm_enable_b.fsm10_en |
-         fsm_enable.fsm_enable_b.fsm11_en |
-         fsm_enable.fsm_enable_b.fsm12_en |
-         fsm_enable.fsm_enable_b.fsm13_en |
-         fsm_enable.fsm_enable_b.fsm14_en |
-         fsm_enable.fsm_enable_b.fsm15_en |
-         fsm_enable.fsm_enable_b.fsm16_en) == PROPERTY_ENABLE)
+    ret =  lsm6dso_fsm_data_rate_get(ctx, &fsm_odr);
+    if (ret != 0) { return ret; }
+
+    switch (fsm_odr)
     {
-      ret =  lsm6dso_fsm_data_rate_get(ctx, &fsm_odr);
-
-      if (ret == 0)
-      {
-        switch (fsm_odr)
+      case LSM6DSO_ODR_FSM_12Hz5:
+        if (val == LSM6DSO_XL_ODR_OFF)
         {
-          case LSM6DSO_ODR_FSM_12Hz5:
-            if (val == LSM6DSO_XL_ODR_OFF)
-            {
-              odr_xl = LSM6DSO_XL_ODR_12Hz5;
-            }
-
-            else
-            {
-              odr_xl = val;
-            }
-
-            break;
-
-          case LSM6DSO_ODR_FSM_26Hz:
-            if (val == LSM6DSO_XL_ODR_OFF)
-            {
-              odr_xl = LSM6DSO_XL_ODR_26Hz;
-            }
-
-            else if (val == LSM6DSO_XL_ODR_12Hz5)
-            {
-              odr_xl = LSM6DSO_XL_ODR_26Hz;
-            }
-
-            else
-            {
-              odr_xl = val;
-            }
-
-            break;
-
-          case LSM6DSO_ODR_FSM_52Hz:
-            if (val == LSM6DSO_XL_ODR_OFF)
-            {
-              odr_xl = LSM6DSO_XL_ODR_52Hz;
-            }
-
-            else if (val == LSM6DSO_XL_ODR_12Hz5)
-            {
-              odr_xl = LSM6DSO_XL_ODR_52Hz;
-            }
-
-            else if (val == LSM6DSO_XL_ODR_26Hz)
-            {
-              odr_xl = LSM6DSO_XL_ODR_52Hz;
-            }
-
-            else
-            {
-              odr_xl = val;
-            }
-
-            break;
-
-          case LSM6DSO_ODR_FSM_104Hz:
-            if (val == LSM6DSO_XL_ODR_OFF)
-            {
-              odr_xl = LSM6DSO_XL_ODR_104Hz;
-            }
-
-            else if (val == LSM6DSO_XL_ODR_12Hz5)
-            {
-              odr_xl = LSM6DSO_XL_ODR_104Hz;
-            }
-
-            else if (val == LSM6DSO_XL_ODR_26Hz)
-            {
-              odr_xl = LSM6DSO_XL_ODR_104Hz;
-            }
-
-            else if (val == LSM6DSO_XL_ODR_52Hz)
-            {
-              odr_xl = LSM6DSO_XL_ODR_104Hz;
-            }
-
-            else
-            {
-              odr_xl = val;
-            }
-
-            break;
-
-          default:
-            odr_xl = val;
-            break;
+          odr_xl = LSM6DSO_XL_ODR_12Hz5;
         }
-      }
+        else
+        {
+          odr_xl = val;
+        }
+
+        break;
+
+      case LSM6DSO_ODR_FSM_26Hz:
+        if (val == LSM6DSO_XL_ODR_OFF)
+        {
+          odr_xl = LSM6DSO_XL_ODR_26Hz;
+        }
+        else if (val == LSM6DSO_XL_ODR_12Hz5)
+        {
+          odr_xl = LSM6DSO_XL_ODR_26Hz;
+        }
+        else
+        {
+          odr_xl = val;
+        }
+
+        break;
+
+      case LSM6DSO_ODR_FSM_52Hz:
+        if (val == LSM6DSO_XL_ODR_OFF)
+        {
+          odr_xl = LSM6DSO_XL_ODR_52Hz;
+        }
+        else if (val == LSM6DSO_XL_ODR_12Hz5)
+        {
+          odr_xl = LSM6DSO_XL_ODR_52Hz;
+        }
+        else if (val == LSM6DSO_XL_ODR_26Hz)
+        {
+          odr_xl = LSM6DSO_XL_ODR_52Hz;
+        }
+        else
+        {
+          odr_xl = val;
+        }
+
+        break;
+
+      case LSM6DSO_ODR_FSM_104Hz:
+        if (val == LSM6DSO_XL_ODR_OFF)
+        {
+          odr_xl = LSM6DSO_XL_ODR_104Hz;
+        }
+        else if (val == LSM6DSO_XL_ODR_12Hz5)
+        {
+          odr_xl = LSM6DSO_XL_ODR_104Hz;
+        }
+        else if (val == LSM6DSO_XL_ODR_26Hz)
+        {
+          odr_xl = LSM6DSO_XL_ODR_104Hz;
+        }
+        else if (val == LSM6DSO_XL_ODR_52Hz)
+        {
+          odr_xl = LSM6DSO_XL_ODR_104Hz;
+        }
+        else
+        {
+          odr_xl = val;
+        }
+
+        break;
+
+      default:
+        odr_xl = val;
+        break;
     }
   }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL1_XL, (uint8_t *)&reg, 1);
-  }
-
-  if (ret == 0)
-  {
-    reg.odr_xl = (uint8_t) odr_xl;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL1_XL, (uint8_t *)&reg, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL1_XL, (uint8_t *)&reg, 1);
+  reg.odr_xl = (uint8_t) odr_xl;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_CTRL1_XL, (uint8_t *)&reg, 1);
 
   return ret;
 }
@@ -552,132 +531,111 @@ int32_t lsm6dso_gy_data_rate_set(stmdev_ctx_t *ctx,
 
   /* Check the Finite State Machine data rate constraints */
   ret =  lsm6dso_fsm_enable_get(ctx, &fsm_enable);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
+  if ((fsm_enable.fsm_enable_a.fsm1_en  |
+       fsm_enable.fsm_enable_a.fsm2_en  |
+       fsm_enable.fsm_enable_a.fsm3_en  |
+       fsm_enable.fsm_enable_a.fsm4_en  |
+       fsm_enable.fsm_enable_a.fsm5_en  |
+       fsm_enable.fsm_enable_a.fsm6_en  |
+       fsm_enable.fsm_enable_a.fsm7_en  |
+       fsm_enable.fsm_enable_a.fsm8_en  |
+       fsm_enable.fsm_enable_b.fsm9_en  |
+       fsm_enable.fsm_enable_b.fsm10_en |
+       fsm_enable.fsm_enable_b.fsm11_en |
+       fsm_enable.fsm_enable_b.fsm12_en |
+       fsm_enable.fsm_enable_b.fsm13_en |
+       fsm_enable.fsm_enable_b.fsm14_en |
+       fsm_enable.fsm_enable_b.fsm15_en |
+       fsm_enable.fsm_enable_b.fsm16_en) == PROPERTY_ENABLE)
   {
-    if ((fsm_enable.fsm_enable_a.fsm1_en  |
-         fsm_enable.fsm_enable_a.fsm2_en  |
-         fsm_enable.fsm_enable_a.fsm3_en  |
-         fsm_enable.fsm_enable_a.fsm4_en  |
-         fsm_enable.fsm_enable_a.fsm5_en  |
-         fsm_enable.fsm_enable_a.fsm6_en  |
-         fsm_enable.fsm_enable_a.fsm7_en  |
-         fsm_enable.fsm_enable_a.fsm8_en  |
-         fsm_enable.fsm_enable_b.fsm9_en  |
-         fsm_enable.fsm_enable_b.fsm10_en |
-         fsm_enable.fsm_enable_b.fsm11_en |
-         fsm_enable.fsm_enable_b.fsm12_en |
-         fsm_enable.fsm_enable_b.fsm13_en |
-         fsm_enable.fsm_enable_b.fsm14_en |
-         fsm_enable.fsm_enable_b.fsm15_en |
-         fsm_enable.fsm_enable_b.fsm16_en) == PROPERTY_ENABLE)
+    ret =  lsm6dso_fsm_data_rate_get(ctx, &fsm_odr);
+    if (ret != 0) { return ret; }
+
+    switch (fsm_odr)
     {
-      ret =  lsm6dso_fsm_data_rate_get(ctx, &fsm_odr);
-
-      if (ret == 0)
-      {
-        switch (fsm_odr)
+      case LSM6DSO_ODR_FSM_12Hz5:
+        if (val == LSM6DSO_GY_ODR_OFF)
         {
-          case LSM6DSO_ODR_FSM_12Hz5:
-            if (val == LSM6DSO_GY_ODR_OFF)
-            {
-              odr_gy = LSM6DSO_GY_ODR_12Hz5;
-            }
-
-            else
-            {
-              odr_gy = val;
-            }
-
-            break;
-
-          case LSM6DSO_ODR_FSM_26Hz:
-            if (val == LSM6DSO_GY_ODR_OFF)
-            {
-              odr_gy = LSM6DSO_GY_ODR_26Hz;
-            }
-
-            else if (val == LSM6DSO_GY_ODR_12Hz5)
-            {
-              odr_gy = LSM6DSO_GY_ODR_26Hz;
-            }
-
-            else
-            {
-              odr_gy = val;
-            }
-
-            break;
-
-          case LSM6DSO_ODR_FSM_52Hz:
-            if (val == LSM6DSO_GY_ODR_OFF)
-            {
-              odr_gy = LSM6DSO_GY_ODR_52Hz;
-            }
-
-            else if (val == LSM6DSO_GY_ODR_12Hz5)
-            {
-              odr_gy = LSM6DSO_GY_ODR_52Hz;
-            }
-
-            else if (val == LSM6DSO_GY_ODR_26Hz)
-            {
-              odr_gy = LSM6DSO_GY_ODR_52Hz;
-            }
-
-            else
-            {
-              odr_gy = val;
-            }
-
-            break;
-
-          case LSM6DSO_ODR_FSM_104Hz:
-            if (val == LSM6DSO_GY_ODR_OFF)
-            {
-              odr_gy = LSM6DSO_GY_ODR_104Hz;
-            }
-
-            else if (val == LSM6DSO_GY_ODR_12Hz5)
-            {
-              odr_gy = LSM6DSO_GY_ODR_104Hz;
-            }
-
-            else if (val == LSM6DSO_GY_ODR_26Hz)
-            {
-              odr_gy = LSM6DSO_GY_ODR_104Hz;
-            }
-
-            else if (val == LSM6DSO_GY_ODR_52Hz)
-            {
-              odr_gy = LSM6DSO_GY_ODR_104Hz;
-            }
-
-            else
-            {
-              odr_gy = val;
-            }
-
-            break;
-
-          default:
-            odr_gy = val;
-            break;
+          odr_gy = LSM6DSO_GY_ODR_12Hz5;
         }
-      }
+        else
+        {
+          odr_gy = val;
+        }
+
+        break;
+
+      case LSM6DSO_ODR_FSM_26Hz:
+        if (val == LSM6DSO_GY_ODR_OFF)
+        {
+          odr_gy = LSM6DSO_GY_ODR_26Hz;
+        }
+        else if (val == LSM6DSO_GY_ODR_12Hz5)
+        {
+          odr_gy = LSM6DSO_GY_ODR_26Hz;
+        }
+        else
+        {
+          odr_gy = val;
+        }
+
+        break;
+
+      case LSM6DSO_ODR_FSM_52Hz:
+        if (val == LSM6DSO_GY_ODR_OFF)
+        {
+          odr_gy = LSM6DSO_GY_ODR_52Hz;
+        }
+        else if (val == LSM6DSO_GY_ODR_12Hz5)
+        {
+          odr_gy = LSM6DSO_GY_ODR_52Hz;
+        }
+        else if (val == LSM6DSO_GY_ODR_26Hz)
+        {
+          odr_gy = LSM6DSO_GY_ODR_52Hz;
+        }
+        else
+        {
+          odr_gy = val;
+        }
+
+        break;
+
+      case LSM6DSO_ODR_FSM_104Hz:
+        if (val == LSM6DSO_GY_ODR_OFF)
+        {
+          odr_gy = LSM6DSO_GY_ODR_104Hz;
+        }
+        else if (val == LSM6DSO_GY_ODR_12Hz5)
+        {
+          odr_gy = LSM6DSO_GY_ODR_104Hz;
+        }
+        else if (val == LSM6DSO_GY_ODR_26Hz)
+        {
+          odr_gy = LSM6DSO_GY_ODR_104Hz;
+        }
+        else if (val == LSM6DSO_GY_ODR_52Hz)
+        {
+          odr_gy = LSM6DSO_GY_ODR_104Hz;
+        }
+        else
+        {
+          odr_gy = val;
+        }
+
+        break;
+
+      default:
+        odr_gy = val;
+        break;
     }
   }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL2_G, (uint8_t *)&reg, 1);
-  }
-
-  if (ret == 0)
-  {
-    reg.odr_g = (uint8_t) odr_gy;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL2_G, (uint8_t *)&reg, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL2_G, (uint8_t *)&reg, 1);
+  reg.odr_g = (uint8_t) odr_gy;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_CTRL2_G, (uint8_t *)&reg, 1);
 
   return ret;
 }
@@ -873,23 +831,17 @@ int32_t lsm6dso_xl_power_mode_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL5_C, (uint8_t *) &ctrl5_c, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ctrl5_c.xl_ulp_en = ((uint8_t)val & 0x02U) >> 1;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL5_C, (uint8_t *) &ctrl5_c, 1);
-  }
+  ctrl5_c.xl_ulp_en = ((uint8_t)val & 0x02U) >> 1;
+  ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL5_C, (uint8_t *) &ctrl5_c, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL6_C, (uint8_t *) &ctrl6_c, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL6_C, (uint8_t *) &ctrl6_c, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ctrl6_c.xl_hm_mode = (uint8_t)val & 0x01U;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL6_C, (uint8_t *) &ctrl6_c, 1);
-  }
+  ctrl6_c.xl_hm_mode = (uint8_t)val & 0x01U;
+  ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL6_C, (uint8_t *) &ctrl6_c, 1);
 
   return ret;
 }
@@ -1508,18 +1460,16 @@ int32_t lsm6dso_number_of_steps_get(stmdev_ctx_t *ctx, uint16_t *val)
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_STEP_COUNTER_L, buff, 2);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_STEP_COUNTER_L, buff, 2);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    *val = buff[1];
-    *val = (*val * 256U) +  buff[0];
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  *val = buff[1];
+  *val = (*val * 256U) +  buff[0];
+
+exit:
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -1537,22 +1487,16 @@ int32_t lsm6dso_steps_reset(stmdev_ctx_t *ctx)
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_SRC, (uint8_t *)&reg, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_SRC, (uint8_t *)&reg, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    reg.pedo_rst_step = PROPERTY_ENABLE;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_SRC, (uint8_t *)&reg, 1);
-  }
+  reg.pedo_rst_step = PROPERTY_ENABLE;
+  ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_SRC, (uint8_t *)&reg, 1);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+exit:
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -1626,24 +1570,19 @@ int32_t lsm6dso_odr_cal_reg_get(stmdev_ctx_t *ctx, uint8_t *val)
   *         hub configuration registers.[set]
   *
   * @param  ctx      read / write interface definitions
-  * @param  val      change the values of reg_access in
-  *                               reg FUNC_CFG_ACCESS
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
+  * @param  val      change register page (reg_access in FUNC_CFG_ACCESS)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
 int32_t lsm6dso_mem_bank_set(stmdev_ctx_t *ctx,
                              lsm6dso_reg_access_t val)
 {
-  lsm6dso_func_cfg_access_t reg;
+  lsm6dso_func_cfg_access_t reg = {0};
   int32_t ret;
 
-  ret = lsm6dso_read_reg(ctx, LSM6DSO_FUNC_CFG_ACCESS, (uint8_t *)&reg, 1);
-
-  if (ret == 0)
-  {
-    reg.reg_access = (uint8_t)val;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_FUNC_CFG_ACCESS, (uint8_t *)&reg, 1);
-  }
+  /*  no need to read it first as the pther bits are reserved and must be zero */
+  reg.reg_access = (uint8_t)val;
+  ret = lsm6dso_write_reg(ctx, LSM6DSO_FUNC_CFG_ACCESS, (uint8_t *)&reg, 1);
 
   return ret;
 }
@@ -1653,9 +1592,8 @@ int32_t lsm6dso_mem_bank_set(stmdev_ctx_t *ctx,
   *         hub configuration registers.[get]
   *
   * @param  ctx      read / write interface definitions
-  * @param  val      Get the values of reg_access in
-  *                               reg FUNC_CFG_ACCESS
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
+  * @param  val      Get the values of reg_access in reg FUNC_CFG_ACCESS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
 int32_t lsm6dso_mem_bank_get(stmdev_ctx_t *ctx,
@@ -1697,68 +1635,9 @@ int32_t lsm6dso_mem_bank_get(stmdev_ctx_t *ctx,
   * @retval             interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dso_ln_pg_write_byte(stmdev_ctx_t *ctx, uint16_t address,
-                                 uint8_t *val)
+int32_t lsm6dso_ln_pg_write_byte(stmdev_ctx_t *ctx, uint16_t address, uint8_t *val)
 {
-  lsm6dso_page_rw_t page_rw;
-  lsm6dso_page_sel_t page_sel;
-  lsm6dso_page_address_t page_address;
-  int32_t ret;
-
-  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
-  }
-
-  if (ret == 0)
-  {
-    page_rw.page_rw = 0x02; /* page_write enable */
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_SEL, (uint8_t *) &page_sel, 1);
-  }
-
-  if (ret == 0)
-  {
-    page_sel.page_sel = ((uint8_t)(address >> 8) & 0x0FU);
-    page_sel.not_used_01 = 1;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_SEL, (uint8_t *) &page_sel, 1);
-  }
-
-  if (ret == 0)
-  {
-    page_address.page_addr = (uint8_t)address & 0xFFU;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_ADDRESS,
-                            (uint8_t *)&page_address, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_VALUE, val, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
-  }
-
-  if (ret == 0)
-  {
-    page_rw.page_rw = 0x00; /* page_write disable */
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
-
-  return ret;
+  return lsm6dso_ln_pg_write(ctx, address, val, 1);
 }
 
 /**
@@ -1777,85 +1656,69 @@ int32_t lsm6dso_ln_pg_write(stmdev_ctx_t *ctx, uint16_t address,
   lsm6dso_page_rw_t page_rw;
   lsm6dso_page_sel_t page_sel;
   lsm6dso_page_address_t  page_address;
-  uint16_t addr_pointed;
+  uint8_t msb;
+  uint8_t lsb;
   int32_t ret;
-
   uint8_t i ;
-  addr_pointed = address;
+
+  msb = ((uint8_t)(address >> 8) & 0x0FU);
+  lsb = (uint8_t)address & 0xFFU;
+
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
-  }
+  /* set page write */
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
+  page_rw.page_rw = 0x02; /* page_write enable*/
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    page_rw.page_rw = 0x02; /* page_write enable*/
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
-  }
+  /* select page */
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_SEL, (uint8_t *) &page_sel, 1);
+  page_sel.page_sel = msb;
+  page_sel.not_used_01 = 1;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_PAGE_SEL, (uint8_t *) &page_sel, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_SEL, (uint8_t *) &page_sel, 1);
-  }
+  /* set page addr */
+  page_address.page_addr = lsb;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_PAGE_ADDRESS,
+                           (uint8_t *)&page_address, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
+  for (i = 0; ((i < len) && (ret == 0)); i++)
   {
-    page_sel.page_sel = ((uint8_t)(addr_pointed >> 8) & 0x0FU);
-    page_sel.not_used_01 = 1;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_SEL, (uint8_t *) &page_sel, 1);
-  }
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_VALUE, &buf[i], 1);
+    if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    page_address.page_addr = (uint8_t)(addr_pointed & 0x00FFU);
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_ADDRESS,
-                            (uint8_t *)&page_address, 1);
-  }
+    lsb++;
 
-  if (ret == 0)
-  {
-    for (i = 0; ((i < len) && (ret == 0)); i++)
+    /* Check if page wrap */
+    if (((lsb & 0xFFU) == 0x00U) && (ret == 0))
     {
-      ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_VALUE, &buf[i], 1);
-      addr_pointed++;
+      msb++;
+      ret += lsm6dso_read_reg(ctx, LSM6DSO_PAGE_SEL, (uint8_t *)&page_sel, 1);
+      if (ret != 0) { goto exit; }
 
-      /* Check if page wrap */
-      if (((addr_pointed % 0x0100U) == 0x00U) && (ret == 0))
-      {
-        ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_SEL, (uint8_t *)&page_sel, 1);
-
-        if (ret == 0)
-        {
-          page_sel.page_sel = ((uint8_t)(addr_pointed >> 8) & 0x0FU);
-          page_sel.not_used_01 = 1;
-          ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_SEL,
-                                  (uint8_t *)&page_sel, 1);
-        }
-      }
+      page_sel.page_sel = msb;
+      page_sel.not_used_01 = 1;
+      ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_SEL, (uint8_t *)&page_sel, 1);
+      if (ret != 0) { goto exit; }
     }
-
-    page_sel.page_sel = 0;
-    page_sel.not_used_01 = 1;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_SEL, (uint8_t *) &page_sel, 1);
   }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
-  }
+  page_sel.page_sel = 0;
+  page_sel.not_used_01 = 1;
+  ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_SEL, (uint8_t *) &page_sel, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    page_rw.page_rw = 0x00; /* page_write disable */
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
-  }
+  /* unset page write */
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
+  page_rw.page_rw = 0x00; /* page_write disable */
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+exit:
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -1869,66 +1732,80 @@ int32_t lsm6dso_ln_pg_write(stmdev_ctx_t *ctx, uint16_t address,
   * @retval             interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dso_ln_pg_read_byte(stmdev_ctx_t *ctx, uint16_t address,
-                                uint8_t *val)
+int32_t lsm6dso_ln_pg_read_byte(stmdev_ctx_t *ctx, uint16_t address, uint8_t *val)
+{
+  return lsm6dso_ln_pg_read(ctx, address, val, 1);
+}
+
+int32_t lsm6dso_ln_pg_read(stmdev_ctx_t *ctx, uint16_t address, uint8_t *buf,
+                           uint8_t len)
 {
   lsm6dso_page_rw_t page_rw;
   lsm6dso_page_sel_t page_sel;
   lsm6dso_page_address_t  page_address;
+  uint8_t msb;
+  uint8_t lsb;
   int32_t ret;
+  uint8_t i ;
+
+  msb = ((uint8_t)(address >> 8) & 0x0FU);
+  lsb = (uint8_t)address & 0xFFU;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
-  }
+  /* set page write */
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
+  page_rw.page_rw = 0x01; /* page_read enable*/
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    page_rw.page_rw = 0x01; /* page_read enable*/
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
-  }
+  /* select page */
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_SEL, (uint8_t *) &page_sel, 1);
+  page_sel.page_sel = msb;
+  page_sel.not_used_01 = 1;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_PAGE_SEL, (uint8_t *) &page_sel, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
+  for (i = 0; ((i < len) && (ret == 0)); i++)
   {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_SEL, (uint8_t *) &page_sel, 1);
-  }
-
-  if (ret == 0)
-  {
-    page_sel.page_sel = ((uint8_t)(address >> 8) & 0x0FU);
-    page_sel.not_used_01 = 1;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_SEL, (uint8_t *) &page_sel, 1);
-  }
-
-  if (ret == 0)
-  {
-    page_address.page_addr = (uint8_t)address & 0x00FFU;
+    /* set page addr */
+    page_address.page_addr = lsb;
     ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_ADDRESS,
                             (uint8_t *)&page_address, 1);
+    if (ret != 0) { goto exit; }
+
+    ret += lsm6dso_read_reg(ctx, LSM6DSO_PAGE_VALUE, &buf[i], 1);
+    if (ret != 0) { goto exit; }
+
+    lsb++;
+
+    /* Check if page wrap */
+    if (((lsb & 0xFFU) == 0x00U) && (ret == 0))
+    {
+      msb++;
+      ret += lsm6dso_read_reg(ctx, LSM6DSO_PAGE_SEL, (uint8_t *)&page_sel, 1);
+      if (ret != 0) { goto exit; }
+
+      page_sel.page_sel = msb;
+      page_sel.not_used_01 = 1;
+      ret += lsm6dso_write_reg(ctx, LSM6DSO_PAGE_SEL, (uint8_t *)&page_sel, 1);
+      if (ret != 0) { goto exit; }
+    }
   }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_VALUE, val, 1);
-  }
+  page_sel.page_sel = 0;
+  page_sel.not_used_01 = 1;
+  ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_SEL, (uint8_t *) &page_sel, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
-  }
+  /* unset page write */
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
+  page_rw.page_rw = 0x00; /* page_write disable */
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
 
-  if (ret == 0)
-  {
-    page_rw.page_rw = 0x00; /* page_read disable */
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+exit:
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -3307,24 +3184,14 @@ int32_t lsm6dso_aux_den_mode_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_read_reg(ctx, LSM6DSO_INT_OIS, (uint8_t *) &int_ois, 1);
+  int_ois.lvl2_ois = (uint8_t)val & 0x01U;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_INT_OIS, (uint8_t *) &int_ois, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    int_ois.lvl2_ois = (uint8_t)val & 0x01U;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_INT_OIS, (uint8_t *) &int_ois, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL1_OIS, (uint8_t *) &ctrl1_ois, 1);
-  }
-
-  if (ret == 0)
-  {
-    ctrl1_ois.lvl1_ois = ((uint8_t)val & 0x02U) >> 1;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL1_OIS,
-                            (uint8_t *) &ctrl1_ois, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL1_OIS, (uint8_t *) &ctrl1_ois, 1);
+  ctrl1_ois.lvl1_ois = ((uint8_t)val & 0x02U) >> 1;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_CTRL1_OIS,
+                           (uint8_t *) &ctrl1_ois, 1);
 
   return ret;
 }
@@ -3345,29 +3212,28 @@ int32_t lsm6dso_aux_den_mode_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_read_reg(ctx, LSM6DSO_INT_OIS, (uint8_t *) &int_ois, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL1_OIS, (uint8_t *) &ctrl1_ois, 1);
+  if (ret != 0) { return ret; }
+
+  switch ((ctrl1_ois.lvl1_ois << 1) + int_ois.lvl2_ois)
   {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL1_OIS, (uint8_t *) &ctrl1_ois, 1);
+     case LSM6DSO_AUX_DEN_DISABLE:
+       *val = LSM6DSO_AUX_DEN_DISABLE;
+       break;
 
-    switch ((ctrl1_ois.lvl1_ois << 1) + int_ois.lvl2_ois)
-    {
-      case LSM6DSO_AUX_DEN_DISABLE:
-        *val = LSM6DSO_AUX_DEN_DISABLE;
-        break;
+     case LSM6DSO_AUX_DEN_LEVEL_LATCH:
+       *val = LSM6DSO_AUX_DEN_LEVEL_LATCH;
+       break;
 
-      case LSM6DSO_AUX_DEN_LEVEL_LATCH:
-        *val = LSM6DSO_AUX_DEN_LEVEL_LATCH;
-        break;
+     case LSM6DSO_AUX_DEN_LEVEL_TRIG:
+       *val = LSM6DSO_AUX_DEN_LEVEL_TRIG;
+       break;
 
-      case LSM6DSO_AUX_DEN_LEVEL_TRIG:
-        *val = LSM6DSO_AUX_DEN_LEVEL_TRIG;
-        break;
-
-      default:
-        *val = LSM6DSO_AUX_DEN_DISABLE;
-        break;
-    }
+     default:
+       *val = LSM6DSO_AUX_DEN_DISABLE;
+       break;
   }
 
   return ret;
@@ -4257,25 +4123,13 @@ int32_t lsm6dso_i3c_disable_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
+  ctrl9_xl.i3c_disable = ((uint8_t)val & 0x80U) >> 7;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ctrl9_xl.i3c_disable = ((uint8_t)val & 0x80U) >> 7;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_I3C_BUS_AVB,
-                           (uint8_t *)&i3c_bus_avb, 1);
-  }
-
-  if (ret == 0)
-  {
-    i3c_bus_avb.i3c_bus_avb_sel = (uint8_t)val & 0x03U;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_I3C_BUS_AVB,
-                            (uint8_t *)&i3c_bus_avb, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_I3C_BUS_AVB, (uint8_t *)&i3c_bus_avb, 1);
+  i3c_bus_avb.i3c_bus_avb_sel = (uint8_t)val & 0x03U;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_I3C_BUS_AVB, (uint8_t *)&i3c_bus_avb, 1);
 
   return ret;
 }
@@ -4297,38 +4151,34 @@ int32_t lsm6dso_i3c_disable_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
+  ret += lsm6dso_read_reg(ctx, LSM6DSO_I3C_BUS_AVB, (uint8_t *)&i3c_bus_avb, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
+  switch ((ctrl9_xl.i3c_disable << 7) | i3c_bus_avb.i3c_bus_avb_sel)
   {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_I3C_BUS_AVB,
-                           (uint8_t *)&i3c_bus_avb, 1);
+    case LSM6DSO_I3C_DISABLE:
+      *val = LSM6DSO_I3C_DISABLE;
+      break;
 
-    switch ((ctrl9_xl.i3c_disable << 7) | i3c_bus_avb.i3c_bus_avb_sel)
-    {
-      case LSM6DSO_I3C_DISABLE:
-        *val = LSM6DSO_I3C_DISABLE;
-        break;
+    case LSM6DSO_I3C_ENABLE_T_50us:
+      *val = LSM6DSO_I3C_ENABLE_T_50us;
+      break;
 
-      case LSM6DSO_I3C_ENABLE_T_50us:
-        *val = LSM6DSO_I3C_ENABLE_T_50us;
-        break;
+    case LSM6DSO_I3C_ENABLE_T_2us:
+      *val = LSM6DSO_I3C_ENABLE_T_2us;
+      break;
 
-      case LSM6DSO_I3C_ENABLE_T_2us:
-        *val = LSM6DSO_I3C_ENABLE_T_2us;
-        break;
+    case LSM6DSO_I3C_ENABLE_T_1ms:
+      *val = LSM6DSO_I3C_ENABLE_T_1ms;
+      break;
 
-      case LSM6DSO_I3C_ENABLE_T_1ms:
-        *val = LSM6DSO_I3C_ENABLE_T_1ms;
-        break;
+    case LSM6DSO_I3C_ENABLE_T_25ms:
+      *val = LSM6DSO_I3C_ENABLE_T_25ms;
+      break;
 
-      case LSM6DSO_I3C_ENABLE_T_25ms:
-        *val = LSM6DSO_I3C_ENABLE_T_25ms;
-        break;
-
-      default:
-        *val = LSM6DSO_I3C_DISABLE;
-        break;
-    }
+    default:
+      *val = LSM6DSO_I3C_DISABLE;
+      break;
   }
 
   return ret;
@@ -4580,34 +4430,19 @@ int32_t lsm6dso_int_notification_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG0, (uint8_t *) &tap_cfg0, 1);
+  tap_cfg0.lir = (uint8_t)val & 0x01U;
+  tap_cfg0.int_clr_on_read = (uint8_t)val & 0x01U;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_TAP_CFG0, (uint8_t *) &tap_cfg0, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    tap_cfg0.lir = (uint8_t)val & 0x01U;
-    tap_cfg0.int_clr_on_read = (uint8_t)val & 0x01U;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_TAP_CFG0, (uint8_t *) &tap_cfg0, 1);
-  }
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
+  page_rw.emb_func_lir = ((uint8_t)val & 0x02U) >> 1;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
-  }
-
-  if (ret == 0)
-  {
-    page_rw.emb_func_lir = ((uint8_t)val & 0x02U) >> 1;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -4628,59 +4463,39 @@ int32_t lsm6dso_int_notification_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG0, (uint8_t *) &tap_cfg0, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  ret += lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
+  if (ret != 0) { goto exit; }
+
+  switch ((page_rw.emb_func_lir << 1) | tap_cfg0.lir)
   {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+    case LSM6DSO_ALL_INT_PULSED:
+      *val = LSM6DSO_ALL_INT_PULSED;
+      break;
+
+    case LSM6DSO_BASE_LATCHED_EMB_PULSED:
+      *val = LSM6DSO_BASE_LATCHED_EMB_PULSED;
+      break;
+
+    case LSM6DSO_BASE_PULSED_EMB_LATCHED:
+      *val = LSM6DSO_BASE_PULSED_EMB_LATCHED;
+      break;
+
+    case LSM6DSO_ALL_INT_LATCHED:
+      *val = LSM6DSO_ALL_INT_LATCHED;
+      break;
+
+    default:
+      *val = LSM6DSO_ALL_INT_PULSED;
+      break;
   }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
-  }
+  ret += lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
-
-  if (ret == 0)
-  {
-    switch ((page_rw.emb_func_lir << 1) | tap_cfg0.lir)
-    {
-      case LSM6DSO_ALL_INT_PULSED:
-        *val = LSM6DSO_ALL_INT_PULSED;
-        break;
-
-      case LSM6DSO_BASE_LATCHED_EMB_PULSED:
-        *val = LSM6DSO_BASE_LATCHED_EMB_PULSED;
-        break;
-
-      case LSM6DSO_BASE_PULSED_EMB_LATCHED:
-        *val = LSM6DSO_BASE_PULSED_EMB_LATCHED;
-        break;
-
-      case LSM6DSO_ALL_INT_LATCHED:
-        *val = LSM6DSO_ALL_INT_LATCHED;
-        break;
-
-      default:
-        *val = LSM6DSO_ALL_INT_PULSED;
-        break;
-    }
-
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+exit:
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -5941,26 +5756,15 @@ int32_t lsm6dso_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val)
   lsm6dso_free_fall_t free_fall;
   int32_t ret;
 
-  ret = lsm6dso_read_reg(ctx, LSM6DSO_WAKE_UP_DUR,
-                         (uint8_t *)&wake_up_dur, 1);
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+  ret += lsm6dso_read_reg(ctx, LSM6DSO_FREE_FALL, (uint8_t *)&free_fall, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_FREE_FALL, (uint8_t *)&free_fall, 1);
-  }
+  wake_up_dur.ff_dur = ((uint8_t)val & 0x20U) >> 5;
+  free_fall.ff_dur = (uint8_t)val & 0x1FU;
 
-  if (ret == 0)
-  {
-    wake_up_dur.ff_dur = ((uint8_t)val & 0x20U) >> 5;
-    free_fall.ff_dur = (uint8_t)val & 0x1FU;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_WAKE_UP_DUR,
-                            (uint8_t *)&wake_up_dur, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_FREE_FALL, (uint8_t *)&free_fall, 1);
-  }
+  ret = lsm6dso_write_reg(ctx, LSM6DSO_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_FREE_FALL, (uint8_t *)&free_fall, 1);
 
   return ret;
 }
@@ -6018,22 +5822,14 @@ int32_t lsm6dso_fifo_watermark_set(stmdev_ctx_t *ctx, uint16_t val)
   lsm6dso_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
 
-  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_CTRL2,
-                         (uint8_t *)&fifo_ctrl2, 1);
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    fifo_ctrl1.wtm = 0x00FFU & (uint8_t)val;
-    fifo_ctrl2.wtm = (uint8_t)((0x0100U & val) >> 8);
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_FIFO_CTRL1,
-                            (uint8_t *)&fifo_ctrl1, 1);
-  }
+  fifo_ctrl1.wtm = 0x00FFU & (uint8_t)val;
+  fifo_ctrl2.wtm = (uint8_t)((0x0100U & val) >> 8);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_FIFO_CTRL2,
-                            (uint8_t *)&fifo_ctrl2, 1);
-  }
+  ret = lsm6dso_write_reg(ctx, LSM6DSO_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
 
   return ret;
 }
@@ -6052,13 +5848,11 @@ int32_t lsm6dso_fifo_watermark_get(stmdev_ctx_t *ctx, uint16_t *val)
   lsm6dso_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
 
-  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_CTRL1,
-                         (uint8_t *)&fifo_ctrl1, 1);
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
 
   if (ret == 0)
   {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_CTRL2,
-                           (uint8_t *)&fifo_ctrl2, 1);
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
     *val = ((uint16_t)fifo_ctrl2.wtm << 8) + (uint16_t)fifo_ctrl1.wtm;
   }
 
@@ -6081,22 +5875,13 @@ int32_t lsm6dso_compression_algo_init_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_INIT_B, (uint8_t *)&reg, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_INIT_B, (uint8_t *)&reg, 1);
+  reg.fifo_compr_init = val;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_INIT_B, (uint8_t *)&reg, 1);
 
-  if (ret == 0)
-  {
-    reg.fifo_compr_init = val;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_INIT_B, (uint8_t *)&reg, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -6117,17 +5902,10 @@ int32_t lsm6dso_compression_algo_init_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  ret += lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_INIT_B, (uint8_t *)&reg, 1);
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_INIT_B, (uint8_t *)&reg, 1);
-  }
-
-  if (ret == 0)
-  {
-    *val = reg.fifo_compr_init;
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  *val = reg.fifo_compr_init;
 
   return ret;
 }
@@ -6889,22 +6667,14 @@ int32_t lsm6dso_batch_counter_threshold_set(stmdev_ctx_t *ctx,
   lsm6dso_counter_bdr_reg2_t counter_bdr_reg2;
   int32_t ret;
 
-  ret = lsm6dso_read_reg(ctx, LSM6DSO_COUNTER_BDR_REG1,
-                         (uint8_t *)&counter_bdr_reg1, 1);
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_COUNTER_BDR_REG1, (uint8_t *)&counter_bdr_reg1, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    counter_bdr_reg2.cnt_bdr_th =  0x00FFU & (uint8_t)val;
-    counter_bdr_reg1.cnt_bdr_th = (uint8_t)(0x0700U & val) >> 8;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_COUNTER_BDR_REG1,
-                            (uint8_t *)&counter_bdr_reg1, 1);
-  }
+  counter_bdr_reg2.cnt_bdr_th =  0x00FFU & (uint8_t)val;
+  counter_bdr_reg1.cnt_bdr_th = (uint8_t)(0x0700U & val) >> 8;
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_COUNTER_BDR_REG2,
-                            (uint8_t *)&counter_bdr_reg2, 1);
-  }
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_COUNTER_BDR_REG1, (uint8_t *)&counter_bdr_reg1, 1);
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_COUNTER_BDR_REG2, (uint8_t *)&counter_bdr_reg2, 1);
 
   return ret;
 }
@@ -7174,24 +6944,13 @@ int32_t lsm6dso_fifo_pedo_batch_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_FIFO_CFG,
-                           (uint8_t *)&reg, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_FIFO_CFG, (uint8_t *)&reg, 1);
+  reg.pedo_fifo_en = val;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_FIFO_CFG, (uint8_t *)&reg, 1);
 
-  if (ret == 0)
-  {
-    reg.pedo_fifo_en = val;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_FIFO_CFG,
-                            (uint8_t *)&reg, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -7211,278 +6970,61 @@ int32_t lsm6dso_fifo_pedo_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_FIFO_CFG,
-                           (uint8_t *)&reg, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_FIFO_CFG, (uint8_t *)&reg, 1);
+  *val = reg.pedo_fifo_en;
 
-  if (ret == 0)
-  {
-    *val = reg.pedo_fifo_en;
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
 
 /**
-  * @brief   Enable FIFO batching data of first slave.[set]
+  * @brief   Enable FIFO batching data of slave idx.[set]
   *
   * @param  ctx      read / write interface definitions
-  * @param  val      change the values of  batch_ext_sens_0_en in
-  *                  reg SLV0_CONFIG
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
+  * @param  val      Enable FIFO data batching of slave idx
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dso_sh_batch_slave_0_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dso_sh_batch_slave_set(stmdev_ctx_t *ctx, uint8_t idx, uint8_t val)
 {
   lsm6dso_slv0_config_t reg;
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV0_CONFIG, (uint8_t *)&reg, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV0_CONFIG + 3U*idx, (uint8_t *)&reg, 1);
+  reg.batch_ext_sens_0_en = val;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_SLV0_CONFIG + 3U*idx, (uint8_t *)&reg, 1);
 
-  if (ret == 0)
-  {
-    reg.batch_ext_sens_0_en = val;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV0_CONFIG, (uint8_t *)&reg, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
 
 /**
-  * @brief  Enable FIFO batching data of first slave.[get]
+  * @brief  Enable FIFO batching data of slave idx.[get]
   *
   * @param  ctx      read / write interface definitions
-  * @param  val      Get the values of  batch_ext_sens_0_en in
-  *                  reg SLV0_CONFIG
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
+  * @param  val      Enable FIFO data batching of slave idx
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dso_sh_batch_slave_0_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dso_sh_batch_slave_get(stmdev_ctx_t *ctx, uint8_t idx, uint8_t *val)
 {
   lsm6dso_slv0_config_t reg;
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV0_CONFIG, (uint8_t *)&reg, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV0_CONFIG + 3U*idx, (uint8_t *)&reg, 1);
+  *val = reg.batch_ext_sens_0_en;
 
-  if (ret == 0)
-  {
-    *val = reg.batch_ext_sens_0_en;
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
-
-  return ret;
-}
-
-/**
-  * @brief  Enable FIFO batching data of second slave.[set]
-  *
-  * @param  ctx      read / write interface definitions
-  * @param  val      change the values of  batch_ext_sens_1_en in
-  *                  reg SLV1_CONFIG
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
-  *
-  */
-int32_t lsm6dso_sh_batch_slave_1_set(stmdev_ctx_t *ctx, uint8_t val)
-{
-  lsm6dso_slv1_config_t reg;
-  int32_t ret;
-
-  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV1_CONFIG, (uint8_t *)&reg, 1);
-  }
-
-  if (ret == 0)
-  {
-    reg.batch_ext_sens_1_en = val;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV1_CONFIG, (uint8_t *)&reg, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
-
-  return ret;
-}
-
-/**
-  * @brief   Enable FIFO batching data of second slave.[get]
-  *
-  * @param  ctx      read / write interface definitions
-  * @param  val      Get the values of  batch_ext_sens_1_en in
-  *                  reg SLV1_CONFIG
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
-  *
-  */
-int32_t lsm6dso_sh_batch_slave_1_get(stmdev_ctx_t *ctx, uint8_t *val)
-{
-  lsm6dso_slv1_config_t reg;
-  int32_t ret;
-
-  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV1_CONFIG, (uint8_t *)&reg, 1);
-    *val = reg.batch_ext_sens_1_en;
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
-
-  return ret;
-}
-
-/**
-  * @brief  Enable FIFO batching data of third slave.[set]
-  *
-  * @param  ctx      read / write interface definitions
-  * @param  val      change the values of  batch_ext_sens_2_en in
-  *                  reg SLV2_CONFIG
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
-  *
-  */
-int32_t lsm6dso_sh_batch_slave_2_set(stmdev_ctx_t *ctx, uint8_t val)
-{
-  lsm6dso_slv2_config_t reg;
-  int32_t ret;
-
-  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV2_CONFIG, (uint8_t *)&reg, 1);
-  }
-
-  if (ret == 0)
-  {
-    reg.batch_ext_sens_2_en = val;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV2_CONFIG, (uint8_t *)&reg, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
-
-  return ret;
-}
-
-/**
-  * @brief  Enable FIFO batching data of third slave.[get]
-  *
-  * @param  ctx      read / write interface definitions
-  * @param  val      Get the values of  batch_ext_sens_2_en in
-  *                  reg SLV2_CONFIG
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
-  *
-  */
-int32_t lsm6dso_sh_batch_slave_2_get(stmdev_ctx_t *ctx, uint8_t *val)
-{
-  lsm6dso_slv2_config_t reg;
-  int32_t ret;
-
-  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV2_CONFIG, (uint8_t *)&reg, 1);
-  }
-
-  if (ret == 0)
-  {
-    *val = reg.batch_ext_sens_2_en;
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
-
-  return ret;
-}
-
-/**
-  * @brief   Enable FIFO batching data of fourth slave.[set]
-  *
-  * @param  ctx      read / write interface definitions
-  * @param  val      change the values of  batch_ext_sens_3_en
-  *                  in reg SLV3_CONFIG
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
-  *
-  */
-int32_t lsm6dso_sh_batch_slave_3_set(stmdev_ctx_t *ctx, uint8_t val)
-{
-  lsm6dso_slv3_config_t reg;
-  int32_t ret;
-
-  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV3_CONFIG, (uint8_t *)&reg, 1);
-  }
-
-  if (ret == 0)
-  {
-    reg.batch_ext_sens_3_en = val;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV3_CONFIG, (uint8_t *)&reg, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
-
-  return ret;
-}
-
-/**
-  * @brief  Enable FIFO batching data of fourth slave.[get]
-  *
-  * @param  ctx      read / write interface definitions
-  * @param  val      Get the values of  batch_ext_sens_3_en in
-  *                  reg SLV3_CONFIG
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
-  *
-  */
-int32_t lsm6dso_sh_batch_slave_3_get(stmdev_ctx_t *ctx, uint8_t *val)
-{
-  lsm6dso_slv3_config_t reg;
-  int32_t ret;
-
-  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV3_CONFIG, (uint8_t *)&reg, 1);
-  }
-
-  if (ret == 0)
-  {
-    *val = reg.batch_ext_sens_3_en;
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -7916,17 +7458,12 @@ int32_t lsm6dso_pedo_step_detect_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_STATUS, (uint8_t *)&reg, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_STATUS, (uint8_t *)&reg, 1);
+  *val = reg.is_step_det;
 
-  if (ret == 0)
-  {
-    *val = reg.is_step_det;
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -7983,14 +7520,8 @@ int32_t lsm6dso_pedo_steps_period_set(stmdev_ctx_t *ctx, uint16_t val)
 
   buff[1] = (uint8_t)(val / 256U);
   buff[0] = (uint8_t)(val - (buff[1] * 256U));
-  ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_PEDO_SC_DELTAT_L,
-                                 &buff[0]);
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_PEDO_SC_DELTAT_H,
-                                   &buff[1]);
-  }
+  ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_PEDO_SC_DELTAT_L, &buff[0]);
+  ret += lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_PEDO_SC_DELTAT_H, &buff[1]);
 
   return ret;
 }
@@ -8009,16 +7540,11 @@ int32_t lsm6dso_pedo_steps_period_get(stmdev_ctx_t *ctx,
   uint8_t buff[2];
   int32_t ret;
 
-  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_PEDO_SC_DELTAT_L,
-                                &buff[0]);
+  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_PEDO_SC_DELTAT_L, &buff[0]);
+  ret += lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_PEDO_SC_DELTAT_H, &buff[1]);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_PEDO_SC_DELTAT_H,
-                                  &buff[1]);
-    *val = buff[1];
-    *val = (*val * 256U) +  buff[0];
-  }
+  *val = buff[1];
+  *val = (*val * 256U) +  buff[0];
 
   return ret;
 }
@@ -8115,17 +7641,12 @@ int32_t lsm6dso_motion_flag_data_ready_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_STATUS, (uint8_t *)&reg, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_STATUS, (uint8_t *)&reg, 1);
+  *val = reg.is_sigmot;
 
-  if (ret == 0)
-  {
-    *val = reg.is_sigmot;
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -8158,17 +7679,12 @@ int32_t lsm6dso_tilt_flag_data_ready_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_STATUS, (uint8_t *)&reg, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_STATUS, (uint8_t *)&reg, 1);
+  *val = reg.is_tilt;
 
-  if (ret == 0)
-  {
-    *val = reg.is_tilt;
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -8201,14 +7717,9 @@ int32_t lsm6dso_mag_sensitivity_set(stmdev_ctx_t *ctx, uint16_t val)
 
   buff[1] = (uint8_t)(val / 256U);
   buff[0] = (uint8_t)(val - (buff[1] * 256U));
-  ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SENSITIVITY_L,
-                                 &buff[0]);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SENSITIVITY_H,
-                                   &buff[1]);
-  }
+  ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SENSITIVITY_L, &buff[0]);
+  ret += lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SENSITIVITY_H, &buff[1]);
 
   return ret;
 }
@@ -8226,16 +7737,11 @@ int32_t lsm6dso_mag_sensitivity_get(stmdev_ctx_t *ctx, uint16_t *val)
   uint8_t buff[2];
   int32_t ret;
 
-  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SENSITIVITY_L,
-                                &buff[0]);
+  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SENSITIVITY_L, &buff[0]);
+  ret += lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SENSITIVITY_H, &buff[1]);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SENSITIVITY_H,
-                                  &buff[1]);
-    *val = buff[1];
-    *val = (*val * 256U) +  buff[0];
-  }
+  *val = buff[1];
+  *val = (*val * 256U) +  buff[0];
 
   return ret;
 }
@@ -8251,7 +7757,6 @@ int32_t lsm6dso_mag_sensitivity_get(stmdev_ctx_t *ctx, uint16_t *val)
 int32_t lsm6dso_mag_offset_set(stmdev_ctx_t *ctx, int16_t *val)
 {
   uint8_t buff[6];
-  int32_t ret;
 
   buff[1] = (uint8_t)((uint16_t)val[0] / 256U);
   buff[0] = (uint8_t)((uint16_t)val[0] - (buff[1] * 256U));
@@ -8259,34 +7764,8 @@ int32_t lsm6dso_mag_offset_set(stmdev_ctx_t *ctx, int16_t *val)
   buff[2] = (uint8_t)((uint16_t)val[1] - (buff[3] * 256U));
   buff[5] = (uint8_t)((uint16_t)val[2] / 256U);
   buff[4] = (uint8_t)((uint16_t)val[2] - (buff[5] * 256U));
-  ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_OFFX_L, &buff[0]);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_OFFX_H, &buff[1]);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_OFFY_L, &buff[2]);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_OFFY_H, &buff[3]);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_OFFZ_L, &buff[4]);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_OFFZ_H, &buff[5]);
-  }
-
-  return ret;
+  return lsm6dso_ln_pg_write(ctx, LSM6DSO_MAG_OFFX_L, &buff[0], 6);
 }
 
 /**
@@ -8302,38 +7781,14 @@ int32_t lsm6dso_mag_offset_get(stmdev_ctx_t *ctx, int16_t *val)
   uint8_t buff[6];
   int32_t ret;
 
-  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_OFFX_L, &buff[0]);
+  ret = lsm6dso_ln_pg_read(ctx, LSM6DSO_MAG_OFFX_L, &buff[0], 6);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_OFFX_H, &buff[1]);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_OFFY_L, &buff[2]);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_OFFY_H, &buff[3]);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_OFFZ_L, &buff[4]);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_OFFZ_H, &buff[5]);
-    val[0] = (int16_t)buff[1];
-    val[0] = (val[0] * 256) + (int16_t)buff[0];
-    val[1] = (int16_t)buff[3];
-    val[1] = (val[1] * 256) + (int16_t)buff[2];
-    val[2] = (int16_t)buff[5];
-    val[2] = (val[2] * 256) + (int16_t)buff[4];
-  }
+  val[0] = (int16_t)buff[1];
+  val[0] = (val[0] * 256) + (int16_t)buff[0];
+  val[1] = (int16_t)buff[3];
+  val[1] = (val[1] * 256) + (int16_t)buff[2];
+  val[2] = (int16_t)buff[5];
+  val[2] = (val[2] * 256) + (int16_t)buff[4];
 
   return ret;
 }
@@ -8355,9 +7810,7 @@ int32_t lsm6dso_mag_offset_get(stmdev_ctx_t *ctx, int16_t *val)
 int32_t lsm6dso_mag_soft_iron_set(stmdev_ctx_t *ctx, int16_t *val)
 {
   uint8_t buff[12];
-  int32_t ret;
 
-  uint8_t index;
   buff[1] = (uint8_t)((uint16_t)val[0] / 256U);
   buff[0] = (uint8_t)((uint16_t)val[0] - (buff[1] * 256U));
   buff[3] = (uint8_t)((uint16_t)val[1] / 256U);
@@ -8370,88 +7823,8 @@ int32_t lsm6dso_mag_soft_iron_set(stmdev_ctx_t *ctx, int16_t *val)
   buff[8] = (uint8_t)((uint16_t)val[4] - (buff[9] * 256U));
   buff[11] = (uint8_t)((uint16_t)val[5] / 256U);
   buff[10] = (uint8_t)((uint16_t)val[5] - (buff[11] * 256U));
-  index = 0x00U;
-  ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SI_XX_L,
-                                 &buff[index]);
 
-  if (ret == 0)
-  {
-    index++;
-    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SI_XX_H,
-                                   &buff[index]);
-  }
-
-  if (ret == 0)
-  {
-    index++;
-    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SI_XY_L,
-                                   &buff[index]);
-  }
-
-  if (ret == 0)
-  {
-    index++;
-    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SI_XY_H,
-                                   &buff[index]);
-  }
-
-  if (ret == 0)
-  {
-    index++;
-    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SI_XZ_L,
-                                   &buff[index]);
-  }
-
-  if (ret == 0)
-  {
-    index++;
-    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SI_XZ_H,
-                                   &buff[index]);
-  }
-
-  if (ret == 0)
-  {
-    index++;
-    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SI_YY_L,
-                                   &buff[index]);
-  }
-
-  if (ret == 0)
-  {
-    index++;
-    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SI_YY_H,
-                                   &buff[index]);
-  }
-
-  if (ret == 0)
-  {
-    index++;
-    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SI_YZ_L,
-                                   &buff[index]);
-  }
-
-  if (ret == 0)
-  {
-    index++;
-    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SI_YZ_H,
-                                   &buff[index]);
-  }
-
-  if (ret == 0)
-  {
-    index++;
-    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SI_ZZ_L,
-                                   &buff[index]);
-  }
-
-  if (ret == 0)
-  {
-    index++;
-    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SI_ZZ_H,
-                                   &buff[index]);
-  }
-
-  return ret;
+  return lsm6dso_ln_pg_write(ctx, LSM6DSO_MAG_SI_XX_L, &buff[0], 12);
 }
 
 /**
@@ -8474,75 +7847,7 @@ int32_t lsm6dso_mag_soft_iron_get(stmdev_ctx_t *ctx, int16_t *val)
   uint8_t buff[12];
   int32_t ret;
 
-  uint8_t index;
-  index = 0x00U;
-  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SI_XX_L, &buff[index]);
-
-  if (ret == 0)
-  {
-    index++;
-    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SI_XX_H, &buff[index]);
-  }
-
-  if (ret == 0)
-  {
-    index++;
-    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SI_XY_L, &buff[index]);
-  }
-
-  if (ret == 0)
-  {
-    index++;
-    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SI_XY_H, &buff[index]);
-  }
-
-  if (ret == 0)
-  {
-    index++;
-    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SI_XZ_L, &buff[index]);
-  }
-
-  if (ret == 0)
-  {
-    index++;
-    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SI_XZ_H, &buff[index]);
-  }
-
-  if (ret == 0)
-  {
-    index++;
-    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SI_YY_L, &buff[index]);
-  }
-
-  if (ret == 0)
-  {
-    index++;
-    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SI_YY_H, &buff[index]);
-  }
-
-  if (ret == 0)
-  {
-    index++;
-    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SI_YZ_L, &buff[index]);
-  }
-
-  if (ret == 0)
-  {
-    index++;
-    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SI_YZ_H, &buff[index]);
-  }
-
-  if (ret == 0)
-  {
-    index++;
-    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SI_ZZ_L, &buff[index]);
-  }
-
-  if (ret == 0)
-  {
-    index++;
-    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SI_ZZ_H, &buff[index]);
-  }
+  ret = lsm6dso_ln_pg_read(ctx, LSM6DSO_MAG_SI_XX_L, &buff[0], 12);
 
   val[0] = (int16_t)buff[1];
   val[0] = (val[0] * 256) + (int16_t)buff[0];
@@ -8577,14 +7882,12 @@ int32_t lsm6dso_mag_z_orient_set(stmdev_ctx_t *ctx,
   lsm6dso_mag_cfg_a_t reg;
   int32_t ret;
 
-  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_CFG_A,
-                                (uint8_t *)&reg);
+  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_CFG_A, (uint8_t *)&reg);
 
   if (ret == 0)
   {
     reg.mag_z_axis = (uint8_t) val;
-    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_CFG_A,
-                                   (uint8_t *)&reg);
+    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_CFG_A, (uint8_t *)&reg);
   }
 
   return ret;
@@ -8661,14 +7964,12 @@ int32_t lsm6dso_mag_y_orient_set(stmdev_ctx_t *ctx,
   lsm6dso_mag_cfg_a_t reg;
   int32_t ret;
 
-  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_CFG_A,
-                                (uint8_t *)&reg);
+  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_CFG_A, (uint8_t *)&reg);
 
   if (ret == 0)
   {
     reg.mag_y_axis = (uint8_t)val;
-    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_CFG_A,
-                                   (uint8_t *) &reg);
+    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_CFG_A, (uint8_t *) &reg);
   }
 
   return ret;
@@ -8745,14 +8046,12 @@ int32_t lsm6dso_mag_x_orient_set(stmdev_ctx_t *ctx,
   lsm6dso_mag_cfg_b_t reg;
   int32_t ret;
 
-  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_CFG_B,
-                                (uint8_t *)&reg);
+  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_CFG_B, (uint8_t *)&reg);
 
   if (ret == 0)
   {
     reg.mag_x_axis = (uint8_t)val;
-    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_CFG_B,
-                                   (uint8_t *)&reg);
+    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_CFG_B, (uint8_t *)&reg);
   }
 
   return ret;
@@ -8841,17 +8140,12 @@ int32_t lsm6dso_long_cnt_flag_data_ready_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_STATUS, (uint8_t *)&reg, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_STATUS, (uint8_t *)&reg, 1);
+  *val = reg.is_fsm_lc;
 
-  if (ret == 0)
-  {
-    *val = reg.is_fsm_lc;
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -8870,23 +8164,12 @@ int32_t lsm6dso_fsm_enable_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_FSM_ENABLE_A,
-                            (uint8_t *)&val->fsm_enable_a, 1);
-  }
+  ret = lsm6dso_write_reg(ctx, LSM6DSO_FSM_ENABLE_A, (uint8_t *)&val->fsm_enable_a, 1);
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_FSM_ENABLE_B, (uint8_t *)&val->fsm_enable_b, 1);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_FSM_ENABLE_B,
-                            (uint8_t *)&val->fsm_enable_b, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -8905,16 +8188,8 @@ int32_t lsm6dso_fsm_enable_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_FSM_ENABLE_A, (uint8_t *) val, 2);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_read_reg(ctx, LSM6DSO_FSM_ENABLE_A, (uint8_t *) val, 2);
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -8935,17 +8210,10 @@ int32_t lsm6dso_long_cnt_set(stmdev_ctx_t *ctx, uint16_t val)
 
   buff[1] = (uint8_t)(val / 256U);
   buff[0] = (uint8_t)(val - (buff[1] * 256U));
+
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_FSM_LONG_COUNTER_L, buff, 2);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_FSM_LONG_COUNTER_L, buff, 2);
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -8965,18 +8233,11 @@ int32_t lsm6dso_long_cnt_get(stmdev_ctx_t *ctx, uint16_t *val)
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  ret += lsm6dso_read_reg(ctx, LSM6DSO_FSM_LONG_COUNTER_L, buff, 2);
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_FSM_LONG_COUNTER_L, buff, 2);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-    *val = buff[1];
-    *val = (*val * 256U) +  buff[0];
-  }
+  *val = buff[1];
+  *val = (*val * 256U) +  buff[0];
 
   return ret;
 }
@@ -8997,24 +8258,13 @@ int32_t lsm6dso_long_clr_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_FSM_LONG_COUNTER_CLEAR,
-                           (uint8_t *)&reg, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FSM_LONG_COUNTER_CLEAR, (uint8_t *)&reg, 1);
+  reg. fsm_lc_clr = (uint8_t)val;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_FSM_LONG_COUNTER_CLEAR, (uint8_t *)&reg, 1);
 
-  if (ret == 0)
-  {
-    reg. fsm_lc_clr = (uint8_t)val;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_FSM_LONG_COUNTER_CLEAR,
-                            (uint8_t *)&reg, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -9035,39 +8285,32 @@ int32_t lsm6dso_long_clr_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FSM_LONG_COUNTER_CLEAR, (uint8_t *)&reg, 1);
+  if (ret != 0) { goto exit; }
+
+  switch (reg.fsm_lc_clr)
   {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_FSM_LONG_COUNTER_CLEAR,
-                           (uint8_t *)&reg, 1);
-  }
+    case LSM6DSO_LC_NORMAL:
+      *val = LSM6DSO_LC_NORMAL;
+      break;
 
-  if (ret == 0)
-  {
-    switch (reg.fsm_lc_clr)
-    {
-      case LSM6DSO_LC_NORMAL:
-        *val = LSM6DSO_LC_NORMAL;
-        break;
+     case LSM6DSO_LC_CLEAR:
+       *val = LSM6DSO_LC_CLEAR;
+       break;
 
-      case LSM6DSO_LC_CLEAR:
-        *val = LSM6DSO_LC_CLEAR;
-        break;
+     case LSM6DSO_LC_CLEAR_DONE:
+       *val = LSM6DSO_LC_CLEAR_DONE;
+       break;
 
-      case LSM6DSO_LC_CLEAR_DONE:
-        *val = LSM6DSO_LC_CLEAR_DONE;
-        break;
+     default:
+       *val = LSM6DSO_LC_NORMAL;
+       break;
+   }
 
-      default:
-        *val = LSM6DSO_LC_NORMAL;
-        break;
-    }
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+exit:
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -9085,16 +8328,8 @@ int32_t lsm6dso_fsm_out_get(stmdev_ctx_t *ctx, lsm6dso_fsm_out_t *val)
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_FSM_OUTS1, (uint8_t *)val, 16);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_read_reg(ctx, LSM6DSO_FSM_OUTS1, (uint8_t *)val, 16);
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -9114,26 +8349,18 @@ int32_t lsm6dso_fsm_data_rate_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_ODR_CFG_B,
-                           (uint8_t *)&reg, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_ODR_CFG_B, (uint8_t *)&reg, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    reg.not_used_01 = 3; /* set default values */
-    reg.not_used_02 = 2; /* set default values */
-    reg.fsm_odr = (uint8_t)val;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_ODR_CFG_B,
-                            (uint8_t *)&reg, 1);
-  }
+  reg.not_used_01 = 3; /* set default values */
+  reg.not_used_02 = 2; /* set default values */
+  reg.fsm_odr = (uint8_t)val;
+  ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_ODR_CFG_B, (uint8_t *)&reg, 1);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+exit:
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -9153,40 +8380,36 @@ int32_t lsm6dso_fsm_data_rate_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_ODR_CFG_B, (uint8_t *)&reg, 1);
+  if (ret != 0) { goto exit; }
+
+  switch (reg.fsm_odr)
   {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_ODR_CFG_B,
-                           (uint8_t *)&reg, 1);
+    case LSM6DSO_ODR_FSM_12Hz5:
+      *val = LSM6DSO_ODR_FSM_12Hz5;
+      break;
+
+    case LSM6DSO_ODR_FSM_26Hz:
+      *val = LSM6DSO_ODR_FSM_26Hz;
+      break;
+
+    case LSM6DSO_ODR_FSM_52Hz:
+      *val = LSM6DSO_ODR_FSM_52Hz;
+      break;
+
+    case LSM6DSO_ODR_FSM_104Hz:
+      *val = LSM6DSO_ODR_FSM_104Hz;
+      break;
+
+    default:
+      *val = LSM6DSO_ODR_FSM_12Hz5;
+      break;
   }
 
-  if (ret == 0)
-  {
-    switch (reg.fsm_odr)
-    {
-      case LSM6DSO_ODR_FSM_12Hz5:
-        *val = LSM6DSO_ODR_FSM_12Hz5;
-        break;
-
-      case LSM6DSO_ODR_FSM_26Hz:
-        *val = LSM6DSO_ODR_FSM_26Hz;
-        break;
-
-      case LSM6DSO_ODR_FSM_52Hz:
-        *val = LSM6DSO_ODR_FSM_52Hz;
-        break;
-
-      case LSM6DSO_ODR_FSM_104Hz:
-        *val = LSM6DSO_ODR_FSM_104Hz;
-        break;
-
-      default:
-        *val = LSM6DSO_ODR_FSM_12Hz5;
-        break;
-    }
-
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+exit:
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -9205,22 +8428,16 @@ int32_t lsm6dso_fsm_init_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_INIT_B, (uint8_t *)&reg, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_INIT_B, (uint8_t *)&reg, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    reg.fsm_init = val;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_INIT_B, (uint8_t *)&reg, 1);
-  }
+  reg.fsm_init = val;
+  ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_INIT_B, (uint8_t *)&reg, 1);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+exit:
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -9239,17 +8456,12 @@ int32_t lsm6dso_fsm_init_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_INIT_B, (uint8_t *)&reg, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_INIT_B, (uint8_t *)&reg, 1);
 
-  if (ret == 0)
-  {
-    *val = reg.fsm_init;
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  *val = reg.fsm_init;
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -9273,14 +8485,9 @@ int32_t lsm6dso_long_cnt_int_value_set(stmdev_ctx_t *ctx,
 
   buff[1] = (uint8_t)(val / 256U);
   buff[0] = (uint8_t)(val - (buff[1] * 256U));
-  ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_FSM_LC_TIMEOUT_L,
-                                 &buff[0]);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_FSM_LC_TIMEOUT_H,
-                                   &buff[1]);
-  }
+  ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_FSM_LC_TIMEOUT_L, &buff[0]);
+  ret += lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_FSM_LC_TIMEOUT_H, &buff[1]);
 
   return ret;
 }
@@ -9302,16 +8509,11 @@ int32_t lsm6dso_long_cnt_int_value_get(stmdev_ctx_t *ctx,
   uint8_t buff[2];
   int32_t ret;
 
-  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_FSM_LC_TIMEOUT_L,
-                                &buff[0]);
+  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_FSM_LC_TIMEOUT_L, &buff[0]);
+  ret += lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_FSM_LC_TIMEOUT_H, &buff[1]);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_FSM_LC_TIMEOUT_H,
-                                  &buff[1]);
-    *val = buff[1];
-    *val = (*val * 256U) +  buff[0];
-  }
+  *val = buff[1];
+  *val = (*val * 256U) +  buff[0];
 
   return ret;
 }
@@ -9368,14 +8570,9 @@ int32_t lsm6dso_fsm_start_address_set(stmdev_ctx_t *ctx, uint16_t val)
 
   buff[1] = (uint8_t)(val / 256U);
   buff[0] = (uint8_t)(val - (buff[1] * 256U));
-  ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_FSM_START_ADD_L,
-                                 &buff[0]);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_FSM_START_ADD_H,
-                                   &buff[1]);
-  }
+  ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_FSM_START_ADD_L, &buff[0]);
+  ret += lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_FSM_START_ADD_H, &buff[1]);
 
   return ret;
 }
@@ -9396,13 +8593,10 @@ int32_t lsm6dso_fsm_start_address_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_FSM_START_ADD_L, &buff[0]);
+  ret += lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_FSM_START_ADD_H, &buff[1]);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_FSM_START_ADD_H, &buff[1]);
-    *val = buff[1];
-    *val = (*val * 256U) +  buff[0];
-  }
+  *val = buff[1];
+  *val = (*val * 256U) +  buff[0];
 
   return ret;
 }
@@ -9435,17 +8629,8 @@ int32_t lsm6dso_sh_read_data_raw_get(stmdev_ctx_t *ctx, uint8_t *val,
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_SENSOR_HUB_1, (uint8_t *) val,
-                           len);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_read_reg(ctx, LSM6DSO_SENSOR_HUB_1, (uint8_t *) val, len);
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -9465,22 +8650,13 @@ int32_t lsm6dso_sh_slave_connected_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
+  reg.aux_sens_on = (uint8_t)val;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
 
-  if (ret == 0)
-  {
-    reg.aux_sens_on = (uint8_t)val;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -9500,39 +8676,34 @@ int32_t lsm6dso_sh_slave_connected_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
+
+  switch (reg.aux_sens_on)
   {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
+    case LSM6DSO_SLV_0:
+      *val = LSM6DSO_SLV_0;
+      break;
+
+    case LSM6DSO_SLV_0_1:
+      *val = LSM6DSO_SLV_0_1;
+      break;
+
+    case LSM6DSO_SLV_0_1_2:
+      *val = LSM6DSO_SLV_0_1_2;
+      break;
+
+    case LSM6DSO_SLV_0_1_2_3:
+      *val = LSM6DSO_SLV_0_1_2_3;
+      break;
+
+    default:
+      *val = LSM6DSO_SLV_0;
+      break;
   }
 
-  if (ret == 0)
-  {
-    switch (reg.aux_sens_on)
-    {
-      case LSM6DSO_SLV_0:
-        *val = LSM6DSO_SLV_0;
-        break;
-
-      case LSM6DSO_SLV_0_1:
-        *val = LSM6DSO_SLV_0_1;
-        break;
-
-      case LSM6DSO_SLV_0_1_2:
-        *val = LSM6DSO_SLV_0_1_2;
-        break;
-
-      case LSM6DSO_SLV_0_1_2_3:
-        *val = LSM6DSO_SLV_0_1_2_3;
-        break;
-
-      default:
-        *val = LSM6DSO_SLV_0;
-        break;
-    }
-
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -9551,22 +8722,13 @@ int32_t lsm6dso_sh_master_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
+  reg.master_on = val;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
 
-  if (ret == 0)
-  {
-    reg.master_on = val;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -9585,17 +8747,11 @@ int32_t lsm6dso_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
-  }
-
-  if (ret == 0)
-  {
-    *val = reg.master_on;
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
+  *val = reg.master_on;
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -9615,22 +8771,13 @@ int32_t lsm6dso_sh_pin_mode_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
+  reg.shub_pu_en = (uint8_t)val;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
 
-  if (ret == 0)
-  {
-    reg.shub_pu_en = (uint8_t)val;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -9650,31 +8797,26 @@ int32_t lsm6dso_sh_pin_mode_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
+
+  switch (reg.shub_pu_en)
   {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
+    case LSM6DSO_EXT_PULL_UP:
+      *val = LSM6DSO_EXT_PULL_UP;
+      break;
+
+    case LSM6DSO_INTERNAL_PULL_UP:
+      *val = LSM6DSO_INTERNAL_PULL_UP;
+      break;
+
+    default:
+      *val = LSM6DSO_EXT_PULL_UP;
+      break;
   }
 
-  if (ret == 0)
-  {
-    switch (reg.shub_pu_en)
-    {
-      case LSM6DSO_EXT_PULL_UP:
-        *val = LSM6DSO_EXT_PULL_UP;
-        break;
-
-      case LSM6DSO_INTERNAL_PULL_UP:
-        *val = LSM6DSO_INTERNAL_PULL_UP;
-        break;
-
-      default:
-        *val = LSM6DSO_EXT_PULL_UP;
-        break;
-    }
-
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -9694,22 +8836,13 @@ int32_t lsm6dso_sh_pass_through_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
+  reg.pass_through_mode = val;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
 
-  if (ret == 0)
-  {
-    reg.pass_through_mode = val;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -9729,17 +8862,12 @@ int32_t lsm6dso_sh_pass_through_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
+  *val = reg.pass_through_mode;
 
-  if (ret == 0)
-  {
-    *val = reg.pass_through_mode;
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -9759,22 +8887,13 @@ int32_t lsm6dso_sh_syncro_mode_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
+  reg.start_config = (uint8_t)val;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
 
-  if (ret == 0)
-  {
-    reg.start_config = (uint8_t)val;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -9794,31 +8913,26 @@ int32_t lsm6dso_sh_syncro_mode_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
+
+  switch (reg.start_config)
   {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
+    case LSM6DSO_EXT_ON_INT2_PIN:
+      *val = LSM6DSO_EXT_ON_INT2_PIN;
+      break;
+
+    case LSM6DSO_XL_GY_DRDY:
+      *val = LSM6DSO_XL_GY_DRDY;
+      break;
+
+    default:
+      *val = LSM6DSO_EXT_ON_INT2_PIN;
+      break;
   }
 
-  if (ret == 0)
-  {
-    switch (reg.start_config)
-    {
-      case LSM6DSO_EXT_ON_INT2_PIN:
-        *val = LSM6DSO_EXT_ON_INT2_PIN;
-        break;
-
-      case LSM6DSO_XL_GY_DRDY:
-        *val = LSM6DSO_XL_GY_DRDY;
-        break;
-
-      default:
-        *val = LSM6DSO_EXT_ON_INT2_PIN;
-        break;
-    }
-
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -9839,22 +8953,13 @@ int32_t lsm6dso_sh_write_mode_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
+  reg.write_once = (uint8_t)val;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
 
-  if (ret == 0)
-  {
-    reg.write_once = (uint8_t)val;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -9875,31 +8980,26 @@ int32_t lsm6dso_sh_write_mode_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
+
+  switch (reg.write_once)
   {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
+    case LSM6DSO_EACH_SH_CYCLE:
+      *val = LSM6DSO_EACH_SH_CYCLE;
+      break;
+
+    case LSM6DSO_ONLY_FIRST_CYCLE:
+      *val = LSM6DSO_ONLY_FIRST_CYCLE;
+      break;
+
+    default:
+      *val = LSM6DSO_EACH_SH_CYCLE;
+      break;
   }
 
-  if (ret == 0)
-  {
-    switch (reg.write_once)
-    {
-      case LSM6DSO_EACH_SH_CYCLE:
-        *val = LSM6DSO_EACH_SH_CYCLE;
-        break;
-
-      case LSM6DSO_ONLY_FIRST_CYCLE:
-        *val = LSM6DSO_ONLY_FIRST_CYCLE;
-        break;
-
-      default:
-        *val = LSM6DSO_EACH_SH_CYCLE;
-        break;
-    }
-
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -9917,28 +9017,17 @@ int32_t lsm6dso_sh_reset_set(stmdev_ctx_t *ctx)
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
+  reg.rst_master_regs = PROPERTY_ENABLE;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    reg.rst_master_regs = PROPERTY_ENABLE;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
-  }
+  reg.rst_master_regs = PROPERTY_DISABLE;
+  ret = lsm6dso_write_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
 
-  if (ret == 0)
-  {
-    reg.rst_master_regs = PROPERTY_DISABLE;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -9957,17 +9046,12 @@ int32_t lsm6dso_sh_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t *)&reg, 1);
+  *val = reg.rst_master_regs;
 
-  if (ret == 0)
-  {
-    *val = reg.rst_master_regs;
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -9987,22 +9071,13 @@ int32_t lsm6dso_sh_data_rate_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV0_CONFIG, (uint8_t *)&reg, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV0_CONFIG, (uint8_t *)&reg, 1);
+  reg.shub_odr = (uint8_t)val;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_SLV0_CONFIG, (uint8_t *)&reg, 1);
 
-  if (ret == 0)
-  {
-    reg.shub_odr = (uint8_t)val;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV0_CONFIG, (uint8_t *)&reg, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -10022,39 +9097,34 @@ int32_t lsm6dso_sh_data_rate_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV0_CONFIG, (uint8_t *)&reg, 1);
+
+  switch (reg.shub_odr)
   {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV0_CONFIG, (uint8_t *)&reg, 1);
+    case LSM6DSO_SH_ODR_104Hz:
+      *val = LSM6DSO_SH_ODR_104Hz;
+      break;
+
+    case LSM6DSO_SH_ODR_52Hz:
+      *val = LSM6DSO_SH_ODR_52Hz;
+      break;
+
+    case LSM6DSO_SH_ODR_26Hz:
+      *val = LSM6DSO_SH_ODR_26Hz;
+      break;
+
+    case LSM6DSO_SH_ODR_13Hz:
+      *val = LSM6DSO_SH_ODR_13Hz;
+      break;
+
+    default:
+      *val = LSM6DSO_SH_ODR_104Hz;
+      break;
   }
 
-  if (ret == 0)
-  {
-    switch (reg.shub_odr)
-    {
-      case LSM6DSO_SH_ODR_104Hz:
-        *val = LSM6DSO_SH_ODR_104Hz;
-        break;
-
-      case LSM6DSO_SH_ODR_52Hz:
-        *val = LSM6DSO_SH_ODR_52Hz;
-        break;
-
-      case LSM6DSO_SH_ODR_26Hz:
-        *val = LSM6DSO_SH_ODR_26Hz;
-        break;
-
-      case LSM6DSO_SH_ODR_13Hz:
-        *val = LSM6DSO_SH_ODR_13Hz;
-        break;
-
-      default:
-        *val = LSM6DSO_SH_ODR_104Hz;
-        break;
-    }
-
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -10077,36 +9147,26 @@ int32_t lsm6dso_sh_cfg_write(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    reg.slave0 = val->slv0_add;
-    reg.rw_0 = 0;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV0_ADD, (uint8_t *)&reg, 1);
-  }
+  reg.slave0 = val->slv0_add;
+  reg.rw_0 = 0;
+  ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV0_ADD, (uint8_t *)&reg, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV0_SUBADD,
-                            &(val->slv0_subadd), 1);
-  }
+  ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV0_SUBADD, &(val->slv0_subadd), 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_DATAWRITE_SLV0,
-                            &(val->slv0_data), 1);
-  }
+  ret = lsm6dso_write_reg(ctx, LSM6DSO_DATAWRITE_SLV0, &(val->slv0_data), 1);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+exit:
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
 
 /**
-  * @brief  Configure slave 0 for perform a read.[set]
+  * @brief  Configure slave idx to perform a read.[set]
   *
   * @param  ctx      read / write interface definitions
   * @param  val      Structure that contain
@@ -10116,7 +9176,7 @@ int32_t lsm6dso_sh_cfg_write(stmdev_ctx_t *ctx,
   * @retval             interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dso_sh_slv0_cfg_read(stmdev_ctx_t *ctx,
+int32_t lsm6dso_sh_slv_cfg_read(stmdev_ctx_t *ctx, uint8_t idx,
                                  lsm6dso_sh_cfg_read_t *val)
 {
   lsm6dso_slv0_add_t slv0_add;
@@ -10124,199 +9184,22 @@ int32_t lsm6dso_sh_slv0_cfg_read(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    slv0_add.slave0 = val->slv_add;
-    slv0_add.rw_0 = 1;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV0_ADD, (uint8_t *)&slv0_add, 1);
-  }
+  slv0_add.slave0 = val->slv_add;
+  slv0_add.rw_0 = 1;
+  ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV0_ADD + idx*3U, (uint8_t *)&slv0_add, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV0_SUBADD,
-                            &(val->slv_subadd), 1);
-  }
+  ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV0_SUBADD + idx*3U, &(val->slv_subadd), 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV0_CONFIG,
-                           (uint8_t *)&slv0_config, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV0_CONFIG + idx*3U, (uint8_t *)&slv0_config, 1);
+  slv0_config.slave0_numop = val->slv_len;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_SLV0_CONFIG + idx*3U, (uint8_t *)&slv0_config, 1);
 
-  if (ret == 0)
-  {
-    slv0_config.slave0_numop = val->slv_len;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV0_CONFIG,
-                            (uint8_t *)&slv0_config, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
-
-  return ret;
-}
-
-/**
-  * @brief  Configure slave 0 for perform a write/read.[set]
-  *
-  * @param  ctx      read / write interface definitions
-  * @param  val      Structure that contain
-  *                      - uint8_t slv1_add;    8 bit i2c device address
-  *                      - uint8_t slv1_subadd; 8 bit register device address
-  *                      - uint8_t slv1_len;    num of bit to read
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
-  *
-  */
-int32_t lsm6dso_sh_slv1_cfg_read(stmdev_ctx_t *ctx,
-                                 lsm6dso_sh_cfg_read_t *val)
-{
-  lsm6dso_slv1_add_t slv1_add;
-  lsm6dso_slv1_config_t slv1_config;
-  int32_t ret;
-
-  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
-
-  if (ret == 0)
-  {
-    slv1_add.slave1_add = val->slv_add;
-    slv1_add.r_1 = 1;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV1_ADD, (uint8_t *)&slv1_add, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV1_SUBADD,
-                            &(val->slv_subadd), 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV1_CONFIG,
-                           (uint8_t *)&slv1_config, 1);
-  }
-
-  if (ret == 0)
-  {
-    slv1_config.slave1_numop = val->slv_len;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV1_CONFIG,
-                            (uint8_t *)&slv1_config, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
-
-  return ret;
-}
-
-/**
-  * @brief  Configure slave 0 for perform a write/read.[set]
-  *
-  * @param  ctx      read / write interface definitions
-  * @param  val      Structure that contain
-  *                      - uint8_t slv2_add;    8 bit i2c device address
-  *                      - uint8_t slv2_subadd; 8 bit register device address
-  *                      - uint8_t slv2_len;    num of bit to read
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
-  *
-  */
-int32_t lsm6dso_sh_slv2_cfg_read(stmdev_ctx_t *ctx,
-                                 lsm6dso_sh_cfg_read_t *val)
-{
-  lsm6dso_slv2_add_t slv2_add;
-  lsm6dso_slv2_config_t slv2_config;
-  int32_t ret;
-
-  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
-
-  if (ret == 0)
-  {
-    slv2_add.slave2_add = val->slv_add;
-    slv2_add.r_2 = 1;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV2_ADD, (uint8_t *)&slv2_add, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV2_SUBADD,
-                            &(val->slv_subadd), 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV2_CONFIG,
-                           (uint8_t *)&slv2_config, 1);
-  }
-
-  if (ret == 0)
-  {
-    slv2_config.slave2_numop = val->slv_len;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV2_CONFIG,
-                            (uint8_t *)&slv2_config, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
-
-  return ret;
-}
-
-/**
-  * @brief Configure slave 0 for perform a write/read.[set]
-  *
-  * @param  ctx      read / write interface definitions
-  * @param  val      Structure that contain
-  *                      - uint8_t slv3_add;    8 bit i2c device address
-  *                      - uint8_t slv3_subadd; 8 bit register device address
-  *                      - uint8_t slv3_len;    num of bit to read
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
-  *
-  */
-int32_t lsm6dso_sh_slv3_cfg_read(stmdev_ctx_t *ctx,
-                                 lsm6dso_sh_cfg_read_t *val)
-{
-  lsm6dso_slv3_add_t slv3_add;
-  lsm6dso_slv3_config_t slv3_config;
-  int32_t ret;
-
-  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
-
-  if (ret == 0)
-  {
-    slv3_add.slave3_add = val->slv_add;
-    slv3_add.r_3 = 1;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV3_ADD, (uint8_t *)&slv3_add, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV3_SUBADD,
-                            &(val->slv_subadd), 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV3_CONFIG,
-                           (uint8_t *)&slv3_config, 1);
-  }
-
-  if (ret == 0)
-  {
-    slv3_config.slave3_numop = val->slv_len;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV3_CONFIG,
-                            (uint8_t *)&slv3_config, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+exit:
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -10326,7 +9209,7 @@ int32_t lsm6dso_sh_slv3_cfg_read(stmdev_ctx_t *ctx,
   *
   * @param  ctx      read / write interface definitions
   * @param  val      union of registers from STATUS_MASTER to
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
 int32_t lsm6dso_sh_status_get(stmdev_ctx_t *ctx,
@@ -10334,17 +9217,7 @@ int32_t lsm6dso_sh_status_get(stmdev_ctx_t *ctx,
 {
   int32_t ret;
 
-  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_STATUS_MASTER, (uint8_t *) val, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_STATUS_MASTER_MAINPAGE, (uint8_t *) val, 1);
 
   return ret;
 }
@@ -10381,17 +9254,12 @@ int32_t lsm6dso_id_get(stmdev_ctx_t *ctx, stmdev_ctx_t *aux_ctx,
 
   if (ctx != NULL)
   {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_WHO_AM_I,
-                           (uint8_t *) & (val->ui), 1);
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_WHO_AM_I, (uint8_t *) & (val->ui), 1);
   }
 
   if (aux_ctx != NULL)
   {
-    if (ret == 0)
-    {
-      ret = lsm6dso_read_reg(aux_ctx, LSM6DSO_WHO_AM_I,
-                             (uint8_t *) & (val->aux), 1);
-    }
+    ret += lsm6dso_read_reg(aux_ctx, LSM6DSO_WHO_AM_I, (uint8_t *) & (val->aux), 1);
   }
 
   return ret;
@@ -10416,53 +9284,25 @@ int32_t lsm6dso_init_set(stmdev_ctx_t *ctx, lsm6dso_init_t val)
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_INIT_B,
-                           (uint8_t *)&emb_func_init_b, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_INIT_B, (uint8_t *)&emb_func_init_b, 1);
+  emb_func_init_b.fifo_compr_init = (uint8_t)val & ((uint8_t)LSM6DSO_FIFO_COMP >> 2);
+  emb_func_init_b.fsm_init = (uint8_t)val & ((uint8_t)LSM6DSO_FSM >> 3);
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_INIT_B, (uint8_t *)&emb_func_init_b, 1);
 
-  if (ret == 0)
-  {
-    emb_func_init_b.fifo_compr_init = (uint8_t)val
-                                      & ((uint8_t)LSM6DSO_FIFO_COMP >> 2);
-    emb_func_init_b.fsm_init = (uint8_t)val
-                               & ((uint8_t)LSM6DSO_FSM >> 3);
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_INIT_B,
-                            (uint8_t *)&emb_func_init_b, 1);
-  }
+  ret += lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_INIT_A, (uint8_t *)&emb_func_init_a, 1);
+  emb_func_init_a.step_det_init = ((uint8_t)val & (uint8_t)LSM6DSO_PEDO) >> 5;
+  emb_func_init_a.tilt_init = ((uint8_t)val & (uint8_t)LSM6DSO_TILT) >> 6;
+  emb_func_init_a.sig_mot_init = ((uint8_t)val & (uint8_t)LSM6DSO_SMOTION) >> 7;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_INIT_A, (uint8_t *)&emb_func_init_a, 1);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_INIT_A,
-                           (uint8_t *)&emb_func_init_a, 1);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    emb_func_init_a.step_det_init = ((uint8_t)val
-                                     & (uint8_t)LSM6DSO_PEDO) >> 5;
-    emb_func_init_a.tilt_init = ((uint8_t)val
-                                 & (uint8_t)LSM6DSO_TILT) >> 6;
-    emb_func_init_a.sig_mot_init = ((uint8_t)val
-                                    & (uint8_t)LSM6DSO_SMOTION) >> 7;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_INIT_A,
-                            (uint8_t *)&emb_func_init_a, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
-  }
-
-  if (((val == LSM6DSO_BOOT) || (val == LSM6DSO_RESET)) &&
-      (ret == 0))
+  if (((val == LSM6DSO_BOOT) || (val == LSM6DSO_RESET)) && (ret == 0))
   {
     ctrl3_c.boot = (uint8_t)val & (uint8_t)LSM6DSO_BOOT;
     ctrl3_c.sw_reset = ((uint8_t)val & (uint8_t)LSM6DSO_RESET) >> 1;
@@ -10767,37 +9607,19 @@ int32_t lsm6dso_pin_conf_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_read_reg(ctx, LSM6DSO_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  pin_ctrl.ois_pu_dis = ~val.aux_sdo_ocs_pull_up;
+  pin_ctrl.sdo_pu_en  = val.sdo_sa0_pull_up;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    pin_ctrl.ois_pu_dis = ~val.aux_sdo_ocs_pull_up;
-    pin_ctrl.sdo_pu_en  = val.sdo_sa0_pull_up;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ctrl3_c.pp_od = ~val.int1_int2_push_pull;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
-  }
-
-  if (ret == 0)
-  {
-    ctrl3_c.pp_od = ~val.int1_int2_push_pull;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_I3C_BUS_AVB,
-                           (uint8_t *)&i3c_bus_avb, 1);
-  }
-
-  if (ret == 0)
-  {
-    i3c_bus_avb.pd_dis_int1 = ~val.int1_pull_down;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_I3C_BUS_AVB,
-                            (uint8_t *)&i3c_bus_avb, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_I3C_BUS_AVB, (uint8_t *)&i3c_bus_avb, 1);
+  i3c_bus_avb.pd_dis_int1 = ~val.int1_pull_down;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_I3C_BUS_AVB, (uint8_t *)&i3c_bus_avb, 1);
 
   return ret;
 }
@@ -10820,25 +9642,18 @@ int32_t lsm6dso_pin_conf_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_read_reg(ctx, LSM6DSO_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    val->aux_sdo_ocs_pull_up = ~pin_ctrl.ois_pu_dis;
-    val->aux_sdo_ocs_pull_up =  pin_ctrl.sdo_pu_en;
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
-  }
+  val->aux_sdo_ocs_pull_up = ~pin_ctrl.ois_pu_dis;
+  val->aux_sdo_ocs_pull_up =  pin_ctrl.sdo_pu_en;
 
-  if (ret == 0)
-  {
-    val->int1_int2_push_pull = ~ctrl3_c.pp_od;
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_I3C_BUS_AVB,
-                           (uint8_t *)&i3c_bus_avb, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    val->int1_pull_down = ~i3c_bus_avb.pd_dis_int1;
-  }
+  val->int1_int2_push_pull = ~ctrl3_c.pp_od;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_I3C_BUS_AVB, (uint8_t *)&i3c_bus_avb, 1);
+  val->int1_pull_down = ~i3c_bus_avb.pd_dis_int1;
 
   return ret;
 }
@@ -10860,45 +9675,24 @@ int32_t lsm6dso_interrupt_mode_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ctrl3_c.h_lactive = val.active_low;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ctrl3_c.h_lactive = val.active_low;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG0, (uint8_t *) &tap_cfg0, 1);
+  tap_cfg0.lir = val.base_latched;
+  tap_cfg0.int_clr_on_read = val.base_latched | val.emb_latched;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_TAP_CFG0, (uint8_t *) &tap_cfg0, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG0, (uint8_t *) &tap_cfg0, 1);
-  }
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    tap_cfg0.lir = val.base_latched;
-    tap_cfg0.int_clr_on_read = val.base_latched | val.emb_latched;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_TAP_CFG0, (uint8_t *) &tap_cfg0, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
+  page_rw.emb_func_lir = val.emb_latched;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
-  }
-
-  if (ret == 0)
-  {
-    page_rw.emb_func_lir = val.emb_latched;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -10920,33 +9714,22 @@ int32_t lsm6dso_interrupt_mode_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    val->active_low = ctrl3_c.h_lactive;
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG0, (uint8_t *) &tap_cfg0, 1);
-  }
+  val->active_low = ctrl3_c.h_lactive;
 
-  if (ret == 0)
-  {
-    val->base_latched = (tap_cfg0.lir & tap_cfg0.int_clr_on_read);
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG0, (uint8_t *) &tap_cfg0, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
-  }
+  val->base_latched = (tap_cfg0.lir & tap_cfg0.int_clr_on_read);
 
-  if (ret == 0)
-  {
-    val->emb_latched = (page_rw.emb_func_lir & tap_cfg0.int_clr_on_read);
-  }
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t *) &page_rw, 1);
+  val->emb_latched = (page_rw.emb_func_lir & tap_cfg0.int_clr_on_read);
+
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -10966,13 +9749,15 @@ int32_t lsm6dso_pin_int1_route_set(stmdev_ctx_t *ctx,
   lsm6dso_emb_func_int1_t   emb_func_int1;
   lsm6dso_fsm_int1_a_t      fsm_int1_a;
   lsm6dso_fsm_int1_b_t      fsm_int1_b;
-  lsm6dso_int1_ctrl_t       int1_ctrl;
+  lsm6dso_int1_ctrl_t       int1_ctrl = {0};
   lsm6dso_int2_ctrl_t       int2_ctrl;
   lsm6dso_tap_cfg2_t        tap_cfg2;
   lsm6dso_md2_cfg_t         md2_cfg;
   lsm6dso_md1_cfg_t         md1_cfg;
   lsm6dso_ctrl4_c_t         ctrl4_c;
   int32_t                    ret;
+
+  /* INT1_CTRL */
   int1_ctrl.int1_drdy_xl   = val.drdy_xl;
   int1_ctrl.int1_drdy_g    = val.drdy_g;
   int1_ctrl.int1_boot      = val.boot;
@@ -10981,13 +9766,36 @@ int32_t lsm6dso_pin_int1_route_set(stmdev_ctx_t *ctx,
   int1_ctrl.int1_fifo_full = val.fifo_full;
   int1_ctrl.int1_cnt_bdr   = val.fifo_bdr;
   int1_ctrl.den_drdy_flag  = val.den_flag;
-  md1_cfg.int1_shub         = val.sh_endop;
-  md1_cfg.int1_6d           = val.six_d;
-  md1_cfg.int1_double_tap   = val.double_tap;
-  md1_cfg.int1_ff           = val.free_fall;
-  md1_cfg.int1_wu           = val.wake_up;
-  md1_cfg.int1_single_tap   = val.single_tap;
-  md1_cfg.int1_sleep_change = val.sleep_change;
+  ret = lsm6dso_write_reg(ctx, LSM6DSO_INT1_CTRL, (uint8_t *)&int1_ctrl, 1);
+  if (ret != 0) { return ret; }
+
+  /* DRDY for temperature and/or timestamp */
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+  if (ret != 0) { return ret; }
+
+  if ((val.drdy_temp | val.timestamp) != PROPERTY_DISABLE)
+  {
+    ctrl4_c.int2_on_int1 = PROPERTY_ENABLE;
+  }
+  else
+  {
+    ctrl4_c.int2_on_int1 = PROPERTY_DISABLE;
+  }
+
+  ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+  if (ret != 0) { return ret; }
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
+  int2_ctrl.int2_drdy_temp = val.drdy_temp;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
+  if (ret != 0) { return ret; }
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  md2_cfg.int2_timestamp = val.timestamp;
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  if (ret != 0) { return ret; }
+
+  /* emmbedded and FSM events */
   emb_func_int1.not_used_01 = 0;
   emb_func_int1.int1_step_detector = val.step_detector;
   emb_func_int1.int1_tilt          = val.tilt;
@@ -11010,164 +9818,99 @@ int32_t lsm6dso_pin_int1_route_set(stmdev_ctx_t *ctx,
   fsm_int1_b.int1_fsm14 = val.fsm14;
   fsm_int1_b.int1_fsm15 = val.fsm15;
   fsm_int1_b.int1_fsm16 = val.fsm16;
-  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
 
-  if (ret == 0)
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret != 0) { return ret; }
+
+  ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_INT1, (uint8_t *)&emb_func_int1, 1);
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_FSM_INT1_A, (uint8_t *)&fsm_int1_a, 1);
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_FSM_INT1_B, (uint8_t *)&fsm_int1_b, 1);
+
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  if (ret != 0) { return ret; }
+
+  /* MD1_CFG */
+  md1_cfg.int1_shub         = val.sh_endop;
+  md1_cfg.int1_6d           = val.six_d;
+  md1_cfg.int1_double_tap   = val.double_tap;
+  md1_cfg.int1_ff           = val.free_fall;
+  md1_cfg.int1_wu           = val.wake_up;
+  md1_cfg.int1_single_tap   = val.single_tap;
+  md1_cfg.int1_sleep_change = val.sleep_change;
+
+  if ((emb_func_int1.int1_fsm_lc
+       | emb_func_int1.int1_sig_mot
+       | emb_func_int1.int1_step_detector
+       | emb_func_int1.int1_tilt
+       | fsm_int1_a.int1_fsm1
+       | fsm_int1_a.int1_fsm2
+       | fsm_int1_a.int1_fsm3
+       | fsm_int1_a.int1_fsm4
+       | fsm_int1_a.int1_fsm5
+       | fsm_int1_a.int1_fsm6
+       | fsm_int1_a.int1_fsm7
+       | fsm_int1_a.int1_fsm8
+       | fsm_int1_b.int1_fsm9
+       | fsm_int1_b.int1_fsm10
+       | fsm_int1_b.int1_fsm11
+       | fsm_int1_b.int1_fsm12
+       | fsm_int1_b.int1_fsm13
+       | fsm_int1_b.int1_fsm14
+       | fsm_int1_b.int1_fsm15
+       | fsm_int1_b.int1_fsm16) != PROPERTY_DISABLE)
   {
-    if ((val.drdy_temp | val.timestamp) != PROPERTY_DISABLE)
-    {
-      ctrl4_c.int2_on_int1 = PROPERTY_ENABLE;
-    }
-
-    else
-    {
-      ctrl4_c.int2_on_int1 = PROPERTY_DISABLE;
-    }
-
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+    md1_cfg.int1_emb_func = PROPERTY_ENABLE;
+  }
+  else
+  {
+    md1_cfg.int1_emb_func = PROPERTY_DISABLE;
   }
 
-  if (ret == 0)
+  ret = lsm6dso_write_reg(ctx, LSM6DSO_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  if (ret != 0) { return ret; }
+
+  /* set interrupts_enable = 1 in TAP_CFG2 if it is the case */
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG2, (uint8_t *) &tap_cfg2, 1);
+  ret += lsm6dso_pin_int2_route_get(ctx, NULL, &pin_int2_route);
+  if (ret != 0) { return ret; }
+
+  if ((pin_int2_route.fifo_bdr
+       | pin_int2_route.drdy_g
+       | pin_int2_route.drdy_temp
+       | pin_int2_route.drdy_xl
+       | pin_int2_route.fifo_full
+       | pin_int2_route.fifo_ovr
+       | pin_int2_route.fifo_th
+       | pin_int2_route.six_d
+       | pin_int2_route.double_tap
+       | pin_int2_route.free_fall
+       | pin_int2_route.wake_up
+       | pin_int2_route.single_tap
+       | pin_int2_route.sleep_change
+       | int1_ctrl.den_drdy_flag
+       | int1_ctrl.int1_boot
+       | int1_ctrl.int1_cnt_bdr
+       | int1_ctrl.int1_drdy_g
+       | int1_ctrl.int1_drdy_xl
+       | int1_ctrl.int1_fifo_full
+       | int1_ctrl.int1_fifo_ovr
+       | int1_ctrl.int1_fifo_th
+       | md1_cfg.int1_shub
+       | md1_cfg.int1_6d
+       | md1_cfg.int1_double_tap
+       | md1_cfg.int1_ff
+       | md1_cfg.int1_wu
+       | md1_cfg.int1_single_tap
+       | md1_cfg.int1_sleep_change) != PROPERTY_DISABLE)
   {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+    tap_cfg2.interrupts_enable = PROPERTY_ENABLE;
+  }
+  else
+  {
+    tap_cfg2.interrupts_enable = PROPERTY_DISABLE;
   }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_INT1,
-                            (uint8_t *)&emb_func_int1, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_FSM_INT1_A,
-                            (uint8_t *)&fsm_int1_a, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_FSM_INT1_B,
-                            (uint8_t *)&fsm_int1_b, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
-
-  if (ret == 0)
-  {
-    if ((emb_func_int1.int1_fsm_lc
-         | emb_func_int1.int1_sig_mot
-         | emb_func_int1.int1_step_detector
-         | emb_func_int1.int1_tilt
-         | fsm_int1_a.int1_fsm1
-         | fsm_int1_a.int1_fsm2
-         | fsm_int1_a.int1_fsm3
-         | fsm_int1_a.int1_fsm4
-         | fsm_int1_a.int1_fsm5
-         | fsm_int1_a.int1_fsm6
-         | fsm_int1_a.int1_fsm7
-         | fsm_int1_a.int1_fsm8
-         | fsm_int1_b.int1_fsm9
-         | fsm_int1_b.int1_fsm10
-         | fsm_int1_b.int1_fsm11
-         | fsm_int1_b.int1_fsm12
-         | fsm_int1_b.int1_fsm13
-         | fsm_int1_b.int1_fsm14
-         | fsm_int1_b.int1_fsm15
-         | fsm_int1_b.int1_fsm16) != PROPERTY_DISABLE)
-    {
-      md1_cfg.int1_emb_func = PROPERTY_ENABLE;
-    }
-
-    else
-    {
-      md1_cfg.int1_emb_func = PROPERTY_DISABLE;
-    }
-
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_INT1_CTRL,
-                            (uint8_t *)&int1_ctrl, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_MD1_CFG, (uint8_t *)&md1_cfg, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
-  }
-
-  if (ret == 0)
-  {
-    int2_ctrl.int2_drdy_temp = val.drdy_temp;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_MD2_CFG, (uint8_t *)&md2_cfg, 1);
-  }
-
-  if (ret == 0)
-  {
-    md2_cfg.int2_timestamp = val.timestamp;
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_MD2_CFG, (uint8_t *)&md2_cfg, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG2, (uint8_t *) &tap_cfg2, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_pin_int2_route_get(ctx, NULL, &pin_int2_route);
-  }
-
-  if (ret == 0)
-  {
-    if ((pin_int2_route.fifo_bdr
-         | pin_int2_route.drdy_g
-         | pin_int2_route.drdy_temp
-         | pin_int2_route.drdy_xl
-         | pin_int2_route.fifo_full
-         | pin_int2_route.fifo_ovr
-         | pin_int2_route.fifo_th
-         | pin_int2_route.six_d
-         | pin_int2_route.double_tap
-         | pin_int2_route.free_fall
-         | pin_int2_route.wake_up
-         | pin_int2_route.single_tap
-         | pin_int2_route.sleep_change
-         | int1_ctrl.den_drdy_flag
-         | int1_ctrl.int1_boot
-         | int1_ctrl.int1_cnt_bdr
-         | int1_ctrl.int1_drdy_g
-         | int1_ctrl.int1_drdy_xl
-         | int1_ctrl.int1_fifo_full
-         | int1_ctrl.int1_fifo_ovr
-         | int1_ctrl.int1_fifo_th
-         | md1_cfg.int1_shub
-         | md1_cfg.int1_6d
-         | md1_cfg.int1_double_tap
-         | md1_cfg.int1_ff
-         | md1_cfg.int1_wu
-         | md1_cfg.int1_single_tap
-         | md1_cfg.int1_sleep_change) != PROPERTY_DISABLE)
-    {
-      tap_cfg2.interrupts_enable = PROPERTY_ENABLE;
-    }
-
-    else
-    {
-      tap_cfg2.interrupts_enable = PROPERTY_DISABLE;
-    }
-
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_TAP_CFG2, (uint8_t *) &tap_cfg2, 1);
-  }
+  ret = lsm6dso_write_reg(ctx, LSM6DSO_TAP_CFG2, (uint8_t *) &tap_cfg2, 1);
 
   return ret;
 }
@@ -11192,67 +9935,40 @@ int32_t lsm6dso_pin_int1_route_get(stmdev_ctx_t *ctx,
   lsm6dso_md1_cfg_t         md1_cfg;
   lsm6dso_ctrl4_c_t         ctrl4_c;
   int32_t                    ret;
+
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_INT1,
-                           (uint8_t *)&emb_func_int1, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_INT1, (uint8_t *)&emb_func_int1, 1);
+  ret += lsm6dso_read_reg(ctx, LSM6DSO_FSM_INT1_A, (uint8_t *)&fsm_int1_a, 1);
+  ret += lsm6dso_read_reg(ctx, LSM6DSO_FSM_INT1_B, (uint8_t *)&fsm_int1_b, 1);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_FSM_INT1_A,
-                           (uint8_t *)&fsm_int1_a, 1);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_FSM_INT1_B,
-                           (uint8_t *)&fsm_int1_b, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_INT1_CTRL, (uint8_t *)&int1_ctrl, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_INT1_CTRL,
-                           (uint8_t *)&int1_ctrl, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_MD1_CFG, (uint8_t *)&md1_cfg, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+  if (ret != 0) { return ret; }
 
   if (ctrl4_c.int2_on_int1 == PROPERTY_ENABLE)
   {
-    if (ret == 0)
-    {
-      ret = lsm6dso_read_reg(ctx, LSM6DSO_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
-      val->drdy_temp = int2_ctrl.int2_drdy_temp;
-    }
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
+    val->drdy_temp = int2_ctrl.int2_drdy_temp;
 
-    if (ret == 0)
-    {
-      ret = lsm6dso_read_reg(ctx, LSM6DSO_MD2_CFG, (uint8_t *)&md2_cfg, 1);
-      val->timestamp = md2_cfg.int2_timestamp;
-    }
+    ret += lsm6dso_read_reg(ctx, LSM6DSO_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+    val->timestamp = md2_cfg.int2_timestamp;
   }
-
   else
   {
     val->drdy_temp = PROPERTY_DISABLE;
     val->timestamp = PROPERTY_DISABLE;
   }
+  if (ret != 0) { return ret; }
 
   val->drdy_xl   = int1_ctrl.int1_drdy_xl;
   val->drdy_g    = int1_ctrl.int1_drdy_g;
@@ -11322,15 +10038,10 @@ int32_t lsm6dso_pin_int2_route_set(stmdev_ctx_t *ctx,
 
   if (aux_ctx != NULL)
   {
-    ret = lsm6dso_read_reg(aux_ctx, LSM6DSO_INT_OIS,
-                           (uint8_t *)&int_ois, 1);
-
-    if (ret == 0)
-    {
-      int_ois.int2_drdy_ois = val.drdy_ois;
-      ret = lsm6dso_write_reg(aux_ctx, LSM6DSO_INT_OIS,
-                              (uint8_t *)&int_ois, 1);
-    }
+    ret = lsm6dso_read_reg(aux_ctx, LSM6DSO_INT_OIS, (uint8_t *)&int_ois, 1);
+    int_ois.int2_drdy_ois = val.drdy_ois;
+    ret += lsm6dso_write_reg(aux_ctx, LSM6DSO_INT_OIS, (uint8_t *)&int_ois, 1);
+    if (ret != 0) { return ret; }
   }
 
   if (ctx != NULL)
@@ -11343,6 +10054,9 @@ int32_t lsm6dso_pin_int2_route_set(stmdev_ctx_t *ctx,
     int2_ctrl.int2_fifo_full = val.fifo_full;
     int2_ctrl.int2_cnt_bdr   = val.fifo_bdr;
     int2_ctrl.not_used_01    = 0;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
+    if (ret != 0) { return ret; }
+
     md2_cfg.int2_timestamp    = val.timestamp;
     md2_cfg.int2_6d           = val.six_d;
     md2_cfg.int2_double_tap   = val.double_tap;
@@ -11373,139 +10087,95 @@ int32_t lsm6dso_pin_int2_route_set(stmdev_ctx_t *ctx,
     fsm_int2_b.int2_fsm15 = val.fsm15;
     fsm_int2_b.int2_fsm16 = val.fsm16;
 
-    if (ret == 0)
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+
+    if ((val.drdy_temp | val.timestamp) != PROPERTY_DISABLE)
     {
-      ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
-
-      if (ret == 0)
-      {
-        if ((val.drdy_temp | val.timestamp) != PROPERTY_DISABLE)
-        {
-          ctrl4_c.int2_on_int1 = PROPERTY_DISABLE;
-        }
-
-        ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
-      }
+      ctrl4_c.int2_on_int1 = PROPERTY_DISABLE;
     }
 
-    if (ret == 0)
+    ret += lsm6dso_write_reg(ctx, LSM6DSO_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+    if (ret != 0) { return ret; }
+
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+
+    ret += lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_INT2, (uint8_t *)&emb_func_int2, 1);
+    ret += lsm6dso_write_reg(ctx, LSM6DSO_FSM_INT2_A, (uint8_t *)&fsm_int2_a, 1);
+    ret += lsm6dso_write_reg(ctx, LSM6DSO_FSM_INT2_B, (uint8_t *)&fsm_int2_b, 1);
+
+    ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+    if (ret != 0) { return ret; }
+
+    if ((emb_func_int2.int2_fsm_lc
+         | emb_func_int2.int2_sig_mot
+         | emb_func_int2.int2_step_detector
+         | emb_func_int2.int2_tilt
+         | fsm_int2_a.int2_fsm1
+         | fsm_int2_a.int2_fsm2
+         | fsm_int2_a.int2_fsm3
+         | fsm_int2_a.int2_fsm4
+         | fsm_int2_a.int2_fsm5
+         | fsm_int2_a.int2_fsm6
+         | fsm_int2_a.int2_fsm7
+         | fsm_int2_a.int2_fsm8
+         | fsm_int2_b.int2_fsm9
+         | fsm_int2_b.int2_fsm10
+         | fsm_int2_b.int2_fsm11
+         | fsm_int2_b.int2_fsm12
+         | fsm_int2_b.int2_fsm13
+         | fsm_int2_b.int2_fsm14
+         | fsm_int2_b.int2_fsm15
+         | fsm_int2_b.int2_fsm16) != PROPERTY_DISABLE)
     {
-      ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+      md2_cfg.int2_emb_func = PROPERTY_ENABLE;
+    }
+    else
+    {
+      md2_cfg.int2_emb_func = PROPERTY_DISABLE;
     }
 
-    if (ret == 0)
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+    if (ret != 0) { return ret; }
+
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG2, (uint8_t *) &tap_cfg2, 1);
+    ret += lsm6dso_pin_int1_route_get(ctx, &pin_int1_route);
+
+    if ((val.fifo_bdr
+         | val.drdy_g
+         | val.drdy_temp
+         | val.drdy_xl
+         | val.fifo_full
+         | val.fifo_ovr
+         | val.fifo_th
+         | val.six_d
+         | val.double_tap
+         | val.free_fall
+         | val.wake_up
+         | val.single_tap
+         | val.sleep_change
+         | pin_int1_route.den_flag
+         | pin_int1_route.boot
+         | pin_int1_route.fifo_bdr
+         | pin_int1_route.drdy_g
+         | pin_int1_route.drdy_xl
+         | pin_int1_route.fifo_full
+         | pin_int1_route.fifo_ovr
+         | pin_int1_route.fifo_th
+         | pin_int1_route.six_d
+         | pin_int1_route.double_tap
+         | pin_int1_route.free_fall
+         | pin_int1_route.wake_up
+         | pin_int1_route.single_tap
+         | pin_int1_route.sleep_change) != PROPERTY_DISABLE)
     {
-      ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_INT2,
-                              (uint8_t *)&emb_func_int2, 1);
+      tap_cfg2.interrupts_enable = PROPERTY_ENABLE;
+    }
+    else
+    {
+      tap_cfg2.interrupts_enable = PROPERTY_DISABLE;
     }
 
-    if (ret == 0)
-    {
-      ret = lsm6dso_write_reg(ctx, LSM6DSO_FSM_INT2_A,
-                              (uint8_t *)&fsm_int2_a, 1);
-    }
-
-    if (ret == 0)
-    {
-      ret = lsm6dso_write_reg(ctx, LSM6DSO_FSM_INT2_B,
-                              (uint8_t *)&fsm_int2_b, 1);
-    }
-
-    if (ret == 0)
-    {
-      ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-    }
-
-    if (ret == 0)
-    {
-      if ((emb_func_int2.int2_fsm_lc
-           | emb_func_int2.int2_sig_mot
-           | emb_func_int2.int2_step_detector
-           | emb_func_int2.int2_tilt
-           | fsm_int2_a.int2_fsm1
-           | fsm_int2_a.int2_fsm2
-           | fsm_int2_a.int2_fsm3
-           | fsm_int2_a.int2_fsm4
-           | fsm_int2_a.int2_fsm5
-           | fsm_int2_a.int2_fsm6
-           | fsm_int2_a.int2_fsm7
-           | fsm_int2_a.int2_fsm8
-           | fsm_int2_b.int2_fsm9
-           | fsm_int2_b.int2_fsm10
-           | fsm_int2_b.int2_fsm11
-           | fsm_int2_b.int2_fsm12
-           | fsm_int2_b.int2_fsm13
-           | fsm_int2_b.int2_fsm14
-           | fsm_int2_b.int2_fsm15
-           | fsm_int2_b.int2_fsm16) != PROPERTY_DISABLE)
-      {
-        md2_cfg.int2_emb_func = PROPERTY_ENABLE;
-      }
-
-      else
-      {
-        md2_cfg.int2_emb_func = PROPERTY_DISABLE;
-      }
-
-      ret = lsm6dso_write_reg(ctx, LSM6DSO_INT2_CTRL,
-                              (uint8_t *)&int2_ctrl, 1);
-    }
-
-    if (ret == 0)
-    {
-      ret = lsm6dso_write_reg(ctx, LSM6DSO_MD2_CFG, (uint8_t *)&md2_cfg, 1);
-    }
-
-    if (ret == 0)
-    {
-      ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG2, (uint8_t *) &tap_cfg2, 1);
-    }
-
-    if (ret == 0)
-    {
-      ret = lsm6dso_pin_int1_route_get(ctx, &pin_int1_route);
-    }
-
-    if (ret == 0)
-    {
-      if ((val.fifo_bdr
-           | val.drdy_g
-           | val.drdy_temp
-           | val.drdy_xl
-           | val.fifo_full
-           | val.fifo_ovr
-           | val.fifo_th
-           | val.six_d
-           | val.double_tap
-           | val.free_fall
-           | val.wake_up
-           | val.single_tap
-           | val.sleep_change
-           | pin_int1_route.den_flag
-           | pin_int1_route.boot
-           | pin_int1_route.fifo_bdr
-           | pin_int1_route.drdy_g
-           | pin_int1_route.drdy_xl
-           | pin_int1_route.fifo_full
-           | pin_int1_route.fifo_ovr
-           | pin_int1_route.fifo_th
-           | pin_int1_route.six_d
-           | pin_int1_route.double_tap
-           | pin_int1_route.free_fall
-           | pin_int1_route.wake_up
-           | pin_int1_route.single_tap
-           | pin_int1_route.sleep_change) != PROPERTY_DISABLE)
-      {
-        tap_cfg2.interrupts_enable = PROPERTY_ENABLE;
-      }
-
-      else
-      {
-        tap_cfg2.interrupts_enable = PROPERTY_DISABLE;
-      }
-
-      ret = lsm6dso_write_reg(ctx, LSM6DSO_TAP_CFG2, (uint8_t *) &tap_cfg2, 1);
-    }
+    ret += lsm6dso_write_reg(ctx, LSM6DSO_TAP_CFG2, (uint8_t *) &tap_cfg2, 1);
   }
 
   return ret;
@@ -11674,111 +10344,90 @@ int32_t lsm6dso_all_sources_get(stmdev_ctx_t *ctx,
   lsm6dso_d6d_src_t                  d6d_src;
   uint8_t                            reg[5];
   int32_t                            ret;
+
   ret = lsm6dso_read_reg(ctx, LSM6DSO_ALL_INT_SRC, reg, 5);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    bytecpy((uint8_t *)&all_int_src, &reg[0]);
-    bytecpy((uint8_t *)&wake_up_src, &reg[1]);
-    bytecpy((uint8_t *)&tap_src, &reg[2]);
-    bytecpy((uint8_t *)&d6d_src, &reg[3]);
-    bytecpy((uint8_t *)&status_reg, &reg[4]);
-    val->timestamp = all_int_src.timestamp_endcount;
-    val->wake_up_z    = wake_up_src.z_wu;
-    val->wake_up_y    = wake_up_src.y_wu;
-    val->wake_up_x    = wake_up_src.x_wu;
-    val->wake_up      = wake_up_src.wu_ia;
-    val->sleep_state  = wake_up_src.sleep_state;
-    val->free_fall    = wake_up_src.ff_ia;
-    val->sleep_change = wake_up_src.sleep_change_ia;
-    val->tap_x      = tap_src.x_tap;
-    val->tap_y      = tap_src.y_tap;
-    val->tap_z      = tap_src.z_tap;
-    val->tap_sign   = tap_src.tap_sign;
-    val->double_tap = tap_src.double_tap;
-    val->single_tap = tap_src.single_tap;
-    val->six_d_xl = d6d_src.xl;
-    val->six_d_xh = d6d_src.xh;
-    val->six_d_yl = d6d_src.yl;
-    val->six_d_yh = d6d_src.yh;
-    val->six_d_zl = d6d_src.zl;
-    val->six_d_zh = d6d_src.zh;
-    val->six_d    = d6d_src.d6d_ia;
-    val->den_flag = d6d_src.den_drdy;
-    val->drdy_xl   = status_reg.xlda;
-    val->drdy_g    = status_reg.gda;
-    val->drdy_temp = status_reg.tda;
-  }
+  bytecpy((uint8_t *)&all_int_src, &reg[0]);
+  bytecpy((uint8_t *)&wake_up_src, &reg[1]);
+  bytecpy((uint8_t *)&tap_src, &reg[2]);
+  bytecpy((uint8_t *)&d6d_src, &reg[3]);
+  bytecpy((uint8_t *)&status_reg, &reg[4]);
+  val->timestamp = all_int_src.timestamp_endcount;
+  val->wake_up_z    = wake_up_src.z_wu;
+  val->wake_up_y    = wake_up_src.y_wu;
+  val->wake_up_x    = wake_up_src.x_wu;
+  val->wake_up      = wake_up_src.wu_ia;
+  val->sleep_state  = wake_up_src.sleep_state;
+  val->free_fall    = wake_up_src.ff_ia;
+  val->sleep_change = wake_up_src.sleep_change_ia;
+  val->tap_x      = tap_src.x_tap;
+  val->tap_y      = tap_src.y_tap;
+  val->tap_z      = tap_src.z_tap;
+  val->tap_sign   = tap_src.tap_sign;
+  val->double_tap = tap_src.double_tap;
+  val->single_tap = tap_src.single_tap;
+  val->six_d_xl = d6d_src.xl;
+  val->six_d_xh = d6d_src.xh;
+  val->six_d_yl = d6d_src.yl;
+  val->six_d_yh = d6d_src.yh;
+  val->six_d_zl = d6d_src.zl;
+  val->six_d_zh = d6d_src.zh;
+  val->six_d    = d6d_src.d6d_ia;
+  val->den_flag = d6d_src.den_drdy;
+  val->drdy_xl   = status_reg.xlda;
+  val->drdy_g    = status_reg.gda;
+  val->drdy_temp = status_reg.tda;
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_STATUS_MAINPAGE, reg, 3);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_STATUS_MAINPAGE, reg, 3);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    bytecpy((uint8_t *)&emb_func_status_mainpage, &reg[0]);
-    bytecpy((uint8_t *)&fsm_status_a_mainpage, &reg[1]);
-    bytecpy((uint8_t *)&fsm_status_b_mainpage, &reg[2]);
-    val->step_detector = emb_func_status_mainpage.is_step_det;
-    val->tilt          = emb_func_status_mainpage.is_tilt;
-    val->sig_mot       = emb_func_status_mainpage.is_sigmot;
-    val->fsm_lc        = emb_func_status_mainpage.is_fsm_lc;
-    val->fsm1 = fsm_status_a_mainpage.is_fsm1;
-    val->fsm2 = fsm_status_a_mainpage.is_fsm2;
-    val->fsm3 = fsm_status_a_mainpage.is_fsm3;
-    val->fsm4 = fsm_status_a_mainpage.is_fsm4;
-    val->fsm5 = fsm_status_a_mainpage.is_fsm5;
-    val->fsm6 = fsm_status_a_mainpage.is_fsm6;
-    val->fsm7 = fsm_status_a_mainpage.is_fsm7;
-    val->fsm8 = fsm_status_a_mainpage.is_fsm8;
-    val->fsm9  = fsm_status_b_mainpage.is_fsm9;
-    val->fsm10 = fsm_status_b_mainpage.is_fsm10;
-    val->fsm11 = fsm_status_b_mainpage.is_fsm11;
-    val->fsm12 = fsm_status_b_mainpage.is_fsm12;
-    val->fsm13 = fsm_status_b_mainpage.is_fsm13;
-    val->fsm14 = fsm_status_b_mainpage.is_fsm14;
-    val->fsm15 = fsm_status_b_mainpage.is_fsm15;
-    val->fsm16 = fsm_status_b_mainpage.is_fsm16;
-  }
+  bytecpy((uint8_t *)&emb_func_status_mainpage, &reg[0]);
+  bytecpy((uint8_t *)&fsm_status_a_mainpage, &reg[1]);
+  bytecpy((uint8_t *)&fsm_status_b_mainpage, &reg[2]);
+  val->step_detector = emb_func_status_mainpage.is_step_det;
+  val->tilt          = emb_func_status_mainpage.is_tilt;
+  val->sig_mot       = emb_func_status_mainpage.is_sigmot;
+  val->fsm_lc        = emb_func_status_mainpage.is_fsm_lc;
+  val->fsm1 = fsm_status_a_mainpage.is_fsm1;
+  val->fsm2 = fsm_status_a_mainpage.is_fsm2;
+  val->fsm3 = fsm_status_a_mainpage.is_fsm3;
+  val->fsm4 = fsm_status_a_mainpage.is_fsm4;
+  val->fsm5 = fsm_status_a_mainpage.is_fsm5;
+  val->fsm6 = fsm_status_a_mainpage.is_fsm6;
+  val->fsm7 = fsm_status_a_mainpage.is_fsm7;
+  val->fsm8 = fsm_status_a_mainpage.is_fsm8;
+  val->fsm9  = fsm_status_b_mainpage.is_fsm9;
+  val->fsm10 = fsm_status_b_mainpage.is_fsm10;
+  val->fsm11 = fsm_status_b_mainpage.is_fsm11;
+  val->fsm12 = fsm_status_b_mainpage.is_fsm12;
+  val->fsm13 = fsm_status_b_mainpage.is_fsm13;
+  val->fsm14 = fsm_status_b_mainpage.is_fsm14;
+  val->fsm15 = fsm_status_b_mainpage.is_fsm15;
+  val->fsm16 = fsm_status_b_mainpage.is_fsm16;
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_STATUS_MASTER_MAINPAGE, reg, 3);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_STATUS_MASTER_MAINPAGE, reg, 3);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    bytecpy((uint8_t *)&status_master_mainpage, &reg[0]);
-    bytecpy((uint8_t *)&fifo_status1, &reg[1]);
-    bytecpy((uint8_t *)&fifo_status2, &reg[2]);
-    val->sh_endop       = status_master_mainpage.sens_hub_endop;
-    val->sh_slave0_nack = status_master_mainpage.slave0_nack;
-    val->sh_slave1_nack = status_master_mainpage.slave1_nack;
-    val->sh_slave2_nack = status_master_mainpage.slave2_nack;
-    val->sh_slave3_nack = status_master_mainpage.slave3_nack;
-    val->sh_wr_once     = status_master_mainpage.wr_once_done;
-    val->fifo_diff = (256U * fifo_status2.diff_fifo) +
-                     fifo_status1.diff_fifo;
-    val->fifo_ovr_latched = fifo_status2.over_run_latched;
-    val->fifo_bdr         = fifo_status2.counter_bdr_ia;
-    val->fifo_full        = fifo_status2.fifo_full_ia;
-    val->fifo_ovr         = fifo_status2.fifo_ovr_ia;
-    val->fifo_th          = fifo_status2.fifo_wtm_ia;
-  }
+  bytecpy((uint8_t *)&status_master_mainpage, &reg[0]);
+  bytecpy((uint8_t *)&fifo_status1, &reg[1]);
+  bytecpy((uint8_t *)&fifo_status2, &reg[2]);
+  val->sh_endop       = status_master_mainpage.sens_hub_endop;
+  val->sh_slave0_nack = status_master_mainpage.slave0_nack;
+  val->sh_slave1_nack = status_master_mainpage.slave1_nack;
+  val->sh_slave2_nack = status_master_mainpage.slave2_nack;
+  val->sh_slave3_nack = status_master_mainpage.slave3_nack;
+  val->sh_wr_once     = status_master_mainpage.wr_once_done;
+  val->fifo_diff = (256U * fifo_status2.diff_fifo) +
+                   fifo_status1.diff_fifo;
+  val->fifo_ovr_latched = fifo_status2.over_run_latched;
+  val->fifo_bdr         = fifo_status2.counter_bdr_ia;
+  val->fifo_full        = fifo_status2.fifo_full_ia;
+  val->fifo_ovr         = fifo_status2.fifo_ovr_ia;
+  val->fifo_th          = fifo_status2.fifo_wtm_ia;
 
   return ret;
 }
-
-/*
- * `-Wmaybe-uninitialized` warning is disabled for the `lsm6dso_mode_set`
- * function because GCC 12 and above may report a false positive warning
- * claiming that the `ctrl2_ois` variable may be used uninitialized.
- */
-#if defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
 
 /**
   * @brief  Sensor conversion parameters selection.[set]
@@ -11797,13 +10446,13 @@ int32_t lsm6dso_mode_set(stmdev_ctx_t *ctx, stmdev_ctx_t *aux_ctx,
 {
   lsm6dso_func_cfg_access_t func_cfg_access;
   lsm6dso_ctrl1_ois_t ctrl1_ois;
-  lsm6dso_ctrl2_ois_t ctrl2_ois;
+  lsm6dso_ctrl2_ois_t ctrl2_ois = {0};
   lsm6dso_ctrl3_ois_t ctrl3_ois;
   lsm6dso_ctrl1_xl_t ctrl1_xl;
   lsm6dso_ctrl8_xl_t ctrl8_xl;
   lsm6dso_ctrl2_g_t ctrl2_g;
-  lsm6dso_ctrl3_c_t ctrl3_c;
-  lsm6dso_ctrl4_c_t ctrl4_c;
+  lsm6dso_ctrl3_c_t ctrl3_c = {0};
+  lsm6dso_ctrl4_c_t ctrl4_c = {0};
   lsm6dso_ctrl5_c_t ctrl5_c;
   lsm6dso_ctrl6_c_t ctrl6_c;
   lsm6dso_ctrl7_g_t ctrl7_g;
@@ -11845,6 +10494,8 @@ int32_t lsm6dso_mode_set(stmdev_ctx_t *ctx, stmdev_ctx_t *aux_ctx,
   if (ctx != NULL)
   {
     ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL1_XL, reg, 8);
+    if (ret != 0) { return ret; }
+
     bytecpy((uint8_t *)&ctrl1_xl, &reg[0]);
     bytecpy((uint8_t *)&ctrl2_g,  &reg[1]);
     bytecpy((uint8_t *)&ctrl3_c,  &reg[2]);
@@ -11854,42 +10505,32 @@ int32_t lsm6dso_mode_set(stmdev_ctx_t *ctx, stmdev_ctx_t *aux_ctx,
     bytecpy((uint8_t *)&ctrl7_g,  &reg[6]);
     bytecpy((uint8_t *)&ctrl8_xl, &reg[7]);
 
-    if (ret == 0)
-    {
-      ret = lsm6dso_read_reg(ctx, LSM6DSO_FUNC_CFG_ACCESS,
-                             (uint8_t *)&func_cfg_access, 1);
-    }
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
 
     /* if toggle xl ultra low power mode, turn off xl before reconfigure */
     if (ctrl5_c.xl_ulp_en != xl_ulp_en)
     {
       ctrl1_xl.odr_xl = (uint8_t) 0x00U;
-      ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL1_XL,
-                              (uint8_t *)&ctrl1_xl, 1);
+      ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL1_XL, (uint8_t *)&ctrl1_xl, 1);
     }
   }
 
   /* reading OIS registers to be configured */
   if (aux_ctx != NULL)
   {
-    if (ret == 0)
-    {
-      ret = lsm6dso_read_reg(aux_ctx, LSM6DSO_CTRL1_OIS, reg, 3);
-    }
+    ret = lsm6dso_read_reg(aux_ctx, LSM6DSO_CTRL1_OIS, reg, 3);
+    if (ret != 0) { return ret; }
 
     bytecpy((uint8_t *)&ctrl1_ois, &reg[0]);
     bytecpy((uint8_t *)&ctrl2_ois, &reg[1]);
     bytecpy((uint8_t *)&ctrl3_ois, &reg[2]);
   }
-
   else
   {
     if (ctx != NULL)
     {
-      if (ret == 0)
-      {
-        ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL1_OIS, reg, 3);
-      }
+      ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL1_OIS, reg, 3);
+      if (ret != 0) { return ret; }
 
       bytecpy((uint8_t *)&ctrl1_ois, &reg[0]);
       bytecpy((uint8_t *)&ctrl2_ois, &reg[1]);
@@ -12161,7 +10802,7 @@ int32_t lsm6dso_mode_set(stmdev_ctx_t *ctx, stmdev_ctx_t *aux_ctx,
   }
 
   /* OIS new configuration */
-  ctrl7_g.ois_on_en = val->ois.ctrl_md & 0x01U;
+  ctrl7_g.ois_on_en = (val->ois.ctrl_md == LSM6DSO_OIS_MIXED) ? 1U : 0U;
 
   switch (val->ois.ctrl_md)
   {
@@ -12210,16 +10851,9 @@ int32_t lsm6dso_mode_set(stmdev_ctx_t *ctx, stmdev_ctx_t *aux_ctx,
     bytecpy(&reg[6], (uint8_t *)&ctrl7_g);
     bytecpy(&reg[7], (uint8_t *)&ctrl8_xl);
 
-    if (ret == 0)
-    {
-      ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL1_XL, (uint8_t *)&reg, 8);
-    }
-
-    if (ret == 0)
-    {
-      ret = lsm6dso_write_reg(ctx, LSM6DSO_FUNC_CFG_ACCESS,
-                              (uint8_t *)&func_cfg_access, 1);
-    }
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL1_XL, (uint8_t *)&reg, 8);
+    ret += lsm6dso_write_reg(ctx, LSM6DSO_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+    if (ret != 0) { return ret; }
   }
 
   /* writing OIS checked configuration */
@@ -12229,18 +10863,11 @@ int32_t lsm6dso_mode_set(stmdev_ctx_t *ctx, stmdev_ctx_t *aux_ctx,
     bytecpy(&reg[1], (uint8_t *)&ctrl2_ois);
     bytecpy(&reg[2], (uint8_t *)&ctrl3_ois);
 
-    if (ret == 0)
-    {
-      ret = lsm6dso_write_reg(aux_ctx, LSM6DSO_CTRL1_OIS, reg, 3);
-    }
+    ret = lsm6dso_write_reg(aux_ctx, LSM6DSO_CTRL1_OIS, reg, 3);
   }
 
   return ret;
 }
-
-#if defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
 
 /**
   * @brief  Sensor conversion parameters selection.[get]
@@ -12280,6 +10907,8 @@ int32_t lsm6dso_mode_get(stmdev_ctx_t *ctx, stmdev_ctx_t *aux_ctx,
   if (ctx != NULL)
   {
     ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL1_XL, reg, 7);
+    if (ret != 0) { return ret; }
+
     bytecpy((uint8_t *)&ctrl1_xl, &reg[0]);
     bytecpy((uint8_t *)&ctrl2_g,  &reg[1]);
     bytecpy((uint8_t *)&ctrl3_c,  &reg[2]);
@@ -12288,48 +10917,29 @@ int32_t lsm6dso_mode_get(stmdev_ctx_t *ctx, stmdev_ctx_t *aux_ctx,
     bytecpy((uint8_t *)&ctrl6_c,  &reg[5]);
     bytecpy((uint8_t *)&ctrl7_g,  &reg[6]);
 
-    if (ret == 0)
-    {
-      ret = lsm6dso_read_reg(ctx, LSM6DSO_FUNC_CFG_ACCESS,
-                             (uint8_t *)&func_cfg_access, 1);
-    }
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+    if (ret != 0) { return ret; }
 
-    if (ret == 0)
-    {
-      ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
-    }
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+    if (ret != 0) { return ret; }
 
-    if (ret == 0)
-    {
-      ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_ODR_CFG_B, reg, 1);
-      bytecpy((uint8_t *)&emb_func_odr_cfg_b, &reg[0]);
-    }
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_ODR_CFG_B, reg, 1);
+    bytecpy((uint8_t *)&emb_func_odr_cfg_b, &reg[0]);
 
-    if (ret == 0)
-    {
-      ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_EN_B,
-                             (uint8_t *)&emb_func_en_b, 1);
-    }
+    ret += lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
+    bytecpy((uint8_t *)&fsm_enable_b, &reg[1]);
 
-    if (ret == 0)
-    {
-      ret = lsm6dso_read_reg(ctx, LSM6DSO_FSM_ENABLE_A, reg, 2);
-      bytecpy((uint8_t *)&fsm_enable_a, &reg[0]);
-      bytecpy((uint8_t *)&fsm_enable_b, &reg[1]);
-    }
+    ret += lsm6dso_read_reg(ctx, LSM6DSO_FSM_ENABLE_A, reg, 2);
+    bytecpy((uint8_t *)&fsm_enable_a, &reg[0]);
 
-    if (ret == 0)
-    {
-      ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-    }
+    ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+    if (ret != 0) { return ret; }
   }
 
   if (aux_ctx != NULL)
   {
-    if (ret == 0)
-    {
-      ret = lsm6dso_read_reg(aux_ctx, LSM6DSO_CTRL1_OIS, reg, 3);
-    }
+    ret = lsm6dso_read_reg(aux_ctx, LSM6DSO_CTRL1_OIS, reg, 3);
+    if (ret != 0) { return ret; }
 
     bytecpy((uint8_t *)&ctrl1_ois, &reg[0]);
     bytecpy((uint8_t *)&ctrl2_ois, &reg[1]);
@@ -12340,10 +10950,8 @@ int32_t lsm6dso_mode_get(stmdev_ctx_t *ctx, stmdev_ctx_t *aux_ctx,
   {
     if (ctx != NULL)
     {
-      if (ret == 0)
-      {
-        ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL1_OIS, reg, 3);
-      }
+      ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL1_OIS, reg, 3);
+      if (ret != 0) { return ret; }
 
       bytecpy((uint8_t *)&ctrl1_ois, &reg[0]);
       bytecpy((uint8_t *)&ctrl2_ois, &reg[1]);
@@ -12793,11 +11401,10 @@ int32_t lsm6dso_mode_get(stmdev_ctx_t *ctx, stmdev_ctx_t *aux_ctx,
       break;
 
     default:
-      ctrl1_ois.fs_g_ois = (uint8_t)val->ois.gy.fs;
-      ctrl1_ois.ois_en_spi2 = (uint8_t)val->ois.gy.odr |
-                              (uint8_t)val->ois.xl.odr;
-      ctrl1_ois.mode4_en = (uint8_t) val->ois.xl.odr;
-      ctrl3_ois.fs_xl_ois = (uint8_t)val->ois.xl.fs;
+      val->ois.gy.fs = LSM6DSO_GY_OIS_250dps;
+      val->ois.gy.odr = LSM6DSO_GY_OIS_OFF;
+      val->ois.xl.odr = LSM6DSO_XL_OIS_OFF;
+      val->ois.xl.fs = LSM6DSO_XL_OIS_2g;
       val->ois.ctrl_md = LSM6DSO_OIS_ONLY_AUX;
       break;
   }
@@ -12827,6 +11434,7 @@ int32_t lsm6dso_data_get(stmdev_ctx_t *ctx, stmdev_ctx_t *aux_ctx,
   if (ctx != NULL)
   {
     ret = lsm6dso_read_reg(ctx, LSM6DSO_OUT_TEMP_L, buff, 14);
+    if (ret != 0) { return ret; }
   }
 
   j = 0;
@@ -12907,10 +11515,8 @@ int32_t lsm6dso_data_get(stmdev_ctx_t *ctx, stmdev_ctx_t *aux_ctx,
   /* read data from ois chain */
   if (aux_ctx != NULL)
   {
-    if (ret == 0)
-    {
-      ret = lsm6dso_read_reg(aux_ctx, LSM6DSO_OUTX_L_G, buff, 12);
-    }
+    ret = lsm6dso_read_reg(aux_ctx, LSM6DSO_OUTX_L_G, buff, 12);
+    if (ret != 0) { return ret; }
   }
 
   j = 0;
@@ -12925,28 +11531,23 @@ int32_t lsm6dso_data_get(stmdev_ctx_t *ctx, stmdev_ctx_t *aux_ctx,
     switch (md->ois.gy.fs)
     {
       case LSM6DSO_GY_UI_250dps:
-        data->ois.gy.mdps[i] = lsm6dso_from_fs250_to_mdps(
-                                 data->ois.gy.raw[i]);
+        data->ois.gy.mdps[i] = lsm6dso_from_fs250_to_mdps(data->ois.gy.raw[i]);
         break;
 
       case LSM6DSO_GY_UI_125dps:
-        data->ois.gy.mdps[i] = lsm6dso_from_fs125_to_mdps(
-                                 data->ois.gy.raw[i]);
+        data->ois.gy.mdps[i] = lsm6dso_from_fs125_to_mdps(data->ois.gy.raw[i]);
         break;
 
       case LSM6DSO_GY_UI_500dps:
-        data->ois.gy.mdps[i] = lsm6dso_from_fs500_to_mdps(
-                                 data->ois.gy.raw[i]);
+        data->ois.gy.mdps[i] = lsm6dso_from_fs500_to_mdps(data->ois.gy.raw[i]);
         break;
 
       case LSM6DSO_GY_UI_1000dps:
-        data->ois.gy.mdps[i] = lsm6dso_from_fs1000_to_mdps(
-                                 data->ois.gy.raw[i]);
+        data->ois.gy.mdps[i] = lsm6dso_from_fs1000_to_mdps(data->ois.gy.raw[i]);
         break;
 
       case LSM6DSO_GY_UI_2000dps:
-        data->ois.gy.mdps[i] = lsm6dso_from_fs2000_to_mdps(
-                                 data->ois.gy.raw[i]);
+        data->ois.gy.mdps[i] = lsm6dso_from_fs2000_to_mdps(data->ois.gy.raw[i]);
         break;
 
       default:
@@ -12988,7 +11589,6 @@ int32_t lsm6dso_data_get(stmdev_ctx_t *ctx, stmdev_ctx_t *aux_ctx,
 
   return ret;
 }
-
 /**
   * @brief  Embedded functions.[set]
   *
@@ -13006,41 +11606,24 @@ int32_t lsm6dso_embedded_sens_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_EN_A,
-                           (uint8_t *)&emb_func_en_a, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  ret += lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_EN_B,
-                           (uint8_t *)&emb_func_en_b, 1);
-    emb_func_en_b.fsm_en = val->fsm;
-    emb_func_en_a.tilt_en = val->tilt;
-    emb_func_en_a.pedo_en = val->step;
-    emb_func_en_b.pedo_adv_en = val->step_adv;
-    emb_func_en_a.sign_motion_en = val->sig_mot;
-    emb_func_en_b.fifo_compr_en = val->fifo_compr;
-  }
+  emb_func_en_b.fsm_en = val->fsm;
+  emb_func_en_a.tilt_en = val->tilt;
+  emb_func_en_a.pedo_en = val->step;
+  emb_func_en_b.pedo_adv_en = val->step_adv;
+  emb_func_en_a.sign_motion_en = val->sig_mot;
+  emb_func_en_b.fifo_compr_en = val->fifo_compr;
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_EN_A,
-                            (uint8_t *)&emb_func_en_a, 1);
-  }
+  ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_EN_B,
-                            (uint8_t *)&emb_func_en_b, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+exit:
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -13062,29 +11645,19 @@ int32_t lsm6dso_embedded_sens_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_EN_A,
-                           (uint8_t *)&emb_func_en_a, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  ret += lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_EN_B,
-                           (uint8_t *)&emb_func_en_b, 1);
-    emb_sens->fsm = emb_func_en_b.fsm_en;
-    emb_sens->tilt = emb_func_en_a.tilt_en;
-    emb_sens->step = emb_func_en_a.pedo_en;
-    emb_sens->step_adv = emb_func_en_b.pedo_adv_en;
-    emb_sens->sig_mot = emb_func_en_a.sign_motion_en;
-    emb_sens->fifo_compr = emb_func_en_b.fifo_compr_en;
-  }
+  emb_sens->fsm = emb_func_en_b.fsm_en;
+  emb_sens->tilt = emb_func_en_a.tilt_en;
+  emb_sens->step = emb_func_en_a.pedo_en;
+  emb_sens->step_adv = emb_func_en_b.pedo_adv_en;
+  emb_sens->sig_mot = emb_func_en_a.sign_motion_en;
+  emb_sens->fifo_compr = emb_func_en_b.fifo_compr_en;
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }
@@ -13105,41 +11678,24 @@ int32_t lsm6dso_embedded_sens_off(stmdev_ctx_t *ctx)
   int32_t ret;
 
   ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_EN_A,
-                           (uint8_t *)&emb_func_en_a, 1);
-  }
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  ret += lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_EN_B,
-                           (uint8_t *)&emb_func_en_b, 1);
-    emb_func_en_b.fsm_en = PROPERTY_DISABLE;
-    emb_func_en_a.tilt_en = PROPERTY_DISABLE;
-    emb_func_en_a.pedo_en = PROPERTY_DISABLE;
-    emb_func_en_b.pedo_adv_en = PROPERTY_DISABLE;
-    emb_func_en_a.sign_motion_en = PROPERTY_DISABLE;
-    emb_func_en_b.fifo_compr_en = PROPERTY_DISABLE;
-  }
+  emb_func_en_b.fsm_en = PROPERTY_DISABLE;
+  emb_func_en_a.tilt_en = PROPERTY_DISABLE;
+  emb_func_en_a.pedo_en = PROPERTY_DISABLE;
+  emb_func_en_b.pedo_adv_en = PROPERTY_DISABLE;
+  emb_func_en_a.sign_motion_en = PROPERTY_DISABLE;
+  emb_func_en_b.fifo_compr_en = PROPERTY_DISABLE;
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_EN_A,
-                            (uint8_t *)&emb_func_en_a, 1);
-  }
+  ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  ret += lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
 
-  if (ret == 0)
-  {
-    ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_EN_B,
-                            (uint8_t *)&emb_func_en_b, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-  }
+exit:
+  ret += lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 
   return ret;
 }

--- a/sensor/stmemsc/lsm6dso_STdC/driver/lsm6dso_reg.h
+++ b/sensor/stmemsc/lsm6dso_STdC/driver/lsm6dso_reg.h
@@ -2931,8 +2931,8 @@ int32_t lsm6dso_ln_pg_read_byte(stmdev_ctx_t *ctx, uint16_t address,
                                 uint8_t *val);
 int32_t lsm6dso_ln_pg_write(stmdev_ctx_t *ctx, uint16_t address,
                             uint8_t *buf, uint8_t len);
-int32_t lsm6dso_ln_pg_read(stmdev_ctx_t *ctx, uint16_t address,
-                           uint8_t *val);
+int32_t lsm6dso_ln_pg_read(stmdev_ctx_t *ctx, uint16_t address, uint8_t *buf,
+                           uint8_t len);
 
 typedef enum
 {
@@ -3647,17 +3647,8 @@ int32_t lsm6dso_fifo_sensor_tag_get(stmdev_ctx_t *ctx,
 int32_t lsm6dso_fifo_pedo_batch_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dso_fifo_pedo_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_sh_batch_slave_0_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_sh_batch_slave_0_get(stmdev_ctx_t *ctx, uint8_t *val);
-
-int32_t lsm6dso_sh_batch_slave_1_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_sh_batch_slave_1_get(stmdev_ctx_t *ctx, uint8_t *val);
-
-int32_t lsm6dso_sh_batch_slave_2_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_sh_batch_slave_2_get(stmdev_ctx_t *ctx, uint8_t *val);
-
-int32_t lsm6dso_sh_batch_slave_3_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_sh_batch_slave_3_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_sh_batch_slave_set(stmdev_ctx_t *ctx, uint8_t idx, uint8_t val);
+int32_t lsm6dso_sh_batch_slave_get(stmdev_ctx_t *ctx, uint8_t idx, uint8_t *val);
 
 typedef enum
 {
@@ -3952,13 +3943,7 @@ typedef struct
   uint8_t   slv_subadd;
   uint8_t   slv_len;
 } lsm6dso_sh_cfg_read_t;
-int32_t lsm6dso_sh_slv0_cfg_read(stmdev_ctx_t *ctx,
-                                 lsm6dso_sh_cfg_read_t *val);
-int32_t lsm6dso_sh_slv1_cfg_read(stmdev_ctx_t *ctx,
-                                 lsm6dso_sh_cfg_read_t *val);
-int32_t lsm6dso_sh_slv2_cfg_read(stmdev_ctx_t *ctx,
-                                 lsm6dso_sh_cfg_read_t *val);
-int32_t lsm6dso_sh_slv3_cfg_read(stmdev_ctx_t *ctx,
+int32_t lsm6dso_sh_slv_cfg_read(stmdev_ctx_t *ctx, uint8_t idx,
                                  lsm6dso_sh_cfg_read_t *val);
 
 int32_t lsm6dso_sh_status_get(stmdev_ctx_t *ctx,

--- a/sensor/stmemsc/lsm6dsv16bx_STdC/driver/lsm6dsv16bx_reg.c
+++ b/sensor/stmemsc/lsm6dsv16bx_STdC/driver/lsm6dsv16bx_reg.c
@@ -174,6 +174,11 @@ uint64_t lsm6dsv16bx_from_lsb_to_nsec(uint32_t lsb)
   return ((uint64_t)lsb * 21750);
 }
 
+float_t lsm6dsv16bx_from_lsb_to_mv(int16_t lsb)
+{
+  return ((float_t)lsb) / 78.0f;
+}
+
 /**
   * @}
   *

--- a/sensor/stmemsc/lsm6dsv16bx_STdC/driver/lsm6dsv16bx_reg.h
+++ b/sensor/stmemsc/lsm6dsv16bx_STdC/driver/lsm6dsv16bx_reg.h
@@ -2648,6 +2648,8 @@ float_t lsm6dsv16bx_from_lsb_to_celsius(int16_t lsb);
 
 uint64_t lsm6dsv16bx_from_lsb_to_nsec(uint32_t lsb);
 
+float_t lsm6dsv16bx_from_lsb_to_mv(int16_t lsb);
+
 typedef enum
 {
   LSM6DSV16BX_READY                               = 0x0,
@@ -2755,7 +2757,7 @@ typedef enum
   LSM6DSV16BX_500dps                              = 0x2,
   LSM6DSV16BX_1000dps                             = 0x3,
   LSM6DSV16BX_2000dps                             = 0x4,
-  LSM6DSV16BX_4000dps                             = 0x5,
+  LSM6DSV16BX_4000dps                             = 0xc,
 } lsm6dsv16bx_gy_full_scale_t;
 int32_t lsm6dsv16bx_gy_full_scale_set(stmdev_ctx_t *ctx,
                                       lsm6dsv16bx_gy_full_scale_t val);

--- a/sensor/stmemsc/lsm6dsv16x_STdC/driver/lsm6dsv16x_reg.c
+++ b/sensor/stmemsc/lsm6dsv16x_STdC/driver/lsm6dsv16x_reg.c
@@ -174,6 +174,11 @@ float_t lsm6dsv16x_from_lsb_to_nsec(uint32_t lsb)
   return ((float_t)lsb * 21750.0f);
 }
 
+float_t lsm6dsv16x_from_lsb_to_mv(int16_t lsb)
+{
+  return ((float_t)lsb) / 78.0f;
+}
+
 /**
   * @}
   *
@@ -248,14 +253,9 @@ int32_t lsm6dsv16x_xl_offset_mg_set(stmdev_ctx_t *ctx,
   float_t tmp;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_X_OFS_USR, (uint8_t *)&x_ofs_usr, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_X_OFS_USR, (uint8_t *)&x_ofs_usr, 1);
+  if (ret != 0) { return ret; }
 
 
   if ((val.x_mg < (0.0078125f * 127.0f)) && (val.x_mg > (0.0078125f * -127.0f)) &&
@@ -296,22 +296,11 @@ int32_t lsm6dsv16x_xl_offset_mg_set(stmdev_ctx_t *ctx,
     x_ofs_usr.x_ofs_usr = 0xFFU;
   }
 
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_X_OFS_USR, (uint8_t *)&x_ofs_usr, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1);
-  }
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_X_OFS_USR, (uint8_t *)&x_ofs_usr, 1);
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1);
+
   return ret;
 }
 
@@ -333,18 +322,10 @@ int32_t lsm6dsv16x_xl_offset_mg_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_X_OFS_USR, (uint8_t *)&x_ofs_usr, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_X_OFS_USR, (uint8_t *)&x_ofs_usr, 1);
+  if (ret != 0) { return ret; }
 
   if (ctrl9.usr_off_w == PROPERTY_DISABLE)
   {
@@ -382,23 +363,15 @@ int32_t lsm6dsv16x_reset_set(stmdev_ctx_t *ctx, lsm6dsv16x_reset_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL3, (uint8_t *)&ctrl3, 1);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  if (ret != 0) { return ret; }
 
   ctrl3.boot = ((uint8_t)val & 0x04U) >> 2;
   ctrl3.sw_reset = ((uint8_t)val & 0x02U) >> 1;
   func_cfg_access.sw_por = (uint8_t)val & 0x01U;
 
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL3, (uint8_t *)&ctrl3, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
-  }
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL3, (uint8_t *)&ctrl3, 1);
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
 
   return ret;
 }
@@ -418,10 +391,8 @@ int32_t lsm6dsv16x_reset_get(stmdev_ctx_t *ctx, lsm6dsv16x_reset_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL3, (uint8_t *)&ctrl3, 1);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  if (ret != 0) { return ret; }
 
   switch ((ctrl3.sw_reset << 2) + (ctrl3.boot << 1) + func_cfg_access.sw_por)
   {
@@ -445,6 +416,7 @@ int32_t lsm6dsv16x_reset_get(stmdev_ctx_t *ctx, lsm6dsv16x_reset_t *val)
       *val = LSM6DSV16X_GLOBAL_RST;
       break;
   }
+
   return ret;
 }
 
@@ -462,13 +434,11 @@ int32_t lsm6dsv16x_mem_bank_set(stmdev_ctx_t *ctx, lsm6dsv16x_mem_bank_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    func_cfg_access.shub_reg_access = ((uint8_t)val & 0x02U) >> 1;
-    func_cfg_access.emb_func_reg_access = (uint8_t)val & 0x01U;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
-  }
+  func_cfg_access.shub_reg_access = ((uint8_t)val & 0x02U) >> 1;
+  func_cfg_access.emb_func_reg_access = (uint8_t)val & 0x01U;
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
 
   return ret;
 }
@@ -487,6 +457,7 @@ int32_t lsm6dsv16x_mem_bank_get(stmdev_ctx_t *ctx, lsm6dsv16x_mem_bank_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  if (ret != 0) { return ret; }
 
   switch ((func_cfg_access.shub_reg_access << 1) + func_cfg_access.emb_func_reg_access)
   {
@@ -506,6 +477,7 @@ int32_t lsm6dsv16x_mem_bank_get(stmdev_ctx_t *ctx, lsm6dsv16x_mem_bank_t *val)
       *val = LSM6DSV16X_MAIN_MEM_BANK;
       break;
   }
+
   return ret;
 }
 
@@ -544,11 +516,11 @@ int32_t lsm6dsv16x_xl_data_rate_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL1, (uint8_t *)&ctrl1, 1);
-  if (ret == 0)
-  {
-    ctrl1.odr_xl = (uint8_t)val & 0x0Fu;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL1, (uint8_t *)&ctrl1, 1);
-  }
+  if (ret != 0) { return ret; }
+
+  ctrl1.odr_xl = (uint8_t)val & 0x0Fu;
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL1, (uint8_t *)&ctrl1, 1);
+  if (ret != 0) { return ret; }
 
   sel = ((uint8_t)val >> 4) & 0xFU;
   if (sel != 0U)
@@ -579,6 +551,8 @@ int32_t lsm6dsv16x_xl_data_rate_get(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL1, (uint8_t *)&ctrl1, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_HAODR_CFG, (uint8_t *)&haodr, 1);
+  if (ret != 0) { return ret; }
+
   sel = haodr.haodr_sel;
 
   switch (ctrl1.odr_xl)
@@ -749,6 +723,7 @@ int32_t lsm6dsv16x_xl_data_rate_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_ODR_OFF;
       break;
   }
+
   return ret;
 }
 
@@ -790,6 +765,7 @@ int32_t lsm6dsv16x_xl_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_xl_mode_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL1, (uint8_t *)&ctrl1, 1);
+  if (ret != 0) { return ret; }
 
   switch (ctrl1.op_mode_xl)
   {
@@ -825,6 +801,7 @@ int32_t lsm6dsv16x_xl_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_xl_mode_t *val)
       *val = LSM6DSV16X_XL_HIGH_PERFORMANCE_MD;
       break;
   }
+
   return ret;
 }
 
@@ -845,12 +822,9 @@ int32_t lsm6dsv16x_gy_data_rate_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL2, (uint8_t *)&ctrl2, 1);
-
-  if (ret == 0)
-  {
-    ctrl2.odr_g = (uint8_t)val & 0x0Fu;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL2, (uint8_t *)&ctrl2, 1);
-  }
+  ctrl2.odr_g = (uint8_t)val & 0x0Fu;
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL2, (uint8_t *)&ctrl2, 1);
+  if (ret != 0) { return ret; }
 
   sel = ((uint8_t)val >> 4) & 0xFU;
   if (sel != 0U)
@@ -881,6 +855,8 @@ int32_t lsm6dsv16x_gy_data_rate_get(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL2, (uint8_t *)&ctrl2, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_HAODR_CFG, (uint8_t *)&haodr, 1);
+  if (ret != 0) { return ret; }
+
   sel = haodr.haodr_sel;
 
   switch (ctrl2.odr_g)
@@ -1051,6 +1027,7 @@ int32_t lsm6dsv16x_gy_data_rate_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_ODR_OFF;
       break;
   }
+
   return ret;
 }
 
@@ -1091,6 +1068,8 @@ int32_t lsm6dsv16x_gy_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_gy_mode_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL2, (uint8_t *)&ctrl2, 1);
+  if (ret != 0) { return ret; }
+
   switch (ctrl2.op_mode_g)
   {
     case LSM6DSV16X_GY_HIGH_PERFORMANCE_MD:
@@ -1113,6 +1092,7 @@ int32_t lsm6dsv16x_gy_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_gy_mode_t *val)
       *val = LSM6DSV16X_GY_HIGH_PERFORMANCE_MD;
       break;
   }
+
   return ret;
 }
 
@@ -1154,7 +1134,6 @@ int32_t lsm6dsv16x_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val)
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL3, (uint8_t *)&ctrl3, 1);
   *val = ctrl3.if_inc;
-
 
   return ret;
 }
@@ -1304,6 +1283,7 @@ int32_t lsm6dsv16x_data_ready_mode_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_DRDY_LATCHED;
       break;
   }
+
   return ret;
 }
 
@@ -1323,20 +1303,13 @@ int32_t lsm6dsv16x_interrupt_enable_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&func, 1);
+  func.interrupts_enable = val.enable;
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&func, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    func.interrupts_enable = val.enable;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&func, 1);
-  }
-
-  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&cfg, 1);
-
-  if (ret == 0)
-  {
-    cfg.lir = val.lir;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&cfg, 1);
-  }
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&cfg, 1);
+  cfg.lir = val.lir;
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&cfg, 1);
 
   return ret;
 }
@@ -1358,6 +1331,7 @@ int32_t lsm6dsv16x_interrupt_enable_get(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&func, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&cfg, 1);
+  if (ret != 0) { return ret; }
 
   val->enable = func.interrupts_enable;
   val->lir = cfg.lir;
@@ -1405,6 +1379,7 @@ int32_t lsm6dsv16x_gy_full_scale_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL6, (uint8_t *)&ctrl6, 1);
+  if (ret != 0) { return ret; }
 
   switch (ctrl6.fs_g)
   {
@@ -1436,6 +1411,7 @@ int32_t lsm6dsv16x_gy_full_scale_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_125dps;
       break;
   }
+
   return ret;
 }
 
@@ -1479,6 +1455,7 @@ int32_t lsm6dsv16x_xl_full_scale_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL8, (uint8_t *)&ctrl8, 1);
+  if (ret != 0) { return ret; }
 
   switch (ctrl8.fs_xl)
   {
@@ -1502,6 +1479,7 @@ int32_t lsm6dsv16x_xl_full_scale_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_2g;
       break;
   }
+
   return ret;
 }
 
@@ -1588,6 +1566,7 @@ int32_t lsm6dsv16x_xl_self_test_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL10, (uint8_t *)&ctrl10, 1);
+  if (ret != 0) { return ret; }
 
   switch (ctrl10.st_xl)
   {
@@ -1607,6 +1586,7 @@ int32_t lsm6dsv16x_xl_self_test_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_XL_ST_DISABLE;
       break;
   }
+
   return ret;
 }
 
@@ -1650,6 +1630,7 @@ int32_t lsm6dsv16x_gy_self_test_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL10, (uint8_t *)&ctrl10, 1);
+  if (ret != 0) { return ret; }
 
   switch (ctrl10.st_g)
   {
@@ -1669,6 +1650,7 @@ int32_t lsm6dsv16x_gy_self_test_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_GY_ST_DISABLE;
       break;
   }
+
   return ret;
 }
 
@@ -1712,6 +1694,7 @@ int32_t lsm6dsv16x_ois_xl_self_test_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SPI2_INT_OIS, (uint8_t *)&spi2_int_ois, 1);
+  if (ret != 0) { return ret; }
 
   switch (spi2_int_ois.st_xl_ois)
   {
@@ -1731,6 +1714,7 @@ int32_t lsm6dsv16x_ois_xl_self_test_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_OIS_XL_ST_DISABLE;
       break;
   }
+
   return ret;
 }
 
@@ -1775,6 +1759,7 @@ int32_t lsm6dsv16x_ois_gy_self_test_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SPI2_INT_OIS, (uint8_t *)&spi2_int_ois, 1);
+  if (ret != 0) { return ret; }
 
   switch (spi2_int_ois.st_g_ois)
   {
@@ -1794,6 +1779,7 @@ int32_t lsm6dsv16x_ois_gy_self_test_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_OIS_GY_ST_DISABLE;
       break;
   }
+
   return ret;
 }
 
@@ -1821,6 +1807,7 @@ int32_t lsm6dsv16x_pin_int1_route_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_INT1_CTRL, (uint8_t *)&int1_ctrl, 1);
+  if (ret != 0) { return ret; }
 
   int1_ctrl.int1_drdy_xl       = val->drdy_xl;
   int1_ctrl.int1_drdy_g        = val->drdy_g;
@@ -1829,10 +1816,11 @@ int32_t lsm6dsv16x_pin_int1_route_set(stmdev_ctx_t *ctx,
   int1_ctrl.int1_fifo_full     = val->fifo_full;
   int1_ctrl.int1_cnt_bdr       = val->cnt_bdr;
 
-  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_INT1_CTRL, (uint8_t *)&int1_ctrl,
-                              1);
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_INT1_CTRL, (uint8_t *)&int1_ctrl, 1);
+  if (ret != 0) { return ret; }
 
-  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  if (ret != 0) { return ret; }
 
   md1_cfg.int1_shub            = val->shub;
   md1_cfg.int1_emb_func        = val->emb_func;
@@ -1843,7 +1831,7 @@ int32_t lsm6dsv16x_pin_int1_route_set(stmdev_ctx_t *ctx,
   md1_cfg.int1_ff              = val->freefall;
   md1_cfg.int1_sleep_change    = val->sleep_change;
 
-  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MD1_CFG, (uint8_t *)&md1_cfg, 1);
 
   return ret;
 }
@@ -1864,6 +1852,7 @@ int32_t lsm6dsv16x_pin_int1_route_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_INT1_CTRL, (uint8_t *)&int1_ctrl, 1);
+  if (ret != 0) { return ret; }
 
   val->drdy_xl   = int1_ctrl.int1_drdy_xl;
   val->drdy_g    = int1_ctrl.int1_drdy_g;
@@ -1872,7 +1861,8 @@ int32_t lsm6dsv16x_pin_int1_route_get(stmdev_ctx_t *ctx,
   val->fifo_full = int1_ctrl.int1_fifo_full;
   val->cnt_bdr   = int1_ctrl.int1_cnt_bdr;
 
-  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  if (ret != 0) { return ret; }
 
   val->shub         = md1_cfg.int1_shub;
   val->emb_func     = md1_cfg.int1_emb_func;
@@ -1902,6 +1892,7 @@ int32_t lsm6dsv16x_pin_int2_route_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
+  if (ret != 0) { return ret; }
 
   int2_ctrl.int2_drdy_xl          = val->drdy_xl;
   int2_ctrl.int2_drdy_g           = val->drdy_g;
@@ -1912,10 +1903,11 @@ int32_t lsm6dsv16x_pin_int2_route_set(stmdev_ctx_t *ctx,
   int2_ctrl.int2_drdy_g_eis       = val->drdy_g_eis;
   int2_ctrl.int2_emb_func_endop   = val->emb_func_endop;
 
-  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_INT2_CTRL, (uint8_t *)&int2_ctrl,
-                              1);
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
+  if (ret != 0) { return ret; }
 
-  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  if (ret != 0) { return ret; }
 
   md2_cfg.int2_timestamp       = val->timestamp;
   md2_cfg.int2_emb_func        = val->emb_func;
@@ -1926,7 +1918,7 @@ int32_t lsm6dsv16x_pin_int2_route_set(stmdev_ctx_t *ctx,
   md2_cfg.int2_ff              = val->freefall;
   md2_cfg.int2_sleep_change    = val->sleep_change;
 
-  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MD2_CFG, (uint8_t *)&md2_cfg, 1);
 
   return ret;
 }
@@ -1947,6 +1939,7 @@ int32_t lsm6dsv16x_pin_int2_route_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
+  if (ret != 0) { return ret; }
 
   val->drdy_xl        = int2_ctrl.int2_drdy_xl;
   val->drdy_g         = int2_ctrl.int2_drdy_g;
@@ -1957,7 +1950,8 @@ int32_t lsm6dsv16x_pin_int2_route_get(stmdev_ctx_t *ctx,
   val->drdy_g_eis     = int2_ctrl.int2_drdy_g_eis;
   val->emb_func_endop = int2_ctrl.int2_emb_func_endop;
 
-  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  if (ret != 0) { return ret; }
 
   val->timestamp      = md2_cfg.int2_timestamp;
   val->emb_func       = md2_cfg.int2_emb_func;
@@ -2005,16 +1999,13 @@ int32_t lsm6dsv16x_all_sources_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
-  if (ret == 0)
-  {
-    functions_enable.dis_rst_lir_all_int = PROPERTY_ENABLE;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
-  }
+  functions_enable.dis_rst_lir_all_int = PROPERTY_ENABLE;
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_STATUS1, (uint8_t *)&buff, 4);
-  }
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_STATUS1, (uint8_t *)&buff, 4);
+  if (ret != 0) { return ret; }
+
   bytecpy((uint8_t *)&fifo_status2, &buff[1]);
   bytecpy((uint8_t *)&all_int_src, &buff[2]);
   bytecpy((uint8_t *)&status_reg, &buff[3]);
@@ -2036,20 +2027,13 @@ int32_t lsm6dsv16x_all_sources_get(stmdev_ctx_t *ctx,
   val->drdy_ois = status_reg.ois_drdy;
   val->timestamp = status_reg.timestamp_endcount;
 
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
-  }
-  if (ret == 0)
-  {
-    functions_enable.dis_rst_lir_all_int = PROPERTY_DISABLE;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
-  }
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
+  functions_enable.dis_rst_lir_all_int = PROPERTY_DISABLE;
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_STATUS_REG_OIS, (uint8_t *)&buff, 8);
-  }
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_STATUS_REG_OIS, (uint8_t *)&buff, 8);
+  if (ret != 0) { return ret; }
 
   bytecpy((uint8_t *)&status_reg_ois, &buff[0]);
   bytecpy((uint8_t *)&wake_up_src, &buff[1]);
@@ -2100,19 +2084,12 @@ int32_t lsm6dsv16x_all_sources_get(stmdev_ctx_t *ctx,
   val->mlc4 = mlc_status_mainpage.is_mlc4;
 
 
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EXEC_STATUS, (uint8_t *)&emb_func_exec_status, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
-  }
+  /* embedded func */
+  ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EXEC_STATUS, (uint8_t *)&emb_func_exec_status, 1);
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
+  if (ret != 0) { return ret; }
 
   val->emb_func_stand_by = emb_func_exec_status.emb_func_endop;
   val->emb_func_time_exceed = emb_func_exec_status.emb_func_exec_ovr;
@@ -2123,15 +2100,8 @@ int32_t lsm6dsv16x_all_sources_get(stmdev_ctx_t *ctx,
   val->step_detector = emb_func_src.step_detected;
 
   /* sensor hub */
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_STATUS_MASTER, (uint8_t *)&status_shub, 1);
-  }
-  ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_STATUS_MASTER_MAINPAGE, (uint8_t *)&status_shub, 1);
+  if (ret != 0) { return ret; }
 
   val->sh_endop = status_shub.sens_hub_endop;
   val->sh_wr_once = status_shub.wr_once_done;
@@ -2150,6 +2120,8 @@ int32_t lsm6dsv16x_flag_data_ready_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_STATUS_REG, (uint8_t *)&status, 1);
+  if (ret != 0) { return ret; }
+
   val->drdy_xl = status.xlda;
   val->drdy_gy = status.gda;
   val->drdy_temp = status.tda;
@@ -2205,6 +2177,8 @@ int32_t lsm6dsv16x_temperature_raw_get(stmdev_ctx_t *ctx, int16_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_OUT_TEMP_L, &buff[0], 2);
+  if (ret != 0) { return ret; }
+
   *val = (int16_t)buff[1];
   *val = (*val * 256) + (int16_t)buff[0];
 
@@ -2225,6 +2199,8 @@ int32_t lsm6dsv16x_angular_rate_raw_get(stmdev_ctx_t *ctx, int16_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_OUTX_L_G, &buff[0], 6);
+  if (ret != 0) { return ret; }
+
   val[0] = (int16_t)buff[1];
   val[0] = (val[0] * 256) + (int16_t)buff[0];
   val[1] = (int16_t)buff[3];
@@ -2249,6 +2225,8 @@ int32_t lsm6dsv16x_ois_angular_rate_raw_get(stmdev_ctx_t *ctx, int16_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SPI2_OUTX_L_G_OIS, &buff[0], 6);
+  if (ret != 0) { return ret; }
+
   val[0] = (int16_t)buff[1];
   val[0] = (*val * 256) + (int16_t)buff[0];
   val[1] = (int16_t)buff[3];
@@ -2273,6 +2251,8 @@ int32_t lsm6dsv16x_ois_eis_angular_rate_raw_get(stmdev_ctx_t *ctx, int16_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_OUTX_L_G_OIS_EIS, &buff[0], 6);
+  if (ret != 0) { return ret; }
+
   val[0] = (int16_t)buff[1];
   val[0] = (*val * 256) + (int16_t)buff[0];
   val[1] = (int16_t)buff[3];
@@ -2297,6 +2277,8 @@ int32_t lsm6dsv16x_acceleration_raw_get(stmdev_ctx_t *ctx, int16_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_OUTX_L_A, &buff[0], 6);
+  if (ret != 0) { return ret; }
+
   val[0] = (int16_t)buff[1];
   val[0] = (val[0] * 256) + (int16_t)buff[0];
   val[1] = (int16_t)buff[3];
@@ -2321,6 +2303,8 @@ int32_t lsm6dsv16x_dual_acceleration_raw_get(stmdev_ctx_t *ctx, int16_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_OUTX_L_A_OIS_DUALC, &buff[0], 6);
+  if (ret != 0) { return ret; }
+
   val[0] = (int16_t)buff[1];
   val[0] = (val[0] * 256) + (int16_t)buff[0];
   val[1] = (int16_t)buff[3];
@@ -2345,6 +2329,8 @@ int32_t lsm6dsv16x_ah_qvar_raw_get(stmdev_ctx_t *ctx, int16_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_AH_QVAR_OUT_L, &buff[0], 2);
+  if (ret != 0) { return ret; }
+
   *val = (int16_t)buff[1];
   *val = (*val * 256) + (int16_t)buff[0];
 
@@ -2393,27 +2379,33 @@ int32_t lsm6dsv16x_ln_pg_write(stmdev_ctx_t *ctx, uint16_t address,
   lsb = (uint8_t)address & 0xFFU;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0) { return ret; }
 
   /* set page write */
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_RW, (uint8_t *)&page_rw, 1);
   page_rw.page_read = PROPERTY_DISABLE;
   page_rw.page_write = PROPERTY_ENABLE;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_RW, (uint8_t *)&page_rw, 1);
+  if (ret != 0) { goto exit; }
 
   /* select page */
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
   page_sel.page_sel = msb;
   page_sel.not_used0 = 1; // Default value
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  if (ret != 0) { goto exit; }
 
   /* set page addr */
   page_address.page_addr = lsb;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_ADDRESS,
                               (uint8_t *)&page_address, 1);
+  if (ret != 0) { goto exit; }
 
   for (i = 0; ((i < len) && (ret == 0)); i++)
   {
     ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_VALUE, &buf[i], 1);
+    if (ret != 0) { goto exit; }
+
     lsb++;
 
     /* Check if page wrap */
@@ -2421,19 +2413,19 @@ int32_t lsm6dsv16x_ln_pg_write(stmdev_ctx_t *ctx, uint16_t address,
     {
       msb++;
       ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
+      if (ret != 0) { goto exit; }
 
-      if (ret == 0)
-      {
-        page_sel.page_sel = msb;
-        page_sel.not_used0 = 1; // Default value
-        ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
-      }
+      page_sel.page_sel = msb;
+      page_sel.not_used0 = 1; // Default value
+      ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
+      if (ret != 0) { goto exit; }
     }
   }
 
   page_sel.page_sel = 0;
   page_sel.not_used0 = 1;// Default value
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  if (ret != 0) { goto exit; }
 
   /* unset page write */
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_RW, (uint8_t *)&page_rw, 1);
@@ -2441,6 +2433,7 @@ int32_t lsm6dsv16x_ln_pg_write(stmdev_ctx_t *ctx, uint16_t address,
   page_rw.page_write = PROPERTY_DISABLE;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_RW, (uint8_t *)&page_rw, 1);
 
+exit:
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
   return ret;
@@ -2476,27 +2469,33 @@ int32_t lsm6dsv16x_ln_pg_read(stmdev_ctx_t *ctx, uint16_t address, uint8_t *buf,
   lsb = (uint8_t)address & 0xFFU;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0) { return ret; }
 
   /* set page write */
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_RW, (uint8_t *)&page_rw, 1);
   page_rw.page_read = PROPERTY_ENABLE;
   page_rw.page_write = PROPERTY_DISABLE;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_RW, (uint8_t *)&page_rw, 1);
+  if (ret != 0) { goto exit; }
 
   /* select page */
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
   page_sel.page_sel = msb;
   page_sel.not_used0 = 1; // Default value
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  if (ret != 0) { goto exit; }
 
   /* set page addr */
   page_address.page_addr = lsb;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_ADDRESS,
                               (uint8_t *)&page_address, 1);
+  if (ret != 0) { goto exit; }
 
   for (i = 0; ((i < len) && (ret == 0)); i++)
   {
     ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_VALUE, &buf[i], 1);
+    if (ret != 0) { goto exit; }
+
     lsb++;
 
     /* Check if page wrap */
@@ -2504,19 +2503,19 @@ int32_t lsm6dsv16x_ln_pg_read(stmdev_ctx_t *ctx, uint16_t address, uint8_t *buf,
     {
       msb++;
       ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
+      if (ret != 0) { goto exit; }
 
-      if (ret == 0)
-      {
-        page_sel.page_sel = msb;
-        page_sel.not_used0 = 1; // Default value
-        ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
-      }
+      page_sel.page_sel = msb;
+      page_sel.not_used0 = 1; // Default value
+      ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
+      if (ret != 0) { goto exit; }
     }
   }
 
   page_sel.page_sel = 0;
   page_sel.not_used0 = 1;// Default value
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  if (ret != 0) { goto exit; }
 
   /* unset page write */
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_RW, (uint8_t *)&page_rw, 1);
@@ -2524,6 +2523,7 @@ int32_t lsm6dsv16x_ln_pg_read(stmdev_ctx_t *ctx, uint16_t address, uint8_t *buf,
   page_rw.page_write = PROPERTY_DISABLE;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_RW, (uint8_t *)&page_rw, 1);
 
+exit:
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
   return ret;
@@ -2567,11 +2567,9 @@ int32_t lsm6dsv16x_emb_function_dbg_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL10, (uint8_t *)&ctrl10, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    *val = ctrl10.emb_func_debug;
-  }
+  *val = ctrl10.emb_func_debug;
 
   return ret;
 }
@@ -2629,6 +2627,8 @@ int32_t lsm6dsv16x_den_polarity_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL4, (uint8_t *)&ctrl4, 1);
+  if (ret != 0) { return ret; }
+
   switch (ctrl4.int2_in_lh)
   {
     case LSM6DSV16X_DEN_ACT_LOW:
@@ -2643,6 +2643,7 @@ int32_t lsm6dsv16x_den_polarity_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_DEN_ACT_LOW;
       break;
   }
+
   return ret;
 }
 
@@ -2660,43 +2661,42 @@ int32_t lsm6dsv16x_den_conf_set(stmdev_ctx_t *ctx, lsm6dsv16x_den_conf_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_DEN, (uint8_t *)&den, 1);
-  if (ret == 0)
+  if (ret != 0) { return ret; }
+
+  den.den_z = val.den_z;
+  den.den_y = val.den_y;
+  den.den_x = val.den_x;
+
+  den.lvl2_en = (uint8_t)val.mode & 0x1U;
+  den.lvl1_en = ((uint8_t)val.mode & 0x2U) >> 1;
+
+  if (val.stamp_in_gy_data == PROPERTY_ENABLE && val.stamp_in_xl_data == PROPERTY_ENABLE)
   {
-    den.den_z = val.den_z;
-    den.den_y = val.den_y;
-    den.den_x = val.den_x;
-
-    den.lvl2_en = (uint8_t)val.mode & 0x1U;
-    den.lvl1_en = ((uint8_t)val.mode & 0x2U) >> 1;
-
-    if (val.stamp_in_gy_data == PROPERTY_ENABLE && val.stamp_in_xl_data == PROPERTY_ENABLE)
-    {
-      den.den_xl_g = PROPERTY_DISABLE;
-      den.den_xl_en = PROPERTY_ENABLE;
-    }
-    else if (val.stamp_in_gy_data == PROPERTY_ENABLE && val.stamp_in_xl_data == PROPERTY_DISABLE)
-    {
-      den.den_xl_g = PROPERTY_DISABLE;
-      den.den_xl_en = PROPERTY_DISABLE;
-    }
-    else if (val.stamp_in_gy_data == PROPERTY_DISABLE && val.stamp_in_xl_data == PROPERTY_ENABLE)
-    {
-      den.den_xl_g = PROPERTY_ENABLE;
-      den.den_xl_en = PROPERTY_DISABLE;
-    }
-    else
-    {
-      den.den_xl_g = PROPERTY_DISABLE;
-      den.den_xl_en = PROPERTY_DISABLE;
-      den.den_z = PROPERTY_DISABLE;
-      den.den_y = PROPERTY_DISABLE;
-      den.den_x = PROPERTY_DISABLE;
-      den.lvl2_en = PROPERTY_DISABLE;
-      den.lvl1_en = PROPERTY_DISABLE;
-    }
-
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_DEN, (uint8_t *)&den, 1);
+    den.den_xl_g = PROPERTY_DISABLE;
+    den.den_xl_en = PROPERTY_ENABLE;
   }
+  else if (val.stamp_in_gy_data == PROPERTY_ENABLE && val.stamp_in_xl_data == PROPERTY_DISABLE)
+  {
+    den.den_xl_g = PROPERTY_DISABLE;
+    den.den_xl_en = PROPERTY_DISABLE;
+  }
+  else if (val.stamp_in_gy_data == PROPERTY_DISABLE && val.stamp_in_xl_data == PROPERTY_ENABLE)
+  {
+    den.den_xl_g = PROPERTY_ENABLE;
+    den.den_xl_en = PROPERTY_DISABLE;
+  }
+  else
+  {
+    den.den_xl_g = PROPERTY_DISABLE;
+    den.den_xl_en = PROPERTY_DISABLE;
+    den.den_z = PROPERTY_DISABLE;
+    den.den_y = PROPERTY_DISABLE;
+    den.den_x = PROPERTY_DISABLE;
+    den.lvl2_en = PROPERTY_DISABLE;
+    den.lvl1_en = PROPERTY_DISABLE;
+  }
+
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_DEN, (uint8_t *)&den, 1);
 
   return ret;
 }
@@ -2716,6 +2716,7 @@ int32_t lsm6dsv16x_den_conf_get(stmdev_ctx_t *ctx, lsm6dsv16x_den_conf_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_DEN, (uint8_t *)&den, 1);
+  if (ret != 0) { return ret; }
 
   val->den_z = den.den_z;
   val->den_y = den.den_y;
@@ -2815,6 +2816,7 @@ int32_t lsm6dsv16x_eis_gy_full_scale_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
+  if (ret != 0) { return ret; }
 
   switch (ctrl_eis.fs_g_eis)
   {
@@ -2928,6 +2930,7 @@ int32_t lsm6dsv16x_gy_eis_data_rate_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
+  if (ret != 0) { return ret; }
 
   switch (ctrl_eis.odr_g_eis)
   {
@@ -2947,6 +2950,7 @@ int32_t lsm6dsv16x_gy_eis_data_rate_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_EIS_1920Hz;
       break;
   }
+
   return ret;
 }
 
@@ -3044,7 +3048,6 @@ int32_t lsm6dsv16x_fifo_xl_dual_fsm_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
   *val = fifo_ctrl2.xl_dualc_batch_from_fsm;
 
-
   return ret;
 }
 
@@ -3087,6 +3090,8 @@ int32_t lsm6dsv16x_fifo_compress_algo_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+  if (ret != 0) { return ret; }
+
   switch (fifo_ctrl2.uncompr_rate)
   {
     case LSM6DSV16X_CMP_DISABLE:
@@ -3172,25 +3177,16 @@ int32_t lsm6dsv16x_fifo_compress_algo_real_time_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
-  if (ret == 0)
-  {
-    fifo_ctrl2.fifo_compr_rt_en = val;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
-  }
+  fifo_ctrl2.fifo_compr_rt_en = val;
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
-  }
-  if (ret == 0)
-  {
-    emb_func_en_b.fifo_compr_en = val;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
-  }
+  ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0) { return ret; }
+
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
+  emb_func_en_b.fifo_compr_en = val;
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
   return ret;
@@ -3298,6 +3294,8 @@ int32_t lsm6dsv16x_fifo_xl_batch_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL3, (uint8_t *)&fifo_ctrl3, 1);
+  if (ret != 0) { return ret; }
+
   switch (fifo_ctrl3.bdr_xl)
   {
     case LSM6DSV16X_XL_NOT_BATCHED:
@@ -3356,6 +3354,7 @@ int32_t lsm6dsv16x_fifo_xl_batch_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_XL_NOT_BATCHED;
       break;
   }
+
   return ret;
 }
 
@@ -3398,6 +3397,8 @@ int32_t lsm6dsv16x_fifo_gy_batch_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL3, (uint8_t *)&fifo_ctrl3, 1);
+  if (ret != 0) { return ret; }
+
   switch (fifo_ctrl3.bdr_gy)
   {
     case LSM6DSV16X_GY_NOT_BATCHED:
@@ -3497,6 +3498,8 @@ int32_t lsm6dsv16x_fifo_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_fifo_mode_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
+  if (ret != 0) { return ret; }
+
   switch (fifo_ctrl4.fifo_mode)
   {
     case LSM6DSV16X_BYPASS_MODE:
@@ -3615,6 +3618,8 @@ int32_t lsm6dsv16x_fifo_temp_batch_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
+  if (ret != 0) { return ret; }
+
   switch (fifo_ctrl4.odr_t_batch)
   {
     case LSM6DSV16X_TEMP_NOT_BATCHED:
@@ -3679,6 +3684,8 @@ int32_t lsm6dsv16x_fifo_timestamp_batch_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
+  if (ret != 0) { return ret; }
+
   switch (fifo_ctrl4.dec_ts_batch)
   {
     case LSM6DSV16X_TMSTMP_NOT_BATCHED:
@@ -3701,6 +3708,7 @@ int32_t lsm6dsv16x_fifo_timestamp_batch_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_TMSTMP_NOT_BATCHED;
       break;
   }
+
   return ret;
 }
 
@@ -3740,6 +3748,8 @@ int32_t lsm6dsv16x_fifo_batch_counter_threshold_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_COUNTER_BDR_REG1, &buff[0], 2);
+  if (ret != 0) { return ret; }
+
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
 
@@ -3785,6 +3795,8 @@ int32_t lsm6dsv16x_fifo_batch_cnt_event_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_COUNTER_BDR_REG1, (uint8_t *)&counter_bdr_reg1, 1);
+  if (ret != 0) { return ret; }
+
   switch (counter_bdr_reg1.trig_counter_bdr)
   {
     case LSM6DSV16X_XL_BATCH_EVENT:
@@ -3803,6 +3815,7 @@ int32_t lsm6dsv16x_fifo_batch_cnt_event_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_XL_BATCH_EVENT;
       break;
   }
+
   return ret;
 }
 
@@ -3814,6 +3827,8 @@ int32_t lsm6dsv16x_fifo_status_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_STATUS1, (uint8_t *)&buff[0], 2);
+  if (ret != 0) { return ret; }
+
   bytecpy((uint8_t *)&status, &buff[1]);
 
   val->fifo_bdr = status.counter_bdr_ia;
@@ -3851,6 +3866,8 @@ int32_t lsm6dsv16x_fifo_out_raw_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_DATA_OUT_TAG, buff, 7);
+  if (ret != 0) { return ret; }
+
   bytecpy((uint8_t *)&fifo_data_out_tag, &buff[0]);
 
   switch (fifo_data_out_tag.tag_sensor)
@@ -3998,16 +4015,12 @@ int32_t lsm6dsv16x_fifo_stpcnt_batch_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
-  }
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    emb_func_fifo_en_a.step_counter_fifo_en = val;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
-  }
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
+  emb_func_fifo_en_a.step_counter_fifo_en = val;
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
+
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
   return ret;
@@ -4027,11 +4040,9 @@ int32_t lsm6dsv16x_fifo_stpcnt_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
-  }
+  if (ret != 0) { return ret; }
 
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
   *val = emb_func_fifo_en_a.step_counter_fifo_en;
 
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
@@ -4053,16 +4064,12 @@ int32_t lsm6dsv16x_fifo_mlc_batch_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
-  }
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    emb_func_fifo_en_a.mlc_fifo_en = val;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
-  }
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
+  emb_func_fifo_en_a.mlc_fifo_en = val;
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
+
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
   return ret;
@@ -4082,11 +4089,9 @@ int32_t lsm6dsv16x_fifo_mlc_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
-  }
+  if (ret != 0) { return ret; }
 
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
   *val = emb_func_fifo_en_a.mlc_fifo_en;
 
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
@@ -4108,16 +4113,12 @@ int32_t lsm6dsv16x_fifo_mlc_filt_batch_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_B, (uint8_t *)&emb_func_fifo_en_b, 1);
-  }
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    emb_func_fifo_en_b.mlc_filter_feature_fifo_en = val;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_B, (uint8_t *)&emb_func_fifo_en_b, 1);
-  }
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_B, (uint8_t *)&emb_func_fifo_en_b, 1);
+  emb_func_fifo_en_b.mlc_filter_feature_fifo_en = val;
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_B, (uint8_t *)&emb_func_fifo_en_b, 1);
+
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
   return ret;
@@ -4137,11 +4138,9 @@ int32_t lsm6dsv16x_fifo_mlc_filt_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_B, (uint8_t *)&emb_func_fifo_en_b, 1);
-  }
+  if (ret != 0) { return ret; }
 
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_B, (uint8_t *)&emb_func_fifo_en_b, 1);
   *val = emb_func_fifo_en_b.mlc_filter_feature_fifo_en;
 
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
@@ -4150,54 +4149,24 @@ int32_t lsm6dsv16x_fifo_mlc_filt_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
 }
 
 /**
-  * @brief  Enable FIFO data batching of first slave.[set]
+  * @brief  Enable FIFO data batching of slave idx.[set]
   *
   * @param  ctx      read / write interface definitions
-  * @param  val      Enable FIFO data batching of first slave.
+  * @param  val      Enable FIFO data batching of slave idx.
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_batch_sh_slave_0_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_fifo_sh_batch_slave_set(stmdev_ctx_t *ctx, uint8_t idx, uint8_t val)
 {
-  lsm6dsv16x_slv0_config_t slv0_config;
+  lsm6dsv16x_slv0_config_t slv_config;
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV0_CONFIG, (uint8_t *)&slv0_config, 1);
-  }
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    slv0_config.batch_ext_sens_0_en = val;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_CONFIG, (uint8_t *)&slv0_config, 1);
-  }
-  ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-
-  return ret;
-}
-
-/**
-  * @brief  Enable FIFO data batching of first slave.[get]
-  *
-  * @param  ctx      read / write interface definitions
-  * @param  val      Enable FIFO data batching of first slave.
-  * @retval          interface status (MANDATORY: return 0 -> no Error)
-  *
-  */
-int32_t lsm6dsv16x_fifo_batch_sh_slave_0_get(stmdev_ctx_t *ctx, uint8_t *val)
-{
-  lsm6dsv16x_slv0_config_t slv0_config;
-  int32_t ret;
-
-  ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV0_CONFIG, (uint8_t *)&slv0_config, 1);
-  }
-
-  *val = slv0_config.batch_ext_sens_0_en;
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV0_CONFIG + idx*3U, (uint8_t *)&slv_config, 1);
+  slv_config.batch_ext_sens_0_en = val;
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_CONFIG + idx*3U, (uint8_t *)&slv_config, 1);
 
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
@@ -4205,164 +4174,23 @@ int32_t lsm6dsv16x_fifo_batch_sh_slave_0_get(stmdev_ctx_t *ctx, uint8_t *val)
 }
 
 /**
-  * @brief  Enable FIFO data batching of second slave.[set]
+  * @brief  Enable FIFO data batching of slave idx.[get]
   *
   * @param  ctx      read / write interface definitions
-  * @param  val      Enable FIFO data batching of second slave.
+  * @param  val      Enable FIFO data batching of slave idx.
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_batch_sh_slave_1_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_fifo_sh_batch_slave_get(stmdev_ctx_t *ctx, uint8_t idx, uint8_t *val)
 {
-  lsm6dsv16x_slv1_config_t slv1_config;
+  lsm6dsv16x_slv0_config_t slv_config;
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV1_CONFIG, (uint8_t *)&slv1_config, 1);
-  }
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    slv1_config.batch_ext_sens_1_en = val;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV1_CONFIG, (uint8_t *)&slv1_config, 1);
-  }
-  ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-
-  return ret;
-}
-
-/**
-  * @brief  Enable FIFO data batching of second slave.[get]
-  *
-  * @param  ctx      read / write interface definitions
-  * @param  val      Enable FIFO data batching of second slave.
-  * @retval          interface status (MANDATORY: return 0 -> no Error)
-  *
-  */
-int32_t lsm6dsv16x_fifo_batch_sh_slave_1_get(stmdev_ctx_t *ctx, uint8_t *val)
-{
-  lsm6dsv16x_slv1_config_t slv1_config;
-  int32_t ret;
-
-  ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV1_CONFIG, (uint8_t *)&slv1_config, 1);
-  }
-
-  *val = slv1_config.batch_ext_sens_1_en;
-
-  ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-
-  return ret;
-}
-
-/**
-  * @brief  Enable FIFO data batching of third slave.[set]
-  *
-  * @param  ctx      read / write interface definitions
-  * @param  val      Enable FIFO data batching of third slave.
-  * @retval          interface status (MANDATORY: return 0 -> no Error)
-  *
-  */
-int32_t lsm6dsv16x_fifo_batch_sh_slave_2_set(stmdev_ctx_t *ctx, uint8_t val)
-{
-  lsm6dsv16x_slv2_config_t slv2_config;
-  int32_t ret;
-
-  ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV2_CONFIG, (uint8_t *)&slv2_config, 1);
-  }
-
-  if (ret == 0)
-  {
-    slv2_config.batch_ext_sens_2_en = val;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV2_CONFIG, (uint8_t *)&slv2_config, 1);
-  }
-  ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-
-  return ret;
-}
-
-/**
-  * @brief  Enable FIFO data batching of third slave.[get]
-  *
-  * @param  ctx      read / write interface definitions
-  * @param  val      Enable FIFO data batching of third slave.
-  * @retval          interface status (MANDATORY: return 0 -> no Error)
-  *
-  */
-int32_t lsm6dsv16x_fifo_batch_sh_slave_2_get(stmdev_ctx_t *ctx, uint8_t *val)
-{
-  lsm6dsv16x_slv2_config_t slv2_config;
-  int32_t ret;
-
-  ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV2_CONFIG, (uint8_t *)&slv2_config, 1);
-  }
-
-  *val = slv2_config.batch_ext_sens_2_en;
-
-  ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-
-  return ret;
-}
-
-/**
-  * @brief  Enable FIFO data batching of fourth slave.[set]
-  *
-  * @param  ctx      read / write interface definitions
-  * @param  val      Enable FIFO data batching of fourth slave.
-  * @retval          interface status (MANDATORY: return 0 -> no Error)
-  *
-  */
-int32_t lsm6dsv16x_fifo_batch_sh_slave_3_set(stmdev_ctx_t *ctx, uint8_t val)
-{
-  lsm6dsv16x_slv3_config_t slv3_config;
-  int32_t ret;
-
-  ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV3_CONFIG, (uint8_t *)&slv3_config, 1);
-  }
-
-  if (ret == 0)
-  {
-    slv3_config.batch_ext_sens_3_en = val;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV3_CONFIG, (uint8_t *)&slv3_config, 1);
-  }
-  ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-
-  return ret;
-}
-
-/**
-  * @brief  Enable FIFO data batching of fourth slave.[get]
-  *
-  * @param  ctx      read / write interface definitions
-  * @param  val      Enable FIFO data batching of fourth slave.
-  * @retval          interface status (MANDATORY: return 0 -> no Error)
-  *
-  */
-int32_t lsm6dsv16x_fifo_batch_sh_slave_3_get(stmdev_ctx_t *ctx, uint8_t *val)
-{
-  lsm6dsv16x_slv3_config_t slv3_config;
-  int32_t ret;
-
-  ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV3_CONFIG, (uint8_t *)&slv3_config, 1);
-  }
-
-  *val = slv3_config.batch_ext_sens_3_en;
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV0_CONFIG + idx*3U, (uint8_t *)&slv_config, 1);
+  *val = slv_config.batch_ext_sens_0_en;
 
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
@@ -4481,6 +4309,8 @@ int32_t lsm6dsv16x_filt_anti_spike_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  if (ret != 0) { return ret; }
+
   switch (if_cfg.asf_ctrl)
   {
     case LSM6DSV16X_AUTO:
@@ -4495,6 +4325,7 @@ int32_t lsm6dsv16x_filt_anti_spike_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_AUTO;
       break;
   }
+
   return ret;
 }
 
@@ -4515,36 +4346,19 @@ int32_t lsm6dsv16x_filt_settling_mask_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL4, (uint8_t *)&ctrl4, 1);
+  ctrl4.drdy_mask = val.drdy;
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL4, (uint8_t *)&ctrl4, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ctrl4.drdy_mask = val.drdy;
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
+  emb_func_cfg.emb_func_irq_mask_xl_settl = val.irq_xl;
+  emb_func_cfg.emb_func_irq_mask_g_settl = val.irq_g;
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
+  if (ret != 0) { return ret; }
 
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL4, (uint8_t *)&ctrl4, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
-  }
-
-  if (ret == 0)
-  {
-    emb_func_cfg.emb_func_irq_mask_xl_settl = val.irq_xl;
-    emb_func_cfg.emb_func_irq_mask_g_settl = val.irq_g;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_INT_OIS, (uint8_t *)&ui_int_ois, 1);
-  }
-
-  if (ret == 0)
-  {
-    ui_int_ois.drdy_mask_ois = val.ois_drdy;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_UI_INT_OIS, (uint8_t *)&ui_int_ois, 1);
-  }
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_INT_OIS, (uint8_t *)&ui_int_ois, 1);
+  ui_int_ois.drdy_mask_ois = val.ois_drdy;
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_UI_INT_OIS, (uint8_t *)&ui_int_ois, 1);
 
   return ret;
 }
@@ -4566,14 +4380,8 @@ int32_t lsm6dsv16x_filt_settling_mask_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL4, (uint8_t *)&ctrl4, 1);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_INT_OIS, (uint8_t *)&ui_int_ois, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_INT_OIS, (uint8_t *)&ui_int_ois, 1);
 
   val->irq_xl = emb_func_cfg.emb_func_irq_mask_xl_settl;
   val->irq_g = emb_func_cfg.emb_func_irq_mask_g_settl;
@@ -4667,6 +4475,8 @@ int32_t lsm6dsv16x_filt_gy_lp1_bandwidth_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL6, (uint8_t *)&ctrl6, 1);
+  if (ret != 0) { return ret; }
+
   switch (ctrl6.lpf1_g_bw)
   {
     case LSM6DSV16X_GY_ULTRA_LIGHT:
@@ -4705,6 +4515,7 @@ int32_t lsm6dsv16x_filt_gy_lp1_bandwidth_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_GY_ULTRA_LIGHT;
       break;
   }
+
   return ret;
 }
 
@@ -4790,6 +4601,8 @@ int32_t lsm6dsv16x_filt_xl_lp2_bandwidth_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL8, (uint8_t *)&ctrl8, 1);
+  if (ret != 0) { return ret; }
+
   switch (ctrl8.hp_lpf2_xl_bw)
   {
     case LSM6DSV16X_XL_ULTRA_LIGHT:
@@ -4828,6 +4641,7 @@ int32_t lsm6dsv16x_filt_xl_lp2_bandwidth_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_XL_ULTRA_LIGHT;
       break;
   }
+
   return ret;
 }
 
@@ -4996,6 +4810,8 @@ int32_t lsm6dsv16x_filt_xl_hp_mode_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1);
+  if (ret != 0) { return ret; }
+
   switch (ctrl9.hp_ref_mode_xl)
   {
     case LSM6DSV16X_HP_MD_NORMAL:
@@ -5010,6 +4826,7 @@ int32_t lsm6dsv16x_filt_xl_hp_mode_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_HP_MD_NORMAL;
       break;
   }
+
   return ret;
 }
 
@@ -5029,21 +4846,15 @@ int32_t lsm6dsv16x_filt_wkup_act_feed_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    tap_cfg0.slope_fds = (uint8_t)val & 0x01U;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
-  }
-  if (ret == 0)
-  {
-    wake_up_ths.usr_off_on_wu = ((uint8_t)val & 0x02U) >> 1;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
-  }
+  tap_cfg0.slope_fds = (uint8_t)val & 0x01U;
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  if (ret != 0) { return ret; }
+
+  wake_up_ths.usr_off_on_wu = ((uint8_t)val & 0x02U) >> 1;
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
 
   return ret;
 }
@@ -5064,10 +4875,8 @@ int32_t lsm6dsv16x_filt_wkup_act_feed_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  if (ret != 0) { return ret; }
 
   switch ((wake_up_ths.usr_off_on_wu << 1) + tap_cfg0.slope_fds)
   {
@@ -5087,6 +4896,7 @@ int32_t lsm6dsv16x_filt_wkup_act_feed_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_WK_FEED_SLOPE;
       break;
   }
+
   return ret;
 }
 
@@ -5173,6 +4983,7 @@ int32_t lsm6dsv16x_filt_sixd_feed_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  if (ret != 0) { return ret; }
 
   switch (tap_cfg0.low_pass_on_6d)
   {
@@ -5188,6 +4999,7 @@ int32_t lsm6dsv16x_filt_sixd_feed_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_SIXD_FEED_ODR_DIV_2;
       break;
   }
+
   return ret;
 }
 
@@ -5231,6 +5043,7 @@ int32_t lsm6dsv16x_filt_gy_eis_lp_bandwidth_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
+  if (ret != 0) { return ret; }
 
   switch (ctrl_eis.lpf_g_eis_bw)
   {
@@ -5246,6 +5059,7 @@ int32_t lsm6dsv16x_filt_gy_eis_lp_bandwidth_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_EIS_LP_NORMAL;
       break;
   }
+
   return ret;
 }
 
@@ -5290,6 +5104,7 @@ int32_t lsm6dsv16x_filt_gy_ois_lp_bandwidth_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL2_OIS, (uint8_t *)&ui_ctrl2_ois, 1);
+  if (ret != 0) { return ret; }
 
   switch (ui_ctrl2_ois.lpf1_g_ois_bw)
   {
@@ -5313,6 +5128,7 @@ int32_t lsm6dsv16x_filt_gy_ois_lp_bandwidth_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_OIS_GY_LP_NORMAL;
       break;
   }
+
   return ret;
 }
 
@@ -5356,6 +5172,7 @@ int32_t lsm6dsv16x_filt_xl_ois_lp_bandwidth_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL3_OIS, (uint8_t *)&ui_ctrl3_ois, 1);
+  if (ret != 0) { return ret; }
 
   switch (ui_ctrl3_ois.lpf_xl_ois_bw)
   {
@@ -5395,6 +5212,7 @@ int32_t lsm6dsv16x_filt_xl_ois_lp_bandwidth_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_OIS_XL_LP_ULTRA_LIGHT;
       break;
   }
+
   return ret;
 }
 
@@ -5451,6 +5269,7 @@ int32_t lsm6dsv16x_fsm_permission_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  if (ret != 0) { return ret; }
 
   switch (func_cfg_access.fsm_wr_ctrl_en)
   {
@@ -5466,6 +5285,7 @@ int32_t lsm6dsv16x_fsm_permission_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_PROTECT_CTRL_REGS;
       break;
   }
+
   return ret;
 }
 
@@ -5504,14 +5324,12 @@ int32_t lsm6dsv16x_fsm_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_fsm_mode_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FSM_ENABLE, (uint8_t *)&fsm_enable, 1);
-  }
+  if (ret != 0) { return ret; }
+
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FSM_ENABLE, (uint8_t *)&fsm_enable, 1);
+  if (ret != 0) { goto exit; }
+
   if ((val.fsm1_en | val.fsm2_en | val.fsm1_en | val.fsm1_en
        | val.fsm1_en | val.fsm2_en | val.fsm1_en | val.fsm1_en) == PROPERTY_ENABLE)
   {
@@ -5521,22 +5339,20 @@ int32_t lsm6dsv16x_fsm_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_fsm_mode_t val)
   {
     emb_func_en_b.fsm_en = PROPERTY_DISABLE;
   }
-  if (ret == 0)
-  {
-    fsm_enable.fsm1_en = val.fsm1_en;
-    fsm_enable.fsm2_en = val.fsm2_en;
-    fsm_enable.fsm3_en = val.fsm3_en;
-    fsm_enable.fsm4_en = val.fsm4_en;
-    fsm_enable.fsm5_en = val.fsm5_en;
-    fsm_enable.fsm6_en = val.fsm6_en;
-    fsm_enable.fsm7_en = val.fsm7_en;
-    fsm_enable.fsm8_en = val.fsm8_en;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FSM_ENABLE, (uint8_t *)&fsm_enable, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
-  }
+
+  fsm_enable.fsm1_en = val.fsm1_en;
+  fsm_enable.fsm2_en = val.fsm2_en;
+  fsm_enable.fsm3_en = val.fsm3_en;
+  fsm_enable.fsm4_en = val.fsm4_en;
+  fsm_enable.fsm5_en = val.fsm5_en;
+  fsm_enable.fsm6_en = val.fsm6_en;
+  fsm_enable.fsm7_en = val.fsm7_en;
+  fsm_enable.fsm8_en = val.fsm8_en;
+
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FSM_ENABLE, (uint8_t *)&fsm_enable, 1);
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
+
+exit:
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
   return ret;
@@ -5556,11 +5372,9 @@ int32_t lsm6dsv16x_fsm_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_fsm_mode_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FSM_ENABLE, (uint8_t *)&fsm_enable, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FSM_ENABLE, (uint8_t *)&fsm_enable, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
+  if (ret != 0) { return ret; }
 
   val->fsm1_en = fsm_enable.fsm1_en;
   val->fsm2_en = fsm_enable.fsm2_en;
@@ -5590,7 +5404,8 @@ int32_t lsm6dsv16x_fsm_long_cnt_set(stmdev_ctx_t *ctx, uint16_t val)
   buff[1] = (uint8_t)(val / 256U);
   buff[0] = (uint8_t)(val - (buff[1] * 256U));
 
-  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FSM_LONG_COUNTER_L, (uint8_t *)&buff[0], 2);
+  ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FSM_LONG_COUNTER_L, (uint8_t *)&buff[0], 2);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
   return ret;
@@ -5610,11 +5425,9 @@ int32_t lsm6dsv16x_fsm_long_cnt_get(stmdev_ctx_t *ctx, uint16_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FSM_LONG_COUNTER_L, &buff[0], 2);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FSM_LONG_COUNTER_L, &buff[0], 2);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
+  if (ret != 0) { return ret; }
 
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
@@ -5635,10 +5448,7 @@ int32_t lsm6dsv16x_fsm_out_get(stmdev_ctx_t *ctx, lsm6dsv16x_fsm_out_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FSM_OUTS1, (uint8_t *)val, 8);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FSM_OUTS1, (uint8_t *)val, 8);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
   return ret;
@@ -5659,16 +5469,13 @@ int32_t lsm6dsv16x_fsm_data_rate_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FSM_ODR, (uint8_t *)&fsm_odr, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FSM_ODR, (uint8_t *)&fsm_odr, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    fsm_odr.fsm_odr = (uint8_t)val & 0x07U;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FSM_ODR, (uint8_t *)&fsm_odr, 1);
-  }
+  fsm_odr.fsm_odr = (uint8_t)val & 0x07U;
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FSM_ODR, (uint8_t *)&fsm_odr, 1);
+
+exit:
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
   return ret;
@@ -5689,12 +5496,9 @@ int32_t lsm6dsv16x_fsm_data_rate_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FSM_ODR, (uint8_t *)&fsm_odr, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FSM_ODR, (uint8_t *)&fsm_odr, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-
+  if (ret != 0) { return ret; }
 
   switch (fsm_odr.fsm_odr)
   {
@@ -5730,6 +5534,7 @@ int32_t lsm6dsv16x_fsm_data_rate_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_FSM_15Hz;
       break;
   }
+
   return ret;
 }
 
@@ -5921,10 +5726,7 @@ int32_t lsm6dsv16x_sflp_game_gbias_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_sflp_data_rate_get(ctx, &sflp_odr);
-  if (ret != 0)
-  {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   /* Calculate k factor */
   switch (sflp_odr)
@@ -6089,6 +5891,8 @@ int32_t lsm6dsv16x_fsm_ext_sens_sensitivity_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_FSM_EXT_SENSITIVITY_L, &buff[0], 2);
+  if (ret != 0) { return ret; }
+
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
 
@@ -6135,6 +5939,7 @@ int32_t lsm6dsv16x_fsm_ext_sens_offset_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_FSM_EXT_OFFX_L, &buff[0], 6);
+  if (ret != 0) { return ret; }
 
   val->x = buff[1];
   val->x = (val->x * 256U) + buff[0];
@@ -6192,6 +5997,7 @@ int32_t lsm6dsv16x_fsm_ext_sens_matrix_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_FSM_EXT_MATRIX_XX_L, &buff[0], 12);
+  if (ret != 0) { return ret; }
 
   val->xx = buff[1];
   val->xx = (val->xx * 256U) + buff[0];
@@ -6224,11 +6030,8 @@ int32_t lsm6dsv16x_fsm_ext_sens_z_orient_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
-  if (ret == 0)
-  {
-    ext_cfg_a.ext_z_axis = (uint8_t)val & 0x07U;
-    ret = lsm6dsv16x_ln_pg_write(ctx, LSM6DSV16X_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
-  }
+  ext_cfg_a.ext_z_axis = (uint8_t)val & 0x07U;
+  ret += lsm6dsv16x_ln_pg_write(ctx, LSM6DSV16X_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
 
   return ret;
 }
@@ -6248,6 +6051,8 @@ int32_t lsm6dsv16x_fsm_ext_sens_z_orient_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
+  if (ret != 0) { return ret; }
+
   switch (ext_cfg_a.ext_z_axis)
   {
     case LSM6DSV16X_Z_EQ_Y:
@@ -6278,6 +6083,7 @@ int32_t lsm6dsv16x_fsm_ext_sens_z_orient_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_Z_EQ_Y;
       break;
   }
+
   return ret;
 }
 
@@ -6320,6 +6126,8 @@ int32_t lsm6dsv16x_fsm_ext_sens_y_orient_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
+  if (ret != 0) { return ret; }
+
   switch (ext_cfg_a.ext_y_axis)
   {
     case LSM6DSV16X_Y_EQ_Y:
@@ -6350,6 +6158,7 @@ int32_t lsm6dsv16x_fsm_ext_sens_y_orient_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_Y_EQ_Y;
       break;
   }
+
   return ret;
 }
 
@@ -6392,6 +6201,8 @@ int32_t lsm6dsv16x_fsm_ext_sens_x_orient_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EXT_CFG_B, (uint8_t *)&ext_cfg_b, 1);
+  if (ret != 0) { return ret; }
+
   switch (ext_cfg_b.ext_x_axis)
   {
     case LSM6DSV16X_X_EQ_Y:
@@ -6422,6 +6233,7 @@ int32_t lsm6dsv16x_fsm_ext_sens_x_orient_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_X_EQ_Y;
       break;
   }
+
   return ret;
 }
 
@@ -6459,6 +6271,8 @@ int32_t lsm6dsv16x_fsm_long_cnt_timeout_get(stmdev_ctx_t *ctx, uint16_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_FSM_LC_TIMEOUT_L, &buff[0], 2);
+  if (ret != 0) { return ret; }
+
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
 
@@ -6541,6 +6355,8 @@ int32_t lsm6dsv16x_fsm_start_address_get(stmdev_ctx_t *ctx, uint16_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_FSM_START_ADD_L, &buff[0], 2);
+  if (ret != 0) { return ret; }
+
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
 
@@ -6575,21 +6391,13 @@ int32_t lsm6dsv16x_ff_time_windows_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
-  if (ret == 0)
-  {
-    wake_up_dur.ff_dur = ((uint8_t)val & 0x20U) >> 5;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FREE_FALL, (uint8_t *)&free_fall, 1);
-  }
+  wake_up_dur.ff_dur = ((uint8_t)val & 0x20U) >> 5;
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    free_fall.ff_dur = (uint8_t)val & 0x1FU;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FREE_FALL, (uint8_t *)&free_fall, 1);
-  }
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FREE_FALL, (uint8_t *)&free_fall, 1);
+  free_fall.ff_dur = (uint8_t)val & 0x1FU;
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FREE_FALL, (uint8_t *)&free_fall, 1);
 
   return ret;
 }
@@ -6609,10 +6417,7 @@ int32_t lsm6dsv16x_ff_time_windows_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FREE_FALL, (uint8_t *)&free_fall, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FREE_FALL, (uint8_t *)&free_fall, 1);
 
   *val = (wake_up_dur.ff_dur << 5) + free_fall.ff_dur;
 
@@ -6658,6 +6463,8 @@ int32_t lsm6dsv16x_ff_thresholds_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FREE_FALL, (uint8_t *)&free_fall, 1);
+  if (ret != 0) { return ret; }
+
   switch (free_fall.ff_ths)
   {
     case LSM6DSV16X_156_mg:
@@ -6696,6 +6503,7 @@ int32_t lsm6dsv16x_ff_thresholds_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_156_mg;
       break;
   }
+
   return ret;
 }
 
@@ -6727,34 +6535,32 @@ int32_t lsm6dsv16x_mlc_set(stmdev_ctx_t *ctx, lsm6dsv16x_mlc_mode_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_en_a, 1);
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_B, (uint8_t *)&emb_en_b, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
+  switch(val)
   {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_en_a, 1);
-    ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_B, (uint8_t *)&emb_en_b, 1);
-
-    switch(val)
-    {
-      case LSM6DSV16X_MLC_OFF:
-        emb_en_a.mlc_before_fsm_en = 0;
-        emb_en_b.mlc_en = 0;
-        break;
-      case LSM6DSV16X_MLC_ON:
-        emb_en_a.mlc_before_fsm_en = 0;
-        emb_en_b.mlc_en = 1;
-        break;
-      case LSM6DSV16X_MLC_ON_BEFORE_FSM:
-        emb_en_a.mlc_before_fsm_en = 1;
-        emb_en_b.mlc_en = 0;
-        break;
-      default:
-        break;
-    }
-
-    ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_en_a, 1);
-    ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_B, (uint8_t *)&emb_en_b, 1);
+    case LSM6DSV16X_MLC_OFF:
+      emb_en_a.mlc_before_fsm_en = 0;
+      emb_en_b.mlc_en = 0;
+      break;
+    case LSM6DSV16X_MLC_ON:
+      emb_en_a.mlc_before_fsm_en = 0;
+      emb_en_b.mlc_en = 1;
+      break;
+    case LSM6DSV16X_MLC_ON_BEFORE_FSM:
+      emb_en_a.mlc_before_fsm_en = 1;
+      emb_en_b.mlc_en = 0;
+      break;
+    default:
+      break;
   }
 
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_en_a, 1);
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_B, (uint8_t *)&emb_en_b, 1);
+
+exit:
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
   return ret;
@@ -6775,30 +6581,28 @@ int32_t lsm6dsv16x_mlc_get(stmdev_ctx_t *ctx, lsm6dsv16x_mlc_mode_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_en_a, 1);
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_B, (uint8_t *)&emb_en_b, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
+  if (emb_en_a.mlc_before_fsm_en == 0U && emb_en_b.mlc_en == 0U)
   {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_en_a, 1);
-    ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_B, (uint8_t *)&emb_en_b, 1);
-
-    if (emb_en_a.mlc_before_fsm_en == 0U && emb_en_b.mlc_en == 0U)
-    {
-      *val = LSM6DSV16X_MLC_OFF;
-    }
-    else if (emb_en_a.mlc_before_fsm_en == 0U && emb_en_b.mlc_en == 1U)
-    {
-      *val = LSM6DSV16X_MLC_ON;
-    }
-    else if (emb_en_a.mlc_before_fsm_en == 1U)
-    {
-      *val = LSM6DSV16X_MLC_ON_BEFORE_FSM;
-    }
-    else
-    {
+    *val = LSM6DSV16X_MLC_OFF;
+  }
+  else if (emb_en_a.mlc_before_fsm_en == 0U && emb_en_b.mlc_en == 1U)
+  {
+    *val = LSM6DSV16X_MLC_ON;
+  }
+  else if (emb_en_a.mlc_before_fsm_en == 1U)
+  {
+    *val = LSM6DSV16X_MLC_ON_BEFORE_FSM;
+  }
+  else
+  {
       /* Do nothing */
-    }
   }
 
+exit:
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
   return ret;
@@ -6819,16 +6623,13 @@ int32_t lsm6dsv16x_mlc_data_rate_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MLC_ODR, (uint8_t *)&mlc_odr, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MLC_ODR, (uint8_t *)&mlc_odr, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    mlc_odr.mlc_odr = (uint8_t)val & 0x07U;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MLC_ODR, (uint8_t *)&mlc_odr, 1);
-  }
+  mlc_odr.mlc_odr = (uint8_t)val & 0x07U;
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MLC_ODR, (uint8_t *)&mlc_odr, 1);
+
+exit:
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
   return ret;
@@ -6849,11 +6650,9 @@ int32_t lsm6dsv16x_mlc_data_rate_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MLC_ODR, (uint8_t *)&mlc_odr, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MLC_ODR, (uint8_t *)&mlc_odr, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
+  if (ret != 0) { return ret; }
 
   switch (mlc_odr.mlc_odr)
   {
@@ -6889,6 +6688,7 @@ int32_t lsm6dsv16x_mlc_data_rate_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_MLC_15Hz;
       break;
   }
+
   return ret;
 }
 
@@ -6910,6 +6710,7 @@ int32_t lsm6dsv16x_mlc_out_get(stmdev_ctx_t *ctx, lsm6dsv16x_mlc_out_t *val)
     ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MLC1_SRC, (uint8_t *)val, 4);
   }
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
+
   return ret;
 }
 
@@ -6949,6 +6750,8 @@ int32_t lsm6dsv16x_mlc_ext_sens_sensitivity_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_MLC_EXT_SENSITIVITY_L, &buff[0], 2);
+  if (ret != 0) { return ret; }
+
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
 
@@ -7007,6 +6810,8 @@ int32_t lsm6dsv16x_ois_ctrl_mode_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  if (ret != 0) { return ret; }
+
   switch (func_cfg_access.ois_ctrl_from_ui)
   {
     case LSM6DSV16X_OIS_CTRL_FROM_OIS:
@@ -7021,6 +6826,7 @@ int32_t lsm6dsv16x_ois_ctrl_mode_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_OIS_CTRL_FROM_OIS;
       break;
   }
+
   return ret;
 }
 
@@ -7148,6 +6954,8 @@ int32_t lsm6dsv16x_ois_handshake_from_ui_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_HANDSHAKE_CTRL, (uint8_t *)&ui_handshake_ctrl, 1);
+  if (ret != 0) { return ret; }
+
   val->ack = ui_handshake_ctrl.ui_shared_ack;
   val->req = ui_handshake_ctrl.ui_shared_req;
 
@@ -7194,6 +7002,8 @@ int32_t lsm6dsv16x_ois_handshake_from_ois_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SPI2_HANDSHAKE_CTRL, (uint8_t *)&spi2_handshake_ctrl, 1);
+  if (ret != 0) { return ret; }
+
   val->ack = spi2_handshake_ctrl.spi2_shared_ack;
   val->req = spi2_handshake_ctrl.spi2_shared_req;
 
@@ -7314,6 +7124,8 @@ int32_t lsm6dsv16x_ois_chain_get(stmdev_ctx_t *ctx, lsm6dsv16x_ois_chain_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
+  if (ret != 0) { return ret; }
+
   val->gy = ui_ctrl1_ois.ois_g_en;
   val->xl = ui_ctrl1_ois.ois_xl_en;
 
@@ -7359,6 +7171,8 @@ int32_t lsm6dsv16x_ois_gy_full_scale_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL2_OIS, (uint8_t *)&ui_ctrl2_ois, 1);
+  if (ret != 0) { return ret; }
+
   switch (ui_ctrl2_ois.fs_g_ois)
   {
     case LSM6DSV16X_OIS_125dps:
@@ -7385,6 +7199,7 @@ int32_t lsm6dsv16x_ois_gy_full_scale_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_OIS_125dps;
       break;
   }
+
   return ret;
 }
 
@@ -7427,6 +7242,8 @@ int32_t lsm6dsv16x_ois_xl_full_scale_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL3_OIS, (uint8_t *)&ui_ctrl3_ois, 1);
+  if (ret != 0) { return ret; }
+
   switch (ui_ctrl3_ois.fs_xl_ois)
   {
     case LSM6DSV16X_OIS_2g:
@@ -7449,6 +7266,7 @@ int32_t lsm6dsv16x_ois_xl_full_scale_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_OIS_2g;
       break;
   }
+
   return ret;
 }
 
@@ -7504,6 +7322,8 @@ int32_t lsm6dsv16x_6d_threshold_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
+  if (ret != 0) { return ret; }
+
   switch (tap_ths_6d.sixd_ths)
   {
     case LSM6DSV16X_DEG_80:
@@ -7526,6 +7346,7 @@ int32_t lsm6dsv16x_6d_threshold_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_DEG_80;
       break;
   }
+
   return ret;
 }
 
@@ -7623,6 +7444,8 @@ int32_t lsm6dsv16x_ah_qvar_zin_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL7, (uint8_t *)&ctrl7, 1);
+  if (ret != 0) { return ret; }
+
   switch (ctrl7.ah_qvar_c_zin)
   {
     case LSM6DSV16X_2400MOhm:
@@ -7645,6 +7468,7 @@ int32_t lsm6dsv16x_ah_qvar_zin_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_2400MOhm;
       break;
   }
+
   return ret;
 }
 
@@ -7744,6 +7568,8 @@ int32_t lsm6dsv16x_i3c_reset_mode_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  if (ret != 0) { return ret; }
+
   switch (pin_ctrl.ibhr_por_en)
   {
     case LSM6DSV16X_SW_RST_DYN_ADDRESS_RST:
@@ -7758,6 +7584,7 @@ int32_t lsm6dsv16x_i3c_reset_mode_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_SW_RST_DYN_ADDRESS_RST;
       break;
   }
+
   return ret;
 }
 
@@ -7800,6 +7627,8 @@ int32_t lsm6dsv16x_i3c_ibi_time_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL5, (uint8_t *)&ctrl5, 1);
+  if (ret != 0) { return ret; }
+
   switch (ctrl5.bus_act_sel)
   {
     case LSM6DSV16X_IBI_2us:
@@ -7822,6 +7651,7 @@ int32_t lsm6dsv16x_i3c_ibi_time_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_IBI_2us;
       break;
   }
+
   return ret;
 }
 
@@ -7890,20 +7720,14 @@ int32_t lsm6dsv16x_sh_master_interface_pull_up_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_read_data_raw_get(stmdev_ctx_t *ctx,
-                                        lsm6dsv16x_emb_sh_read_t *val,
+int32_t lsm6dsv16x_sh_read_data_raw_get(stmdev_ctx_t *ctx, uint8_t *val,
                                         uint8_t len)
 {
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SENSOR_HUB_1, (uint8_t *) val,
-                              len);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SENSOR_HUB_1, val, len);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-
 
   return ret;
 }
@@ -7923,16 +7747,13 @@ int32_t lsm6dsv16x_sh_slave_connected_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    master_config.aux_sens_on = (uint8_t)val & 0x3U;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  master_config.aux_sens_on = (uint8_t)val & 0x3U;
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+
+exit:
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
   return ret;
@@ -7953,11 +7774,9 @@ int32_t lsm6dsv16x_sh_slave_connected_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
+  if (ret != 0) { return ret; }
 
   switch (master_config.aux_sens_on)
   {
@@ -7981,6 +7800,7 @@ int32_t lsm6dsv16x_sh_slave_connected_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_SLV_0;
       break;
   }
+
   return ret;
 }
 
@@ -7998,16 +7818,13 @@ int32_t lsm6dsv16x_sh_master_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    master_config.master_on = val;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  master_config.master_on = val;
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+
+exit:
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
   return ret;
@@ -8027,10 +7844,7 @@ int32_t lsm6dsv16x_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
 
   *val = master_config.master_on;
 
@@ -8053,16 +7867,13 @@ int32_t lsm6dsv16x_sh_pass_through_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    master_config.pass_through_mode = val;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  master_config.pass_through_mode = val;
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+
+exit:
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
   return ret;
@@ -8082,10 +7893,7 @@ int32_t lsm6dsv16x_sh_pass_through_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
 
   *val = master_config.pass_through_mode;
 
@@ -8109,16 +7917,13 @@ int32_t lsm6dsv16x_sh_syncro_mode_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    master_config.start_config = (uint8_t)val & 0x01U;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  master_config.start_config = (uint8_t)val & 0x01U;
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+
+exit:
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
   return ret;
@@ -8139,11 +7944,9 @@ int32_t lsm6dsv16x_sh_syncro_mode_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
+  if (ret != 0) { return ret; }
 
   switch (master_config.start_config)
   {
@@ -8159,6 +7962,7 @@ int32_t lsm6dsv16x_sh_syncro_mode_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_SH_TRG_XL_GY_DRDY;
       break;
   }
+
   return ret;
 }
 
@@ -8177,16 +7981,13 @@ int32_t lsm6dsv16x_sh_write_mode_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    master_config.write_once = (uint8_t)val & 0x01U;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  master_config.write_once = (uint8_t)val & 0x01U;
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+
+exit:
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
   return ret;
@@ -8207,12 +8008,9 @@ int32_t lsm6dsv16x_sh_write_mode_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-
+  if (ret != 0) { return ret; }
 
   switch (master_config.write_once)
   {
@@ -8228,6 +8026,7 @@ int32_t lsm6dsv16x_sh_write_mode_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_EACH_SH_CYCLE;
       break;
   }
+
   return ret;
 }
 
@@ -8245,16 +8044,13 @@ int32_t lsm6dsv16x_sh_reset_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    master_config.rst_master_regs = val;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  master_config.rst_master_regs = val;
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+
+exit:
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
   return ret;
@@ -8274,10 +8070,7 @@ int32_t lsm6dsv16x_sh_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
 
   *val = master_config.rst_master_regs;
 
@@ -8304,25 +8097,21 @@ int32_t lsm6dsv16x_sh_cfg_write(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    reg.slave0_add = val->slv0_add;
-    reg.rw_0 = 0;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_ADD, (uint8_t *)&reg, 1);
-  }
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_SUBADD,
-                               &(val->slv0_subadd), 1);
-  }
+  reg.slave0_add = val->slv0_add;
+  reg.rw_0 = 0;
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_ADD, (uint8_t *)&reg, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_DATAWRITE_SLV0,
-                               &(val->slv0_data), 1);
-  }
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_SUBADD,
+                             &(val->slv0_subadd), 1);
+  if (ret != 0) { goto exit; }
 
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_DATAWRITE_SLV0,
+                             &(val->slv0_data), 1);
+
+exit:
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
   return ret;
@@ -8343,16 +8132,13 @@ int32_t lsm6dsv16x_sh_data_rate_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV0_CONFIG, (uint8_t *)&slv0_config, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV0_CONFIG, (uint8_t *)&slv0_config, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    slv0_config.shub_odr = (uint8_t)val & 0x07U;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_CONFIG, (uint8_t *)&slv0_config, 1);
-  }
+  slv0_config.shub_odr = (uint8_t)val & 0x07U;
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_CONFIG, (uint8_t *)&slv0_config, 1);
+
+exit:
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
   return ret;
@@ -8373,11 +8159,9 @@ int32_t lsm6dsv16x_sh_data_rate_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV0_CONFIG, (uint8_t *)&slv0_config, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV0_CONFIG, (uint8_t *)&slv0_config, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
+  if (ret != 0) { return ret; }
 
   switch (slv0_config.shub_odr)
   {
@@ -8409,209 +8193,69 @@ int32_t lsm6dsv16x_sh_data_rate_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_SH_15Hz;
       break;
   }
+
   return ret;
 }
 
 /**
-  * @brief  Configure slave 0 for perform a read.[set]
+  * @brief  Configure slave idx for perform a read.[set]
   *
   * @param  ctx      read / write interface definitions
   * @param  val      Structure that contain
-  *                      - uint8_t slv1_add;    8 bit i2c device address
-  *                      - uint8_t slv1_subadd; 8 bit register device address
-  *                      - uint8_t slv1_len;    num of bit to read
+  *                      - uint8_t slv_add;    8 bit i2c device address
+  *                      - uint8_t slv_subadd; 8 bit register device address
+  *                      - uint8_t slv_len;    num of bit to read
   * @retval             interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_slv0_cfg_read(stmdev_ctx_t *ctx,
-                                    lsm6dsv16x_sh_cfg_read_t *val)
+int32_t lsm6dsv16x_sh_slv_cfg_read(stmdev_ctx_t *ctx, uint8_t idx,
+                                   lsm6dsv16x_sh_cfg_read_t *val)
 {
-  lsm6dsv16x_slv0_add_t slv0_add;
-  lsm6dsv16x_slv0_config_t slv0_config;
+  lsm6dsv16x_slv0_add_t slv_add;
+  lsm6dsv16x_slv0_config_t slv_config;
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    slv0_add.slave0_add = val->slv_add;
-    slv0_add.rw_0 = 1;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_ADD, (uint8_t *)&slv0_add, 1);
-  }
+  slv_add.slave0_add = val->slv_add;
+  slv_add.rw_0 = 1;
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_ADD + idx*3U,
+                             (uint8_t *)&slv_add, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_SUBADD,
-                               &(val->slv_subadd), 1);
-  }
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_SUBADD + idx*3U,
+                             &(val->slv_subadd), 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV0_CONFIG,
-                              (uint8_t *)&slv0_config, 1);
-  }
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV0_CONFIG + idx*3U,
+                            (uint8_t *)&slv_config, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    slv0_config.slave0_numop = val->slv_len;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_CONFIG,
-                               (uint8_t *)&slv0_config, 1);
-  }
+  slv_config.slave0_numop = val->slv_len;
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_CONFIG + idx*3U,
+                             (uint8_t *)&slv_config, 1);
 
+exit:
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
   return ret;
 }
 
 /**
-  * @brief  Configure slave 0 for perform a write/read.[set]
+  * @brief  Sensor hub source register.[get]
   *
   * @param  ctx      read / write interface definitions
-  * @param  val      Structure that contain
-  *                      - uint8_t slv1_add;    8 bit i2c device address
-  *                      - uint8_t slv1_subadd; 8 bit register device address
-  *                      - uint8_t slv1_len;    num of bit to read
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
+  * @param  val      union of registers from STATUS_MASTER to
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_slv1_cfg_read(stmdev_ctx_t *ctx,
-                                    lsm6dsv16x_sh_cfg_read_t *val)
+int32_t lsm6dsv16x_sh_status_get(stmdev_ctx_t *ctx,
+                                 lsm6dsv16x_status_master_t *val)
 {
-  lsm6dsv16x_slv1_add_t slv1_add;
-  lsm6dsv16x_slv1_config_t slv1_config;
   int32_t ret;
 
-  ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-
-  if (ret == 0)
-  {
-    slv1_add.slave1_add = val->slv_add;
-    slv1_add.r_1 = 1;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV1_ADD, (uint8_t *)&slv1_add, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV1_SUBADD,
-                               &(val->slv_subadd), 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV1_CONFIG,
-                              (uint8_t *)&slv1_config, 1);
-  }
-
-  if (ret == 0)
-  {
-    slv1_config.slave1_numop = val->slv_len;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV1_CONFIG,
-                               (uint8_t *)&slv1_config, 1);
-  }
-
-  ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-
-  return ret;
-}
-
-/**
-  * @brief  Configure slave 0 for perform a write/read.[set]
-  *
-  * @param  ctx      read / write interface definitions
-  * @param  val      Structure that contain
-  *                      - uint8_t slv2_add;    8 bit i2c device address
-  *                      - uint8_t slv2_subadd; 8 bit register device address
-  *                      - uint8_t slv2_len;    num of bit to read
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
-  *
-  */
-int32_t lsm6dsv16x_sh_slv2_cfg_read(stmdev_ctx_t *ctx,
-                                    lsm6dsv16x_sh_cfg_read_t *val)
-{
-  lsm6dsv16x_slv2_add_t slv2_add;
-  lsm6dsv16x_slv2_config_t slv2_config;
-  int32_t ret;
-
-  ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-
-  if (ret == 0)
-  {
-    slv2_add.slave2_add = val->slv_add;
-    slv2_add.r_2 = 1;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV2_ADD, (uint8_t *)&slv2_add, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV2_SUBADD,
-                               &(val->slv_subadd), 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV2_CONFIG,
-                              (uint8_t *)&slv2_config, 1);
-  }
-
-  if (ret == 0)
-  {
-    slv2_config.slave2_numop = val->slv_len;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV2_CONFIG,
-                               (uint8_t *)&slv2_config, 1);
-  }
-
-  ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-
-  return ret;
-}
-
-/**
-  * @brief Configure slave 0 for perform a write/read.[set]
-  *
-  * @param  ctx      read / write interface definitions
-  * @param  val      Structure that contain
-  *                      - uint8_t slv3_add;    8 bit i2c device address
-  *                      - uint8_t slv3_subadd; 8 bit register device address
-  *                      - uint8_t slv3_len;    num of bit to read
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
-  *
-  */
-int32_t lsm6dsv16x_sh_slv3_cfg_read(stmdev_ctx_t *ctx,
-                                    lsm6dsv16x_sh_cfg_read_t *val)
-{
-  lsm6dsv16x_slv3_add_t slv3_add;
-  lsm6dsv16x_slv3_config_t slv3_config;
-  int32_t ret;
-
-  ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-
-  if (ret == 0)
-  {
-    slv3_add.slave3_add = val->slv_add;
-    slv3_add.r_3 = 1;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV3_ADD, (uint8_t *)&slv3_add, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV3_SUBADD,
-                               &(val->slv_subadd), 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV3_CONFIG,
-                              (uint8_t *)&slv3_config, 1);
-  }
-
-  if (ret == 0)
-  {
-    slv3_config.slave3_numop = val->slv_len;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV3_CONFIG,
-                               (uint8_t *)&slv3_config, 1);
-  }
-
-  ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_STATUS_MASTER_MAINPAGE, (uint8_t *) val, 1);
 
   return ret;
 }
@@ -8710,6 +8354,8 @@ int32_t lsm6dsv16x_ui_i2c_i3c_mode_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  if (ret != 0) { return ret; }
+
   switch (if_cfg.i2c_i3c_disable)
   {
     case LSM6DSV16X_I2C_I3C_ENABLE:
@@ -8724,6 +8370,7 @@ int32_t lsm6dsv16x_ui_i2c_i3c_mode_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_I2C_I3C_ENABLE;
       break;
   }
+
   return ret;
 }
 
@@ -8764,6 +8411,8 @@ int32_t lsm6dsv16x_spi_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_spi_mode_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  if (ret != 0) { return ret; }
+
   switch (if_cfg.sim)
   {
     case LSM6DSV16X_SPI_4_WIRE:
@@ -8778,6 +8427,7 @@ int32_t lsm6dsv16x_spi_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_spi_mode_t *val)
       *val = LSM6DSV16X_SPI_4_WIRE;
       break;
   }
+
   return ret;
 }
 
@@ -8860,6 +8510,8 @@ int32_t lsm6dsv16x_spi2_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_spi2_mode_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
+  if (ret != 0) { return ret; }
+
   switch (ui_ctrl1_ois.sim_ois)
   {
     case LSM6DSV16X_SPI2_4_WIRE:
@@ -8874,6 +8526,7 @@ int32_t lsm6dsv16x_spi2_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_spi2_mode_t *val)
       *val = LSM6DSV16X_SPI2_4_WIRE;
       break;
   }
+
   return ret;
 }
 
@@ -8905,15 +8558,11 @@ int32_t lsm6dsv16x_sigmot_mode_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
-  }
-  if (ret == 0)
-  {
-    emb_func_en_a.sign_motion_en = val;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
-  }
+  if (ret != 0) { return ret; }
+
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  emb_func_en_a.sign_motion_en = val;
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
 
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
@@ -8934,10 +8583,9 @@ int32_t lsm6dsv16x_sigmot_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
-  }
+  if (ret != 0) { return ret; }
+
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
   *val = emb_func_en_a.sign_motion_en;
 
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
@@ -8974,35 +8622,30 @@ int32_t lsm6dsv16x_stpcnt_mode_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
-  }
+  if (ret != 0) { return ret; }
+
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
+  if (ret != 0) { goto exit; }
+
   if ((val.false_step_rej == PROPERTY_ENABLE)
       && ((emb_func_en_a.mlc_before_fsm_en & emb_func_en_b.mlc_en) ==
           PROPERTY_DISABLE))
   {
     emb_func_en_a.mlc_before_fsm_en = PROPERTY_ENABLE;
   }
-  if (ret == 0)
-  {
-    emb_func_en_a.pedo_en = val.step_counter_enable;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
-  }
+
+  emb_func_en_a.pedo_en = val.step_counter_enable;
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+
+exit:
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
   if (ret == 0)
   {
     ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_PEDO_CMD_REG, (uint8_t *)&pedo_cmd_reg, 1);
-  }
-  if (ret == 0)
-  {
     pedo_cmd_reg.fp_rejection_en = val.false_step_rej;
-    ret = lsm6dsv16x_ln_pg_write(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_PEDO_CMD_REG, (uint8_t *)&pedo_cmd_reg, 1);
+    ret += lsm6dsv16x_ln_pg_write(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_PEDO_CMD_REG, (uint8_t *)&pedo_cmd_reg, 1);
   }
 
   return ret;
@@ -9024,16 +8667,13 @@ int32_t lsm6dsv16x_stpcnt_mode_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_PEDO_CMD_REG, (uint8_t *)&pedo_cmd_reg, 1);
-  }
+  ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_PEDO_CMD_REG, (uint8_t *)&pedo_cmd_reg, 1);
+  if (ret != 0) { return ret; }
+
   val->false_step_rej = pedo_cmd_reg.fp_rejection_en;
   val->step_counter_enable = emb_func_en_a.pedo_en;
 
@@ -9054,11 +8694,9 @@ int32_t lsm6dsv16x_stpcnt_steps_get(stmdev_ctx_t *ctx, uint16_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_STEP_COUNTER_L, &buff[0], 2);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_STEP_COUNTER_L, &buff[0], 2);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
+  if (ret != 0) { return ret; }
 
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
@@ -9080,16 +8718,15 @@ int32_t lsm6dsv16x_stpcnt_rst_step_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
-  }
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    emb_func_src.pedo_rst_step = val;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
-  }
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
+  if (ret != 0) { goto exit; }
+
+  emb_func_src.pedo_rst_step = val;
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
+
+exit:
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
   return ret;
@@ -9109,11 +8746,9 @@ int32_t lsm6dsv16x_stpcnt_rst_step_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
-  }
+  if (ret != 0) { return ret; }
 
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
   *val = emb_func_src.pedo_rst_step;
 
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
@@ -9197,6 +8832,8 @@ int32_t lsm6dsv16x_stpcnt_period_get(stmdev_ctx_t *ctx, uint16_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_PEDO_SC_DELTAT_L, &buff[0], 2);
+  if (ret != 0) { return ret; }
+
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
 
@@ -9229,14 +8866,16 @@ int32_t lsm6dsv16x_sflp_game_rotation_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
-    emb_func_en_a.sflp_game_en = val;
-    ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A,
-                                (uint8_t *)&emb_func_en_a, 1);
-  }
+  if (ret != 0) { return ret; }
 
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  if (ret != 0) { goto exit; }
+
+  emb_func_en_a.sflp_game_en = val;
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A,
+                              (uint8_t *)&emb_func_en_a, 1);
+
+exit:
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
   return ret;
@@ -9256,11 +8895,10 @@ int32_t lsm6dsv16x_sflp_game_rotation_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
-    *val = emb_func_en_a.sflp_game_en;
-  }
+  if (ret != 0) { return ret; }
+
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  *val = emb_func_en_a.sflp_game_en;
 
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
@@ -9282,13 +8920,15 @@ int32_t lsm6dsv16x_sflp_data_rate_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SFLP_ODR, (uint8_t *)&sflp_odr, 1);
-    sflp_odr.sflp_game_odr = (uint8_t)val & 0x07U;
-    ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SFLP_ODR, (uint8_t *)&sflp_odr, 1);
-  }
+  if (ret != 0) { return ret; }
 
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SFLP_ODR, (uint8_t *)&sflp_odr, 1);
+  if (ret != 0) { goto exit; }
+
+  sflp_odr.sflp_game_odr = (uint8_t)val & 0x07U;
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SFLP_ODR, (uint8_t *)&sflp_odr, 1);
+
+exit:
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
   return ret;
@@ -9311,6 +8951,7 @@ int32_t lsm6dsv16x_sflp_data_rate_get(stmdev_ctx_t *ctx,
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SFLP_ODR, (uint8_t *)&sflp_odr, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
+  if (ret != 0) { return ret; }
 
   switch (sflp_odr.sflp_game_odr)
   {
@@ -9342,6 +8983,7 @@ int32_t lsm6dsv16x_sflp_data_rate_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_SFLP_15Hz;
       break;
   }
+
   return ret;
 }
 
@@ -9399,6 +9041,8 @@ int32_t lsm6dsv16x_tap_detection_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  if (ret != 0) { return ret; }
+
   val->tap_x_en = tap_cfg0.tap_x_en;
   val->tap_y_en = tap_cfg0.tap_y_en;
   val->tap_z_en = tap_cfg0.tap_z_en;
@@ -9423,31 +9067,17 @@ int32_t lsm6dsv16x_tap_thresholds_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
+  if (ret != 0) { return ret; }
 
   tap_cfg1.tap_ths_x = val.x;
   tap_cfg2.tap_ths_y = val.y;
   tap_ths_6d.tap_ths_z = val.z;
 
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
-  }
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
 
   return ret;
 }
@@ -9469,14 +9099,9 @@ int32_t lsm6dsv16x_tap_thresholds_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
-  }
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
+  if (ret != 0) { return ret; }
 
   val->x  = tap_cfg1.tap_ths_x;
   val->y = tap_cfg2.tap_ths_y;
@@ -9524,6 +9149,8 @@ int32_t lsm6dsv16x_tap_axis_priority_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+  if (ret != 0) { return ret; }
+
   switch (tap_cfg1.tap_priority)
   {
     case LSM6DSV16X_XYZ :
@@ -9554,6 +9181,7 @@ int32_t lsm6dsv16x_tap_axis_priority_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_XYZ ;
       break;
   }
+
   return ret;
 }
 
@@ -9598,6 +9226,8 @@ int32_t lsm6dsv16x_tap_time_windows_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_DUR, (uint8_t *)&tap_dur, 1);
+  if (ret != 0) { return ret; }
+
   val->shock = tap_dur.shock;
   val->quiet = tap_dur.quiet;
   val->tap_gap = tap_dur.dur;
@@ -9642,6 +9272,8 @@ int32_t lsm6dsv16x_tap_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_tap_mode_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
+  if (ret != 0) { return ret; }
+
   switch (wake_up_ths.single_double_tap)
   {
     case LSM6DSV16X_ONLY_SINGLE:
@@ -9656,6 +9288,7 @@ int32_t lsm6dsv16x_tap_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_tap_mode_t *val)
       *val = LSM6DSV16X_ONLY_SINGLE;
       break;
   }
+
   return ret;
 }
 
@@ -9686,15 +9319,12 @@ int32_t lsm6dsv16x_tilt_mode_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
-  }
-  if (ret == 0)
-  {
-    emb_func_en_a.tilt_en = val;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
-  }
+  if (ret != 0) { return ret; }
+
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  emb_func_en_a.tilt_en = val;
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
   return ret;
@@ -9714,10 +9344,9 @@ int32_t lsm6dsv16x_tilt_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
-  }
+  if (ret != 0) { return ret; }
+
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
   *val = emb_func_en_a.tilt_en;
 
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
@@ -9752,6 +9381,8 @@ int32_t lsm6dsv16x_timestamp_raw_get(stmdev_ctx_t *ctx, uint32_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TIMESTAMP0, &buff[0], 4);
+  if (ret != 0) { return ret; }
+
   *val = buff[3];
   *val = (*val * 256U) + buff[2];
   *val = (*val * 256U) + buff[1];
@@ -9852,6 +9483,8 @@ int32_t lsm6dsv16x_act_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_act_mode_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
+  if (ret != 0) { return ret; }
+
   switch (functions_enable.inact_en)
   {
     case LSM6DSV16X_XL_AND_GY_NOT_AFFECTED:
@@ -9874,6 +9507,7 @@ int32_t lsm6dsv16x_act_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_act_mode_t *val)
       *val = LSM6DSV16X_XL_AND_GY_NOT_AFFECTED;
       break;
   }
+
   return ret;
 }
 
@@ -9916,6 +9550,8 @@ int32_t lsm6dsv16x_act_from_sleep_to_act_dur_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
+  if (ret != 0) { return ret; }
+
   switch (inactivity_dur.inact_dur)
   {
     case LSM6DSV16X_SLEEP_TO_ACT_AT_1ST_SAMPLE:
@@ -9938,6 +9574,7 @@ int32_t lsm6dsv16x_act_from_sleep_to_act_dur_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_SLEEP_TO_ACT_AT_1ST_SAMPLE;
       break;
   }
+
   return ret;
 }
 
@@ -9980,6 +9617,8 @@ int32_t lsm6dsv16x_act_sleep_xl_odr_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
+  if (ret != 0) { return ret; }
+
   switch (inactivity_dur.xl_inact_odr)
   {
     case LSM6DSV16X_1Hz875:
@@ -10002,6 +9641,7 @@ int32_t lsm6dsv16x_act_sleep_xl_odr_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV16X_1Hz875;
       break;
   }
+
   return ret;
 }
 
@@ -10026,6 +9666,7 @@ int32_t lsm6dsv16x_act_thresholds_set(stmdev_ctx_t *ctx,
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_INACTIVITY_THS, (uint8_t *)&inactivity_ths, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+  if (ret != 0) { return ret; }
 
   inactivity_dur.wu_inact_ths_w = val->inactivity_cfg.wu_inact_ths_w;
   inactivity_dur.xl_inact_odr = val->inactivity_cfg.xl_inact_odr;
@@ -10064,6 +9705,7 @@ int32_t lsm6dsv16x_act_thresholds_get(stmdev_ctx_t *ctx,
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_INACTIVITY_THS, (uint8_t *)&inactivity_ths, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+  if (ret != 0) { return ret; }
 
   val->inactivity_cfg.wu_inact_ths_w = inactivity_dur.wu_inact_ths_w;
   val->inactivity_cfg.xl_inact_odr = inactivity_dur.xl_inact_odr;
@@ -10116,6 +9758,8 @@ int32_t lsm6dsv16x_act_wkup_time_windows_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+  if (ret != 0) { return ret; }
+
   val->shock = wake_up_dur.wake_dur;
   val->quiet = wake_up_dur.sleep_dur;
 

--- a/sensor/stmemsc/lsm6dsv16x_STdC/driver/lsm6dsv16x_reg.h
+++ b/sensor/stmemsc/lsm6dsv16x_STdC/driver/lsm6dsv16x_reg.h
@@ -3896,6 +3896,8 @@ float_t lsm6dsv16x_from_lsb_to_celsius(int16_t lsb);
 
 float_t lsm6dsv16x_from_lsb_to_nsec(uint32_t lsb);
 
+float_t lsm6dsv16x_from_lsb_to_mv(int16_t lsb);
+
 int32_t lsm6dsv16x_xl_offset_on_out_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv16x_xl_offset_on_out_get(stmdev_ctx_t *ctx, uint8_t *val);
 
@@ -4036,7 +4038,7 @@ typedef enum
   LSM6DSV16X_500dps  = 0x2,
   LSM6DSV16X_1000dps = 0x3,
   LSM6DSV16X_2000dps = 0x4,
-  LSM6DSV16X_4000dps = 0x5,
+  LSM6DSV16X_4000dps = 0xc,
 } lsm6dsv16x_gy_full_scale_t;
 int32_t lsm6dsv16x_gy_full_scale_set(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_gy_full_scale_t val);
@@ -4484,17 +4486,8 @@ int32_t lsm6dsv16x_fifo_mlc_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
 int32_t lsm6dsv16x_fifo_mlc_filt_batch_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv16x_fifo_mlc_filt_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_fifo_batch_sh_slave_0_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_fifo_batch_sh_slave_0_get(stmdev_ctx_t *ctx, uint8_t *val);
-
-int32_t lsm6dsv16x_fifo_batch_sh_slave_1_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_fifo_batch_sh_slave_1_get(stmdev_ctx_t *ctx, uint8_t *val);
-
-int32_t lsm6dsv16x_fifo_batch_sh_slave_2_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_fifo_batch_sh_slave_2_get(stmdev_ctx_t *ctx, uint8_t *val);
-
-int32_t lsm6dsv16x_fifo_batch_sh_slave_3_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_fifo_batch_sh_slave_3_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_fifo_sh_batch_slave_set(stmdev_ctx_t *ctx, uint8_t idx, uint8_t val);
+int32_t lsm6dsv16x_fifo_sh_batch_slave_get(stmdev_ctx_t *ctx, uint8_t idx, uint8_t *val);
 
 typedef struct
 {
@@ -4982,29 +4975,7 @@ int32_t lsm6dsv16x_sh_master_interface_pull_up_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_sh_master_interface_pull_up_get(stmdev_ctx_t *ctx,
                                                    uint8_t *val);
 
-typedef struct
-{
-  lsm6dsv16x_sensor_hub_1_t   sh_byte_1;
-  lsm6dsv16x_sensor_hub_2_t   sh_byte_2;
-  lsm6dsv16x_sensor_hub_3_t   sh_byte_3;
-  lsm6dsv16x_sensor_hub_4_t   sh_byte_4;
-  lsm6dsv16x_sensor_hub_5_t   sh_byte_5;
-  lsm6dsv16x_sensor_hub_6_t   sh_byte_6;
-  lsm6dsv16x_sensor_hub_7_t   sh_byte_7;
-  lsm6dsv16x_sensor_hub_8_t   sh_byte_8;
-  lsm6dsv16x_sensor_hub_9_t   sh_byte_9;
-  lsm6dsv16x_sensor_hub_10_t  sh_byte_10;
-  lsm6dsv16x_sensor_hub_11_t  sh_byte_11;
-  lsm6dsv16x_sensor_hub_12_t  sh_byte_12;
-  lsm6dsv16x_sensor_hub_13_t  sh_byte_13;
-  lsm6dsv16x_sensor_hub_14_t  sh_byte_14;
-  lsm6dsv16x_sensor_hub_15_t  sh_byte_15;
-  lsm6dsv16x_sensor_hub_16_t  sh_byte_16;
-  lsm6dsv16x_sensor_hub_17_t  sh_byte_17;
-  lsm6dsv16x_sensor_hub_18_t  sh_byte_18;
-} lsm6dsv16x_emb_sh_read_t;
-int32_t lsm6dsv16x_sh_read_data_raw_get(stmdev_ctx_t *ctx,
-                                        lsm6dsv16x_emb_sh_read_t *val,
+int32_t lsm6dsv16x_sh_read_data_raw_get(stmdev_ctx_t *ctx, uint8_t *val,
                                         uint8_t len);
 
 typedef enum
@@ -5076,15 +5047,11 @@ typedef struct
   uint8_t   slv_subadd;
   uint8_t   slv_len;
 } lsm6dsv16x_sh_cfg_read_t;
-int32_t lsm6dsv16x_sh_slv0_cfg_read(stmdev_ctx_t *ctx,
-                                    lsm6dsv16x_sh_cfg_read_t *val);
-int32_t lsm6dsv16x_sh_slv1_cfg_read(stmdev_ctx_t *ctx,
-                                    lsm6dsv16x_sh_cfg_read_t *val);
-int32_t lsm6dsv16x_sh_slv2_cfg_read(stmdev_ctx_t *ctx,
-                                    lsm6dsv16x_sh_cfg_read_t *val);
-int32_t lsm6dsv16x_sh_slv3_cfg_read(stmdev_ctx_t *ctx,
-                                    lsm6dsv16x_sh_cfg_read_t *val);
+int32_t lsm6dsv16x_sh_slv_cfg_read(stmdev_ctx_t *ctx, uint8_t idx,
+                                   lsm6dsv16x_sh_cfg_read_t *val);
 
+int32_t lsm6dsv16x_sh_status_get(stmdev_ctx_t *ctx,
+                                 lsm6dsv16x_status_master_t *val);
 
 int32_t lsm6dsv16x_ui_sdo_pull_up_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv16x_ui_sdo_pull_up_get(stmdev_ctx_t *ctx, uint8_t *val);

--- a/sensor/stmemsc/lsm6dsv_STdC/driver/lsm6dsv_reg.c
+++ b/sensor/stmemsc/lsm6dsv_STdC/driver/lsm6dsv_reg.c
@@ -109,6 +109,11 @@ static void bytecpy(uint8_t *target, uint8_t *source)
   * @{
   *
   */
+float_t lsm6dsv_from_sflp_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.061f;
+}
+
 float_t lsm6dsv_from_fs2_to_mg(int16_t lsb)
 {
   return ((float_t)lsb) * 0.061f;
@@ -243,14 +248,9 @@ int32_t lsm6dsv_xl_offset_mg_set(stmdev_ctx_t *ctx,
   float_t tmp;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_X_OFS_USR, (uint8_t *)&x_ofs_usr, 1);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_X_OFS_USR, (uint8_t *)&x_ofs_usr, 1);
+  if (ret != 0) { return ret; }
 
 
   if ((val.x_mg < (0.0078125f * 127.0f)) && (val.x_mg > (0.0078125f * -127.0f)) &&
@@ -291,22 +291,11 @@ int32_t lsm6dsv_xl_offset_mg_set(stmdev_ctx_t *ctx,
     x_ofs_usr.x_ofs_usr = 0xFFU;
   }
 
-  if (ret == 0)
-  {
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_X_OFS_USR, (uint8_t *)&x_ofs_usr, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_CTRL9, (uint8_t *)&ctrl9, 1);
-  }
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_X_OFS_USR, (uint8_t *)&x_ofs_usr, 1);
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_CTRL9, (uint8_t *)&ctrl9, 1);
+
   return ret;
 }
 
@@ -328,18 +317,10 @@ int32_t lsm6dsv_xl_offset_mg_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_CTRL9, (uint8_t *)&ctrl9, 1);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_X_OFS_USR, (uint8_t *)&x_ofs_usr, 1);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_X_OFS_USR, (uint8_t *)&x_ofs_usr, 1);
+  if (ret != 0) { return ret; }
 
   if (ctrl9.usr_off_w == PROPERTY_DISABLE)
   {
@@ -377,23 +358,15 @@ int32_t lsm6dsv_reset_set(stmdev_ctx_t *ctx, lsm6dsv_reset_t val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_CTRL3, (uint8_t *)&ctrl3, 1);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  if (ret != 0) { return ret; }
 
   ctrl3.boot = ((uint8_t)val & 0x04U) >> 2;
   ctrl3.sw_reset = ((uint8_t)val & 0x02U) >> 1;
   func_cfg_access.sw_por = (uint8_t)val & 0x01U;
 
-  if (ret == 0)
-  {
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_CTRL3, (uint8_t *)&ctrl3, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
-  }
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_CTRL3, (uint8_t *)&ctrl3, 1);
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
 
   return ret;
 }
@@ -413,10 +386,8 @@ int32_t lsm6dsv_reset_get(stmdev_ctx_t *ctx, lsm6dsv_reset_t *val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_CTRL3, (uint8_t *)&ctrl3, 1);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  if (ret != 0) { return ret; }
 
   switch ((ctrl3.sw_reset << 2) + (ctrl3.boot << 1) + func_cfg_access.sw_por)
   {
@@ -440,6 +411,7 @@ int32_t lsm6dsv_reset_get(stmdev_ctx_t *ctx, lsm6dsv_reset_t *val)
       *val = LSM6DSV_GLOBAL_RST;
       break;
   }
+
   return ret;
 }
 
@@ -457,13 +429,11 @@ int32_t lsm6dsv_mem_bank_set(stmdev_ctx_t *ctx, lsm6dsv_mem_bank_t val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    func_cfg_access.shub_reg_access = ((uint8_t)val & 0x02U) >> 1;
-    func_cfg_access.emb_func_reg_access = (uint8_t)val & 0x01U;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
-  }
+  func_cfg_access.shub_reg_access = ((uint8_t)val & 0x02U) >> 1;
+  func_cfg_access.emb_func_reg_access = (uint8_t)val & 0x01U;
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
 
   return ret;
 }
@@ -482,6 +452,7 @@ int32_t lsm6dsv_mem_bank_get(stmdev_ctx_t *ctx, lsm6dsv_mem_bank_t *val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  if (ret != 0) { return ret; }
 
   switch ((func_cfg_access.shub_reg_access << 1) + func_cfg_access.emb_func_reg_access)
   {
@@ -501,6 +472,7 @@ int32_t lsm6dsv_mem_bank_get(stmdev_ctx_t *ctx, lsm6dsv_mem_bank_t *val)
       *val = LSM6DSV_MAIN_MEM_BANK;
       break;
   }
+
   return ret;
 }
 
@@ -534,13 +506,23 @@ int32_t lsm6dsv_xl_data_rate_set(stmdev_ctx_t *ctx,
                                  lsm6dsv_data_rate_t val)
 {
   lsm6dsv_ctrl1_t ctrl1;
+  lsm6dsv_haodr_cfg_t haodr;
+  uint8_t sel;
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_CTRL1, (uint8_t *)&ctrl1, 1);
-  if (ret == 0)
+  if (ret != 0) { return ret; }
+
+  ctrl1.odr_xl = (uint8_t)val & 0x0Fu;
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_CTRL1, (uint8_t *)&ctrl1, 1);
+  if (ret != 0) { return ret; }
+
+  sel = ((uint8_t)val >> 4) & 0xFU;
+  if (sel != 0U)
   {
-    ctrl1.odr_xl = (uint8_t)val & 0x0Fu;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_CTRL1, (uint8_t *)&ctrl1, 1);
+    ret += lsm6dsv_read_reg(ctx, LSM6DSV_HAODR_CFG, (uint8_t *)&haodr, 1);
+    haodr.haodr_sel = sel;
+    ret += lsm6dsv_write_reg(ctx, LSM6DSV_HAODR_CFG, (uint8_t *)&haodr, 1);
   }
 
   return ret;
@@ -558,9 +540,15 @@ int32_t lsm6dsv_xl_data_rate_get(stmdev_ctx_t *ctx,
                                  lsm6dsv_data_rate_t *val)
 {
   lsm6dsv_ctrl1_t ctrl1;
+  lsm6dsv_haodr_cfg_t haodr;
+  uint8_t sel;
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_CTRL1, (uint8_t *)&ctrl1, 1);
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_HAODR_CFG, (uint8_t *)&haodr, 1);
+  if (ret != 0) { return ret; }
+
+  sel = haodr.haodr_sel;
 
   switch (ctrl1.odr_xl)
   {
@@ -577,49 +565,160 @@ int32_t lsm6dsv_xl_data_rate_get(stmdev_ctx_t *ctx,
       break;
 
     case LSM6DSV_ODR_AT_15Hz:
-      *val = LSM6DSV_ODR_AT_15Hz;
+      switch (sel) {
+      default:
+      case 0:
+        *val = LSM6DSV_ODR_AT_15Hz;
+        break;
+      case 1:
+        *val = LSM6DSV_ODR_HA01_AT_15Hz625;
+        break;
+      case 2:
+        *val = LSM6DSV_ODR_HA02_AT_12Hz5;
+        break;
+      }
       break;
 
     case LSM6DSV_ODR_AT_30Hz:
-      *val = LSM6DSV_ODR_AT_30Hz;
+      switch (sel) {
+      default:
+      case 0:
+        *val = LSM6DSV_ODR_AT_30Hz;
+        break;
+      case 1:
+        *val = LSM6DSV_ODR_HA01_AT_31Hz25;
+        break;
+      case 2:
+        *val = LSM6DSV_ODR_HA02_AT_25Hz;
+        break;
+      }
       break;
 
     case LSM6DSV_ODR_AT_60Hz:
-      *val = LSM6DSV_ODR_AT_60Hz;
+      switch (sel) {
+      default:
+      case 0:
+        *val = LSM6DSV_ODR_AT_60Hz;
+        break;
+      case 1:
+        *val = LSM6DSV_ODR_HA01_AT_62Hz5;
+        break;
+      case 2:
+        *val = LSM6DSV_ODR_HA02_AT_50Hz;
+        break;
+      }
       break;
 
     case LSM6DSV_ODR_AT_120Hz:
-      *val = LSM6DSV_ODR_AT_120Hz;
+      switch (sel) {
+      default:
+      case 0:
+        *val = LSM6DSV_ODR_AT_120Hz;
+        break;
+      case 1:
+        *val = LSM6DSV_ODR_HA01_AT_125Hz;
+        break;
+      case 2:
+        *val = LSM6DSV_ODR_HA02_AT_100Hz;
+        break;
+      }
       break;
 
     case LSM6DSV_ODR_AT_240Hz:
-      *val = LSM6DSV_ODR_AT_240Hz;
+      switch (sel) {
+      default:
+      case 0:
+        *val = LSM6DSV_ODR_AT_240Hz;
+        break;
+      case 1:
+        *val = LSM6DSV_ODR_HA01_AT_250Hz;
+        break;
+      case 2:
+        *val = LSM6DSV_ODR_HA02_AT_200Hz;
+        break;
+      }
       break;
 
     case LSM6DSV_ODR_AT_480Hz:
-      *val = LSM6DSV_ODR_AT_480Hz;
+      switch (sel) {
+      default:
+      case 0:
+        *val = LSM6DSV_ODR_AT_480Hz;
+        break;
+      case 1:
+        *val = LSM6DSV_ODR_HA01_AT_500Hz;
+        break;
+      case 2:
+        *val = LSM6DSV_ODR_HA02_AT_400Hz;
+        break;
+      }
       break;
 
     case LSM6DSV_ODR_AT_960Hz:
-      *val = LSM6DSV_ODR_AT_960Hz;
+      switch (sel) {
+      default:
+      case 0:
+        *val = LSM6DSV_ODR_AT_960Hz;
+        break;
+      case 1:
+        *val = LSM6DSV_ODR_HA01_AT_1000Hz;
+        break;
+      case 2:
+        *val = LSM6DSV_ODR_HA02_AT_800Hz;
+        break;
+      }
       break;
 
     case LSM6DSV_ODR_AT_1920Hz:
-      *val = LSM6DSV_ODR_AT_1920Hz;
+      switch (sel) {
+      default:
+      case 0:
+        *val = LSM6DSV_ODR_AT_1920Hz;
+        break;
+      case 1:
+        *val = LSM6DSV_ODR_HA01_AT_2000Hz;
+        break;
+      case 2:
+        *val = LSM6DSV_ODR_HA02_AT_1600Hz;
+        break;
+      }
       break;
 
     case LSM6DSV_ODR_AT_3840Hz:
-      *val = LSM6DSV_ODR_AT_3840Hz;
+      switch (sel) {
+      default:
+      case 0:
+        *val = LSM6DSV_ODR_AT_3840Hz;
+        break;
+      case 1:
+        *val = LSM6DSV_ODR_HA01_AT_4000Hz;
+        break;
+      case 2:
+        *val = LSM6DSV_ODR_HA02_AT_3200Hz;
+        break;
+      }
       break;
 
     case LSM6DSV_ODR_AT_7680Hz:
-      *val = LSM6DSV_ODR_AT_7680Hz;
+      switch (sel) {
+      default:
+      case 0:
+        *val = LSM6DSV_ODR_AT_7680Hz;
+        break;
+      case 1:
+        *val = LSM6DSV_ODR_HA01_AT_8000Hz;
+        break;
+      case 2:
+        *val = LSM6DSV_ODR_HA02_AT_6400Hz;
+        break;
+      }
       break;
 
     default:
       *val = LSM6DSV_ODR_OFF;
       break;
   }
+
   return ret;
 }
 
@@ -627,7 +726,7 @@ int32_t lsm6dsv_xl_data_rate_get(stmdev_ctx_t *ctx,
   * @brief  Accelerometer operating mode selection.[set]
   *
   * @param  ctx      read / write interface definitions
-  * @param  val      XL_HIGH_PERFORMANCE_MD, XL_LOW_POWER_2_AVG_MD, XL_LOW_POWER_4_AVG_MD, XL_LOW_POWER_8_AVG_MD, XL_NORMAL_MD,
+  * @param  val      XL_HIGH_PERFORMANCE_MD, XL_HIGH_ACCURACY_ODR_MD, XL_LOW_POWER_2_AVG_MD, XL_LOW_POWER_4_AVG_MD, XL_LOW_POWER_8_AVG_MD, XL_NORMAL_MD,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
@@ -651,7 +750,7 @@ int32_t lsm6dsv_xl_mode_set(stmdev_ctx_t *ctx, lsm6dsv_xl_mode_t val)
   * @brief  Accelerometer operating mode selection.[get]
   *
   * @param  ctx      read / write interface definitions
-  * @param  val      XL_HIGH_PERFORMANCE_MD, XL_LOW_POWER_2_AVG_MD, XL_LOW_POWER_4_AVG_MD, XL_LOW_POWER_8_AVG_MD, XL_NORMAL_MD,
+  * @param  val      XL_HIGH_PERFORMANCE_MD, XL_HIGH_ACCURACY_ODR_MD, XL_LOW_POWER_2_AVG_MD, XL_LOW_POWER_4_AVG_MD, XL_LOW_POWER_8_AVG_MD, XL_NORMAL_MD,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
@@ -661,11 +760,20 @@ int32_t lsm6dsv_xl_mode_get(stmdev_ctx_t *ctx, lsm6dsv_xl_mode_t *val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_CTRL1, (uint8_t *)&ctrl1, 1);
+  if (ret != 0) { return ret; }
 
   switch (ctrl1.op_mode_xl)
   {
     case LSM6DSV_XL_HIGH_PERFORMANCE_MD:
       *val = LSM6DSV_XL_HIGH_PERFORMANCE_MD;
+      break;
+
+    case LSM6DSV_XL_HIGH_ACCURACY_ODR_MD:
+      *val = LSM6DSV_XL_HIGH_ACCURACY_ODR_MD;
+      break;
+
+    case LSM6DSV_XL_ODR_TRIGGERED_MD:
+      *val = LSM6DSV_XL_ODR_TRIGGERED_MD;
       break;
 
     case LSM6DSV_XL_LOW_POWER_2_AVG_MD:
@@ -688,6 +796,7 @@ int32_t lsm6dsv_xl_mode_get(stmdev_ctx_t *ctx, lsm6dsv_xl_mode_t *val)
       *val = LSM6DSV_XL_HIGH_PERFORMANCE_MD;
       break;
   }
+
   return ret;
 }
 
@@ -703,14 +812,21 @@ int32_t lsm6dsv_gy_data_rate_set(stmdev_ctx_t *ctx,
                                  lsm6dsv_data_rate_t val)
 {
   lsm6dsv_ctrl2_t ctrl2;
+  lsm6dsv_haodr_cfg_t haodr;
+  uint8_t sel;
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_CTRL2, (uint8_t *)&ctrl2, 1);
+  ctrl2.odr_g = (uint8_t)val & 0x0Fu;
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_CTRL2, (uint8_t *)&ctrl2, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
+  sel = ((uint8_t)val >> 4) & 0xFU;
+  if (sel != 0U)
   {
-    ctrl2.odr_g = (uint8_t)val & 0x0Fu;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_CTRL2, (uint8_t *)&ctrl2, 1);
+    ret += lsm6dsv_read_reg(ctx, LSM6DSV_HAODR_CFG, (uint8_t *)&haodr, 1);
+    haodr.haodr_sel = sel;
+    ret += lsm6dsv_write_reg(ctx, LSM6DSV_HAODR_CFG, (uint8_t *)&haodr, 1);
   }
 
   return ret;
@@ -728,9 +844,15 @@ int32_t lsm6dsv_gy_data_rate_get(stmdev_ctx_t *ctx,
                                  lsm6dsv_data_rate_t *val)
 {
   lsm6dsv_ctrl2_t ctrl2;
+  lsm6dsv_haodr_cfg_t haodr;
+  uint8_t sel;
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_CTRL2, (uint8_t *)&ctrl2, 1);
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_HAODR_CFG, (uint8_t *)&haodr, 1);
+  if (ret != 0) { return ret; }
+
+  sel = haodr.haodr_sel;
 
   switch (ctrl2.odr_g)
   {
@@ -747,49 +869,160 @@ int32_t lsm6dsv_gy_data_rate_get(stmdev_ctx_t *ctx,
       break;
 
     case LSM6DSV_ODR_AT_15Hz:
-      *val = LSM6DSV_ODR_AT_15Hz;
+      switch (sel) {
+      default:
+      case 0:
+        *val = LSM6DSV_ODR_AT_15Hz;
+        break;
+      case 1:
+        *val = LSM6DSV_ODR_HA01_AT_15Hz625;
+        break;
+      case 2:
+        *val = LSM6DSV_ODR_HA02_AT_12Hz5;
+        break;
+      }
       break;
 
     case LSM6DSV_ODR_AT_30Hz:
-      *val = LSM6DSV_ODR_AT_30Hz;
+      switch (sel) {
+      default:
+      case 0:
+        *val = LSM6DSV_ODR_AT_30Hz;
+        break;
+      case 1:
+        *val = LSM6DSV_ODR_HA01_AT_31Hz25;
+        break;
+      case 2:
+        *val = LSM6DSV_ODR_HA02_AT_25Hz;
+        break;
+      }
       break;
 
     case LSM6DSV_ODR_AT_60Hz:
-      *val = LSM6DSV_ODR_AT_60Hz;
+      switch (sel) {
+      default:
+      case 0:
+        *val = LSM6DSV_ODR_AT_60Hz;
+        break;
+      case 1:
+        *val = LSM6DSV_ODR_HA01_AT_62Hz5;
+        break;
+      case 2:
+        *val = LSM6DSV_ODR_HA02_AT_50Hz;
+        break;
+      }
       break;
 
     case LSM6DSV_ODR_AT_120Hz:
-      *val = LSM6DSV_ODR_AT_120Hz;
+      switch (sel) {
+      default:
+      case 0:
+        *val = LSM6DSV_ODR_AT_120Hz;
+        break;
+      case 1:
+        *val = LSM6DSV_ODR_HA01_AT_125Hz;
+        break;
+      case 2:
+        *val = LSM6DSV_ODR_HA02_AT_100Hz;
+        break;
+      }
       break;
 
     case LSM6DSV_ODR_AT_240Hz:
-      *val = LSM6DSV_ODR_AT_240Hz;
+      switch (sel) {
+      default:
+      case 0:
+        *val = LSM6DSV_ODR_AT_240Hz;
+        break;
+      case 1:
+        *val = LSM6DSV_ODR_HA01_AT_250Hz;
+        break;
+      case 2:
+        *val = LSM6DSV_ODR_HA02_AT_200Hz;
+        break;
+      }
       break;
 
     case LSM6DSV_ODR_AT_480Hz:
-      *val = LSM6DSV_ODR_AT_480Hz;
+      switch (sel) {
+      default:
+      case 0:
+        *val = LSM6DSV_ODR_AT_480Hz;
+        break;
+      case 1:
+        *val = LSM6DSV_ODR_HA01_AT_500Hz;
+        break;
+      case 2:
+        *val = LSM6DSV_ODR_HA02_AT_400Hz;
+        break;
+      }
       break;
 
     case LSM6DSV_ODR_AT_960Hz:
-      *val = LSM6DSV_ODR_AT_960Hz;
+      switch (sel) {
+      default:
+      case 0:
+        *val = LSM6DSV_ODR_AT_960Hz;
+        break;
+      case 1:
+        *val = LSM6DSV_ODR_HA01_AT_1000Hz;
+        break;
+      case 2:
+        *val = LSM6DSV_ODR_HA02_AT_800Hz;
+        break;
+      }
       break;
 
     case LSM6DSV_ODR_AT_1920Hz:
-      *val = LSM6DSV_ODR_AT_1920Hz;
+      switch (sel) {
+      default:
+      case 0:
+        *val = LSM6DSV_ODR_AT_1920Hz;
+        break;
+      case 1:
+        *val = LSM6DSV_ODR_HA01_AT_2000Hz;
+        break;
+      case 2:
+        *val = LSM6DSV_ODR_HA02_AT_1600Hz;
+        break;
+      }
       break;
 
     case LSM6DSV_ODR_AT_3840Hz:
-      *val = LSM6DSV_ODR_AT_3840Hz;
+      switch (sel) {
+      default:
+      case 0:
+        *val = LSM6DSV_ODR_AT_3840Hz;
+        break;
+      case 1:
+        *val = LSM6DSV_ODR_HA01_AT_4000Hz;
+        break;
+      case 2:
+        *val = LSM6DSV_ODR_HA02_AT_3200Hz;
+        break;
+      }
       break;
 
     case LSM6DSV_ODR_AT_7680Hz:
-      *val = LSM6DSV_ODR_AT_7680Hz;
+      switch (sel) {
+      default:
+      case 0:
+        *val = LSM6DSV_ODR_AT_7680Hz;
+        break;
+      case 1:
+        *val = LSM6DSV_ODR_HA01_AT_8000Hz;
+        break;
+      case 2:
+        *val = LSM6DSV_ODR_HA02_AT_6400Hz;
+        break;
+      }
       break;
 
     default:
       *val = LSM6DSV_ODR_OFF;
       break;
   }
+
   return ret;
 }
 
@@ -797,7 +1030,7 @@ int32_t lsm6dsv_gy_data_rate_get(stmdev_ctx_t *ctx,
   * @brief  Gyroscope operating mode selection.[set]
   *
   * @param  ctx      read / write interface definitions
-  * @param  val      GY_HIGH_PERFORMANCE_MD, GY_SLEEP_MD, GY_LOW_POWER_MD,
+  * @param  val      GY_HIGH_PERFORMANCE_MD, GY_HIGH_ACCURACY_ODR_MD, GY_SLEEP_MD, GY_LOW_POWER_MD,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
@@ -820,7 +1053,7 @@ int32_t lsm6dsv_gy_mode_set(stmdev_ctx_t *ctx, lsm6dsv_gy_mode_t val)
   * @brief  Gyroscope operating mode selection.[get]
   *
   * @param  ctx      read / write interface definitions
-  * @param  val      GY_HIGH_PERFORMANCE_MD, GY_SLEEP_MD, GY_LOW_POWER_MD,
+  * @param  val      GY_HIGH_PERFORMANCE_MD, GY_HIGH_ACCURACY_ODR_MD, GY_SLEEP_MD, GY_LOW_POWER_MD,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
@@ -830,6 +1063,8 @@ int32_t lsm6dsv_gy_mode_get(stmdev_ctx_t *ctx, lsm6dsv_gy_mode_t *val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_CTRL2, (uint8_t *)&ctrl2, 1);
+  if (ret != 0) { return ret; }
+
   switch (ctrl2.op_mode_g)
   {
     case LSM6DSV_GY_HIGH_PERFORMANCE_MD:
@@ -852,6 +1087,7 @@ int32_t lsm6dsv_gy_mode_get(stmdev_ctx_t *ctx, lsm6dsv_gy_mode_t *val)
       *val = LSM6DSV_GY_HIGH_PERFORMANCE_MD;
       break;
   }
+
   return ret;
 }
 
@@ -893,7 +1129,6 @@ int32_t lsm6dsv_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val)
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_CTRL3, (uint8_t *)&ctrl3, 1);
   *val = ctrl3.if_inc;
-
 
   return ret;
 }
@@ -937,6 +1172,53 @@ int32_t lsm6dsv_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_CTRL3, (uint8_t *)&ctrl3, 1);
   *val = ctrl3.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Configure ODR trigger. [set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      number of data in the reference period.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv_odr_trig_cfg_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv_odr_trig_cfg_t odr_trig;
+  int32_t ret;
+
+  if (val >= 1U && val <= 3U) {
+    return -1;
+  }
+
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_ODR_TRIG_CFG, (uint8_t *)&odr_trig, 1);
+
+  if (ret == 0)
+  {
+    odr_trig.odr_trig_nodr = val;
+    ret = lsm6dsv_write_reg(ctx, LSM6DSV_ODR_TRIG_CFG, (uint8_t *)&odr_trig, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Configure ODR trigger. [get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      number of data in the reference period.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv_odr_trig_cfg_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv_odr_trig_cfg_t odr_trig;
+  int32_t ret;
+
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_ODR_TRIG_CFG, (uint8_t *)&odr_trig, 1);
+  *val = odr_trig.odr_trig_nodr;
 
   return ret;
 }
@@ -996,6 +1278,7 @@ int32_t lsm6dsv_data_ready_mode_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_DRDY_LATCHED;
       break;
   }
+
   return ret;
 }
 
@@ -1015,20 +1298,13 @@ int32_t lsm6dsv_interrupt_enable_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_FUNCTIONS_ENABLE, (uint8_t *)&func, 1);
+  func.interrupts_enable = val.enable;
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_FUNCTIONS_ENABLE, (uint8_t *)&func, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    func.interrupts_enable = val.enable;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_FUNCTIONS_ENABLE, (uint8_t *)&func, 1);
-  }
-
-  ret += lsm6dsv_read_reg(ctx, LSM6DSV_TAP_CFG0, (uint8_t *)&cfg, 1);
-
-  if (ret == 0)
-  {
-    cfg.lir = val.lir;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_TAP_CFG0, (uint8_t *)&cfg, 1);
-  }
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_TAP_CFG0, (uint8_t *)&cfg, 1);
+  cfg.lir = val.lir;
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_TAP_CFG0, (uint8_t *)&cfg, 1);
 
   return ret;
 }
@@ -1050,6 +1326,7 @@ int32_t lsm6dsv_interrupt_enable_get(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_FUNCTIONS_ENABLE, (uint8_t *)&func, 1);
   ret += lsm6dsv_read_reg(ctx, LSM6DSV_TAP_CFG0, (uint8_t *)&cfg, 1);
+  if (ret != 0) { return ret; }
 
   val->enable = func.interrupts_enable;
   val->lir = cfg.lir;
@@ -1097,6 +1374,7 @@ int32_t lsm6dsv_gy_full_scale_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_CTRL6, (uint8_t *)&ctrl6, 1);
+  if (ret != 0) { return ret; }
 
   switch (ctrl6.fs_g)
   {
@@ -1128,6 +1406,7 @@ int32_t lsm6dsv_gy_full_scale_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_125dps;
       break;
   }
+
   return ret;
 }
 
@@ -1171,6 +1450,7 @@ int32_t lsm6dsv_xl_full_scale_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_CTRL8, (uint8_t *)&ctrl8, 1);
+  if (ret != 0) { return ret; }
 
   switch (ctrl8.fs_xl)
   {
@@ -1194,6 +1474,7 @@ int32_t lsm6dsv_xl_full_scale_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_2g;
       break;
   }
+
   return ret;
 }
 
@@ -1278,6 +1559,7 @@ int32_t lsm6dsv_xl_self_test_get(stmdev_ctx_t *ctx, lsm6dsv_xl_self_test_t *val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_CTRL10, (uint8_t *)&ctrl10, 1);
+  if (ret != 0) { return ret; }
 
   switch (ctrl10.st_xl)
   {
@@ -1297,6 +1579,7 @@ int32_t lsm6dsv_xl_self_test_get(stmdev_ctx_t *ctx, lsm6dsv_xl_self_test_t *val)
       *val = LSM6DSV_XL_ST_DISABLE;
       break;
   }
+
   return ret;
 }
 
@@ -1338,6 +1621,7 @@ int32_t lsm6dsv_gy_self_test_get(stmdev_ctx_t *ctx, lsm6dsv_gy_self_test_t *val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_CTRL10, (uint8_t *)&ctrl10, 1);
+  if (ret != 0) { return ret; }
 
   switch (ctrl10.st_g)
   {
@@ -1357,6 +1641,7 @@ int32_t lsm6dsv_gy_self_test_get(stmdev_ctx_t *ctx, lsm6dsv_gy_self_test_t *val)
       *val = LSM6DSV_GY_ST_DISABLE;
       break;
   }
+
   return ret;
 }
 
@@ -1400,6 +1685,7 @@ int32_t lsm6dsv_ois_xl_self_test_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_SPI2_INT_OIS, (uint8_t *)&spi2_int_ois, 1);
+  if (ret != 0) { return ret; }
 
   switch (spi2_int_ois.st_xl_ois)
   {
@@ -1419,6 +1705,7 @@ int32_t lsm6dsv_ois_xl_self_test_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_OIS_XL_ST_DISABLE;
       break;
   }
+
   return ret;
 }
 
@@ -1463,6 +1750,7 @@ int32_t lsm6dsv_ois_gy_self_test_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_SPI2_INT_OIS, (uint8_t *)&spi2_int_ois, 1);
+  if (ret != 0) { return ret; }
 
   switch (spi2_int_ois.st_g_ois)
   {
@@ -1482,6 +1770,7 @@ int32_t lsm6dsv_ois_gy_self_test_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_OIS_GY_ST_DISABLE;
       break;
   }
+
   return ret;
 }
 
@@ -1509,6 +1798,7 @@ int32_t lsm6dsv_pin_int1_route_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_INT1_CTRL, (uint8_t *)&int1_ctrl, 1);
+  if (ret != 0) { return ret; }
 
   int1_ctrl.int1_drdy_xl       = val->drdy_xl;
   int1_ctrl.int1_drdy_g        = val->drdy_g;
@@ -1517,10 +1807,11 @@ int32_t lsm6dsv_pin_int1_route_set(stmdev_ctx_t *ctx,
   int1_ctrl.int1_fifo_full     = val->fifo_full;
   int1_ctrl.int1_cnt_bdr       = val->cnt_bdr;
 
-  ret += lsm6dsv_write_reg(ctx, LSM6DSV_INT1_CTRL, (uint8_t *)&int1_ctrl,
-                           1);
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_INT1_CTRL, (uint8_t *)&int1_ctrl, 1);
+  if (ret != 0) { return ret; }
 
-  ret += lsm6dsv_read_reg(ctx, LSM6DSV_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  if (ret != 0) { return ret; }
 
   md1_cfg.int1_shub            = val->shub;
   md1_cfg.int1_emb_func        = val->emb_func;
@@ -1531,7 +1822,7 @@ int32_t lsm6dsv_pin_int1_route_set(stmdev_ctx_t *ctx,
   md1_cfg.int1_ff              = val->freefall;
   md1_cfg.int1_sleep_change    = val->sleep_change;
 
-  ret += lsm6dsv_write_reg(ctx, LSM6DSV_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_MD1_CFG, (uint8_t *)&md1_cfg, 1);
 
   return ret;
 }
@@ -1552,6 +1843,7 @@ int32_t lsm6dsv_pin_int1_route_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_INT1_CTRL, (uint8_t *)&int1_ctrl, 1);
+  if (ret != 0) { return ret; }
 
   val->drdy_xl   = int1_ctrl.int1_drdy_xl;
   val->drdy_g    = int1_ctrl.int1_drdy_g;
@@ -1560,7 +1852,8 @@ int32_t lsm6dsv_pin_int1_route_get(stmdev_ctx_t *ctx,
   val->fifo_full = int1_ctrl.int1_fifo_full;
   val->cnt_bdr   = int1_ctrl.int1_cnt_bdr;
 
-  ret += lsm6dsv_read_reg(ctx, LSM6DSV_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  if (ret != 0) { return ret; }
 
   val->shub         = md1_cfg.int1_shub;
   val->emb_func     = md1_cfg.int1_emb_func;
@@ -1590,6 +1883,7 @@ int32_t lsm6dsv_pin_int2_route_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
+  if (ret != 0) { return ret; }
 
   int2_ctrl.int2_drdy_xl          = val->drdy_xl;
   int2_ctrl.int2_drdy_g           = val->drdy_g;
@@ -1600,10 +1894,11 @@ int32_t lsm6dsv_pin_int2_route_set(stmdev_ctx_t *ctx,
   int2_ctrl.int2_drdy_g_eis       = val->drdy_g_eis;
   int2_ctrl.int2_emb_func_endop   = val->emb_func_endop;
 
-  ret += lsm6dsv_write_reg(ctx, LSM6DSV_INT2_CTRL, (uint8_t *)&int2_ctrl,
-                           1);
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
+  if (ret != 0) { return ret; }
 
-  ret += lsm6dsv_read_reg(ctx, LSM6DSV_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  if (ret != 0) { return ret; }
 
   md2_cfg.int2_timestamp       = val->timestamp;
   md2_cfg.int2_emb_func        = val->emb_func;
@@ -1614,7 +1909,7 @@ int32_t lsm6dsv_pin_int2_route_set(stmdev_ctx_t *ctx,
   md2_cfg.int2_ff              = val->freefall;
   md2_cfg.int2_sleep_change    = val->sleep_change;
 
-  ret += lsm6dsv_write_reg(ctx, LSM6DSV_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_MD2_CFG, (uint8_t *)&md2_cfg, 1);
 
   return ret;
 }
@@ -1635,6 +1930,7 @@ int32_t lsm6dsv_pin_int2_route_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
+  if (ret != 0) { return ret; }
 
   val->drdy_xl        = int2_ctrl.int2_drdy_xl;
   val->drdy_g         = int2_ctrl.int2_drdy_g;
@@ -1645,7 +1941,8 @@ int32_t lsm6dsv_pin_int2_route_get(stmdev_ctx_t *ctx,
   val->drdy_g_eis     = int2_ctrl.int2_drdy_g_eis;
   val->emb_func_endop = int2_ctrl.int2_emb_func_endop;
 
-  ret += lsm6dsv_read_reg(ctx, LSM6DSV_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  if (ret != 0) { return ret; }
 
   val->timestamp      = md2_cfg.int2_timestamp;
   val->emb_func       = md2_cfg.int2_emb_func;
@@ -1691,16 +1988,13 @@ int32_t lsm6dsv_all_sources_get(stmdev_ctx_t *ctx, lsm6dsv_all_sources_t *val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
-  if (ret == 0)
-  {
-    functions_enable.dis_rst_lir_all_int = PROPERTY_ENABLE;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
-  }
+  functions_enable.dis_rst_lir_all_int = PROPERTY_ENABLE;
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_FIFO_STATUS1, (uint8_t *)&buff, 4);
-  }
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_FIFO_STATUS1, (uint8_t *)&buff, 4);
+  if (ret != 0) { return ret; }
+
   bytecpy((uint8_t *)&fifo_status2, &buff[1]);
   bytecpy((uint8_t *)&all_int_src, &buff[2]);
   bytecpy((uint8_t *)&status_reg, &buff[3]);
@@ -1721,20 +2015,13 @@ int32_t lsm6dsv_all_sources_get(stmdev_ctx_t *ctx, lsm6dsv_all_sources_t *val)
   val->drdy_ois = status_reg.ois_drdy;
   val->timestamp = status_reg.timestamp_endcount;
 
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
-  }
-  if (ret == 0)
-  {
-    functions_enable.dis_rst_lir_all_int = PROPERTY_DISABLE;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
-  }
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
+  functions_enable.dis_rst_lir_all_int = PROPERTY_DISABLE;
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_UI_STATUS_REG_OIS, (uint8_t *)&buff, 7);
-  }
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_UI_STATUS_REG_OIS, (uint8_t *)&buff, 8);
+  if (ret != 0) { return ret; }
 
   bytecpy((uint8_t *)&status_reg_ois, &buff[0]);
   bytecpy((uint8_t *)&wake_up_src, &buff[1]);
@@ -1779,19 +2066,13 @@ int32_t lsm6dsv_all_sources_get(stmdev_ctx_t *ctx, lsm6dsv_all_sources_t *val)
   val->fsm8 = fsm_status_mainpage.is_fsm8;
 
 
-  if (ret == 0)
-  {
-    ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_EXEC_STATUS, (uint8_t *)&emb_func_exec_status, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
-  }
+
+  /* embedded func */
+  ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_EXEC_STATUS, (uint8_t *)&emb_func_exec_status, 1);
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
+  if (ret != 0) { return ret; }
 
   val->emb_func_stand_by = emb_func_exec_status.emb_func_endop;
   val->emb_func_time_exceed = emb_func_exec_status.emb_func_exec_ovr;
@@ -1802,15 +2083,8 @@ int32_t lsm6dsv_all_sources_get(stmdev_ctx_t *ctx, lsm6dsv_all_sources_t *val)
   val->step_detector = emb_func_src.step_detected;
 
   /* sensor hub */
-  if (ret == 0)
-  {
-    ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_STATUS_MASTER, (uint8_t *)&status_shub, 1);
-  }
-  ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_STATUS_MASTER_MAINPAGE, (uint8_t *)&status_shub, 1);
+  if (ret != 0) { return ret; }
 
   val->sh_endop = status_shub.sens_hub_endop;
   val->sh_wr_once = status_shub.wr_once_done;
@@ -1829,6 +2103,8 @@ int32_t lsm6dsv_flag_data_ready_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_STATUS_REG, (uint8_t *)&status, 1);
+  if (ret != 0) { return ret; }
+
   val->drdy_xl = status.xlda;
   val->drdy_gy = status.gda;
   val->drdy_temp = status.tda;
@@ -1884,6 +2160,8 @@ int32_t lsm6dsv_temperature_raw_get(stmdev_ctx_t *ctx, int16_t *val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_OUT_TEMP_L, &buff[0], 2);
+  if (ret != 0) { return ret; }
+
   *val = (int16_t)buff[1];
   *val = (*val * 256) + (int16_t)buff[0];
 
@@ -1904,6 +2182,8 @@ int32_t lsm6dsv_angular_rate_raw_get(stmdev_ctx_t *ctx, int16_t *val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_OUTX_L_G, &buff[0], 6);
+  if (ret != 0) { return ret; }
+
   val[0] = (int16_t)buff[1];
   val[0] = (val[0] * 256) + (int16_t)buff[0];
   val[1] = (int16_t)buff[3];
@@ -1928,6 +2208,8 @@ int32_t lsm6dsv_ois_angular_rate_raw_get(stmdev_ctx_t *ctx, int16_t *val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_SPI2_OUTX_L_G_OIS, &buff[0], 6);
+  if (ret != 0) { return ret; }
+
   val[0] = (int16_t)buff[1];
   val[0] = (*val * 256) + (int16_t)buff[0];
   val[1] = (int16_t)buff[3];
@@ -1952,6 +2234,8 @@ int32_t lsm6dsv_ois_eis_angular_rate_raw_get(stmdev_ctx_t *ctx, int16_t *val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_UI_OUTX_L_G_OIS_EIS, &buff[0], 6);
+  if (ret != 0) { return ret; }
+
   val[0] = (int16_t)buff[1];
   val[0] = (*val * 256) + (int16_t)buff[0];
   val[1] = (int16_t)buff[3];
@@ -1976,6 +2260,8 @@ int32_t lsm6dsv_acceleration_raw_get(stmdev_ctx_t *ctx, int16_t *val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_OUTX_L_A, &buff[0], 6);
+  if (ret != 0) { return ret; }
+
   val[0] = (int16_t)buff[1];
   val[0] = (val[0] * 256) + (int16_t)buff[0];
   val[1] = (int16_t)buff[3];
@@ -2000,6 +2286,8 @@ int32_t lsm6dsv_dual_acceleration_raw_get(stmdev_ctx_t *ctx, int16_t *val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_UI_OUTX_L_A_OIS_DUALC, &buff[0], 6);
+  if (ret != 0) { return ret; }
+
   val[0] = (int16_t)buff[1];
   val[0] = (val[0] * 256) + (int16_t)buff[0];
   val[1] = (int16_t)buff[3];
@@ -2052,27 +2340,33 @@ int32_t lsm6dsv_ln_pg_write(stmdev_ctx_t *ctx, uint16_t address,
   lsb = (uint8_t)address & 0xFFU;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
+  if (ret != 0) { return ret; }
 
   /* set page write */
   ret += lsm6dsv_read_reg(ctx, LSM6DSV_PAGE_RW, (uint8_t *)&page_rw, 1);
   page_rw.page_read = PROPERTY_DISABLE;
   page_rw.page_write = PROPERTY_ENABLE;
   ret += lsm6dsv_write_reg(ctx, LSM6DSV_PAGE_RW, (uint8_t *)&page_rw, 1);
+  if (ret != 0) { goto exit; }
 
   /* select page */
   ret += lsm6dsv_read_reg(ctx, LSM6DSV_PAGE_SEL, (uint8_t *)&page_sel, 1);
   page_sel.page_sel = msb;
   page_sel.not_used0 = 1; // Default value
   ret += lsm6dsv_write_reg(ctx, LSM6DSV_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  if (ret != 0) { goto exit; }
 
   /* set page addr */
   page_address.page_addr = lsb;
   ret += lsm6dsv_write_reg(ctx, LSM6DSV_PAGE_ADDRESS,
                            (uint8_t *)&page_address, 1);
+  if (ret != 0) { goto exit; }
 
   for (i = 0; ((i < len) && (ret == 0)); i++)
   {
     ret += lsm6dsv_write_reg(ctx, LSM6DSV_PAGE_VALUE, &buf[i], 1);
+    if (ret != 0) { goto exit; }
+
     lsb++;
 
     /* Check if page wrap */
@@ -2080,19 +2374,19 @@ int32_t lsm6dsv_ln_pg_write(stmdev_ctx_t *ctx, uint16_t address,
     {
       msb++;
       ret += lsm6dsv_read_reg(ctx, LSM6DSV_PAGE_SEL, (uint8_t *)&page_sel, 1);
+      if (ret != 0) { goto exit; }
 
-      if (ret == 0)
-      {
-        page_sel.page_sel = msb;
-        page_sel.not_used0 = 1; // Default value
-        ret += lsm6dsv_write_reg(ctx, LSM6DSV_PAGE_SEL, (uint8_t *)&page_sel, 1);
-      }
+      page_sel.page_sel = msb;
+      page_sel.not_used0 = 1; // Default value
+      ret += lsm6dsv_write_reg(ctx, LSM6DSV_PAGE_SEL, (uint8_t *)&page_sel, 1);
+      if (ret != 0) { goto exit; }
     }
   }
 
   page_sel.page_sel = 0;
   page_sel.not_used0 = 1;// Default value
   ret += lsm6dsv_write_reg(ctx, LSM6DSV_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  if (ret != 0) { goto exit; }
 
   /* unset page write */
   ret += lsm6dsv_read_reg(ctx, LSM6DSV_PAGE_RW, (uint8_t *)&page_rw, 1);
@@ -2100,6 +2394,7 @@ int32_t lsm6dsv_ln_pg_write(stmdev_ctx_t *ctx, uint16_t address,
   page_rw.page_write = PROPERTY_DISABLE;
   ret += lsm6dsv_write_reg(ctx, LSM6DSV_PAGE_RW, (uint8_t *)&page_rw, 1);
 
+exit:
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
 
   return ret;
@@ -2135,27 +2430,33 @@ int32_t lsm6dsv_ln_pg_read(stmdev_ctx_t *ctx, uint16_t address, uint8_t *buf,
   lsb = (uint8_t)address & 0xFFU;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
+  if (ret != 0) { return ret; }
 
   /* set page write */
   ret += lsm6dsv_read_reg(ctx, LSM6DSV_PAGE_RW, (uint8_t *)&page_rw, 1);
   page_rw.page_read = PROPERTY_ENABLE;
   page_rw.page_write = PROPERTY_DISABLE;
   ret += lsm6dsv_write_reg(ctx, LSM6DSV_PAGE_RW, (uint8_t *)&page_rw, 1);
+  if (ret != 0) { goto exit; }
 
   /* select page */
   ret += lsm6dsv_read_reg(ctx, LSM6DSV_PAGE_SEL, (uint8_t *)&page_sel, 1);
   page_sel.page_sel = msb;
   page_sel.not_used0 = 1; // Default value
   ret += lsm6dsv_write_reg(ctx, LSM6DSV_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  if (ret != 0) { goto exit; }
 
   /* set page addr */
   page_address.page_addr = lsb;
   ret += lsm6dsv_write_reg(ctx, LSM6DSV_PAGE_ADDRESS,
                            (uint8_t *)&page_address, 1);
+  if (ret != 0) { goto exit; }
 
   for (i = 0; ((i < len) && (ret == 0)); i++)
   {
     ret += lsm6dsv_read_reg(ctx, LSM6DSV_PAGE_VALUE, &buf[i], 1);
+    if (ret != 0) { goto exit; }
+
     lsb++;
 
     /* Check if page wrap */
@@ -2163,19 +2464,19 @@ int32_t lsm6dsv_ln_pg_read(stmdev_ctx_t *ctx, uint16_t address, uint8_t *buf,
     {
       msb++;
       ret += lsm6dsv_read_reg(ctx, LSM6DSV_PAGE_SEL, (uint8_t *)&page_sel, 1);
+      if (ret != 0) { goto exit; }
 
-      if (ret == 0)
-      {
-        page_sel.page_sel = msb;
-        page_sel.not_used0 = 1; // Default value
-        ret += lsm6dsv_write_reg(ctx, LSM6DSV_PAGE_SEL, (uint8_t *)&page_sel, 1);
-      }
+      page_sel.page_sel = msb;
+      page_sel.not_used0 = 1; // Default value
+      ret += lsm6dsv_write_reg(ctx, LSM6DSV_PAGE_SEL, (uint8_t *)&page_sel, 1);
+      if (ret != 0) { goto exit; }
     }
   }
 
   page_sel.page_sel = 0;
   page_sel.not_used0 = 1;// Default value
   ret += lsm6dsv_write_reg(ctx, LSM6DSV_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  if (ret != 0) { goto exit; }
 
   /* unset page write */
   ret += lsm6dsv_read_reg(ctx, LSM6DSV_PAGE_RW, (uint8_t *)&page_rw, 1);
@@ -2183,6 +2484,7 @@ int32_t lsm6dsv_ln_pg_read(stmdev_ctx_t *ctx, uint16_t address, uint8_t *buf,
   page_rw.page_write = PROPERTY_DISABLE;
   ret += lsm6dsv_write_reg(ctx, LSM6DSV_PAGE_RW, (uint8_t *)&page_rw, 1);
 
+exit:
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
 
   return ret;
@@ -2226,11 +2528,9 @@ int32_t lsm6dsv_emb_function_dbg_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_CTRL10, (uint8_t *)&ctrl10, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    *val = ctrl10.emb_func_debug;
-  }
+  *val = ctrl10.emb_func_debug;
 
   return ret;
 }
@@ -2286,6 +2586,8 @@ int32_t lsm6dsv_den_polarity_get(stmdev_ctx_t *ctx, lsm6dsv_den_polarity_t *val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_CTRL4, (uint8_t *)&ctrl4, 1);
+  if (ret != 0) { return ret; }
+
   switch (ctrl4.int2_in_lh)
   {
     case LSM6DSV_DEN_ACT_LOW:
@@ -2300,6 +2602,7 @@ int32_t lsm6dsv_den_polarity_get(stmdev_ctx_t *ctx, lsm6dsv_den_polarity_t *val)
       *val = LSM6DSV_DEN_ACT_LOW;
       break;
   }
+
   return ret;
 }
 
@@ -2317,43 +2620,42 @@ int32_t lsm6dsv_den_conf_set(stmdev_ctx_t *ctx, lsm6dsv_den_conf_t val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_DEN, (uint8_t *)&den, 1);
-  if (ret == 0)
+  if (ret != 0) { return ret; }
+
+  den.den_z = val.den_z;
+  den.den_y = val.den_y;
+  den.den_x = val.den_x;
+
+  den.lvl2_en = (uint8_t)val.mode & 0x1U;
+  den.lvl1_en = ((uint8_t)val.mode & 0x2U) >> 1;
+
+  if (val.stamp_in_gy_data == PROPERTY_ENABLE && val.stamp_in_xl_data == PROPERTY_ENABLE)
   {
-    den.den_z = val.den_z;
-    den.den_y = val.den_y;
-    den.den_x = val.den_x;
-
-    den.lvl2_en = (uint8_t)val.mode & 0x1U;
-    den.lvl1_en = ((uint8_t)val.mode & 0x2U) >> 1;
-
-    if (val.stamp_in_gy_data == PROPERTY_ENABLE && val.stamp_in_xl_data == PROPERTY_ENABLE)
-    {
-      den.den_xl_g = PROPERTY_DISABLE;
-      den.den_xl_en = PROPERTY_ENABLE;
-    }
-    else if (val.stamp_in_gy_data == PROPERTY_ENABLE && val.stamp_in_xl_data == PROPERTY_DISABLE)
-    {
-      den.den_xl_g = PROPERTY_DISABLE;
-      den.den_xl_en = PROPERTY_DISABLE;
-    }
-    else if (val.stamp_in_gy_data == PROPERTY_DISABLE && val.stamp_in_xl_data == PROPERTY_ENABLE)
-    {
-      den.den_xl_g = PROPERTY_ENABLE;
-      den.den_xl_en = PROPERTY_DISABLE;
-    }
-    else
-    {
-      den.den_xl_g = PROPERTY_DISABLE;
-      den.den_xl_en = PROPERTY_DISABLE;
-      den.den_z = PROPERTY_DISABLE;
-      den.den_y = PROPERTY_DISABLE;
-      den.den_x = PROPERTY_DISABLE;
-      den.lvl2_en = PROPERTY_DISABLE;
-      den.lvl1_en = PROPERTY_DISABLE;
-    }
-
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_DEN, (uint8_t *)&den, 1);
+    den.den_xl_g = PROPERTY_DISABLE;
+    den.den_xl_en = PROPERTY_ENABLE;
   }
+  else if (val.stamp_in_gy_data == PROPERTY_ENABLE && val.stamp_in_xl_data == PROPERTY_DISABLE)
+  {
+    den.den_xl_g = PROPERTY_DISABLE;
+    den.den_xl_en = PROPERTY_DISABLE;
+  }
+  else if (val.stamp_in_gy_data == PROPERTY_DISABLE && val.stamp_in_xl_data == PROPERTY_ENABLE)
+  {
+    den.den_xl_g = PROPERTY_ENABLE;
+    den.den_xl_en = PROPERTY_DISABLE;
+  }
+  else
+  {
+    den.den_xl_g = PROPERTY_DISABLE;
+    den.den_xl_en = PROPERTY_DISABLE;
+    den.den_z = PROPERTY_DISABLE;
+    den.den_y = PROPERTY_DISABLE;
+    den.den_x = PROPERTY_DISABLE;
+    den.lvl2_en = PROPERTY_DISABLE;
+    den.lvl1_en = PROPERTY_DISABLE;
+  }
+
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_DEN, (uint8_t *)&den, 1);
 
   return ret;
 }
@@ -2373,6 +2675,7 @@ int32_t lsm6dsv_den_conf_get(stmdev_ctx_t *ctx, lsm6dsv_den_conf_t *val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_DEN, (uint8_t *)&den, 1);
+  if (ret != 0) { return ret; }
 
   val->den_z = den.den_z;
   val->den_y = den.den_y;
@@ -2404,16 +2707,16 @@ int32_t lsm6dsv_den_conf_get(stmdev_ctx_t *ctx, lsm6dsv_den_conf_t *val)
 
   switch ((den.lvl1_en << 1) + den.lvl2_en)
   {
-    case LEVEL_TRIGGER:
-      val->mode = LEVEL_TRIGGER;
+    case LSM6DSV_LEVEL_TRIGGER:
+      val->mode = LSM6DSV_LEVEL_TRIGGER;
       break;
 
-    case LEVEL_LATCHED:
-      val->mode = LEVEL_LATCHED;
+    case LSM6DSV_LEVEL_LATCHED:
+      val->mode = LSM6DSV_LEVEL_LATCHED;
       break;
 
     default:
-      val->mode = DEN_NOT_DEFINED;
+      val->mode = LSM6DSV_DEN_NOT_DEFINED;
       break;
   }
 
@@ -2472,6 +2775,7 @@ int32_t lsm6dsv_eis_gy_full_scale_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
+  if (ret != 0) { return ret; }
 
   switch (ctrl_eis.fs_g_eis)
   {
@@ -2585,6 +2889,7 @@ int32_t lsm6dsv_gy_eis_data_rate_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
+  if (ret != 0) { return ret; }
 
   switch (ctrl_eis.odr_g_eis)
   {
@@ -2604,6 +2909,7 @@ int32_t lsm6dsv_gy_eis_data_rate_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_EIS_1920Hz;
       break;
   }
+
   return ret;
 }
 
@@ -2701,7 +3007,6 @@ int32_t lsm6dsv_fifo_xl_dual_fsm_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
   *val = fifo_ctrl2.xl_dualc_batch_from_fsm;
 
-
   return ret;
 }
 
@@ -2744,6 +3049,8 @@ int32_t lsm6dsv_fifo_compress_algo_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+  if (ret != 0) { return ret; }
+
   switch (fifo_ctrl2.uncompr_rate)
   {
     case LSM6DSV_CMP_DISABLE:
@@ -2827,25 +3134,16 @@ int32_t lsm6dsv_fifo_compress_algo_real_time_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
-  if (ret == 0)
-  {
-    fifo_ctrl2.fifo_compr_rt_en = val;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
-  }
+  fifo_ctrl2.fifo_compr_rt_en = val;
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
-  }
-  if (ret == 0)
-  {
-    emb_func_en_b.fifo_compr_en = val;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
-  }
+  ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
+  if (ret != 0) { return ret; }
+
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
+  emb_func_en_b.fifo_compr_en = val;
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
 
   return ret;
@@ -2953,6 +3251,8 @@ int32_t lsm6dsv_fifo_xl_batch_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_FIFO_CTRL3, (uint8_t *)&fifo_ctrl3, 1);
+  if (ret != 0) { return ret; }
+
   switch (fifo_ctrl3.bdr_xl)
   {
     case LSM6DSV_XL_NOT_BATCHED:
@@ -3011,6 +3311,7 @@ int32_t lsm6dsv_fifo_xl_batch_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_XL_NOT_BATCHED;
       break;
   }
+
   return ret;
 }
 
@@ -3053,6 +3354,8 @@ int32_t lsm6dsv_fifo_gy_batch_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_FIFO_CTRL3, (uint8_t *)&fifo_ctrl3, 1);
+  if (ret != 0) { return ret; }
+
   switch (fifo_ctrl3.bdr_gy)
   {
     case LSM6DSV_GY_NOT_BATCHED:
@@ -3119,7 +3422,7 @@ int32_t lsm6dsv_fifo_gy_batch_get(stmdev_ctx_t *ctx,
   * @brief  FIFO mode selection.[set]
   *
   * @param  ctx      read / write interface definitions
-  * @param  val      BYPASS_MODE, FIFO_MODE, STREAM_TO_FIFO_MODE, BYPASS_TO_STREAM_MODE, STREAM_MODE, BYPASS_TO_FIFO_MODE,
+  * @param  val      BYPASS_MODE, FIFO_MODE, STREAM_WTM_TO_FULL_MODE, STREAM_TO_FIFO_MODE, BYPASS_TO_STREAM_MODE, STREAM_MODE, BYPASS_TO_FIFO_MODE,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
@@ -3142,7 +3445,7 @@ int32_t lsm6dsv_fifo_mode_set(stmdev_ctx_t *ctx, lsm6dsv_fifo_mode_t val)
   * @brief  FIFO mode selection.[get]
   *
   * @param  ctx      read / write interface definitions
-  * @param  val      BYPASS_MODE, FIFO_MODE, STREAM_TO_FIFO_MODE, BYPASS_TO_STREAM_MODE, STREAM_MODE, BYPASS_TO_FIFO_MODE,
+  * @param  val      BYPASS_MODE, FIFO_MODE, STREAM_WTM_TO_FULL_MODE, STREAM_TO_FIFO_MODE, BYPASS_TO_STREAM_MODE, STREAM_MODE, BYPASS_TO_FIFO_MODE,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
@@ -3152,6 +3455,8 @@ int32_t lsm6dsv_fifo_mode_get(stmdev_ctx_t *ctx, lsm6dsv_fifo_mode_t *val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
+  if (ret != 0) { return ret; }
+
   switch (fifo_ctrl4.fifo_mode)
   {
     case LSM6DSV_BYPASS_MODE:
@@ -3270,6 +3575,8 @@ int32_t lsm6dsv_fifo_temp_batch_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
+  if (ret != 0) { return ret; }
+
   switch (fifo_ctrl4.odr_t_batch)
   {
     case LSM6DSV_TEMP_NOT_BATCHED:
@@ -3334,6 +3641,8 @@ int32_t lsm6dsv_fifo_timestamp_batch_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
+  if (ret != 0) { return ret; }
+
   switch (fifo_ctrl4.dec_ts_batch)
   {
     case LSM6DSV_TMSTMP_NOT_BATCHED:
@@ -3356,6 +3665,7 @@ int32_t lsm6dsv_fifo_timestamp_batch_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_TMSTMP_NOT_BATCHED;
       break;
   }
+
   return ret;
 }
 
@@ -3395,6 +3705,8 @@ int32_t lsm6dsv_fifo_batch_counter_threshold_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_COUNTER_BDR_REG1, &buff[0], 2);
+  if (ret != 0) { return ret; }
+
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
 
@@ -3440,6 +3752,8 @@ int32_t lsm6dsv_fifo_batch_cnt_event_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_COUNTER_BDR_REG1, (uint8_t *)&counter_bdr_reg1, 1);
+  if (ret != 0) { return ret; }
+
   switch (counter_bdr_reg1.trig_counter_bdr)
   {
     case LSM6DSV_XL_BATCH_EVENT:
@@ -3458,6 +3772,7 @@ int32_t lsm6dsv_fifo_batch_cnt_event_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_XL_BATCH_EVENT;
       break;
   }
+
   return ret;
 }
 
@@ -3469,6 +3784,8 @@ int32_t lsm6dsv_fifo_status_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_FIFO_STATUS1, (uint8_t *)&buff[0], 2);
+  if (ret != 0) { return ret; }
+
   bytecpy((uint8_t *)&status, &buff[1]);
 
   val->fifo_bdr = status.counter_bdr_ia;
@@ -3482,11 +3799,19 @@ int32_t lsm6dsv_fifo_status_get(stmdev_ctx_t *ctx,
   return ret;
 }
 
+
 /**
   * @brief  FIFO data output[get]
   *
   * @param  ctx      read / write interface definitions
-  * @param  val      FIFO_EMPTY, GY_NC_TAG, XL_NC_TAG, TIMESTAMP_TAG, TEMPERATURE_TAG, CFG_CHANGE_TAG, XL_NC_T_2_TAG, XL_NC_T_1_TAG, XL_2XC_TAG, XL_3XC_TAG, GY_NC_T_2_TAG, GY_NC_T_1_TAG, GY_2XC_TAG, GY_3XC_TAG, SENSORHUB_SLAVE0_TAG, SENSORHUB_SLAVE1_TAG, SENSORHUB_SLAVE2_TAG, SENSORHUB_SLAVE3_TAG, STEP_CPUNTER_TAG, SENSORHUB_NACK_TAG, MLC_RESULT_TAG, MLC_FILTER, MLC_FEATURE, XL_DUAL_CORE, AH,
+  * @param  val      FIFO_EMPTY, GY_NC_TAG, XL_NC_TAG, TIMESTAMP_TAG,
+                     TEMPERATURE_TAG, CFG_CHANGE_TAG, XL_NC_T_2_TAG,
+                     XL_NC_T_1_TAG, XL_2XC_TAG, XL_3XC_TAG, GY_NC_T_2_TAG,
+                     GY_NC_T_1_TAG, GY_2XC_TAG, GY_3XC_TAG, SENSORHUB_SLAVE0_TAG,
+                     SENSORHUB_SLAVE1_TAG, SENSORHUB_SLAVE2_TAG, SENSORHUB_SLAVE3_TAG,
+                     STEP_COUNTER_TAG, SFLP_GAME_ROTATION_VECTOR_TAG, SFLP_GYROSCOPE_BIAS_TAG,
+                     SFLP_GRAVITY_VECTOR_TAG, SENSORHUB_NACK_TAG, XL_DUAL_CORE,
+                     GY_ENHANCED_EIS,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
@@ -3498,6 +3823,8 @@ int32_t lsm6dsv_fifo_out_raw_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_FIFO_DATA_OUT_TAG, buff, 7);
+  if (ret != 0) { return ret; }
+
   bytecpy((uint8_t *)&fifo_data_out_tag, &buff[0]);
 
   switch (fifo_data_out_tag.tag_sensor)
@@ -3578,6 +3905,18 @@ int32_t lsm6dsv_fifo_out_raw_get(stmdev_ctx_t *ctx,
       val->tag = LSM6DSV_STEP_COUNTER_TAG;
       break;
 
+    case LSM6DSV_SFLP_GAME_ROTATION_VECTOR_TAG:
+      val->tag = LSM6DSV_SFLP_GAME_ROTATION_VECTOR_TAG;
+      break;
+
+    case LSM6DSV_SFLP_GYROSCOPE_BIAS_TAG:
+      val->tag = LSM6DSV_SFLP_GYROSCOPE_BIAS_TAG;
+      break;
+
+    case LSM6DSV_SFLP_GRAVITY_VECTOR_TAG:
+      val->tag = LSM6DSV_SFLP_GRAVITY_VECTOR_TAG;
+      break;
+
     case LSM6DSV_SENSORHUB_NACK_TAG:
       val->tag = LSM6DSV_SENSORHUB_NACK_TAG;
       break;
@@ -3621,16 +3960,12 @@ int32_t lsm6dsv_fifo_stpcnt_batch_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
-  }
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    emb_func_fifo_en_a.step_counter_fifo_en = val;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
-  }
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
+  emb_func_fifo_en_a.step_counter_fifo_en = val;
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
+
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
 
   return ret;
@@ -3650,11 +3985,9 @@ int32_t lsm6dsv_fifo_stpcnt_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
-  }
+  if (ret != 0) { return ret; }
 
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
   *val = emb_func_fifo_en_a.step_counter_fifo_en;
 
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
@@ -3663,54 +3996,24 @@ int32_t lsm6dsv_fifo_stpcnt_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
 }
 
 /**
-  * @brief  Enable FIFO data batching of first slave.[set]
+  * @brief  Enable FIFO data batching of slave idx.[set]
   *
   * @param  ctx      read / write interface definitions
-  * @param  val      Enable FIFO data batching of first slave.
+  * @param  val      Enable FIFO data batching of slave idx.
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv_fifo_batch_sh_slave_0_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv_fifo_sh_batch_slave_set(stmdev_ctx_t *ctx, uint8_t idx, uint8_t val)
 {
-  lsm6dsv_slv0_config_t slv0_config;
+  lsm6dsv_slv0_config_t slv_config;
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_SLV0_CONFIG, (uint8_t *)&slv0_config, 1);
-  }
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    slv0_config.batch_ext_sens_0_en = val;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_SLV0_CONFIG, (uint8_t *)&slv0_config, 1);
-  }
-  ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
-
-  return ret;
-}
-
-/**
-  * @brief  Enable FIFO data batching of first slave.[get]
-  *
-  * @param  ctx      read / write interface definitions
-  * @param  val      Enable FIFO data batching of first slave.
-  * @retval          interface status (MANDATORY: return 0 -> no Error)
-  *
-  */
-int32_t lsm6dsv_fifo_batch_sh_slave_0_get(stmdev_ctx_t *ctx, uint8_t *val)
-{
-  lsm6dsv_slv0_config_t slv0_config;
-  int32_t ret;
-
-  ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_SLV0_CONFIG, (uint8_t *)&slv0_config, 1);
-  }
-
-  *val = slv0_config.batch_ext_sens_0_en;
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_SLV0_CONFIG + idx*3U, (uint8_t *)&slv_config, 1);
+  slv_config.batch_ext_sens_0_en = val;
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_SLV0_CONFIG + idx*3U, (uint8_t *)&slv_config, 1);
 
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
 
@@ -3718,54 +4021,23 @@ int32_t lsm6dsv_fifo_batch_sh_slave_0_get(stmdev_ctx_t *ctx, uint8_t *val)
 }
 
 /**
-  * @brief  Enable FIFO data batching of second slave.[set]
+  * @brief  Enable FIFO data batching of slave idx.[get]
   *
   * @param  ctx      read / write interface definitions
-  * @param  val      Enable FIFO data batching of second slave.
+  * @param  val      Enable FIFO data batching of slave idx.
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv_fifo_batch_sh_slave_1_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv_fifo_sh_batch_slave_get(stmdev_ctx_t *ctx, uint8_t idx, uint8_t *val)
 {
-  lsm6dsv_slv1_config_t slv1_config;
+  lsm6dsv_slv0_config_t slv_config;
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_SLV1_CONFIG, (uint8_t *)&slv1_config, 1);
-  }
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    slv1_config.batch_ext_sens_1_en = val;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_SLV1_CONFIG, (uint8_t *)&slv1_config, 1);
-  }
-  ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
-
-  return ret;
-}
-
-/**
-  * @brief  Enable FIFO data batching of second slave.[get]
-  *
-  * @param  ctx      read / write interface definitions
-  * @param  val      Enable FIFO data batching of second slave.
-  * @retval          interface status (MANDATORY: return 0 -> no Error)
-  *
-  */
-int32_t lsm6dsv_fifo_batch_sh_slave_1_get(stmdev_ctx_t *ctx, uint8_t *val)
-{
-  lsm6dsv_slv1_config_t slv1_config;
-  int32_t ret;
-
-  ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_SLV1_CONFIG, (uint8_t *)&slv1_config, 1);
-  }
-
-  *val = slv1_config.batch_ext_sens_1_en;
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_SLV0_CONFIG + idx*3U, (uint8_t *)&slv_config, 1);
+  *val = slv_config.batch_ext_sens_0_en;
 
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
 
@@ -3773,54 +4045,29 @@ int32_t lsm6dsv_fifo_batch_sh_slave_1_get(stmdev_ctx_t *ctx, uint8_t *val)
 }
 
 /**
-  * @brief  Enable FIFO data batching of third slave.[set]
+  * @brief  Batching in FIFO buffer of SFLP.[set]
   *
   * @param  ctx      read / write interface definitions
-  * @param  val      Enable FIFO data batching of third slave.
+  * @param  val      Batching in FIFO buffer of SFLP values.
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv_fifo_batch_sh_slave_2_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv_fifo_sflp_batch_set(stmdev_ctx_t *ctx,
+                                       lsm6dsv_fifo_sflp_raw_t val)
 {
-  lsm6dsv_slv2_config_t slv2_config;
+  lsm6dsv_emb_func_fifo_en_a_t emb_func_fifo_en_a;
   int32_t ret;
 
-  ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
+  ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
   if (ret == 0)
   {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_SLV2_CONFIG, (uint8_t *)&slv2_config, 1);
+    ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
+    emb_func_fifo_en_a.sflp_game_fifo_en = val.game_rotation;
+    emb_func_fifo_en_a.sflp_gravity_fifo_en = val.gravity;
+    emb_func_fifo_en_a.sflp_gbias_fifo_en = val.gbias;
+    ret += lsm6dsv_write_reg(ctx, LSM6DSV_EMB_FUNC_FIFO_EN_A,
+                                (uint8_t *)&emb_func_fifo_en_a, 1);
   }
-
-  if (ret == 0)
-  {
-    slv2_config.batch_ext_sens_2_en = val;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_SLV2_CONFIG, (uint8_t *)&slv2_config, 1);
-  }
-  ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
-
-  return ret;
-}
-
-/**
-  * @brief  Enable FIFO data batching of third slave.[get]
-  *
-  * @param  ctx      read / write interface definitions
-  * @param  val      Enable FIFO data batching of third slave.
-  * @retval          interface status (MANDATORY: return 0 -> no Error)
-  *
-  */
-int32_t lsm6dsv_fifo_batch_sh_slave_2_get(stmdev_ctx_t *ctx, uint8_t *val)
-{
-  lsm6dsv_slv2_config_t slv2_config;
-  int32_t ret;
-
-  ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_SLV2_CONFIG, (uint8_t *)&slv2_config, 1);
-  }
-
-  *val = slv2_config.batch_ext_sens_2_en;
 
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
 
@@ -3828,54 +4075,28 @@ int32_t lsm6dsv_fifo_batch_sh_slave_2_get(stmdev_ctx_t *ctx, uint8_t *val)
 }
 
 /**
-  * @brief  Enable FIFO data batching of fourth slave.[set]
+  * @brief  Batching in FIFO buffer of SFLP.[get]
   *
   * @param  ctx      read / write interface definitions
-  * @param  val      Enable FIFO data batching of fourth slave.
+  * @param  val      Batching in FIFO buffer of SFLP values.
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv_fifo_batch_sh_slave_3_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv_fifo_sflp_batch_get(stmdev_ctx_t *ctx,
+                                       lsm6dsv_fifo_sflp_raw_t *val)
 {
-  lsm6dsv_slv3_config_t slv3_config;
+  lsm6dsv_emb_func_fifo_en_a_t emb_func_fifo_en_a;
   int32_t ret;
 
-  ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
+  ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
   if (ret == 0)
   {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_SLV3_CONFIG, (uint8_t *)&slv3_config, 1);
+    ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
+
+    val->game_rotation = emb_func_fifo_en_a.sflp_game_fifo_en;
+    val->gravity = emb_func_fifo_en_a.sflp_gravity_fifo_en;
+    val->gbias = emb_func_fifo_en_a.sflp_gbias_fifo_en;
   }
-
-  if (ret == 0)
-  {
-    slv3_config.batch_ext_sens_3_en = val;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_SLV3_CONFIG, (uint8_t *)&slv3_config, 1);
-  }
-  ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
-
-  return ret;
-}
-
-/**
-  * @brief  Enable FIFO data batching of fourth slave.[get]
-  *
-  * @param  ctx      read / write interface definitions
-  * @param  val      Enable FIFO data batching of fourth slave.
-  * @retval          interface status (MANDATORY: return 0 -> no Error)
-  *
-  */
-int32_t lsm6dsv_fifo_batch_sh_slave_3_get(stmdev_ctx_t *ctx, uint8_t *val)
-{
-  lsm6dsv_slv3_config_t slv3_config;
-  int32_t ret;
-
-  ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_SLV3_CONFIG, (uint8_t *)&slv3_config, 1);
-  }
-
-  *val = slv3_config.batch_ext_sens_3_en;
 
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
 
@@ -3935,6 +4156,8 @@ int32_t lsm6dsv_filt_anti_spike_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_IF_CFG, (uint8_t *)&if_cfg, 1);
+  if (ret != 0) { return ret; }
+
   switch (if_cfg.asf_ctrl)
   {
     case LSM6DSV_AUTO:
@@ -3949,6 +4172,7 @@ int32_t lsm6dsv_filt_anti_spike_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_AUTO;
       break;
   }
+
   return ret;
 }
 
@@ -3969,36 +4193,19 @@ int32_t lsm6dsv_filt_settling_mask_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_CTRL4, (uint8_t *)&ctrl4, 1);
+  ctrl4.drdy_mask = val.drdy;
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_CTRL4, (uint8_t *)&ctrl4, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ctrl4.drdy_mask = val.drdy;
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
+  emb_func_cfg.emb_func_irq_mask_xl_settl = val.irq_xl;
+  emb_func_cfg.emb_func_irq_mask_g_settl = val.irq_g;
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
+  if (ret != 0) { return ret; }
 
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_CTRL4, (uint8_t *)&ctrl4, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
-  }
-
-  if (ret == 0)
-  {
-    emb_func_cfg.emb_func_irq_mask_xl_settl = val.irq_xl;
-    emb_func_cfg.emb_func_irq_mask_g_settl = val.irq_g;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_UI_INT_OIS, (uint8_t *)&ui_int_ois, 1);
-  }
-
-  if (ret == 0)
-  {
-    ui_int_ois.drdy_mask_ois = val.ois_drdy;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_UI_INT_OIS, (uint8_t *)&ui_int_ois, 1);
-  }
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_UI_INT_OIS, (uint8_t *)&ui_int_ois, 1);
+  ui_int_ois.drdy_mask_ois = val.ois_drdy;
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_UI_INT_OIS, (uint8_t *)&ui_int_ois, 1);
 
   return ret;
 }
@@ -4020,14 +4227,8 @@ int32_t lsm6dsv_filt_settling_mask_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_CTRL4, (uint8_t *)&ctrl4, 1);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_UI_INT_OIS, (uint8_t *)&ui_int_ois, 1);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_UI_INT_OIS, (uint8_t *)&ui_int_ois, 1);
 
   val->irq_xl = emb_func_cfg.emb_func_irq_mask_xl_settl;
   val->irq_g = emb_func_cfg.emb_func_irq_mask_g_settl;
@@ -4121,6 +4322,8 @@ int32_t lsm6dsv_filt_gy_lp1_bandwidth_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_CTRL6, (uint8_t *)&ctrl6, 1);
+  if (ret != 0) { return ret; }
+
   switch (ctrl6.lpf1_g_bw)
   {
     case LSM6DSV_GY_ULTRA_LIGHT:
@@ -4159,6 +4362,7 @@ int32_t lsm6dsv_filt_gy_lp1_bandwidth_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_GY_ULTRA_LIGHT;
       break;
   }
+
   return ret;
 }
 
@@ -4244,6 +4448,8 @@ int32_t lsm6dsv_filt_xl_lp2_bandwidth_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_CTRL8, (uint8_t *)&ctrl8, 1);
+  if (ret != 0) { return ret; }
+
   switch (ctrl8.hp_lpf2_xl_bw)
   {
     case LSM6DSV_XL_ULTRA_LIGHT:
@@ -4282,6 +4488,7 @@ int32_t lsm6dsv_filt_xl_lp2_bandwidth_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_XL_ULTRA_LIGHT;
       break;
   }
+
   return ret;
 }
 
@@ -4450,6 +4657,8 @@ int32_t lsm6dsv_filt_xl_hp_mode_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_CTRL9, (uint8_t *)&ctrl9, 1);
+  if (ret != 0) { return ret; }
+
   switch (ctrl9.hp_ref_mode_xl)
   {
     case LSM6DSV_HP_MD_NORMAL:
@@ -4464,6 +4673,7 @@ int32_t lsm6dsv_filt_xl_hp_mode_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_HP_MD_NORMAL;
       break;
   }
+
   return ret;
 }
 
@@ -4483,21 +4693,15 @@ int32_t lsm6dsv_filt_wkup_act_feed_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    tap_cfg0.slope_fds = (uint8_t)val & 0x01U;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
-  }
-  if (ret == 0)
-  {
-    wake_up_ths.usr_off_on_wu = ((uint8_t)val & 0x02U) >> 1;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
-  }
+  tap_cfg0.slope_fds = (uint8_t)val & 0x01U;
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  if (ret != 0) { return ret; }
+
+  wake_up_ths.usr_off_on_wu = ((uint8_t)val & 0x02U) >> 1;
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
 
   return ret;
 }
@@ -4518,10 +4722,8 @@ int32_t lsm6dsv_filt_wkup_act_feed_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  if (ret != 0) { return ret; }
 
   switch ((wake_up_ths.usr_off_on_wu << 1) + tap_cfg0.slope_fds)
   {
@@ -4541,6 +4743,7 @@ int32_t lsm6dsv_filt_wkup_act_feed_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_WK_FEED_SLOPE;
       break;
   }
+
   return ret;
 }
 
@@ -4627,6 +4830,7 @@ int32_t lsm6dsv_filt_sixd_feed_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  if (ret != 0) { return ret; }
 
   switch (tap_cfg0.low_pass_on_6d)
   {
@@ -4642,6 +4846,7 @@ int32_t lsm6dsv_filt_sixd_feed_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_SIXD_FEED_ODR_DIV_2;
       break;
   }
+
   return ret;
 }
 
@@ -4685,6 +4890,7 @@ int32_t lsm6dsv_filt_gy_eis_lp_bandwidth_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
+  if (ret != 0) { return ret; }
 
   switch (ctrl_eis.lpf_g_eis_bw)
   {
@@ -4700,6 +4906,7 @@ int32_t lsm6dsv_filt_gy_eis_lp_bandwidth_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_EIS_LP_NORMAL;
       break;
   }
+
   return ret;
 }
 
@@ -4744,6 +4951,7 @@ int32_t lsm6dsv_filt_gy_ois_lp_bandwidth_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_UI_CTRL2_OIS, (uint8_t *)&ui_ctrl2_ois, 1);
+  if (ret != 0) { return ret; }
 
   switch (ui_ctrl2_ois.lpf1_g_ois_bw)
   {
@@ -4767,6 +4975,7 @@ int32_t lsm6dsv_filt_gy_ois_lp_bandwidth_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_OIS_GY_LP_NORMAL;
       break;
   }
+
   return ret;
 }
 
@@ -4810,6 +5019,7 @@ int32_t lsm6dsv_filt_xl_ois_lp_bandwidth_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_UI_CTRL3_OIS, (uint8_t *)&ui_ctrl3_ois, 1);
+  if (ret != 0) { return ret; }
 
   switch (ui_ctrl3_ois.lpf_xl_ois_bw)
   {
@@ -4849,6 +5059,7 @@ int32_t lsm6dsv_filt_xl_ois_lp_bandwidth_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_OIS_XL_LP_ULTRA_LIGHT;
       break;
   }
+
   return ret;
 }
 
@@ -4905,6 +5116,7 @@ int32_t lsm6dsv_fsm_permission_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  if (ret != 0) { return ret; }
 
   switch (func_cfg_access.fsm_wr_ctrl_en)
   {
@@ -4920,6 +5132,7 @@ int32_t lsm6dsv_fsm_permission_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_PROTECT_CTRL_REGS;
       break;
   }
+
   return ret;
 }
 
@@ -4958,14 +5171,12 @@ int32_t lsm6dsv_fsm_mode_set(stmdev_ctx_t *ctx, lsm6dsv_fsm_mode_t val)
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_FSM_ENABLE, (uint8_t *)&fsm_enable, 1);
-  }
+  if (ret != 0) { return ret; }
+
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_FSM_ENABLE, (uint8_t *)&fsm_enable, 1);
+  if (ret != 0) { goto exit; }
+
   if ((val.fsm1_en | val.fsm2_en | val.fsm1_en | val.fsm1_en
        | val.fsm1_en | val.fsm2_en | val.fsm1_en | val.fsm1_en) == PROPERTY_ENABLE)
   {
@@ -4975,22 +5186,20 @@ int32_t lsm6dsv_fsm_mode_set(stmdev_ctx_t *ctx, lsm6dsv_fsm_mode_t val)
   {
     emb_func_en_b.fsm_en = PROPERTY_DISABLE;
   }
-  if (ret == 0)
-  {
-    fsm_enable.fsm1_en = val.fsm1_en;
-    fsm_enable.fsm2_en = val.fsm2_en;
-    fsm_enable.fsm3_en = val.fsm3_en;
-    fsm_enable.fsm4_en = val.fsm4_en;
-    fsm_enable.fsm5_en = val.fsm5_en;
-    fsm_enable.fsm6_en = val.fsm6_en;
-    fsm_enable.fsm7_en = val.fsm7_en;
-    fsm_enable.fsm8_en = val.fsm8_en;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_FSM_ENABLE, (uint8_t *)&fsm_enable, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
-  }
+
+  fsm_enable.fsm1_en = val.fsm1_en;
+  fsm_enable.fsm2_en = val.fsm2_en;
+  fsm_enable.fsm3_en = val.fsm3_en;
+  fsm_enable.fsm4_en = val.fsm4_en;
+  fsm_enable.fsm5_en = val.fsm5_en;
+  fsm_enable.fsm6_en = val.fsm6_en;
+  fsm_enable.fsm7_en = val.fsm7_en;
+  fsm_enable.fsm8_en = val.fsm8_en;
+
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_FSM_ENABLE, (uint8_t *)&fsm_enable, 1);
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
+
+exit:
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
 
   return ret;
@@ -5010,11 +5219,9 @@ int32_t lsm6dsv_fsm_mode_get(stmdev_ctx_t *ctx, lsm6dsv_fsm_mode_t *val)
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_FSM_ENABLE, (uint8_t *)&fsm_enable, 1);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_FSM_ENABLE, (uint8_t *)&fsm_enable, 1);
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
+  if (ret != 0) { return ret; }
 
   val->fsm1_en = fsm_enable.fsm1_en;
   val->fsm2_en = fsm_enable.fsm2_en;
@@ -5044,7 +5251,8 @@ int32_t lsm6dsv_fsm_long_cnt_set(stmdev_ctx_t *ctx, uint16_t val)
   buff[1] = (uint8_t)(val / 256U);
   buff[0] = (uint8_t)(val - (buff[1] * 256U));
 
-  ret = lsm6dsv_write_reg(ctx, LSM6DSV_FSM_LONG_COUNTER_L, (uint8_t *)&buff[0], 2);
+  ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_FSM_LONG_COUNTER_L, (uint8_t *)&buff[0], 2);
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
 
   return ret;
@@ -5064,11 +5272,9 @@ int32_t lsm6dsv_fsm_long_cnt_get(stmdev_ctx_t *ctx, uint16_t *val)
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_FSM_LONG_COUNTER_L, &buff[0], 2);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_FSM_LONG_COUNTER_L, &buff[0], 2);
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
+  if (ret != 0) { return ret; }
 
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
@@ -5089,10 +5295,7 @@ int32_t lsm6dsv_fsm_out_get(stmdev_ctx_t *ctx, lsm6dsv_fsm_out_t *val)
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_FSM_OUTS1, (uint8_t *)val, 8);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_FSM_OUTS1, (uint8_t *)val, 8);
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
 
   return ret;
@@ -5113,16 +5316,13 @@ int32_t lsm6dsv_fsm_data_rate_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_FSM_ODR, (uint8_t *)&fsm_odr, 1);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_FSM_ODR, (uint8_t *)&fsm_odr, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    fsm_odr.fsm_odr = (uint8_t)val & 0x07U;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_FSM_ODR, (uint8_t *)&fsm_odr, 1);
-  }
+  fsm_odr.fsm_odr = (uint8_t)val & 0x07U;
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_FSM_ODR, (uint8_t *)&fsm_odr, 1);
+
+exit:
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
 
   return ret;
@@ -5143,12 +5343,9 @@ int32_t lsm6dsv_fsm_data_rate_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_FSM_ODR, (uint8_t *)&fsm_odr, 1);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_FSM_ODR, (uint8_t *)&fsm_odr, 1);
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
-
+  if (ret != 0) { return ret; }
 
   switch (fsm_odr.fsm_odr)
   {
@@ -5184,6 +5381,325 @@ int32_t lsm6dsv_fsm_data_rate_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_FSM_15Hz;
       break;
   }
+
+  return ret;
+}
+
+/*
+ * Original conversion routines taken from: https://github.com/numpy/numpy
+ *
+ * uint16_t npy_floatbits_to_halfbits(uint32_t f);
+ * uint16_t npy_float_to_half(float_t f);
+ *
+ * Released under BSD-3-Clause License
+ */
+static uint16_t npy_floatbits_to_halfbits(uint32_t f)
+{
+  uint32_t f_exp, f_sig;
+  uint16_t h_sgn, h_exp, h_sig;
+
+  h_sgn = (uint16_t)((f & 0x80000000u) >> 16);
+  f_exp = (f & 0x7f800000u);
+
+  /* Exponent overflow/NaN converts to signed inf/NaN */
+  if (f_exp >= 0x47800000u)
+  {
+    if (f_exp == 0x7f800000u)
+    {
+      /* Inf or NaN */
+      f_sig = (f & 0x007fffffu);
+      if (f_sig != 0U)
+      {
+        /* NaN - propagate the flag in the significand... */
+        uint16_t ret = (uint16_t)(0x7c00u + (f_sig >> 13));
+        /* ...but make sure it stays a NaN */
+        if (ret == 0x7c00u)
+        {
+          ret++;
+        }
+        return h_sgn + ret;
+      }
+      else
+      {
+        /* signed inf */
+        return (uint16_t)(h_sgn + 0x7c00u);
+      }
+    }
+    else
+    {
+      /* overflow to signed inf */
+#if NPY_HALF_GENERATE_OVERFLOW
+      npy_set_floatstatus_overflow();
+#endif
+      return (uint16_t)(h_sgn + 0x7c00u);
+    }
+  }
+
+  /* Exponent underflow converts to a subnormal half or signed zero */
+  if (f_exp <= 0x38000000u)
+  {
+    /*
+     * Signed zeros, subnormal floats, and floats with small
+     * exponents all convert to signed zero half-floats.
+     */
+    if (f_exp < 0x33000000u)
+    {
+#if NPY_HALF_GENERATE_UNDERFLOW
+      /* If f != 0, it underflowed to 0 */
+      if ((f & 0x7fffffff) != 0)
+      {
+        npy_set_floatstatus_underflow();
+      }
+#endif
+      return h_sgn;
+    }
+    /* Make the subnormal significand */
+    f_exp >>= 23;
+    f_sig = (0x00800000u + (f & 0x007fffffu));
+#if NPY_HALF_GENERATE_UNDERFLOW
+    /* If it's not exactly represented, it underflowed */
+    if ((f_sig & (((uint32_t)1 << (126 - f_exp)) - 1)) != 0)
+    {
+      npy_set_floatstatus_underflow();
+    }
+#endif
+    /*
+     * Usually the significand is shifted by 13. For subnormals an
+     * additional shift needs to occur. This shift is one for the largest
+     * exponent giving a subnormal `f_exp = 0x38000000 >> 23 = 112`, which
+     * offsets the new first bit. At most the shift can be 1+10 bits.
+     */
+    f_sig >>= (113U - f_exp);
+    /* Handle rounding by adding 1 to the bit beyond half precision */
+#if NPY_HALF_ROUND_TIES_TO_EVEN
+    /*
+     * If the last bit in the half significand is 0 (already even), and
+     * the remaining bit pattern is 1000...0, then we do not add one
+     * to the bit after the half significand. However, the (113 - f_exp)
+     * shift can lose up to 11 bits, so the || checks them in the original.
+     * In all other cases, we can just add one.
+     */
+    if (((f_sig & 0x00003fffu) != 0x00001000u) || (f & 0x000007ffu))
+    {
+      f_sig += 0x00001000u;
+    }
+#else
+    f_sig += 0x00001000u;
+#endif
+    h_sig = (uint16_t)(f_sig >> 13);
+    /*
+     * If the rounding causes a bit to spill into h_exp, it will
+     * increment h_exp from zero to one and h_sig will be zero.
+     * This is the correct result.
+     */
+    return (uint16_t)(h_sgn + h_sig);
+  }
+
+  /* Regular case with no overflow or underflow */
+  h_exp = (uint16_t)((f_exp - 0x38000000u) >> 13);
+  /* Handle rounding by adding 1 to the bit beyond half precision */
+  f_sig = (f & 0x007fffffu);
+#if NPY_HALF_ROUND_TIES_TO_EVEN
+  /*
+   * If the last bit in the half significand is 0 (already even), and
+   * the remaining bit pattern is 1000...0, then we do not add one
+   * to the bit after the half significand.  In all other cases, we do.
+   */
+  if ((f_sig & 0x00003fffu) != 0x00001000u)
+  {
+    f_sig += 0x00001000u;
+  }
+#else
+  f_sig += 0x00001000u;
+#endif
+  h_sig = (uint16_t)(f_sig >> 13);
+  /*
+   * If the rounding causes a bit to spill into h_exp, it will
+   * increment h_exp by one and h_sig will be zero.  This is the
+   * correct result.  h_exp may increment to 15, at greatest, in
+   * which case the result overflows to a signed inf.
+   */
+#if NPY_HALF_GENERATE_OVERFLOW
+  h_sig += h_exp;
+  if (h_sig == 0x7c00u)
+  {
+    npy_set_floatstatus_overflow();
+  }
+  return h_sgn + h_sig;
+#else
+  return h_sgn + h_exp + h_sig;
+#endif
+}
+
+static uint16_t npy_float_to_half(float_t f)
+{
+  union
+  {
+    float_t f;
+    uint32_t fbits;
+  } conv;
+  conv.f = f;
+  return npy_floatbits_to_halfbits(conv.fbits);
+}
+
+/**
+  * @brief  SFLP GBIAS value. The register value is expressed as half-precision
+  *         floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent
+  *          bits; F: 10 fraction bits).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      GBIAS x/y/z val.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv_sflp_game_gbias_set(stmdev_ctx_t *ctx,
+                                       lsm6dsv_sflp_gbias_t *val)
+{
+  lsm6dsv_sflp_data_rate_t sflp_odr;
+  lsm6dsv_emb_func_exec_status_t emb_func_sts;
+  lsm6dsv_data_ready_t drdy;
+  lsm6dsv_xl_full_scale_t xl_fs;
+  lsm6dsv_ctrl10_t ctrl10;
+  uint8_t master_config;
+  uint8_t emb_func_en_saved[2];
+  uint8_t conf_saved[2];
+  uint8_t reg_zero[2] = {0x0, 0x0};
+  uint16_t gbias_hf[3];
+  float_t k = 0.005f;
+  int16_t xl_data[3];
+  int32_t data_tmp;
+  uint8_t *data_ptr = (uint8_t *)&data_tmp;
+  uint8_t i, j;
+  int32_t ret;
+
+  ret = lsm6dsv_sflp_data_rate_get(ctx, &sflp_odr);
+  if (ret != 0) { return ret; }
+
+  /* Calculate k factor */
+  switch (sflp_odr)
+  {
+    default:
+    case LSM6DSV_SFLP_15Hz:
+      k = 0.04f;
+      break;
+    case LSM6DSV_SFLP_30Hz:
+      k = 0.02f;
+      break;
+    case LSM6DSV_SFLP_60Hz:
+      k = 0.01f;
+      break;
+    case LSM6DSV_SFLP_120Hz:
+      k = 0.005f;
+      break;
+    case LSM6DSV_SFLP_240Hz:
+      k = 0.0025f;
+      break;
+    case LSM6DSV_SFLP_480Hz:
+      k = 0.00125f;
+      break;
+  }
+
+  /* compute gbias as half precision float in order to be put in embedded advanced feature register */
+  gbias_hf[0] = npy_float_to_half(val->gbias_x * (3.14159265358979323846f / 180.0f) / k);
+  gbias_hf[1] = npy_float_to_half(val->gbias_y * (3.14159265358979323846f / 180.0f) / k);
+  gbias_hf[2] = npy_float_to_half(val->gbias_z * (3.14159265358979323846f / 180.0f) / k);
+
+  /* Save sensor configuration and set high-performance mode (if the sensor is in power-down mode, turn it on) */
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_CTRL1, conf_saved, 2);
+  ret += lsm6dsv_xl_mode_set(ctx, LSM6DSV_XL_HIGH_PERFORMANCE_MD);
+  ret += lsm6dsv_gy_mode_set(ctx, LSM6DSV_GY_HIGH_PERFORMANCE_MD);
+  if (((uint8_t)conf_saved[0] & 0x0FU) == (uint8_t)LSM6DSV_ODR_OFF)
+  {
+    ret += lsm6dsv_xl_data_rate_set(ctx, LSM6DSV_ODR_AT_120Hz);
+  }
+
+  /* Make sure to turn the sensor-hub master off */
+  ret += lsm6dsv_sh_master_get(ctx, &master_config);
+  ret += lsm6dsv_sh_master_set(ctx, 0);
+
+  /* disable algos */
+  ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_EN_A, emb_func_en_saved, 2);
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_EMB_FUNC_EN_A, reg_zero, 2);
+  do
+  {
+    ret += lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_EXEC_STATUS,
+                               (uint8_t *)&emb_func_sts, 1);
+  } while (emb_func_sts.emb_func_endop != 1U);
+  ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
+
+  // enable gbias setting
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_CTRL10, (uint8_t *)&ctrl10, 1);
+  ctrl10.emb_func_debug = 1;
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_CTRL10, (uint8_t *)&ctrl10, 1);
+
+  /* enable algos */
+  ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
+  emb_func_en_saved[0] |= 0x02U; /* force SFLP GAME en */
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_EMB_FUNC_EN_A, emb_func_en_saved,
+                              2);
+  ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
+
+  ret += lsm6dsv_xl_full_scale_get(ctx, &xl_fs);
+
+  /* Read XL data */
+  do
+  {
+    ret += lsm6dsv_flag_data_ready_get(ctx, &drdy);
+  } while (drdy.drdy_xl != 1U);
+  ret += lsm6dsv_acceleration_raw_get(ctx, xl_data);
+
+  /* force sflp initialization */
+  ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
+  for (i = 0; i < 3U; i++)
+  {
+    j = 0;
+    data_tmp = (int32_t)xl_data[i];
+    data_tmp <<= xl_fs; // shift based on current fs
+    ret += lsm6dsv_write_reg(ctx, LSM6DSV_SENSOR_HUB_1 + 3U * i,
+                                &data_ptr[j++], 1);
+    ret += lsm6dsv_write_reg(ctx, LSM6DSV_SENSOR_HUB_2 + 3U * i,
+                                &data_ptr[j++], 1);
+    ret += lsm6dsv_write_reg(ctx, LSM6DSV_SENSOR_HUB_3 + 3U * i, &data_ptr[j],
+                                1);
+  }
+  for (i = 0; i < 3U; i++)
+  {
+    j = 0;
+    data_tmp = 0;
+    ret += lsm6dsv_write_reg(ctx, LSM6DSV_SENSOR_HUB_10 + 3U * i,
+                                &data_ptr[j++], 1);
+    ret += lsm6dsv_write_reg(ctx, LSM6DSV_SENSOR_HUB_11 + 3U * i,
+                                &data_ptr[j++], 1);
+    ret += lsm6dsv_write_reg(ctx, LSM6DSV_SENSOR_HUB_12 + 3U * i, &data_ptr[j],
+                                1);
+  }
+  ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
+
+  // wait end_op (and at least 30 us)
+  ctx->mdelay(1);
+  ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
+  do
+  {
+    ret += lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_EXEC_STATUS,
+                               (uint8_t *)&emb_func_sts, 1);
+  } while (emb_func_sts.emb_func_endop != 1U);
+  ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
+
+  /* write gbias in embedded advanced features registers */
+  ret += lsm6dsv_ln_pg_write(ctx, LSM6DSV_SFLP_GAME_GBIASX_L,
+                                (uint8_t *)gbias_hf, 6);
+
+  /* reload previous sensor configuration */
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_CTRL1, conf_saved, 2);
+
+  // disable gbias setting
+  ctrl10.emb_func_debug = 0;
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_CTRL10, (uint8_t *)&ctrl10, 1);
+
+  /* reload previous master configuration */
+  ret += lsm6dsv_sh_master_set(ctx, master_config);
+
   return ret;
 }
 
@@ -5221,6 +5737,8 @@ int32_t lsm6dsv_fsm_ext_sens_sensitivity_get(stmdev_ctx_t *ctx, uint16_t *val)
   int32_t ret;
 
   ret = lsm6dsv_ln_pg_read(ctx, LSM6DSV_FSM_EXT_SENSITIVITY_L, &buff[0], 2);
+  if (ret != 0) { return ret; }
+
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
 
@@ -5267,6 +5785,7 @@ int32_t lsm6dsv_fsm_ext_sens_offset_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_ln_pg_read(ctx, LSM6DSV_FSM_EXT_OFFX_L, &buff[0], 6);
+  if (ret != 0) { return ret; }
 
   val->x = buff[1];
   val->x = (val->x * 256U) + buff[0];
@@ -5324,6 +5843,7 @@ int32_t lsm6dsv_fsm_ext_sens_matrix_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_ln_pg_read(ctx, LSM6DSV_FSM_EXT_MATRIX_XX_L, &buff[0], 12);
+  if (ret != 0) { return ret; }
 
   val->xx = buff[1];
   val->xx = (val->xx * 256U) + buff[0];
@@ -5356,11 +5876,8 @@ int32_t lsm6dsv_fsm_ext_sens_z_orient_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_ln_pg_read(ctx, LSM6DSV_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
-  if (ret == 0)
-  {
-    ext_cfg_a.ext_z_axis = (uint8_t)val & 0x07U;
-    ret = lsm6dsv_ln_pg_write(ctx, LSM6DSV_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
-  }
+  ext_cfg_a.ext_z_axis = (uint8_t)val & 0x07U;
+  ret += lsm6dsv_ln_pg_write(ctx, LSM6DSV_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
 
   return ret;
 }
@@ -5380,6 +5897,8 @@ int32_t lsm6dsv_fsm_ext_sens_z_orient_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_ln_pg_read(ctx, LSM6DSV_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
+  if (ret != 0) { return ret; }
+
   switch (ext_cfg_a.ext_z_axis)
   {
     case LSM6DSV_Z_EQ_Y:
@@ -5410,6 +5929,7 @@ int32_t lsm6dsv_fsm_ext_sens_z_orient_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_Z_EQ_Y;
       break;
   }
+
   return ret;
 }
 
@@ -5452,6 +5972,8 @@ int32_t lsm6dsv_fsm_ext_sens_y_orient_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_ln_pg_read(ctx, LSM6DSV_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
+  if (ret != 0) { return ret; }
+
   switch (ext_cfg_a.ext_y_axis)
   {
     case LSM6DSV_Y_EQ_Y:
@@ -5482,6 +6004,7 @@ int32_t lsm6dsv_fsm_ext_sens_y_orient_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_Y_EQ_Y;
       break;
   }
+
   return ret;
 }
 
@@ -5524,6 +6047,8 @@ int32_t lsm6dsv_fsm_ext_sens_x_orient_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_ln_pg_read(ctx, LSM6DSV_EXT_CFG_B, (uint8_t *)&ext_cfg_b, 1);
+  if (ret != 0) { return ret; }
+
   switch (ext_cfg_b.ext_x_axis)
   {
     case LSM6DSV_X_EQ_Y:
@@ -5554,6 +6079,7 @@ int32_t lsm6dsv_fsm_ext_sens_x_orient_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_X_EQ_Y;
       break;
   }
+
   return ret;
 }
 
@@ -5591,6 +6117,8 @@ int32_t lsm6dsv_fsm_long_cnt_timeout_get(stmdev_ctx_t *ctx, uint16_t *val)
   int32_t ret;
 
   ret = lsm6dsv_ln_pg_read(ctx, LSM6DSV_EMB_ADV_PG_1 + LSM6DSV_FSM_LC_TIMEOUT_L, &buff[0], 2);
+  if (ret != 0) { return ret; }
+
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
 
@@ -5673,6 +6201,8 @@ int32_t lsm6dsv_fsm_start_address_get(stmdev_ctx_t *ctx, uint16_t *val)
   int32_t ret;
 
   ret = lsm6dsv_ln_pg_read(ctx, LSM6DSV_EMB_ADV_PG_1 + LSM6DSV_FSM_START_ADD_L, &buff[0], 2);
+  if (ret != 0) { return ret; }
+
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
 
@@ -5707,21 +6237,13 @@ int32_t lsm6dsv_ff_time_windows_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
-  if (ret == 0)
-  {
-    wake_up_dur.ff_dur = ((uint8_t)val & 0x20U) >> 5;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_FREE_FALL, (uint8_t *)&free_fall, 1);
-  }
+  wake_up_dur.ff_dur = ((uint8_t)val & 0x20U) >> 5;
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    free_fall.ff_dur = (uint8_t)val & 0x1FU;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_FREE_FALL, (uint8_t *)&free_fall, 1);
-  }
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_FREE_FALL, (uint8_t *)&free_fall, 1);
+  free_fall.ff_dur = (uint8_t)val & 0x1FU;
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_FREE_FALL, (uint8_t *)&free_fall, 1);
 
   return ret;
 }
@@ -5741,10 +6263,7 @@ int32_t lsm6dsv_ff_time_windows_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_FREE_FALL, (uint8_t *)&free_fall, 1);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_FREE_FALL, (uint8_t *)&free_fall, 1);
 
   *val = (wake_up_dur.ff_dur << 5) + free_fall.ff_dur;
 
@@ -5790,6 +6309,8 @@ int32_t lsm6dsv_ff_thresholds_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_FREE_FALL, (uint8_t *)&free_fall, 1);
+  if (ret != 0) { return ret; }
+
   switch (free_fall.ff_ths)
   {
     case LSM6DSV_156_mg:
@@ -5883,6 +6404,8 @@ int32_t lsm6dsv_ois_ctrl_mode_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  if (ret != 0) { return ret; }
+
   switch (func_cfg_access.ois_ctrl_from_ui)
   {
     case LSM6DSV_OIS_CTRL_FROM_OIS:
@@ -5897,6 +6420,7 @@ int32_t lsm6dsv_ois_ctrl_mode_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_OIS_CTRL_FROM_OIS;
       break;
   }
+
   return ret;
 }
 
@@ -6024,6 +6548,8 @@ int32_t lsm6dsv_ois_handshake_from_ui_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_UI_HANDSHAKE_CTRL, (uint8_t *)&ui_handshake_ctrl, 1);
+  if (ret != 0) { return ret; }
+
   val->ack = ui_handshake_ctrl.ui_shared_ack;
   val->req = ui_handshake_ctrl.ui_shared_req;
 
@@ -6070,6 +6596,8 @@ int32_t lsm6dsv_ois_handshake_from_ois_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_SPI2_HANDSHAKE_CTRL, (uint8_t *)&spi2_handshake_ctrl, 1);
+  if (ret != 0) { return ret; }
+
   val->ack = spi2_handshake_ctrl.spi2_shared_ack;
   val->req = spi2_handshake_ctrl.spi2_shared_req;
 
@@ -6190,6 +6718,8 @@ int32_t lsm6dsv_ois_chain_get(stmdev_ctx_t *ctx, lsm6dsv_ois_chain_t *val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
+  if (ret != 0) { return ret; }
+
   val->gy = ui_ctrl1_ois.ois_g_en;
   val->xl = ui_ctrl1_ois.ois_xl_en;
 
@@ -6235,6 +6765,8 @@ int32_t lsm6dsv_ois_gy_full_scale_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_UI_CTRL2_OIS, (uint8_t *)&ui_ctrl2_ois, 1);
+  if (ret != 0) { return ret; }
+
   switch (ui_ctrl2_ois.fs_g_ois)
   {
     case LSM6DSV_OIS_125dps:
@@ -6261,6 +6793,7 @@ int32_t lsm6dsv_ois_gy_full_scale_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_OIS_125dps;
       break;
   }
+
   return ret;
 }
 
@@ -6303,6 +6836,8 @@ int32_t lsm6dsv_ois_xl_full_scale_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_UI_CTRL3_OIS, (uint8_t *)&ui_ctrl3_ois, 1);
+  if (ret != 0) { return ret; }
+
   switch (ui_ctrl3_ois.fs_xl_ois)
   {
     case LSM6DSV_OIS_2g:
@@ -6325,6 +6860,7 @@ int32_t lsm6dsv_ois_xl_full_scale_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_OIS_2g;
       break;
   }
+
   return ret;
 }
 
@@ -6378,6 +6914,8 @@ int32_t lsm6dsv_6d_threshold_get(stmdev_ctx_t *ctx, lsm6dsv_6d_threshold_t *val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
+  if (ret != 0) { return ret; }
+
   switch (tap_ths_6d.sixd_ths)
   {
     case LSM6DSV_DEG_80:
@@ -6400,6 +6938,7 @@ int32_t lsm6dsv_6d_threshold_get(stmdev_ctx_t *ctx, lsm6dsv_6d_threshold_t *val)
       *val = LSM6DSV_DEG_80;
       break;
   }
+
   return ret;
 }
 
@@ -6497,6 +7036,8 @@ int32_t lsm6dsv_i3c_reset_mode_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  if (ret != 0) { return ret; }
+
   switch (pin_ctrl.ibhr_por_en)
   {
     case LSM6DSV_SW_RST_DYN_ADDRESS_RST:
@@ -6511,6 +7052,7 @@ int32_t lsm6dsv_i3c_reset_mode_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_SW_RST_DYN_ADDRESS_RST;
       break;
   }
+
   return ret;
 }
 
@@ -6551,6 +7093,8 @@ int32_t lsm6dsv_i3c_ibi_time_get(stmdev_ctx_t *ctx, lsm6dsv_i3c_ibi_time_t *val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_CTRL5, (uint8_t *)&ctrl5, 1);
+  if (ret != 0) { return ret; }
+
   switch (ctrl5.bus_act_sel)
   {
     case LSM6DSV_IBI_2us:
@@ -6573,6 +7117,7 @@ int32_t lsm6dsv_i3c_ibi_time_get(stmdev_ctx_t *ctx, lsm6dsv_i3c_ibi_time_t *val)
       *val = LSM6DSV_IBI_2us;
       break;
   }
+
   return ret;
 }
 
@@ -6639,20 +7184,14 @@ int32_t lsm6dsv_sh_master_interface_pull_up_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv_sh_read_data_raw_get(stmdev_ctx_t *ctx,
-                                     lsm6dsv_emb_sh_read_t *val,
+int32_t lsm6dsv_sh_read_data_raw_get(stmdev_ctx_t *ctx, uint8_t *val,
                                      uint8_t len)
 {
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_SENSOR_HUB_1, (uint8_t *) val,
-                           len);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_SENSOR_HUB_1, val, len);
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
-
 
   return ret;
 }
@@ -6672,16 +7211,13 @@ int32_t lsm6dsv_sh_slave_connected_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    master_config.aux_sens_on = (uint8_t)val & 0x3U;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  master_config.aux_sens_on = (uint8_t)val & 0x3U;
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+
+exit:
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
 
   return ret;
@@ -6702,11 +7238,9 @@ int32_t lsm6dsv_sh_slave_connected_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
+  if (ret != 0) { return ret; }
 
   switch (master_config.aux_sens_on)
   {
@@ -6730,6 +7264,7 @@ int32_t lsm6dsv_sh_slave_connected_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_SLV_0;
       break;
   }
+
   return ret;
 }
 
@@ -6747,16 +7282,13 @@ int32_t lsm6dsv_sh_master_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    master_config.master_on = val;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  master_config.master_on = val;
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+
+exit:
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
 
   return ret;
@@ -6776,10 +7308,7 @@ int32_t lsm6dsv_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
 
   *val = master_config.master_on;
 
@@ -6802,16 +7331,13 @@ int32_t lsm6dsv_sh_pass_through_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    master_config.pass_through_mode = val;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  master_config.pass_through_mode = val;
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+
+exit:
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
 
   return ret;
@@ -6831,10 +7357,7 @@ int32_t lsm6dsv_sh_pass_through_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
 
   *val = master_config.pass_through_mode;
 
@@ -6858,16 +7381,13 @@ int32_t lsm6dsv_sh_syncro_mode_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    master_config.start_config = (uint8_t)val & 0x01U;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  master_config.start_config = (uint8_t)val & 0x01U;
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+
+exit:
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
 
   return ret;
@@ -6888,11 +7408,9 @@ int32_t lsm6dsv_sh_syncro_mode_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
+  if (ret != 0) { return ret; }
 
   switch (master_config.start_config)
   {
@@ -6908,6 +7426,7 @@ int32_t lsm6dsv_sh_syncro_mode_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_SH_TRG_XL_GY_DRDY;
       break;
   }
+
   return ret;
 }
 
@@ -6926,16 +7445,13 @@ int32_t lsm6dsv_sh_write_mode_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    master_config.write_once = (uint8_t)val & 0x01U;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  master_config.write_once = (uint8_t)val & 0x01U;
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+
+exit:
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
 
   return ret;
@@ -6956,12 +7472,9 @@ int32_t lsm6dsv_sh_write_mode_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
-
+  if (ret != 0) { return ret; }
 
   switch (master_config.write_once)
   {
@@ -6977,6 +7490,7 @@ int32_t lsm6dsv_sh_write_mode_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_EACH_SH_CYCLE;
       break;
   }
+
   return ret;
 }
 
@@ -6994,16 +7508,13 @@ int32_t lsm6dsv_sh_reset_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    master_config.rst_master_regs = val;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  master_config.rst_master_regs = val;
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
+
+exit:
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
 
   return ret;
@@ -7023,10 +7534,7 @@ int32_t lsm6dsv_sh_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_MASTER_CONFIG, (uint8_t *)&master_config, 1);
 
   *val = master_config.rst_master_regs;
 
@@ -7053,25 +7561,21 @@ int32_t lsm6dsv_sh_cfg_write(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    reg.slave0_add = val->slv0_add;
-    reg.rw_0 = 0;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_SLV0_ADD, (uint8_t *)&reg, 1);
-  }
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_SLV0_SUBADD,
-                            &(val->slv0_subadd), 1);
-  }
+  reg.slave0_add = val->slv0_add;
+  reg.rw_0 = 0;
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_SLV0_ADD, (uint8_t *)&reg, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_DATAWRITE_SLV0,
-                            &(val->slv0_data), 1);
-  }
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_SLV0_SUBADD,
+                             &(val->slv0_subadd), 1);
+  if (ret != 0) { goto exit; }
 
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_DATAWRITE_SLV0,
+                             &(val->slv0_data), 1);
+
+exit:
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
 
   return ret;
@@ -7091,16 +7595,13 @@ int32_t lsm6dsv_sh_data_rate_set(stmdev_ctx_t *ctx, lsm6dsv_sh_data_rate_t val)
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_SLV0_CONFIG, (uint8_t *)&slv0_config, 1);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_SLV0_CONFIG, (uint8_t *)&slv0_config, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    slv0_config.shub_odr = (uint8_t)val & 0x07U;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_SLV0_CONFIG, (uint8_t *)&slv0_config, 1);
-  }
+  slv0_config.shub_odr = (uint8_t)val & 0x07U;
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_SLV0_CONFIG, (uint8_t *)&slv0_config, 1);
+
+exit:
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
 
   return ret;
@@ -7120,11 +7621,9 @@ int32_t lsm6dsv_sh_data_rate_get(stmdev_ctx_t *ctx, lsm6dsv_sh_data_rate_t *val)
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_SLV0_CONFIG, (uint8_t *)&slv0_config, 1);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_SLV0_CONFIG, (uint8_t *)&slv0_config, 1);
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
+  if (ret != 0) { return ret; }
 
   switch (slv0_config.shub_odr)
   {
@@ -7156,209 +7655,69 @@ int32_t lsm6dsv_sh_data_rate_get(stmdev_ctx_t *ctx, lsm6dsv_sh_data_rate_t *val)
       *val = LSM6DSV_SH_15Hz;
       break;
   }
+
   return ret;
 }
 
 /**
-  * @brief  Configure slave 0 for perform a read.[set]
+  * @brief  Configure slave idx for perform a read.[set]
   *
   * @param  ctx      read / write interface definitions
   * @param  val      Structure that contain
-  *                      - uint8_t slv1_add;    8 bit i2c device address
-  *                      - uint8_t slv1_subadd; 8 bit register device address
-  *                      - uint8_t slv1_len;    num of bit to read
+  *                      - uint8_t slv_add;    8 bit i2c device address
+  *                      - uint8_t slv_subadd; 8 bit register device address
+  *                      - uint8_t slv_len;    num of bit to read
   * @retval             interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv_sh_slv0_cfg_read(stmdev_ctx_t *ctx,
-                                 lsm6dsv_sh_cfg_read_t *val)
+int32_t lsm6dsv_sh_slv_cfg_read(stmdev_ctx_t *ctx, uint8_t idx,
+                                   lsm6dsv_sh_cfg_read_t *val)
 {
-  lsm6dsv_slv0_add_t slv0_add;
-  lsm6dsv_slv0_config_t slv0_config;
+  lsm6dsv_slv0_add_t slv_add;
+  lsm6dsv_slv0_config_t slv_config;
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    slv0_add.slave0_add = val->slv_add;
-    slv0_add.rw_0 = 1;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_SLV0_ADD, (uint8_t *)&slv0_add, 1);
-  }
+  slv_add.slave0_add = val->slv_add;
+  slv_add.rw_0 = 1;
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_SLV0_ADD + idx*3U,
+                             (uint8_t *)&slv_add, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_SLV0_SUBADD,
-                            &(val->slv_subadd), 1);
-  }
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_SLV0_SUBADD + idx*3U,
+                             &(val->slv_subadd), 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_SLV0_CONFIG,
-                           (uint8_t *)&slv0_config, 1);
-  }
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_SLV0_CONFIG + idx*3U,
+                            (uint8_t *)&slv_config, 1);
+  if (ret != 0) { goto exit; }
 
-  if (ret == 0)
-  {
-    slv0_config.slave0_numop = val->slv_len;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_SLV0_CONFIG,
-                            (uint8_t *)&slv0_config, 1);
-  }
+  slv_config.slave0_numop = val->slv_len;
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_SLV0_CONFIG + idx*3U,
+                             (uint8_t *)&slv_config, 1);
 
+exit:
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
 
   return ret;
 }
 
 /**
-  * @brief  Configure slave 0 for perform a write/read.[set]
+  * @brief  Sensor hub source register.[get]
   *
   * @param  ctx      read / write interface definitions
-  * @param  val      Structure that contain
-  *                      - uint8_t slv1_add;    8 bit i2c device address
-  *                      - uint8_t slv1_subadd; 8 bit register device address
-  *                      - uint8_t slv1_len;    num of bit to read
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
+  * @param  val      union of registers from STATUS_MASTER to
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv_sh_slv1_cfg_read(stmdev_ctx_t *ctx,
-                                 lsm6dsv_sh_cfg_read_t *val)
+int32_t lsm6dsv_sh_status_get(stmdev_ctx_t *ctx,
+                              lsm6dsv_status_master_t *val)
 {
-  lsm6dsv_slv1_add_t slv1_add;
-  lsm6dsv_slv1_config_t slv1_config;
   int32_t ret;
 
-  ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
-
-  if (ret == 0)
-  {
-    slv1_add.slave1_add = val->slv_add;
-    slv1_add.r_1 = 1;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_SLV1_ADD, (uint8_t *)&slv1_add, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_SLV1_SUBADD,
-                            &(val->slv_subadd), 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_SLV1_CONFIG,
-                           (uint8_t *)&slv1_config, 1);
-  }
-
-  if (ret == 0)
-  {
-    slv1_config.slave1_numop = val->slv_len;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_SLV1_CONFIG,
-                            (uint8_t *)&slv1_config, 1);
-  }
-
-  ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
-
-  return ret;
-}
-
-/**
-  * @brief  Configure slave 0 for perform a write/read.[set]
-  *
-  * @param  ctx      read / write interface definitions
-  * @param  val      Structure that contain
-  *                      - uint8_t slv2_add;    8 bit i2c device address
-  *                      - uint8_t slv2_subadd; 8 bit register device address
-  *                      - uint8_t slv2_len;    num of bit to read
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
-  *
-  */
-int32_t lsm6dsv_sh_slv2_cfg_read(stmdev_ctx_t *ctx,
-                                 lsm6dsv_sh_cfg_read_t *val)
-{
-  lsm6dsv_slv2_add_t slv2_add;
-  lsm6dsv_slv2_config_t slv2_config;
-  int32_t ret;
-
-  ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
-
-  if (ret == 0)
-  {
-    slv2_add.slave2_add = val->slv_add;
-    slv2_add.r_2 = 1;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_SLV2_ADD, (uint8_t *)&slv2_add, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_SLV2_SUBADD,
-                            &(val->slv_subadd), 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_SLV2_CONFIG,
-                           (uint8_t *)&slv2_config, 1);
-  }
-
-  if (ret == 0)
-  {
-    slv2_config.slave2_numop = val->slv_len;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_SLV2_CONFIG,
-                            (uint8_t *)&slv2_config, 1);
-  }
-
-  ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
-
-  return ret;
-}
-
-/**
-  * @brief Configure slave 0 for perform a write/read.[set]
-  *
-  * @param  ctx      read / write interface definitions
-  * @param  val      Structure that contain
-  *                      - uint8_t slv3_add;    8 bit i2c device address
-  *                      - uint8_t slv3_subadd; 8 bit register device address
-  *                      - uint8_t slv3_len;    num of bit to read
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
-  *
-  */
-int32_t lsm6dsv_sh_slv3_cfg_read(stmdev_ctx_t *ctx,
-                                 lsm6dsv_sh_cfg_read_t *val)
-{
-  lsm6dsv_slv3_add_t slv3_add;
-  lsm6dsv_slv3_config_t slv3_config;
-  int32_t ret;
-
-  ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_SENSOR_HUB_MEM_BANK);
-
-  if (ret == 0)
-  {
-    slv3_add.slave3_add = val->slv_add;
-    slv3_add.r_3 = 1;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_SLV3_ADD, (uint8_t *)&slv3_add, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_SLV3_SUBADD,
-                            &(val->slv_subadd), 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_SLV3_CONFIG,
-                           (uint8_t *)&slv3_config, 1);
-  }
-
-  if (ret == 0)
-  {
-    slv3_config.slave3_numop = val->slv_len;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_SLV3_CONFIG,
-                            (uint8_t *)&slv3_config, 1);
-  }
-
-  ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_STATUS_MASTER_MAINPAGE, (uint8_t *) val, 1);
 
   return ret;
 }
@@ -7457,6 +7816,8 @@ int32_t lsm6dsv_ui_i2c_i3c_mode_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_IF_CFG, (uint8_t *)&if_cfg, 1);
+  if (ret != 0) { return ret; }
+
   switch (if_cfg.i2c_i3c_disable)
   {
     case LSM6DSV_I2C_I3C_ENABLE:
@@ -7471,6 +7832,7 @@ int32_t lsm6dsv_ui_i2c_i3c_mode_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_I2C_I3C_ENABLE;
       break;
   }
+
   return ret;
 }
 
@@ -7511,6 +7873,8 @@ int32_t lsm6dsv_spi_mode_get(stmdev_ctx_t *ctx, lsm6dsv_spi_mode_t *val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_IF_CFG, (uint8_t *)&if_cfg, 1);
+  if (ret != 0) { return ret; }
+
   switch (if_cfg.sim)
   {
     case LSM6DSV_SPI_4_WIRE:
@@ -7525,6 +7889,7 @@ int32_t lsm6dsv_spi_mode_get(stmdev_ctx_t *ctx, lsm6dsv_spi_mode_t *val)
       *val = LSM6DSV_SPI_4_WIRE;
       break;
   }
+
   return ret;
 }
 
@@ -7607,6 +7972,8 @@ int32_t lsm6dsv_spi2_mode_get(stmdev_ctx_t *ctx, lsm6dsv_spi2_mode_t *val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
+  if (ret != 0) { return ret; }
+
   switch (ui_ctrl1_ois.sim_ois)
   {
     case LSM6DSV_SPI2_4_WIRE:
@@ -7621,6 +7988,7 @@ int32_t lsm6dsv_spi2_mode_get(stmdev_ctx_t *ctx, lsm6dsv_spi2_mode_t *val)
       *val = LSM6DSV_SPI2_4_WIRE;
       break;
   }
+
   return ret;
 }
 
@@ -7652,15 +8020,11 @@ int32_t lsm6dsv_sigmot_mode_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
-  }
-  if (ret == 0)
-  {
-    emb_func_en_a.sign_motion_en = val;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
-  }
+  if (ret != 0) { return ret; }
+
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  emb_func_en_a.sign_motion_en = val;
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
 
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
 
@@ -7681,10 +8045,9 @@ int32_t lsm6dsv_sigmot_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
-  }
+  if (ret != 0) { return ret; }
+
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
   *val = emb_func_en_a.sign_motion_en;
 
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
@@ -7716,30 +8079,16 @@ int32_t lsm6dsv_stpcnt_mode_set(stmdev_ctx_t *ctx,
                                 lsm6dsv_stpcnt_mode_t val)
 {
   lsm6dsv_emb_func_en_a_t emb_func_en_a;
-  lsm6dsv_emb_func_en_b_t emb_func_en_b;
-  lsm6dsv_pedo_cmd_reg_t pedo_cmd_reg;
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
-  }
-  if (ret == 0)
-  {
-    emb_func_en_a.pedo_en = val.step_counter_enable;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
-  }
-  ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    ret = lsm6dsv_ln_pg_read(ctx, LSM6DSV_EMB_ADV_PG_1 + LSM6DSV_PEDO_CMD_REG, (uint8_t *)&pedo_cmd_reg, 1);
-  }
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  emb_func_en_a.pedo_en = val.step_counter_enable;
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+
+  ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -7756,21 +8105,12 @@ int32_t lsm6dsv_stpcnt_mode_get(stmdev_ctx_t *ctx,
                                 lsm6dsv_stpcnt_mode_t *val)
 {
   lsm6dsv_emb_func_en_a_t emb_func_en_a;
-  lsm6dsv_pedo_cmd_reg_t pedo_cmd_reg;
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
-
-  if (ret == 0)
-  {
-    ret = lsm6dsv_ln_pg_read(ctx, LSM6DSV_EMB_ADV_PG_1 + LSM6DSV_PEDO_CMD_REG, (uint8_t *)&pedo_cmd_reg, 1);
-  }
-  val->step_counter_enable = emb_func_en_a.pedo_en;
+  if (ret != 0) { return ret; }
 
   return ret;
 }
@@ -7789,11 +8129,9 @@ int32_t lsm6dsv_stpcnt_steps_get(stmdev_ctx_t *ctx, uint16_t *val)
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_STEP_COUNTER_L, &buff[0], 2);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_STEP_COUNTER_L, &buff[0], 2);
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
+  if (ret != 0) { return ret; }
 
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
@@ -7815,16 +8153,15 @@ int32_t lsm6dsv_stpcnt_rst_step_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
-  }
+  if (ret != 0) { return ret; }
 
-  if (ret == 0)
-  {
-    emb_func_src.pedo_rst_step = val;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
-  }
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
+  if (ret != 0) { goto exit; }
+
+  emb_func_src.pedo_rst_step = val;
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
+
+exit:
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
 
   return ret;
@@ -7844,11 +8181,9 @@ int32_t lsm6dsv_stpcnt_rst_step_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
-  }
+  if (ret != 0) { return ret; }
 
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
   *val = emb_func_src.pedo_rst_step;
 
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
@@ -7932,8 +8267,157 @@ int32_t lsm6dsv_stpcnt_period_get(stmdev_ctx_t *ctx, uint16_t *val)
   int32_t ret;
 
   ret = lsm6dsv_ln_pg_read(ctx, LSM6DSV_EMB_ADV_PG_1 + LSM6DSV_PEDO_SC_DELTAT_L, &buff[0], 2);
+  if (ret != 0) { return ret; }
+
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Sensor Fusion Low Power (SFLP)
+  * @brief     This section groups all the functions that manage pedometer.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable SFLP Game Rotation Vector (6x).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enable/Disable game rotation value (0/1).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv_sflp_game_rotation_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
+  if (ret != 0) { return ret; }
+
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  if (ret != 0) { goto exit; }
+
+  emb_func_en_a.sflp_game_en = val;
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_EMB_FUNC_EN_A,
+                              (uint8_t *)&emb_func_en_a, 1);
+
+exit:
+  ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Enable SFLP Game Rotation Vector (6x).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enable/Disable game rotation value (0/1).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv_sflp_game_rotation_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
+  if (ret != 0) { return ret; }
+
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  *val = emb_func_en_a.sflp_game_en;
+
+  ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  SFLP Data Rate (ODR) configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SFLP_15Hz, SFLP_30Hz, SFLP_60Hz, SFLP_120Hz, SFLP_240Hz, SFLP_480Hz
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv_sflp_data_rate_set(stmdev_ctx_t *ctx,
+                                      lsm6dsv_sflp_data_rate_t val)
+{
+  lsm6dsv_sflp_odr_t sflp_odr;
+  int32_t ret;
+
+  ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
+  if (ret != 0) { return ret; }
+
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_SFLP_ODR, (uint8_t *)&sflp_odr, 1);
+  if (ret != 0) { goto exit; }
+
+  sflp_odr.sflp_game_odr = (uint8_t)val & 0x07U;
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_SFLP_ODR, (uint8_t *)&sflp_odr, 1);
+
+exit:
+  ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  SFLP Data Rate (ODR) configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SFLP_15Hz, SFLP_30Hz, SFLP_60Hz, SFLP_120Hz, SFLP_240Hz, SFLP_480Hz
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv_sflp_data_rate_get(stmdev_ctx_t *ctx,
+                                      lsm6dsv_sflp_data_rate_t *val)
+{
+  lsm6dsv_sflp_odr_t sflp_odr;
+  int32_t ret;
+
+  ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_SFLP_ODR, (uint8_t *)&sflp_odr, 1);
+  ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
+  if (ret != 0) { return ret; }
+
+  switch (sflp_odr.sflp_game_odr)
+  {
+    case LSM6DSV_SFLP_15Hz:
+      *val = LSM6DSV_SFLP_15Hz;
+      break;
+
+    case LSM6DSV_SFLP_30Hz:
+      *val = LSM6DSV_SFLP_30Hz;
+      break;
+
+    case LSM6DSV_SFLP_60Hz:
+      *val = LSM6DSV_SFLP_60Hz;
+      break;
+
+    case LSM6DSV_SFLP_120Hz:
+      *val = LSM6DSV_SFLP_120Hz;
+      break;
+
+    case LSM6DSV_SFLP_240Hz:
+      *val = LSM6DSV_SFLP_240Hz;
+      break;
+
+    case LSM6DSV_SFLP_480Hz:
+      *val = LSM6DSV_SFLP_480Hz;
+      break;
+
+    default:
+      *val = LSM6DSV_SFLP_15Hz;
+      break;
+  }
 
   return ret;
 }
@@ -7992,6 +8476,8 @@ int32_t lsm6dsv_tap_detection_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  if (ret != 0) { return ret; }
+
   val->tap_x_en = tap_cfg0.tap_x_en;
   val->tap_y_en = tap_cfg0.tap_y_en;
   val->tap_z_en = tap_cfg0.tap_z_en;
@@ -8016,31 +8502,17 @@ int32_t lsm6dsv_tap_thresholds_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
+  if (ret != 0) { return ret; }
 
   tap_cfg1.tap_ths_x = val.x;
   tap_cfg2.tap_ths_y = val.y;
   tap_ths_6d.tap_ths_z = val.z;
 
-  if (ret == 0)
-  {
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
-  }
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
 
   return ret;
 }
@@ -8062,14 +8534,9 @@ int32_t lsm6dsv_tap_thresholds_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
-  }
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
-  }
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
+  if (ret != 0) { return ret; }
 
   val->x  = tap_cfg1.tap_ths_x;
   val->y = tap_cfg2.tap_ths_y;
@@ -8117,6 +8584,8 @@ int32_t lsm6dsv_tap_axis_priority_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+  if (ret != 0) { return ret; }
+
   switch (tap_cfg1.tap_priority)
   {
     case LSM6DSV_XYZ :
@@ -8147,6 +8616,7 @@ int32_t lsm6dsv_tap_axis_priority_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_XYZ ;
       break;
   }
+
   return ret;
 }
 
@@ -8191,6 +8661,8 @@ int32_t lsm6dsv_tap_time_windows_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_TAP_DUR, (uint8_t *)&tap_dur, 1);
+  if (ret != 0) { return ret; }
+
   val->shock = tap_dur.shock;
   val->quiet = tap_dur.quiet;
   val->tap_gap = tap_dur.dur;
@@ -8235,6 +8707,8 @@ int32_t lsm6dsv_tap_mode_get(stmdev_ctx_t *ctx, lsm6dsv_tap_mode_t *val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
+  if (ret != 0) { return ret; }
+
   switch (wake_up_ths.single_double_tap)
   {
     case LSM6DSV_ONLY_SINGLE:
@@ -8249,6 +8723,7 @@ int32_t lsm6dsv_tap_mode_get(stmdev_ctx_t *ctx, lsm6dsv_tap_mode_t *val)
       *val = LSM6DSV_ONLY_SINGLE;
       break;
   }
+
   return ret;
 }
 
@@ -8279,15 +8754,12 @@ int32_t lsm6dsv_tilt_mode_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
-  }
-  if (ret == 0)
-  {
-    emb_func_en_a.tilt_en = val;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
-  }
+  if (ret != 0) { return ret; }
+
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  emb_func_en_a.tilt_en = val;
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
 
   return ret;
@@ -8307,10 +8779,9 @@ int32_t lsm6dsv_tilt_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
-    ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
-  }
+  if (ret != 0) { return ret; }
+
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
   *val = emb_func_en_a.tilt_en;
 
   ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
@@ -8345,6 +8816,8 @@ int32_t lsm6dsv_timestamp_raw_get(stmdev_ctx_t *ctx, uint32_t *val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_TIMESTAMP0, &buff[0], 4);
+  if (ret != 0) { return ret; }
+
   *val = buff[3];
   *val = (*val * 256U) + buff[2];
   *val = (*val * 256U) + buff[1];
@@ -8445,6 +8918,8 @@ int32_t lsm6dsv_act_mode_get(stmdev_ctx_t *ctx, lsm6dsv_act_mode_t *val)
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
+  if (ret != 0) { return ret; }
+
   switch (functions_enable.inact_en)
   {
     case LSM6DSV_XL_AND_GY_NOT_AFFECTED:
@@ -8467,6 +8942,7 @@ int32_t lsm6dsv_act_mode_get(stmdev_ctx_t *ctx, lsm6dsv_act_mode_t *val)
       *val = LSM6DSV_XL_AND_GY_NOT_AFFECTED;
       break;
   }
+
   return ret;
 }
 
@@ -8509,6 +8985,8 @@ int32_t lsm6dsv_act_from_sleep_to_act_dur_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
+  if (ret != 0) { return ret; }
+
   switch (inactivity_dur.inact_dur)
   {
     case LSM6DSV_SLEEP_TO_ACT_AT_1ST_SAMPLE:
@@ -8531,6 +9009,7 @@ int32_t lsm6dsv_act_from_sleep_to_act_dur_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_SLEEP_TO_ACT_AT_1ST_SAMPLE;
       break;
   }
+
   return ret;
 }
 
@@ -8573,6 +9052,8 @@ int32_t lsm6dsv_act_sleep_xl_odr_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
+  if (ret != 0) { return ret; }
+
   switch (inactivity_dur.xl_inact_odr)
   {
     case LSM6DSV_1Hz875:
@@ -8595,6 +9076,7 @@ int32_t lsm6dsv_act_sleep_xl_odr_get(stmdev_ctx_t *ctx,
       *val = LSM6DSV_1Hz875;
       break;
   }
+
   return ret;
 }
 
@@ -8616,10 +9098,10 @@ int32_t lsm6dsv_act_thresholds_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
-  ret += lsm6dsv_read_reg(ctx, LSM6DSV_INACTIVITY_THS, (uint8_t *)&inactivity_ths,
-                          1);
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_INACTIVITY_THS, (uint8_t *)&inactivity_ths, 1);
   ret += lsm6dsv_read_reg(ctx, LSM6DSV_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
   ret += lsm6dsv_read_reg(ctx, LSM6DSV_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+  if (ret != 0) { return ret; }
 
   inactivity_dur.wu_inact_ths_w = val->inactivity_cfg.wu_inact_ths_w;
   inactivity_dur.xl_inact_odr = val->inactivity_cfg.xl_inact_odr;
@@ -8629,10 +9111,8 @@ int32_t lsm6dsv_act_thresholds_set(stmdev_ctx_t *ctx,
   wake_up_ths.wk_ths = val->threshold;
   wake_up_dur.wake_dur = val->duration;
 
-  ret += lsm6dsv_write_reg(ctx, LSM6DSV_INACTIVITY_DUR,
-                           (uint8_t *)&inactivity_dur, 1);
-  ret += lsm6dsv_write_reg(ctx, LSM6DSV_INACTIVITY_THS,
-                           (uint8_t *)&inactivity_ths, 1);
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
+  ret += lsm6dsv_write_reg(ctx, LSM6DSV_INACTIVITY_THS, (uint8_t *)&inactivity_ths, 1);
   ret += lsm6dsv_write_reg(ctx, LSM6DSV_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
   ret += lsm6dsv_write_reg(ctx, LSM6DSV_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
 
@@ -8656,12 +9136,11 @@ int32_t lsm6dsv_act_thresholds_get(stmdev_ctx_t *ctx,
   lsm6dsv_wake_up_dur_t wake_up_dur;
   int32_t ret;
 
-
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
-  ret += lsm6dsv_read_reg(ctx, LSM6DSV_INACTIVITY_THS, (uint8_t *)&inactivity_ths,
-                          1);
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_INACTIVITY_THS, (uint8_t *)&inactivity_ths, 1);
   ret += lsm6dsv_read_reg(ctx, LSM6DSV_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
   ret += lsm6dsv_read_reg(ctx, LSM6DSV_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+  if (ret != 0) { return ret; }
 
   val->inactivity_cfg.wu_inact_ths_w = inactivity_dur.wu_inact_ths_w;
   val->inactivity_cfg.xl_inact_odr = inactivity_dur.xl_inact_odr;
@@ -8714,6 +9193,8 @@ int32_t lsm6dsv_act_wkup_time_windows_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv_read_reg(ctx, LSM6DSV_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+  if (ret != 0) { return ret; }
+
   val->shock = wake_up_dur.wake_dur;
   val->quiet = wake_up_dur.sleep_dur;
 

--- a/sensor/stmemsc/lsm6dsv_STdC/driver/lsm6dsv_reg.h
+++ b/sensor/stmemsc/lsm6dsv_STdC/driver/lsm6dsv_reg.h
@@ -247,6 +247,16 @@ typedef struct
 #endif /* DRV_BYTE_ORDER */
 } lsm6dsv_if_cfg_t;
 
+#define LSM6DSV_ODR_TRIG_CFG                 0x6U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t odr_trig_nodr        : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t odr_trig_nodr        : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv_odr_trig_cfg_t;
+
 #define LSM6DSV_FIFO_CTRL1                   0x7U
 typedef struct
 {
@@ -1041,6 +1051,28 @@ typedef struct
 #endif /* DRV_BYTE_ORDER */
 } lsm6dsv_d6d_src_t;
 
+#define LSM6DSV_STATUS_MASTER_MAINPAGE      0x48U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sens_hub_endop       : 1;
+  uint8_t not_used0            : 2;
+  uint8_t slave0_nack          : 1;
+  uint8_t slave1_nack          : 1;
+  uint8_t slave2_nack          : 1;
+  uint8_t slave3_nack          : 1;
+  uint8_t wr_once_done         : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t wr_once_done         : 1;
+  uint8_t slave3_nack          : 1;
+  uint8_t slave2_nack          : 1;
+  uint8_t slave1_nack          : 1;
+  uint8_t slave0_nack          : 1;
+  uint8_t not_used0            : 2;
+  uint8_t sens_hub_endop       : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv_status_master_mainpage_t;
+
 #define LSM6DSV_EMB_FUNC_STATUS_MAINPAGE    0x49U
 typedef struct
 {
@@ -1332,6 +1364,18 @@ typedef struct
   uint8_t int2_timestamp       : 1;
 #endif /* DRV_BYTE_ORDER */
 } lsm6dsv_md2_cfg_t;
+
+#define LSM6DSV_HAODR_CFG                  0x62U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t haodr_sel            : 2;
+  uint8_t not_used0            : 6;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0            : 6;
+  uint8_t haodr_sel            : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv_haodr_cfg_t;
 
 #define LSM6DSV_EMB_FUNC_CFG               0x63U
 typedef struct
@@ -1901,7 +1945,9 @@ typedef struct
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t not_used0            : 3;
+  uint8_t not_used0            : 1;
+  uint8_t sflp_game_en         : 1;
+  uint8_t not_used2            : 1;
   uint8_t pedo_en              : 1;
   uint8_t tilt_en              : 1;
   uint8_t sign_motion_en       : 1;
@@ -1911,7 +1957,9 @@ typedef struct
   uint8_t sign_motion_en       : 1;
   uint8_t tilt_en              : 1;
   uint8_t pedo_en              : 1;
-  uint8_t not_used0            : 3;
+  uint8_t not_used2            : 1;
+  uint8_t sflp_game_en         : 1;
+  uint8_t not_used0            : 1;
 #endif /* DRV_BYTE_ORDER */
 } lsm6dsv_emb_func_en_a_t;
 
@@ -2071,7 +2119,6 @@ typedef struct
   uint8_t is_step_det          : 1;
   uint8_t not_used0            : 3;
 #endif /* DRV_BYTE_ORDER */
-
 } lsm6dsv_emb_func_status_t;
 
 #define LSM6DSV_FSM_STATUS                 0x13U
@@ -2096,7 +2143,6 @@ typedef struct
   uint8_t is_fsm2              : 1;
   uint8_t is_fsm1              : 1;
 #endif /* DRV_BYTE_ORDER */
-
 } lsm6dsv_fsm_status_t;
 
 #define LSM6DSV_PAGE_RW                    0x17U
@@ -2119,13 +2165,21 @@ typedef struct
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t not_used0            : 6;
+  uint8_t not_used0            : 1;
+  uint8_t sflp_game_fifo_en    : 1;
+  uint8_t not_used1            : 2;
+  uint8_t sflp_gravity_fifo_en : 1;
+  uint8_t sflp_gbias_fifo_en   : 1;
   uint8_t step_counter_fifo_en : 1;
-  uint8_t not_used1            : 1;
+  uint8_t not_used2            : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t not_used1            : 1;
+  uint8_t not_used2            : 1;
   uint8_t step_counter_fifo_en : 1;
-  uint8_t not_used0            : 6;
+  uint8_t sflp_gbias_fifo_en   : 1;
+  uint8_t sflp_gravity_fifo_en : 1;
+  uint8_t not_used1            : 2;
+  uint8_t sflp_game_fifo_en    : 1;
+  uint8_t not_used0            : 1;
 #endif /* DRV_BYTE_ORDER */
 } lsm6dsv_emb_func_fifo_en_a_t;
 
@@ -2375,6 +2429,20 @@ typedef struct
 #endif /* DRV_BYTE_ORDER */
 } lsm6dsv_fsm_outs8_t;
 
+#define LSM6DSV_SFLP_ODR                   0x5EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0            : 3;
+  uint8_t sflp_game_odr        : 3;
+  uint8_t not_used1            : 2;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1            : 2;
+  uint8_t sflp_game_odr        : 3;
+  uint8_t not_used0            : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv_sflp_odr_t;
+
 #define LSM6DSV_FSM_ODR                    0x5FU
 typedef struct
 {
@@ -2387,7 +2455,6 @@ typedef struct
   uint8_t fsm_odr              : 3;
   uint8_t not_used0            : 3;
 #endif /* DRV_BYTE_ORDER */
-
 } lsm6dsv_fsm_odr_t;
 
 #define LSM6DSV_STEP_COUNTER_L             0x62U
@@ -2436,7 +2503,9 @@ typedef struct
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t not_used0            : 3;
+  uint8_t not_used0            : 1;
+  uint8_t sflp_game_init       : 1;
+  uint8_t not_used2            : 1;
   uint8_t step_det_init        : 1;
   uint8_t tilt_init            : 1;
   uint8_t sig_mot_init         : 1;
@@ -2446,7 +2515,9 @@ typedef struct
   uint8_t sig_mot_init         : 1;
   uint8_t tilt_init            : 1;
   uint8_t step_det_init        : 1;
-  uint8_t not_used0            : 3;
+  uint8_t not_used2            : 1;
+  uint8_t sflp_game_init       : 1;
+  uint8_t not_used0            : 1;
 #endif /* DRV_BYTE_ORDER */
 } lsm6dsv_emb_func_init_a_t;
 
@@ -2476,6 +2547,66 @@ typedef struct
   *
   */
 #define LSM6DSV_EMB_ADV_PG_0              0x000U
+
+#define LSM6DSV_SFLP_GAME_GBIASX_L        0x6EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t gbiasx               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t gbiasx               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv_sflp_game_gbiasx_l_t;
+
+#define LSM6DSV_SFLP_GAME_GBIASX_H        0x6FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t gbiasx               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t gbiasx               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv_sflp_game_gbiasx_h_t;
+
+#define LSM6DSV_SFLP_GAME_GBIASY_L        0x70U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t gbiasy               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t gbiasy               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv_sflp_game_gbiasy_l_t;
+
+#define LSM6DSV_SFLP_GAME_GBIASY_H        0x71U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t gbiasy               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t gbiasy               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv_sflp_game_gbiasy_h_t;
+
+#define LSM6DSV_SFLP_GAME_GBIASZ_L        0x72U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t gbiasz               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t gbiasz               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv_sflp_game_gbiasz_l_t;
+
+#define LSM6DSV_SFLP_GAME_GBIASZ_H        0x73U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t gbiasz               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t gbiasz               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv_sflp_game_gbiasz_h_t;
 
 #define LSM6DSV_FSM_EXT_SENSITIVITY_L     0xBAU
 typedef struct
@@ -3280,11 +3411,24 @@ typedef struct
   *
   */
 
+/**
+  * @defgroup LSM6DSV_Register_Union
+  * @brief    This union group all the registers having a bit-field
+  *           description.
+  *           This union is useful but it's not needed by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
 typedef union
 {
   lsm6dsv_func_cfg_access_t          func_cfg_access;
   lsm6dsv_pin_ctrl_t                 pin_ctrl;
   lsm6dsv_if_cfg_t                   if_cfg;
+  lsm6dsv_odr_trig_cfg_t             odr_trig_cfg;
   lsm6dsv_fifo_ctrl1_t               fifo_ctrl1;
   lsm6dsv_fifo_ctrl2_t               fifo_ctrl2;
   lsm6dsv_fifo_ctrl3_t               fifo_ctrl3;
@@ -3343,6 +3487,7 @@ typedef union
   lsm6dsv_wake_up_src_t              wake_up_src;
   lsm6dsv_tap_src_t                  tap_src;
   lsm6dsv_d6d_src_t                  d6d_src;
+  lsm6dsv_status_master_mainpage_t   status_master_mainpage;
   lsm6dsv_emb_func_status_mainpage_t emb_func_status_mainpage;
   lsm6dsv_fsm_status_mainpage_t      fsm_status_mainpage;
   lsm6dsv_internal_freq_t            internal_freq;
@@ -3529,6 +3674,7 @@ int32_t lsm6dsv_write_reg(stmdev_ctx_t *ctx, uint8_t reg,
                           uint8_t *data,
                           uint16_t len);
 
+float_t lsm6dsv_from_sflp_to_mg(int16_t lsb);
 float_t lsm6dsv_from_fs2_to_mg(int16_t lsb);
 float_t lsm6dsv_from_fs4_to_mg(int16_t lsb);
 float_t lsm6dsv_from_fs8_to_mg(int16_t lsb);
@@ -3595,6 +3741,26 @@ typedef enum
   LSM6DSV_ODR_AT_1920Hz        = 0xA,
   LSM6DSV_ODR_AT_3840Hz        = 0xB,
   LSM6DSV_ODR_AT_7680Hz        = 0xC,
+  LSM6DSV_ODR_HA01_AT_15Hz625  = 0x13,
+  LSM6DSV_ODR_HA01_AT_31Hz25   = 0x14,
+  LSM6DSV_ODR_HA01_AT_62Hz5    = 0x15,
+  LSM6DSV_ODR_HA01_AT_125Hz    = 0x16,
+  LSM6DSV_ODR_HA01_AT_250Hz    = 0x17,
+  LSM6DSV_ODR_HA01_AT_500Hz    = 0x18,
+  LSM6DSV_ODR_HA01_AT_1000Hz   = 0x19,
+  LSM6DSV_ODR_HA01_AT_2000Hz   = 0x1A,
+  LSM6DSV_ODR_HA01_AT_4000Hz   = 0x1B,
+  LSM6DSV_ODR_HA01_AT_8000Hz   = 0x1C,
+  LSM6DSV_ODR_HA02_AT_12Hz5    = 0x23,
+  LSM6DSV_ODR_HA02_AT_25Hz     = 0x24,
+  LSM6DSV_ODR_HA02_AT_50Hz     = 0x25,
+  LSM6DSV_ODR_HA02_AT_100Hz    = 0x26,
+  LSM6DSV_ODR_HA02_AT_200Hz    = 0x27,
+  LSM6DSV_ODR_HA02_AT_400Hz    = 0x28,
+  LSM6DSV_ODR_HA02_AT_800Hz    = 0x29,
+  LSM6DSV_ODR_HA02_AT_1600Hz   = 0x2A,
+  LSM6DSV_ODR_HA02_AT_3200Hz   = 0x2B,
+  LSM6DSV_ODR_HA02_AT_6400Hz   = 0x2C,
 } lsm6dsv_data_rate_t;
 int32_t lsm6dsv_xl_data_rate_set(stmdev_ctx_t *ctx,
                                  lsm6dsv_data_rate_t val);
@@ -3605,10 +3771,12 @@ int32_t lsm6dsv_gy_data_rate_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv_gy_data_rate_get(stmdev_ctx_t *ctx,
                                  lsm6dsv_data_rate_t *val);
 
+
 typedef enum
 {
   LSM6DSV_XL_HIGH_PERFORMANCE_MD   = 0x0,
   LSM6DSV_XL_HIGH_ACCURACY_ODR_MD = 0x1,
+  LSM6DSV_XL_ODR_TRIGGERED_MD      = 0x3,
   LSM6DSV_XL_LOW_POWER_2_AVG_MD    = 0x4,
   LSM6DSV_XL_LOW_POWER_4_AVG_MD    = 0x5,
   LSM6DSV_XL_LOW_POWER_8_AVG_MD    = 0x6,
@@ -3632,6 +3800,9 @@ int32_t lsm6dsv_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 int32_t lsm6dsv_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv_odr_trig_cfg_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv_odr_trig_cfg_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum
 {
@@ -3660,7 +3831,7 @@ typedef enum
   LSM6DSV_500dps  = 0x2,
   LSM6DSV_1000dps = 0x3,
   LSM6DSV_2000dps = 0x4,
-  LSM6DSV_4000dps = 0x5,
+  LSM6DSV_4000dps = 0xc,
 } lsm6dsv_gy_full_scale_t;
 int32_t lsm6dsv_gy_full_scale_set(stmdev_ctx_t *ctx,
                                   lsm6dsv_gy_full_scale_t val);
@@ -3876,9 +4047,9 @@ typedef struct
   uint8_t den_z                : 1;
   enum
   {
-    DEN_NOT_DEFINED = 0x00,
-    LEVEL_TRIGGER   = 0x02,
-    LEVEL_LATCHED   = 0x03,
+    LSM6DSV_DEN_NOT_DEFINED = 0x00,
+    LSM6DSV_LEVEL_TRIGGER   = 0x02,
+    LSM6DSV_LEVEL_LATCHED   = 0x03,
   } mode;
 } lsm6dsv_den_conf_t;
 int32_t lsm6dsv_den_conf_set(stmdev_ctx_t *ctx, lsm6dsv_den_conf_t val);
@@ -4076,6 +4247,9 @@ typedef struct
     LSM6DSV_SENSORHUB_SLAVE2_TAG          = 0x10,
     LSM6DSV_SENSORHUB_SLAVE3_TAG          = 0x11,
     LSM6DSV_STEP_COUNTER_TAG              = 0x12,
+    LSM6DSV_SFLP_GAME_ROTATION_VECTOR_TAG = 0x13,
+    LSM6DSV_SFLP_GYROSCOPE_BIAS_TAG       = 0x16,
+    LSM6DSV_SFLP_GRAVITY_VECTOR_TAG       = 0x17,
     LSM6DSV_SENSORHUB_NACK_TAG            = 0x19,
     LSM6DSV_XL_DUAL_CORE                  = 0x1D,
     LSM6DSV_GY_ENHANCED_EIS               = 0x1E,
@@ -4089,17 +4263,19 @@ int32_t lsm6dsv_fifo_out_raw_get(stmdev_ctx_t *ctx,
 int32_t lsm6dsv_fifo_stpcnt_batch_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv_fifo_stpcnt_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv_fifo_batch_sh_slave_0_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv_fifo_batch_sh_slave_0_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv_fifo_sh_batch_slave_set(stmdev_ctx_t *ctx, uint8_t idx, uint8_t val);
+int32_t lsm6dsv_fifo_sh_batch_slave_get(stmdev_ctx_t *ctx, uint8_t idx, uint8_t *val);
 
-int32_t lsm6dsv_fifo_batch_sh_slave_1_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv_fifo_batch_sh_slave_1_get(stmdev_ctx_t *ctx, uint8_t *val);
-
-int32_t lsm6dsv_fifo_batch_sh_slave_2_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv_fifo_batch_sh_slave_2_get(stmdev_ctx_t *ctx, uint8_t *val);
-
-int32_t lsm6dsv_fifo_batch_sh_slave_3_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv_fifo_batch_sh_slave_3_get(stmdev_ctx_t *ctx, uint8_t *val);
+typedef struct
+{
+  uint8_t game_rotation        : 1;
+  uint8_t gravity              : 1;
+  uint8_t gbias                : 1;
+} lsm6dsv_fifo_sflp_raw_t;
+int32_t lsm6dsv_fifo_sflp_batch_set(stmdev_ctx_t *ctx,
+                                       lsm6dsv_fifo_sflp_raw_t val);
+int32_t lsm6dsv_fifo_sflp_batch_get(stmdev_ctx_t *ctx,
+                                       lsm6dsv_fifo_sflp_raw_t *val);
 
 typedef enum
 {
@@ -4517,29 +4693,7 @@ int32_t lsm6dsv_sh_master_interface_pull_up_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv_sh_master_interface_pull_up_get(stmdev_ctx_t *ctx,
                                                 uint8_t *val);
 
-typedef struct
-{
-  lsm6dsv_sensor_hub_1_t   sh_byte_1;
-  lsm6dsv_sensor_hub_2_t   sh_byte_2;
-  lsm6dsv_sensor_hub_3_t   sh_byte_3;
-  lsm6dsv_sensor_hub_4_t   sh_byte_4;
-  lsm6dsv_sensor_hub_5_t   sh_byte_5;
-  lsm6dsv_sensor_hub_6_t   sh_byte_6;
-  lsm6dsv_sensor_hub_7_t   sh_byte_7;
-  lsm6dsv_sensor_hub_8_t   sh_byte_8;
-  lsm6dsv_sensor_hub_9_t   sh_byte_9;
-  lsm6dsv_sensor_hub_10_t  sh_byte_10;
-  lsm6dsv_sensor_hub_11_t  sh_byte_11;
-  lsm6dsv_sensor_hub_12_t  sh_byte_12;
-  lsm6dsv_sensor_hub_13_t  sh_byte_13;
-  lsm6dsv_sensor_hub_14_t  sh_byte_14;
-  lsm6dsv_sensor_hub_15_t  sh_byte_15;
-  lsm6dsv_sensor_hub_16_t  sh_byte_16;
-  lsm6dsv_sensor_hub_17_t  sh_byte_17;
-  lsm6dsv_sensor_hub_18_t  sh_byte_18;
-} lsm6dsv_emb_sh_read_t;
-int32_t lsm6dsv_sh_read_data_raw_get(stmdev_ctx_t *ctx,
-                                     lsm6dsv_emb_sh_read_t *val,
+int32_t lsm6dsv_sh_read_data_raw_get(stmdev_ctx_t *ctx, uint8_t *val,
                                      uint8_t len);
 
 typedef enum
@@ -4611,14 +4765,11 @@ typedef struct
   uint8_t   slv_subadd;
   uint8_t   slv_len;
 } lsm6dsv_sh_cfg_read_t;
-int32_t lsm6dsv_sh_slv0_cfg_read(stmdev_ctx_t *ctx,
-                                 lsm6dsv_sh_cfg_read_t *val);
-int32_t lsm6dsv_sh_slv1_cfg_read(stmdev_ctx_t *ctx,
-                                 lsm6dsv_sh_cfg_read_t *val);
-int32_t lsm6dsv_sh_slv2_cfg_read(stmdev_ctx_t *ctx,
-                                 lsm6dsv_sh_cfg_read_t *val);
-int32_t lsm6dsv_sh_slv3_cfg_read(stmdev_ctx_t *ctx,
-                                 lsm6dsv_sh_cfg_read_t *val);
+int32_t lsm6dsv_sh_slv_cfg_read(stmdev_ctx_t *ctx, uint8_t idx,
+                                   lsm6dsv_sh_cfg_read_t *val);
+
+int32_t lsm6dsv_sh_status_get(stmdev_ctx_t *ctx,
+                              lsm6dsv_status_master_t *val);
 
 int32_t lsm6dsv_ui_sdo_pull_up_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv_ui_sdo_pull_up_get(stmdev_ctx_t *ctx, uint8_t *val);
@@ -4659,7 +4810,6 @@ int32_t lsm6dsv_sigmot_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 typedef struct
 {
   uint8_t step_counter_enable  : 1;
-  uint8_t false_step_rej       : 1;
 } lsm6dsv_stpcnt_mode_t;
 int32_t lsm6dsv_stpcnt_mode_set(stmdev_ctx_t *ctx,
                                 lsm6dsv_stpcnt_mode_t val);
@@ -4676,6 +4826,32 @@ int32_t lsm6dsv_stpcnt_debounce_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 int32_t lsm6dsv_stpcnt_period_set(stmdev_ctx_t *ctx, uint16_t val);
 int32_t lsm6dsv_stpcnt_period_get(stmdev_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6dsv_sflp_game_rotation_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv_sflp_game_rotation_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef struct
+{
+  float_t gbias_x; /* dps */
+  float_t gbias_y; /* dps */
+  float_t gbias_z; /* dps */
+} lsm6dsv_sflp_gbias_t;
+int32_t lsm6dsv_sflp_game_gbias_set(stmdev_ctx_t *ctx,
+                                       lsm6dsv_sflp_gbias_t *val);
+
+typedef enum
+{
+  LSM6DSV_SFLP_15Hz  = 0x0,
+  LSM6DSV_SFLP_30Hz  = 0x1,
+  LSM6DSV_SFLP_60Hz  = 0x2,
+  LSM6DSV_SFLP_120Hz = 0x3,
+  LSM6DSV_SFLP_240Hz = 0x4,
+  LSM6DSV_SFLP_480Hz = 0x5,
+} lsm6dsv_sflp_data_rate_t;
+int32_t lsm6dsv_sflp_data_rate_set(stmdev_ctx_t *ctx,
+                                      lsm6dsv_sflp_data_rate_t val);
+int32_t lsm6dsv_sflp_data_rate_get(stmdev_ctx_t *ctx,
+                                      lsm6dsv_sflp_data_rate_t *val);
 
 typedef struct
 {

--- a/sensor/stmemsc/sths34pf80_STdC/driver/sths34pf80_reg.c
+++ b/sensor/stmemsc/sths34pf80_STdC/driver/sths34pf80_reg.c
@@ -1,0 +1,2136 @@
+/**
+  ******************************************************************************
+  * @file    sths34pf80_reg.c
+  * @author  Sensors Software Solution Team
+  * @brief   STHS34PF80 driver file
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2021 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+#include "sths34pf80_reg.h"
+
+/**
+  * @defgroup  STHS34PF80
+  * @brief     This file provides a set of functions needed to drive the
+  *            sths34pf80 enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup  Interfaces functions
+  * @brief     This section provide a set of functions used to read and
+  *            write a generic register of the device.
+  *            MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+#ifndef __weak
+#define __weak __attribute__((weak))
+#endif /* __weak */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   communication interface handler.(ptr)
+  * @param  reg   first register address to read.
+  * @param  data  buffer for data read.(ptr)
+  * @param  len   number of consecutive register to read.
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t __weak sths34pf80_read_reg(stmdev_ctx_t *ctx, uint8_t reg,
+                                   uint8_t *data,
+                                   uint16_t len)
+{
+  int32_t ret;
+
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   communication interface handler.(ptr)
+  * @param  reg   first register address to write.
+  * @param  data  the buffer contains data to be written.(ptr)
+  * @param  len   number of consecutive register to write.
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t __weak sths34pf80_write_reg(stmdev_ctx_t *ctx, uint8_t reg,
+                                    uint8_t *data,
+                                    uint16_t len)
+{
+  int32_t ret;
+
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup Common
+  * @brief    Common
+  * @{/
+  *
+  */
+/**
+  * @brief  Device ID.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Device ID.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_device_id_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_WHO_AM_I, val, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Select number of averages for object temperature.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      AVG_TMOS_2, AVG_TMOS_8, AVG_TMOS_32, AVG_TMOS_128, AVG_TMOS_256, AVG_TMOS_512, AVG_TMOS_1024, AVG_TMOS_2048,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_avg_tobject_num_set(stmdev_ctx_t *ctx, sths34pf80_avg_tobject_num_t val)
+{
+  sths34pf80_avg_trim_t avg_trim;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_AVG_TRIM, (uint8_t *)&avg_trim, 1);
+
+  if (ret == 0)
+  {
+    avg_trim.avg_tmos = ((uint8_t)val & 0x7U);
+    ret = sths34pf80_write_reg(ctx, STHS34PF80_AVG_TRIM, (uint8_t *)&avg_trim, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Select number of averages for object temperature.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      AVG_TMOS_2, AVG_TMOS_8, AVG_TMOS_32, AVG_TMOS_128, AVG_TMOS_256, AVG_TMOS_512, AVG_TMOS_1024, AVG_TMOS_2048,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_avg_tobject_num_get(stmdev_ctx_t *ctx, sths34pf80_avg_tobject_num_t *val)
+{
+  sths34pf80_avg_trim_t avg_trim;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_AVG_TRIM, (uint8_t *)&avg_trim, 1);
+
+  switch (avg_trim.avg_tmos)
+  {
+    case STHS34PF80_AVG_TMOS_2:
+      *val = STHS34PF80_AVG_TMOS_2;
+      break;
+
+    case STHS34PF80_AVG_TMOS_8:
+      *val = STHS34PF80_AVG_TMOS_8;
+      break;
+
+    case STHS34PF80_AVG_TMOS_32:
+      *val = STHS34PF80_AVG_TMOS_32;
+      break;
+
+    case STHS34PF80_AVG_TMOS_128:
+      *val = STHS34PF80_AVG_TMOS_128;
+      break;
+
+    case STHS34PF80_AVG_TMOS_256:
+      *val = STHS34PF80_AVG_TMOS_256;
+      break;
+
+    case STHS34PF80_AVG_TMOS_512:
+      *val = STHS34PF80_AVG_TMOS_512;
+      break;
+
+    case STHS34PF80_AVG_TMOS_1024:
+      *val = STHS34PF80_AVG_TMOS_1024;
+      break;
+
+    case STHS34PF80_AVG_TMOS_2048:
+      *val = STHS34PF80_AVG_TMOS_2048;
+      break;
+
+    default:
+      *val = STHS34PF80_AVG_TMOS_2;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select number of averages for ambient temperature.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      AVG_T_8, AVG_T_4, AVG_T_2, AVG_T_1,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_avg_tambient_num_set(stmdev_ctx_t *ctx, sths34pf80_avg_tambient_num_t val)
+{
+  sths34pf80_avg_trim_t avg_trim;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_AVG_TRIM, (uint8_t *)&avg_trim, 1);
+
+  if (ret == 0)
+  {
+    avg_trim.avg_t = ((uint8_t)val & 0x3U);
+    ret = sths34pf80_write_reg(ctx, STHS34PF80_AVG_TRIM, (uint8_t *)&avg_trim, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Select number of averages for ambient temperature.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      AVG_T_8, AVG_T_4, AVG_T_2, AVG_T_1,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_avg_tambient_num_get(stmdev_ctx_t *ctx, sths34pf80_avg_tambient_num_t *val)
+{
+  sths34pf80_avg_trim_t avg_trim;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_AVG_TRIM, (uint8_t *)&avg_trim, 1);
+
+  switch (avg_trim.avg_t)
+  {
+    case STHS34PF80_AVG_T_8:
+      *val = STHS34PF80_AVG_T_8;
+      break;
+
+    case STHS34PF80_AVG_T_4:
+      *val = STHS34PF80_AVG_T_4;
+      break;
+
+    case STHS34PF80_AVG_T_2:
+      *val = STHS34PF80_AVG_T_2;
+      break;
+
+    case STHS34PF80_AVG_T_1:
+      *val = STHS34PF80_AVG_T_1;
+      break;
+
+    default:
+      *val = STHS34PF80_AVG_T_8;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  temperature range.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      range: GAIN_WIDE_MODE, GAIN_DEFAULT_MODE
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_gain_mode_set(stmdev_ctx_t *ctx, sths34pf80_gain_mode_t val)
+{
+  sths34pf80_ctrl0_t ctrl0;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL0, (uint8_t *)&ctrl0, 1);
+
+  if (ret == 0)
+  {
+    ctrl0.gain = (uint8_t)val;
+    ret = sths34pf80_write_reg(ctx, STHS34PF80_CTRL0, (uint8_t *)&ctrl0, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  temperature range.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      range: GAIN_WIDE_MODE, GAIN_DEFAULT_MODE
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_gain_mode_get(stmdev_ctx_t *ctx, sths34pf80_gain_mode_t *val)
+{
+  sths34pf80_ctrl0_t ctrl0;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL0, (uint8_t *)&ctrl0, 1);
+
+  switch (ctrl0.gain)
+  {
+    case STHS34PF80_GAIN_WIDE_MODE:
+      *val = STHS34PF80_GAIN_WIDE_MODE;
+      break;
+
+    case STHS34PF80_GAIN_DEFAULT_MODE:
+      *val = STHS34PF80_GAIN_DEFAULT_MODE;
+      break;
+
+    default:
+      *val = STHS34PF80_GAIN_DEFAULT_MODE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  sensitivity data.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      IN: desired sensitivity value
+  *                  OUT: rounded sensitivity value
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_tmos_sensitivity_set(stmdev_ctx_t *ctx, uint16_t *val)
+{
+  sths34pf80_sens_data_t data;
+  int32_t ret;
+
+  data.sens = (*val >= 2048U) ?
+        (*val - 2048U + 8U) / 16U :
+        (*val - 2048U - 8U) / 16U;
+  ret = sths34pf80_write_reg(ctx, STHS34PF80_SENS_DATA, (uint8_t *)&data, 1);
+  *val = (int8_t)data.sens * 16U + 2048U;
+
+  return ret;
+}
+
+/**
+  * @brief  sensitivity data.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      rounded sensitivity value
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_tmos_sensitivity_get(stmdev_ctx_t *ctx, uint16_t *val)
+{
+  sths34pf80_sens_data_t data;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_SENS_DATA, (uint8_t *)&data, 1);
+  *val = (int8_t)data.sens * 16 + 2048;
+
+  return ret;
+}
+
+/**
+  * @brief  Enter to/Exit from power-down in a safe way
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  ctrl1    Value of CTRL1 register
+  * @param  odr_new  Value of new odr to be set
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+static int32_t sths34pf80_tmos_odr_check_safe_set(stmdev_ctx_t *ctx,
+                                                  sths34pf80_ctrl1_t ctrl1,
+                                                  uint8_t odr_new)
+{
+  sths34pf80_func_status_t func_status;
+  sths34pf80_tmos_drdy_status_t status;
+  int32_t ret = 0;
+
+  if (odr_new > 0U) {
+    /*
+     * Do a clean reset algo procedure everytime odr is changed to an
+     * operative state.
+     */
+    ctrl1.odr = 0;
+    ret = sths34pf80_write_reg(ctx, STHS34PF80_CTRL1, (uint8_t *)&ctrl1, 1);
+
+    ret += sths34pf80_algo_reset(ctx);
+  } else {
+    /* if we need to go to power-down from an operative state
+     * perform the safe power-down.
+     */
+    if ((uint8_t)ctrl1.odr > 0U) {
+      /* reset the DRDY bit */
+      ret = sths34pf80_read_reg(ctx, STHS34PF80_FUNC_STATUS, (uint8_t *)&func_status, 1);
+
+      /* wait DRDY bit go to '1' */
+      do {
+        ret += sths34pf80_tmos_drdy_status_get(ctx, &status);
+
+      } while (status.drdy != 0U);
+
+      /* set ODR to 0 */
+      ctrl1.odr = 0;
+      ret += sths34pf80_write_reg(ctx, STHS34PF80_CTRL1, (uint8_t *)&ctrl1, 1);
+
+      /* reset the DRDY bit */
+      ret += sths34pf80_read_reg(ctx, STHS34PF80_FUNC_STATUS, (uint8_t *)&func_status, 1);
+    }
+  }
+
+  ctrl1.odr = (odr_new & 0xfU);
+  ret += sths34pf80_write_reg(ctx, STHS34PF80_CTRL1, (uint8_t *)&ctrl1, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Selects the tmos odr.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      TMOS_ODR_OFF, TMOS_ODR_AT_0Hz25, TMOS_ODR_AT_0Hz50, TMOS_ODR_1Hz, TMOS_ODR_2Hz, TMOS_ODR_4Hz, TMOS_ODR_8Hz, TMOS_ODR_15Hz, TMOS_ODR_30Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_tmos_odr_set(stmdev_ctx_t *ctx, sths34pf80_tmos_odr_t val)
+{
+  sths34pf80_ctrl1_t ctrl1;
+  sths34pf80_avg_trim_t avg_trim;
+  sths34pf80_tmos_odr_t max_odr = STHS34PF80_TMOS_ODR_AT_30Hz;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL1, (uint8_t *)&ctrl1, 1);
+
+  if (ret == 0)
+  {
+    ret = sths34pf80_read_reg(ctx, STHS34PF80_AVG_TRIM, (uint8_t *)&avg_trim, 1);
+
+    switch(avg_trim.avg_tmos)
+    {
+      default:
+      case STHS34PF80_AVG_TMOS_2:
+      case STHS34PF80_AVG_TMOS_8:
+      case STHS34PF80_AVG_TMOS_32:
+        max_odr = STHS34PF80_TMOS_ODR_AT_30Hz;
+        break;
+      case STHS34PF80_AVG_TMOS_128:
+        max_odr = STHS34PF80_TMOS_ODR_AT_8Hz;
+        break;
+      case STHS34PF80_AVG_TMOS_256:
+        max_odr = STHS34PF80_TMOS_ODR_AT_4Hz;
+        break;
+      case STHS34PF80_AVG_TMOS_512:
+        max_odr = STHS34PF80_TMOS_ODR_AT_2Hz;
+        break;
+      case STHS34PF80_AVG_TMOS_1024:
+        max_odr = STHS34PF80_TMOS_ODR_AT_1Hz;
+        break;
+      case STHS34PF80_AVG_TMOS_2048:
+        max_odr = STHS34PF80_TMOS_ODR_AT_0Hz50;
+        break;
+    }
+  }
+
+  if (ret == 0)
+  {
+    if (val > max_odr)
+    {
+      return -1;
+    }
+
+    ret = sths34pf80_tmos_odr_check_safe_set(ctx, ctrl1, (uint8_t)val);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects the tmos odr.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      TMOS_ODR_OFF, TMOS_ODR_AT_0Hz25, TMOS_ODR_AT_0Hz50, TMOS_ODR_1Hz, TMOS_ODR_2Hz, TMOS_ODR_4Hz, TMOS_ODR_8Hz, TMOS_ODR_15Hz, TMOS_ODR_30Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_tmos_odr_get(stmdev_ctx_t *ctx, sths34pf80_tmos_odr_t *val)
+{
+  sths34pf80_ctrl1_t ctrl1;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL1, (uint8_t *)&ctrl1, 1);
+
+  switch (ctrl1.odr)
+  {
+    case STHS34PF80_TMOS_ODR_OFF:
+      *val = STHS34PF80_TMOS_ODR_OFF;
+      break;
+
+    case STHS34PF80_TMOS_ODR_AT_0Hz25:
+      *val = STHS34PF80_TMOS_ODR_AT_0Hz25;
+      break;
+
+    case STHS34PF80_TMOS_ODR_AT_0Hz50:
+      *val = STHS34PF80_TMOS_ODR_AT_0Hz50;
+      break;
+
+    case STHS34PF80_TMOS_ODR_AT_1Hz:
+      *val = STHS34PF80_TMOS_ODR_AT_1Hz;
+      break;
+
+    case STHS34PF80_TMOS_ODR_AT_2Hz:
+      *val = STHS34PF80_TMOS_ODR_AT_2Hz;
+      break;
+
+    case STHS34PF80_TMOS_ODR_AT_4Hz:
+      *val = STHS34PF80_TMOS_ODR_AT_4Hz;
+      break;
+
+    case STHS34PF80_TMOS_ODR_AT_8Hz:
+      *val = STHS34PF80_TMOS_ODR_AT_8Hz;
+      break;
+
+    case STHS34PF80_TMOS_ODR_AT_15Hz:
+      *val = STHS34PF80_TMOS_ODR_AT_15Hz;
+      break;
+
+    case STHS34PF80_TMOS_ODR_AT_30Hz:
+      *val = STHS34PF80_TMOS_ODR_AT_30Hz;
+      break;
+
+    default:
+      *val = STHS34PF80_TMOS_ODR_OFF;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block Data Update (BDU): output registers are not updated until LSB and MSB have been read). [set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Block Data Update (BDU): output registers are not updated until LSB and MSB have been read).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  sths34pf80_ctrl1_t ctrl1;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL1, (uint8_t *)&ctrl1, 1);
+
+  if (ret == 0)
+  {
+    ctrl1.bdu = val;
+    ret = sths34pf80_write_reg(ctx, STHS34PF80_CTRL1, (uint8_t *)&ctrl1, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Block Data Update (BDU): output registers are not updated until LSB and MSB have been read). [get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Block Data Update (BDU): output registers are not updated until LSB and MSB have been read).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  sths34pf80_ctrl1_t ctrl1;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL1, (uint8_t *)&ctrl1, 1);
+
+  *val = ctrl1.bdu;
+
+
+  return ret;
+}
+
+/**
+  * @brief  Selects data output mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      TMOS_IDLE_MODE, TMOS_ONE_SHOT,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_tmos_one_shot_set(stmdev_ctx_t *ctx, sths34pf80_tmos_one_shot_t val)
+{
+  sths34pf80_ctrl2_t ctrl2;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL2, (uint8_t *)&ctrl2, 1);
+
+  if (ret == 0)
+  {
+    ctrl2.one_shot = ((uint8_t)val & 0x1U);
+    ret = sths34pf80_write_reg(ctx, STHS34PF80_CTRL2, (uint8_t *)&ctrl2, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects data output mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      TMOS_IDLE_MODE, TMOS_ONE_SHOT,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_tmos_one_shot_get(stmdev_ctx_t *ctx, sths34pf80_tmos_one_shot_t *val)
+{
+  sths34pf80_ctrl2_t ctrl2;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL2, (uint8_t *)&ctrl2, 1);
+
+  switch (ctrl2.one_shot)
+  {
+    case STHS34PF80_TMOS_IDLE_MODE:
+      *val = STHS34PF80_TMOS_IDLE_MODE;
+      break;
+
+    case STHS34PF80_TMOS_ONE_SHOT:
+      *val = STHS34PF80_TMOS_ONE_SHOT;
+      break;
+
+    default:
+      *val = STHS34PF80_TMOS_IDLE_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Change memory bank.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      MAIN_MEM_BANK, EMBED_FUNC_MEM_BANK, SENSOR_HUB_MEM_BANK, STRED_MEM_BANK,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_mem_bank_set(stmdev_ctx_t *ctx, sths34pf80_mem_bank_t val)
+{
+  sths34pf80_ctrl2_t ctrl2;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL2, (uint8_t *)&ctrl2, 1);
+
+  if (ret == 0)
+  {
+    ctrl2.func_cfg_access = ((uint8_t)val & 0x1U);
+    ret = sths34pf80_write_reg(ctx, STHS34PF80_CTRL2, (uint8_t *)&ctrl2, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Change memory bank.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      MAIN_MEM_BANK, EMBED_FUNC_MEM_BANK, SENSOR_HUB_MEM_BANK, STRED_MEM_BANK,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_mem_bank_get(stmdev_ctx_t *ctx, sths34pf80_mem_bank_t *val)
+{
+  sths34pf80_ctrl2_t ctrl2;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL2, (uint8_t *)&ctrl2, 1);
+
+  switch (ctrl2.func_cfg_access)
+  {
+    case STHS34PF80_MAIN_MEM_BANK:
+      *val = STHS34PF80_MAIN_MEM_BANK;
+      break;
+
+    case STHS34PF80_EMBED_FUNC_MEM_BANK:
+      *val = STHS34PF80_EMBED_FUNC_MEM_BANK;
+      break;
+
+    default:
+      *val = STHS34PF80_MAIN_MEM_BANK;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Global reset of the device.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      READY, RESTORE_CTRL_REGS,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_boot_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  sths34pf80_ctrl2_t ctrl2;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL2, (uint8_t *)&ctrl2, 1);
+
+  if (ret == 0)
+  {
+    ctrl2.boot = val;
+    ret = sths34pf80_write_reg(ctx, STHS34PF80_CTRL2, (uint8_t *)&ctrl2, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Global reset of the device.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      READY, RESTORE_CTRL_REGS,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  sths34pf80_ctrl2_t ctrl2;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL2, (uint8_t *)&ctrl2, 1);
+  *val = ctrl2.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  status of drdy.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      status of drdy bit (TAMB, TOBJ, TAMB_SHOCK, TPRESENCE, TMOTION).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_tmos_drdy_status_get(stmdev_ctx_t *ctx, sths34pf80_tmos_drdy_status_t *val)
+{
+  sths34pf80_status_t status;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_STATUS, (uint8_t *)&status, 1);
+
+  val->drdy = status.drdy;
+
+  return ret;
+}
+
+/**
+  * @brief  status of internal functions.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      status of internal functions.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_tmos_func_status_get(stmdev_ctx_t *ctx, sths34pf80_tmos_func_status_t *val)
+{
+  sths34pf80_func_status_t func_status;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_FUNC_STATUS, (uint8_t *)&func_status, 1);
+
+  val->tamb_shock_flag = func_status.tamb_shock_flag;
+  val->mot_flag = func_status.mot_flag;
+  val->pres_flag = func_status.pres_flag;
+
+  return ret;
+}
+
+/**
+  * @brief  Object temperature output register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Object temperature output register.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_tobject_raw_get(stmdev_ctx_t *ctx, int16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_TOBJECT_L, &buff[0], 2);
+
+  *val = (int16_t)buff[1];
+  *val = (*val * 256) + (int16_t)buff[0];
+
+  return ret;
+}
+
+/**
+  * @brief  Ambient temperature output register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Ambient temperature output register.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_tambient_raw_get(stmdev_ctx_t *ctx, int16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_TAMBIENT_L, &buff[0], 2);
+
+  *val = (int16_t)buff[1];
+  *val = (*val * 256) + (int16_t)buff[0];
+
+  return ret;
+}
+
+/**
+  * @brief  Object compensation output register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Object compensation output register.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_tobj_comp_raw_get(stmdev_ctx_t *ctx, int16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_TOBJ_COMP_L, &buff[0], 2);
+
+  *val = (int16_t)buff[1];
+  *val = (*val * 256) + (int16_t)buff[0];
+
+  return ret;
+}
+
+/**
+  * @brief  Presence algo data output register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Presence algo data output register.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_tpresence_raw_get(stmdev_ctx_t *ctx, int16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_TPRESENCE_L, &buff[0], 2);
+
+  *val = (int16_t)buff[1];
+  *val = (*val * 256) + (int16_t)buff[0];
+
+  return ret;
+}
+
+/**
+  * @brief  Motion algo data output register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Motion algo data output register.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_tmotion_raw_get(stmdev_ctx_t *ctx, int16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_TMOTION_L, &buff[0], 2);
+
+  *val = (int16_t)buff[1];
+  *val = (*val * 256) + (int16_t)buff[0];
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature ambient shock algo data output register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Temperature ambient shock algo data output register.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_tamb_shock_raw_get(stmdev_ctx_t *ctx, int16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_TAMB_SHOCK_L, &buff[0], 2);
+
+  *val = (int16_t)buff[1];
+  *val = (*val * 256) + (int16_t)buff[0];
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup Filters
+  * @brief    Filters
+  * @{/
+  *
+  */
+/**
+  * @brief  low-pass filter configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      LPF_ODR_DIV_9, LPF_ODR_DIV_20, LPF_ODR_DIV_50, LPF_ODR_DIV_100, LPF_ODR_DIV_200, LPF_ODR_DIV_400, LPF_ODR_DIV_800,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_lpf_m_bandwidth_set(stmdev_ctx_t *ctx, sths34pf80_lpf_bandwidth_t val)
+{
+  sths34pf80_lpf1_t lpf1;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_LPF1, (uint8_t *)&lpf1, 1);
+
+  if (ret == 0)
+  {
+    lpf1.lpf_m = ((uint8_t)val & 0x7U);
+    ret = sths34pf80_write_reg(ctx, STHS34PF80_LPF1, (uint8_t *)&lpf1, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  low-pass filter configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      LPF_ODR_DIV_9, LPF_ODR_DIV_20, LPF_ODR_DIV_50, LPF_ODR_DIV_100, LPF_ODR_DIV_200, LPF_ODR_DIV_400, LPF_ODR_DIV_800,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_lpf_m_bandwidth_get(stmdev_ctx_t *ctx, sths34pf80_lpf_bandwidth_t *val)
+{
+  sths34pf80_lpf1_t lpf1;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_LPF1, (uint8_t *)&lpf1, 1);
+
+  switch ((lpf1.lpf_m))
+  {
+    case STHS34PF80_LPF_ODR_DIV_9:
+      *val = STHS34PF80_LPF_ODR_DIV_9;
+      break;
+
+    case STHS34PF80_LPF_ODR_DIV_20:
+      *val = STHS34PF80_LPF_ODR_DIV_20;
+      break;
+
+    case STHS34PF80_LPF_ODR_DIV_50:
+      *val = STHS34PF80_LPF_ODR_DIV_50;
+      break;
+
+    case STHS34PF80_LPF_ODR_DIV_100:
+      *val = STHS34PF80_LPF_ODR_DIV_100;
+      break;
+
+    case STHS34PF80_LPF_ODR_DIV_200:
+      *val = STHS34PF80_LPF_ODR_DIV_200;
+      break;
+
+    case STHS34PF80_LPF_ODR_DIV_400:
+      *val = STHS34PF80_LPF_ODR_DIV_400;
+      break;
+
+    case STHS34PF80_LPF_ODR_DIV_800:
+      *val = STHS34PF80_LPF_ODR_DIV_800;
+      break;
+
+    default:
+      *val = STHS34PF80_LPF_ODR_DIV_9;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  low-pass filter configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      LPF_ODR_DIV_9, LPF_ODR_DIV_20, LPF_ODR_DIV_50, LPF_ODR_DIV_100, LPF_ODR_DIV_200, LPF_ODR_DIV_400, LPF_ODR_DIV_800,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_lpf_p_m_bandwidth_set(stmdev_ctx_t *ctx, sths34pf80_lpf_bandwidth_t val)
+{
+  sths34pf80_lpf1_t lpf1;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_LPF1, (uint8_t *)&lpf1, 1);
+
+  if (ret == 0)
+  {
+    lpf1.lpf_p_m = ((uint8_t)val & 0x7U);
+    ret = sths34pf80_write_reg(ctx, STHS34PF80_LPF1, (uint8_t *)&lpf1, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  low-pass filter configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      LPF_ODR_DIV_9, LPF_ODR_DIV_20, LPF_ODR_DIV_50, LPF_ODR_DIV_100, LPF_ODR_DIV_200, LPF_ODR_DIV_400, LPF_ODR_DIV_800,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_lpf_p_m_bandwidth_get(stmdev_ctx_t *ctx, sths34pf80_lpf_bandwidth_t *val)
+{
+  sths34pf80_lpf1_t lpf1;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_LPF1, (uint8_t *)&lpf1, 1);
+
+  switch ((lpf1.lpf_p_m))
+  {
+    case STHS34PF80_LPF_ODR_DIV_9:
+      *val = STHS34PF80_LPF_ODR_DIV_9;
+      break;
+
+    case STHS34PF80_LPF_ODR_DIV_20:
+      *val = STHS34PF80_LPF_ODR_DIV_20;
+      break;
+
+    case STHS34PF80_LPF_ODR_DIV_50:
+      *val = STHS34PF80_LPF_ODR_DIV_50;
+      break;
+
+    case STHS34PF80_LPF_ODR_DIV_100:
+      *val = STHS34PF80_LPF_ODR_DIV_100;
+      break;
+
+    case STHS34PF80_LPF_ODR_DIV_200:
+      *val = STHS34PF80_LPF_ODR_DIV_200;
+      break;
+
+    case STHS34PF80_LPF_ODR_DIV_400:
+      *val = STHS34PF80_LPF_ODR_DIV_400;
+      break;
+
+    case STHS34PF80_LPF_ODR_DIV_800:
+      *val = STHS34PF80_LPF_ODR_DIV_800;
+      break;
+
+    default:
+      *val = STHS34PF80_LPF_ODR_DIV_9;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  low-pass filter configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      LPF_ODR_DIV_9, LPF_ODR_DIV_20, LPF_ODR_DIV_50, LPF_ODR_DIV_100, LPF_ODR_DIV_200, LPF_ODR_DIV_400, LPF_ODR_DIV_800,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_lpf_a_t_bandwidth_set(stmdev_ctx_t *ctx, sths34pf80_lpf_bandwidth_t val)
+{
+  sths34pf80_lpf2_t lpf2;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_LPF2, (uint8_t *)&lpf2, 1);
+
+  if (ret == 0)
+  {
+    lpf2.lpf_a_t = ((uint8_t)val & 0x7U);
+    ret = sths34pf80_write_reg(ctx, STHS34PF80_LPF2, (uint8_t *)&lpf2, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  low-pass filter configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      LPF_ODR_DIV_9, LPF_ODR_DIV_20, LPF_ODR_DIV_50, LPF_ODR_DIV_100, LPF_ODR_DIV_200, LPF_ODR_DIV_400, LPF_ODR_DIV_800,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_lpf_a_t_bandwidth_get(stmdev_ctx_t *ctx, sths34pf80_lpf_bandwidth_t *val)
+{
+  sths34pf80_lpf2_t lpf2;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_LPF2, (uint8_t *)&lpf2, 1);
+
+  switch ((lpf2.lpf_a_t))
+  {
+    case STHS34PF80_LPF_ODR_DIV_9:
+      *val = STHS34PF80_LPF_ODR_DIV_9;
+      break;
+
+    case STHS34PF80_LPF_ODR_DIV_20:
+      *val = STHS34PF80_LPF_ODR_DIV_20;
+      break;
+
+    case STHS34PF80_LPF_ODR_DIV_50:
+      *val = STHS34PF80_LPF_ODR_DIV_50;
+      break;
+
+    case STHS34PF80_LPF_ODR_DIV_100:
+      *val = STHS34PF80_LPF_ODR_DIV_100;
+      break;
+
+    case STHS34PF80_LPF_ODR_DIV_200:
+      *val = STHS34PF80_LPF_ODR_DIV_200;
+      break;
+
+    case STHS34PF80_LPF_ODR_DIV_400:
+      *val = STHS34PF80_LPF_ODR_DIV_400;
+      break;
+
+    case STHS34PF80_LPF_ODR_DIV_800:
+      *val = STHS34PF80_LPF_ODR_DIV_800;
+      break;
+
+    default:
+      *val = STHS34PF80_LPF_ODR_DIV_9;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  low-pass filter configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      LPF_ODR_DIV_9, LPF_ODR_DIV_20, LPF_ODR_DIV_50, LPF_ODR_DIV_100, LPF_ODR_DIV_200, LPF_ODR_DIV_400, LPF_ODR_DIV_800,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_lpf_p_bandwidth_set(stmdev_ctx_t *ctx, sths34pf80_lpf_bandwidth_t val)
+{
+  sths34pf80_lpf2_t lpf2;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_LPF2, (uint8_t *)&lpf2, 1);
+
+  if (ret == 0)
+  {
+    lpf2.lpf_p = ((uint8_t)val & 0x7U);
+    ret = sths34pf80_write_reg(ctx, STHS34PF80_LPF2, (uint8_t *)&lpf2, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  low-pass filter configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      LPF_ODR_DIV_9, LPF_ODR_DIV_20, LPF_ODR_DIV_50, LPF_ODR_DIV_100, LPF_ODR_DIV_200, LPF_ODR_DIV_400, LPF_ODR_DIV_800,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_lpf_p_bandwidth_get(stmdev_ctx_t *ctx, sths34pf80_lpf_bandwidth_t *val)
+{
+  sths34pf80_lpf2_t lpf2;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_LPF2, (uint8_t *)&lpf2, 1);
+
+  switch ((lpf2.lpf_p))
+  {
+    case STHS34PF80_LPF_ODR_DIV_9:
+      *val = STHS34PF80_LPF_ODR_DIV_9;
+      break;
+
+    case STHS34PF80_LPF_ODR_DIV_20:
+      *val = STHS34PF80_LPF_ODR_DIV_20;
+      break;
+
+    case STHS34PF80_LPF_ODR_DIV_50:
+      *val = STHS34PF80_LPF_ODR_DIV_50;
+      break;
+
+    case STHS34PF80_LPF_ODR_DIV_100:
+      *val = STHS34PF80_LPF_ODR_DIV_100;
+      break;
+
+    case STHS34PF80_LPF_ODR_DIV_200:
+      *val = STHS34PF80_LPF_ODR_DIV_200;
+      break;
+
+    case STHS34PF80_LPF_ODR_DIV_400:
+      *val = STHS34PF80_LPF_ODR_DIV_400;
+      break;
+
+    case STHS34PF80_LPF_ODR_DIV_800:
+      *val = STHS34PF80_LPF_ODR_DIV_800;
+      break;
+
+    default:
+      *val = STHS34PF80_LPF_ODR_DIV_9;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup Interrupt PINs
+  * @brief    Interrupt PINs
+  * @{/
+  *
+  */
+/**
+  * @brief  Selects interrupts to be routed.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      TMOS_INT_HIZ, TMOS_INT_DRDY, TMOS_INT_OR,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_tmos_route_int_set(stmdev_ctx_t *ctx, sths34pf80_tmos_route_int_t val)
+{
+  sths34pf80_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL3, (uint8_t *)&ctrl3, 1);
+
+  if (ret == 0)
+  {
+    ctrl3.ien = ((uint8_t)val & 0x3U);
+    if (val == STHS34PF80_TMOS_INT_OR) {
+      ctrl3.int_latched = 0; /* guarantee that latched is zero in INT_OR case */
+    }
+    ret = sths34pf80_write_reg(ctx, STHS34PF80_CTRL3, (uint8_t *)&ctrl3, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects interrupts to be routed.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      TMOS_INT_HIZ, TMOS_INT_DRDY, TMOS_INT_OR,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_tmos_route_int_get(stmdev_ctx_t *ctx, sths34pf80_tmos_route_int_t *val)
+{
+  sths34pf80_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL3, (uint8_t *)&ctrl3, 1);
+
+  switch ((ctrl3.ien))
+  {
+    case STHS34PF80_TMOS_INT_HIZ:
+      *val = STHS34PF80_TMOS_INT_HIZ;
+      break;
+
+    case STHS34PF80_TMOS_INT_DRDY:
+      *val = STHS34PF80_TMOS_INT_DRDY;
+      break;
+
+    case STHS34PF80_TMOS_INT_OR:
+      *val = STHS34PF80_TMOS_INT_OR;
+      break;
+
+    default:
+      *val = STHS34PF80_TMOS_INT_HIZ;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects interrupts output.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      TMOS_INT_NONE, TMOS_INT_TSHOCK, TMOS_INT_MOTION, TMOS_INT_TSHOCK_MOTION, TMOS_INT_PRESENCE, TMOS_INT_TSHOCK_PRESENCE, TMOS_INT_MOTION_PRESENCE, TMOS_INT_ALL,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_tmos_int_or_set(stmdev_ctx_t *ctx, sths34pf80_tmos_int_or_t val)
+{
+  sths34pf80_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL3, (uint8_t *)&ctrl3, 1);
+
+  if (ret == 0)
+  {
+    ctrl3.int_msk = ((uint8_t)val & 0x7U);
+    ret = sths34pf80_write_reg(ctx, STHS34PF80_CTRL3, (uint8_t *)&ctrl3, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects interrupts output.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      TMOS_INT_NONE, TMOS_INT_TSHOCK, TMOS_INT_MOTION, TMOS_INT_TSHOCK_MOTION, TMOS_INT_PRESENCE, TMOS_INT_TSHOCK_PRESENCE, TMOS_INT_MOTION_PRESENCE, TMOS_INT_ALL,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_tmos_int_or_get(stmdev_ctx_t *ctx, sths34pf80_tmos_int_or_t *val)
+{
+  sths34pf80_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL3, (uint8_t *)&ctrl3, 1);
+
+  switch ((ctrl3.int_msk))
+  {
+    case STHS34PF80_TMOS_INT_NONE:
+      *val = STHS34PF80_TMOS_INT_NONE;
+      break;
+
+    case STHS34PF80_TMOS_INT_TSHOCK:
+      *val = STHS34PF80_TMOS_INT_TSHOCK;
+      break;
+
+    case STHS34PF80_TMOS_INT_MOTION:
+      *val = STHS34PF80_TMOS_INT_MOTION;
+      break;
+
+    case STHS34PF80_TMOS_INT_TSHOCK_MOTION:
+      *val = STHS34PF80_TMOS_INT_TSHOCK_MOTION;
+      break;
+
+    case STHS34PF80_TMOS_INT_PRESENCE:
+      *val = STHS34PF80_TMOS_INT_PRESENCE;
+      break;
+
+    case STHS34PF80_TMOS_INT_TSHOCK_PRESENCE:
+      *val = STHS34PF80_TMOS_INT_TSHOCK_PRESENCE;
+      break;
+
+    case STHS34PF80_TMOS_INT_MOTION_PRESENCE:
+      *val = STHS34PF80_TMOS_INT_MOTION_PRESENCE;
+      break;
+
+    case STHS34PF80_TMOS_INT_ALL:
+      *val = STHS34PF80_TMOS_INT_ALL;
+      break;
+
+    default:
+      *val = STHS34PF80_TMOS_INT_NONE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open-drain selection on INT1 and INT2 pins.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      PUSH_PULL, OPEN_DRAIN,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_int_mode_set(stmdev_ctx_t *ctx, sths34pf80_int_mode_t val)
+{
+  sths34pf80_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL3, (uint8_t *)&ctrl3, 1);
+
+  if (ret == 0)
+  {
+    ctrl3.pp_od = ((uint8_t)val.pin);
+    ctrl3.int_h_l = ((uint8_t)val.polarity);
+    ret = sths34pf80_write_reg(ctx, STHS34PF80_CTRL3, (uint8_t *)&ctrl3, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open-drain selection on INT1 and INT2 pins.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      PUSH_PULL, OPEN_DRAIN,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_int_mode_get(stmdev_ctx_t *ctx, sths34pf80_int_mode_t *val)
+{
+  sths34pf80_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL3, (uint8_t *)&ctrl3, 1);
+
+  switch (ctrl3.pp_od)
+  {
+    case STHS34PF80_PUSH_PULL:
+      val->pin = STHS34PF80_PUSH_PULL;
+      break;
+
+    case STHS34PF80_OPEN_DRAIN:
+      val->pin = STHS34PF80_OPEN_DRAIN;
+      break;
+
+    default:
+      val->pin = STHS34PF80_PUSH_PULL;
+      break;
+  }
+
+  switch (ctrl3.int_h_l)
+  {
+    case STHS34PF80_ACTIVE_HIGH:
+      val->polarity = STHS34PF80_ACTIVE_HIGH;
+      break;
+
+    case STHS34PF80_ACTIVE_LOW:
+      val->polarity = STHS34PF80_ACTIVE_LOW;
+      break;
+
+    default:
+      val->polarity = STHS34PF80_ACTIVE_HIGH;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  DRDY mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      DRDY_PULSED, DRDY_LATCHED,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_drdy_mode_set(stmdev_ctx_t *ctx, sths34pf80_drdy_mode_t val)
+{
+  sths34pf80_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL3, (uint8_t *)&ctrl3, 1);
+
+  if (ret == 0)
+  {
+    ctrl3.int_latched = (uint8_t)val;
+    ret = sths34pf80_write_reg(ctx, STHS34PF80_CTRL3, (uint8_t *)&ctrl3, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  DRDY mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      DRDY_PULSED, DRDY_LATCHED,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_drdy_mode_get(stmdev_ctx_t *ctx, sths34pf80_drdy_mode_t *val)
+{
+  sths34pf80_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL3, (uint8_t *)&ctrl3, 1);
+
+  switch (ctrl3.int_latched)
+  {
+    case STHS34PF80_DRDY_PULSED:
+      *val = STHS34PF80_DRDY_PULSED;
+      break;
+
+    case STHS34PF80_DRDY_LATCHED:
+      *val = STHS34PF80_DRDY_LATCHED;
+      break;
+
+    default:
+      *val = STHS34PF80_DRDY_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup Embedded
+  * @brief    Embedded
+  * @{/
+  *
+  */
+/**
+  * @brief  Function Configuration write
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  addr     embedded register address
+  * @param  data     embedded register data
+  * @param  len      embedded register data len
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_func_cfg_write(stmdev_ctx_t *ctx, uint8_t addr, uint8_t *data, uint8_t len)
+{
+  sths34pf80_ctrl1_t ctrl1;
+  uint8_t odr;
+  sths34pf80_page_rw_t page_rw = {0};
+  int32_t ret;
+  uint8_t i;
+
+  /* Save current odr and enter PD mode */
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL1, (uint8_t *)&ctrl1, 1);
+  odr = ctrl1.odr;
+  ret += sths34pf80_tmos_odr_check_safe_set(ctx, ctrl1, 0);
+
+  /* Enable access to embedded functions register */
+  ret += sths34pf80_mem_bank_set(ctx, STHS34PF80_EMBED_FUNC_MEM_BANK);
+
+  /* Enable write mode */
+  page_rw.func_cfg_write = 1;
+  ret += sths34pf80_write_reg(ctx, STHS34PF80_PAGE_RW, (uint8_t *)&page_rw, 1);
+
+  /* Select register address (it will autoincrement when writing) */
+  ret += sths34pf80_write_reg(ctx, STHS34PF80_FUNC_CFG_ADDR, &addr, 1);
+
+  for (i = 0; i < len; i++)
+  {
+    /* Write data */
+    ret += sths34pf80_write_reg(ctx, STHS34PF80_FUNC_CFG_DATA, &data[i], 1);
+  }
+
+  /* Disable write mode */
+  page_rw.func_cfg_write = 0;
+  ret += sths34pf80_write_reg(ctx, STHS34PF80_PAGE_RW, (uint8_t *)&page_rw, 1);
+
+  /* Disable access to embedded functions register */
+  ret += sths34pf80_mem_bank_set(ctx, STHS34PF80_MAIN_MEM_BANK);
+
+  /* Set saved odr back */
+  ret += sths34pf80_tmos_odr_check_safe_set(ctx, ctrl1, odr);
+
+  return ret;
+}
+
+/**
+  * @brief  Function Configuration read
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  addr     embedded register address
+  * @param  data     embedded register data
+  * @param  len      embedded register data len
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_func_cfg_read(stmdev_ctx_t *ctx, uint8_t addr, uint8_t *data, uint8_t len)
+{
+  sths34pf80_ctrl1_t ctrl1;
+  uint8_t odr;
+  uint8_t reg_addr;
+  sths34pf80_page_rw_t page_rw = {0};
+  int32_t ret;
+  uint8_t i;
+
+  /* Save current odr and enter PD mode */
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL1, (uint8_t *)&ctrl1, 1);
+  odr = ctrl1.odr;
+  ret += sths34pf80_tmos_odr_check_safe_set(ctx, ctrl1, 0);
+
+  /* Enable access to embedded functions register */
+  ret += sths34pf80_mem_bank_set(ctx, STHS34PF80_EMBED_FUNC_MEM_BANK);
+
+  /* Enable read mode */
+  page_rw.func_cfg_read = 1;
+  ret += sths34pf80_write_reg(ctx, STHS34PF80_PAGE_RW, (uint8_t *)&page_rw, 1);
+
+  for (i = 0; i < len; i++)
+  {
+  /* Select register address */
+    reg_addr = addr + i;
+    ret += sths34pf80_write_reg(ctx, STHS34PF80_FUNC_CFG_ADDR, &reg_addr, 1);
+
+    /* Read data */
+    ret += sths34pf80_read_reg(ctx, STHS34PF80_FUNC_CFG_DATA, &data[i], 1);
+  }
+
+  /* Disable read mode */
+  page_rw.func_cfg_read = 0;
+  ret += sths34pf80_write_reg(ctx, STHS34PF80_PAGE_RW, (uint8_t *)&page_rw, 1);
+
+  /* Disable access to embedded functions register */
+  ret += sths34pf80_mem_bank_set(ctx, STHS34PF80_MAIN_MEM_BANK);
+
+  /* Set saved odr back */
+  ret += sths34pf80_tmos_odr_check_safe_set(ctx, ctrl1, odr);
+
+  return ret;
+}
+
+/**
+  * @brief  Presence threshold.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      presence threshold level
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_presence_threshold_set(stmdev_ctx_t *ctx, uint16_t val)
+{
+  sths34pf80_ctrl1_t ctrl1;
+  uint8_t odr;
+  uint8_t buff[2];
+  int32_t ret;
+
+  if ((val & 0x8000U) != 0x0U) {
+    /* threshold values are on 15 bits */
+    return -1;
+  }
+
+  /* Save current odr and enter PD mode */
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL1, (uint8_t *)&ctrl1, 1);
+  odr = ctrl1.odr;
+  ret += sths34pf80_tmos_odr_check_safe_set(ctx, ctrl1, 0);
+
+  buff[1] = (uint8_t)(val / 256U);
+  buff[0] = (uint8_t)(val - (buff[1] * 256U));
+  ret += sths34pf80_func_cfg_write(ctx, STHS34PF80_PRESENCE_THS, &buff[0], 2);
+
+  ret += sths34pf80_algo_reset(ctx);
+
+  /* Set saved odr back */
+  ret += sths34pf80_tmos_odr_check_safe_set(ctx, ctrl1, odr);
+
+  return ret;
+}
+
+/**
+  * @brief  Presence threshold.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      presence threshold level
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_presence_threshold_get(stmdev_ctx_t *ctx, uint16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = sths34pf80_func_cfg_read(ctx, STHS34PF80_PRESENCE_THS, &buff[0], 2);
+
+  *val = buff[1];
+  *val = (*val * 256U) +  buff[0];
+
+  return ret;
+}
+
+/**
+  * @brief  Motion threshold.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      motion threshold level
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_motion_threshold_set(stmdev_ctx_t *ctx, uint16_t val)
+{
+  sths34pf80_ctrl1_t ctrl1;
+  uint8_t odr;
+  uint8_t buff[2];
+  int32_t ret;
+
+  if ((val & 0x8000U) != 0x0U) {
+    /* threshold values are on 15 bits */
+    return -1;
+  }
+
+  /* Save current odr and enter PD mode */
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL1, (uint8_t *)&ctrl1, 1);
+  odr = ctrl1.odr;
+  ret += sths34pf80_tmos_odr_check_safe_set(ctx, ctrl1, 0);
+
+  buff[1] = (uint8_t)(val / 256U);
+  buff[0] = (uint8_t)(val - (buff[1] * 256U));
+  ret += sths34pf80_func_cfg_write(ctx, STHS34PF80_MOTION_THS, &buff[0], 2);
+
+  ret += sths34pf80_algo_reset(ctx);
+
+  /* Set saved odr back */
+  ret += sths34pf80_tmos_odr_check_safe_set(ctx, ctrl1, odr);
+
+  return ret;
+}
+
+/**
+  * @brief  Motion threshold.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      motion threshold level
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_motion_threshold_get(stmdev_ctx_t *ctx, uint16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = sths34pf80_func_cfg_read(ctx, STHS34PF80_MOTION_THS, &buff[0], 2);
+
+  *val = buff[1];
+  *val = (*val * 256U) +  buff[0];
+
+  return ret;
+}
+
+/**
+  * @brief  Tambient shock threshold.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Tambient shock threshold level
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_tambient_shock_threshold_set(stmdev_ctx_t *ctx, uint16_t val)
+{
+  sths34pf80_ctrl1_t ctrl1;
+  uint8_t odr;
+  uint8_t buff[2];
+  int32_t ret;
+
+  if ((val & 0x8000U) != 0x0U) {
+    /* threshold values are on 15 bits */
+    return -1;
+  }
+
+  /* Save current odr and enter PD mode */
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL1, (uint8_t *)&ctrl1, 1);
+  odr = ctrl1.odr;
+  ret += sths34pf80_tmos_odr_check_safe_set(ctx, ctrl1, 0);
+
+  buff[1] = (uint8_t)(val / 256U);
+  buff[0] = (uint8_t)(val - (buff[1] * 256U));
+  ret += sths34pf80_func_cfg_write(ctx, STHS34PF80_TAMB_SHOCK_THS, &buff[0], 2);
+
+  ret += sths34pf80_algo_reset(ctx);
+
+  /* Set saved odr back */
+  ret += sths34pf80_tmos_odr_check_safe_set(ctx, ctrl1, odr);
+
+  return ret;
+}
+
+/**
+  * @brief  Tambient shock threshold.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Tambient shock threshold level
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_tambient_shock_threshold_get(stmdev_ctx_t *ctx, uint16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = sths34pf80_func_cfg_read(ctx, STHS34PF80_TAMB_SHOCK_THS, &buff[0], 2);
+
+  *val = buff[1];
+  *val = (*val * 256U) +  buff[0];
+
+  return ret;
+}
+
+/**
+  * @brief  Motion hysteresis threshold.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Motion hysteresis value
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_motion_hysteresis_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  sths34pf80_ctrl1_t ctrl1;
+  uint8_t odr;
+  int32_t ret;
+
+  /* Save current odr and enter PD mode */
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL1, (uint8_t *)&ctrl1, 1);
+  odr = ctrl1.odr;
+  ret += sths34pf80_tmos_odr_check_safe_set(ctx, ctrl1, 0);
+
+  ret += sths34pf80_func_cfg_write(ctx, STHS34PF80_HYST_MOTION, &val, 1);
+
+  ret += sths34pf80_algo_reset(ctx);
+
+  /* Set saved odr back */
+  ret += sths34pf80_tmos_odr_check_safe_set(ctx, ctrl1, odr);
+
+  return ret;
+}
+
+/**
+  * @brief  Motion hysteresis threshold.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Motion hysteresis value
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_motion_hysteresis_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  int32_t ret;
+
+  ret = sths34pf80_func_cfg_read(ctx, STHS34PF80_HYST_MOTION, val, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Presence hysteresis.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Presence hysteresis value
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_presence_hysteresis_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  sths34pf80_ctrl1_t ctrl1;
+  uint8_t odr;
+  int32_t ret;
+
+  /* Save current odr and enter PD mode */
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL1, (uint8_t *)&ctrl1, 1);
+  odr = ctrl1.odr;
+  ret += sths34pf80_tmos_odr_check_safe_set(ctx, ctrl1, 0);
+
+  ret += sths34pf80_func_cfg_write(ctx, STHS34PF80_HYST_PRESENCE, &val, 1);
+
+  ret += sths34pf80_algo_reset(ctx);
+
+  /* Set saved odr back */
+  ret += sths34pf80_tmos_odr_check_safe_set(ctx, ctrl1, odr);
+
+  return ret;
+}
+
+/**
+  * @brief  Presence hysteresis.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Presence hysteresis value
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_presence_hysteresis_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  int32_t ret;
+
+  ret = sths34pf80_func_cfg_read(ctx, STHS34PF80_HYST_PRESENCE, val, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Tambient shock hysteresis.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Tambient shock hysteresis value
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_tambient_shock_hysteresis_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  sths34pf80_ctrl1_t ctrl1;
+  uint8_t odr;
+  int32_t ret;
+
+  /* Save current odr and enter PD mode */
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL1, (uint8_t *)&ctrl1, 1);
+  odr = ctrl1.odr;
+  ret += sths34pf80_tmos_odr_check_safe_set(ctx, ctrl1, 0);
+
+  ret += sths34pf80_func_cfg_write(ctx, STHS34PF80_HYST_TAMB_SHOCK, &val, 1);
+
+  ret += sths34pf80_algo_reset(ctx);
+
+  /* Set saved odr back */
+  ret += sths34pf80_tmos_odr_check_safe_set(ctx, ctrl1, odr);
+
+  return ret;
+}
+
+/**
+  * @brief  Tambient shock hysteresis.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Tambient shock hysteresis value
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_tambient_shock_hysteresis_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  int32_t ret;
+
+  ret = sths34pf80_func_cfg_read(ctx, STHS34PF80_HYST_TAMB_SHOCK, val, 1);
+
+  return ret;
+}
+
+typedef struct
+{
+  uint8_t int_pulsed : 1;
+  uint8_t comp_type : 1;
+  uint8_t sel_abs : 1;
+} sths34pf80_algo_config_t;
+
+/**
+  * @brief  Algo configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Algo configuration structure
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+static int32_t sths34pf80_algo_config_set(stmdev_ctx_t *ctx, sths34pf80_algo_config_t val)
+{
+  uint8_t tmp;
+  int32_t ret;
+
+  tmp = (val.int_pulsed << 3) | (val.comp_type << 2) | (val.sel_abs << 1);
+  ret = sths34pf80_func_cfg_write(ctx, STHS34PF80_ALGO_CONFIG, &tmp, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Algo configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Algo configuration structure
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+static int32_t sths34pf80_algo_config_get(stmdev_ctx_t *ctx, sths34pf80_algo_config_t *val)
+{
+  uint8_t tmp;
+  int32_t ret;
+
+  ret = sths34pf80_func_cfg_read(ctx, STHS34PF80_ALGO_CONFIG, &tmp, 1);
+  val->sel_abs = (tmp >> 1) & 0x1U;
+  val->comp_type = (tmp >> 2) & 0x1U;
+  val->int_pulsed = (tmp >> 3) & 0x1U;
+
+  return ret;
+}
+
+/**
+  * @brief  Tobject compensation.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Ambient compensation for object temperature (0, 1)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_tobject_algo_compensation_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  sths34pf80_ctrl1_t ctrl1;
+  uint8_t odr;
+  sths34pf80_algo_config_t config;
+  int32_t ret;
+
+  /* Save current odr and enter PD mode */
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL1, (uint8_t *)&ctrl1, 1);
+  odr = ctrl1.odr;
+  ret += sths34pf80_tmos_odr_check_safe_set(ctx, ctrl1, 0);
+  if (ret != 0) { return ret; }
+
+  ret = sths34pf80_algo_config_get(ctx, &config);
+  config.comp_type = val;
+  ret += sths34pf80_algo_config_set(ctx, config);
+  ret += sths34pf80_algo_reset(ctx);
+
+  /* Set saved odr back */
+  ret += sths34pf80_tmos_odr_check_safe_set(ctx, ctrl1, odr);
+
+  return ret;
+}
+
+/**
+  * @brief  Tobject compensation.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Ambient compensation for object temperature (0, 1)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_tobject_algo_compensation_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  sths34pf80_algo_config_t config;
+  int32_t ret;
+
+  ret = sths34pf80_algo_config_get(ctx, &config);
+  *val = config.comp_type;
+
+  return ret;
+}
+
+/**
+  * @brief  presence absolute value.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Presence absolute value (0, 1)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_presence_abs_value_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  sths34pf80_ctrl1_t ctrl1;
+  uint8_t odr;
+  sths34pf80_algo_config_t config;
+  int32_t ret;
+
+  /* Save current odr and enter PD mode */
+  ret = sths34pf80_read_reg(ctx, STHS34PF80_CTRL1, (uint8_t *)&ctrl1, 1);
+  odr = ctrl1.odr;
+  ret += sths34pf80_tmos_odr_check_safe_set(ctx, ctrl1, 0);
+  if (ret != 0) { return ret; }
+
+  ret = sths34pf80_algo_config_get(ctx, &config);
+  config.sel_abs = val;
+  ret += sths34pf80_algo_config_set(ctx, config);
+  ret += sths34pf80_algo_reset(ctx);
+
+  /* Set saved odr back */
+  ret += sths34pf80_tmos_odr_check_safe_set(ctx, ctrl1, odr);
+
+  return ret;
+}
+
+/**
+  * @brief  presence absolute value.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Presence absolute value (0, 1)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_presence_abs_value_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  sths34pf80_algo_config_t config;
+  int32_t ret;
+
+  ret = sths34pf80_algo_config_get(ctx, &config);
+  *val = config.sel_abs;
+
+  return ret;
+}
+
+/**
+  * @brief  int_or mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      int_pulsed value (0, 1)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_int_or_pulsed_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  sths34pf80_algo_config_t config;
+  int32_t ret;
+
+  ret = sths34pf80_algo_config_get(ctx, &config);
+  config.int_pulsed = val;
+  ret += sths34pf80_algo_config_set(ctx, config);
+
+  return ret;
+}
+
+/**
+  * @brief  int_or mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      int_pulsed value (0, 1)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_int_or_pulsed_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  sths34pf80_algo_config_t config;
+  int32_t ret;
+
+  ret = sths34pf80_algo_config_get(ctx, &config);
+  *val = config.int_pulsed;
+
+  return ret;
+}
+
+/**
+  * @brief  Reset algo
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      reset algo structure
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t sths34pf80_algo_reset(stmdev_ctx_t *ctx)
+{
+  uint8_t tmp;
+  int32_t ret;
+
+  tmp = 1;
+  ret = sths34pf80_func_cfg_write(ctx, STHS34PF80_RESET_ALGO, &tmp, 1);
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */

--- a/sensor/stmemsc/sths34pf80_STdC/driver/sths34pf80_reg.h
+++ b/sensor/stmemsc/sths34pf80_STdC/driver/sths34pf80_reg.h
@@ -1,0 +1,779 @@
+/**
+  ******************************************************************************
+  * @file    sths34pf80_reg.h
+  * @author  Sensors Software Solution Team
+  * @brief   This file contains all the functions prototypes for the
+  *          sths34pf80_reg.c driver.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2021 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef STHS34PF80_REGS_H
+#define STHS34PF80_REGS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <stddef.h>
+#include <math.h>
+
+/** @addtogroup STHS34PF80
+  * @{
+  *
+  */
+
+/** @defgroup  Endianness definitions
+  * @{
+  *
+  */
+
+#ifndef DRV_BYTE_ORDER
+#ifndef __BYTE_ORDER__
+
+#define DRV_LITTLE_ENDIAN 1234
+#define DRV_BIG_ENDIAN    4321
+
+/** if _BYTE_ORDER is not defined, choose the endianness of your architecture
+  * by uncommenting the define which fits your platform endianness
+  */
+//#define DRV_BYTE_ORDER    DRV_BIG_ENDIAN
+#define DRV_BYTE_ORDER    DRV_LITTLE_ENDIAN
+
+#else /* defined __BYTE_ORDER__ */
+
+#define DRV_LITTLE_ENDIAN  __ORDER_LITTLE_ENDIAN__
+#define DRV_BIG_ENDIAN     __ORDER_BIG_ENDIAN__
+#define DRV_BYTE_ORDER     __BYTE_ORDER__
+
+#endif /* __BYTE_ORDER__*/
+#endif /* DRV_BYTE_ORDER */
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup STMicroelectronics sensors common types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t bit7       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit0       : 1;
+#endif /* DRV_BYTE_ORDER */
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+/** @addtogroup  Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, const uint8_t *, uint16_t);
+typedef int32_t (*stmdev_read_ptr)(void *, uint8_t, uint8_t *, uint16_t);
+typedef void (*stmdev_mdelay_ptr)(uint32_t millisec);
+
+typedef struct
+{
+  /** Component mandatory fields **/
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
+  /** Component optional fields **/
+  stmdev_mdelay_ptr   mdelay;
+  /** Customizable optional pointer **/
+  void *handle;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+  *              You can create a sensor configuration by your own or using
+  *              Unico / Unicleo tools available on STMicroelectronics
+  *              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct
+{
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup STHS34PF80_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format **/
+#define STHS34PF80_I2C_ADD                    0xB5U
+
+/** Device Identification (Who am I) **/
+#define STHS34PF80_ID                         0xD3U
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup bitfields page main
+  * @{
+  *
+  */
+
+#define STHS34PF80_LPF1    0x0CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t lpf_m  : 3;
+  uint8_t lpf_p_m  : 3;
+  uint8_t not_used0  : 2;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0  : 2;
+  uint8_t lpf_p_m  : 3;
+  uint8_t lpf_m  : 3;
+#endif /* DRV_BYTE_ORDER */
+} sths34pf80_lpf1_t;
+
+#define STHS34PF80_LPF2    0x0DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t lpf_a_t  : 3;
+  uint8_t lpf_p  : 3;
+  uint8_t not_used0  : 2;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0  : 2;
+  uint8_t lpf_p  : 3;
+  uint8_t lpf_a_t  : 3;
+#endif /* DRV_BYTE_ORDER */
+} sths34pf80_lpf2_t;
+
+#define STHS34PF80_WHO_AM_I    0x0FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t id  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t id  : 8;
+#endif /* DRV_BYTE_ORDER */
+} sths34pf80_who_am_i_t;
+
+#define STHS34PF80_AVG_TRIM    0x10U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t avg_tmos  : 3;
+  uint8_t not_used0  : 1;
+  uint8_t avg_t  : 2;
+  uint8_t not_used1  : 2;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1  : 2;
+  uint8_t avg_t  : 2;
+  uint8_t not_used0  : 1;
+  uint8_t avg_tmos  : 3;
+#endif /* DRV_BYTE_ORDER */
+} sths34pf80_avg_trim_t;
+
+#define STHS34PF80_CTRL0    0x17U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0  : 4;
+  uint8_t gain       : 3;
+  uint8_t not_used1  : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1  : 1;
+  uint8_t gain       : 3;
+  uint8_t not_used0  : 4;
+#endif /* DRV_BYTE_ORDER */
+} sths34pf80_ctrl0_t;
+
+#define STHS34PF80_SENS_DATA    0x1DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sens  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sens  : 8;
+#endif /* DRV_BYTE_ORDER */
+} sths34pf80_sens_data_t;
+
+#define STHS34PF80_CTRL1    0x20U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t odr  : 4;
+  uint8_t bdu  : 1;
+  uint8_t not_used0  : 3;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0  : 3;
+  uint8_t bdu  : 1;
+  uint8_t odr  : 4;
+#endif /* DRV_BYTE_ORDER */
+} sths34pf80_ctrl1_t;
+
+#define STHS34PF80_CTRL2    0x21U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t one_shot  : 1;
+  uint8_t not_used0  : 3;
+  uint8_t func_cfg_access  : 1;
+  uint8_t not_used1  : 2;
+  uint8_t boot  : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t boot  : 1;
+  uint8_t not_used1  : 2;
+  uint8_t func_cfg_access  : 1;
+  uint8_t not_used0  : 3;
+  uint8_t one_shot  : 1;
+#endif /* DRV_BYTE_ORDER */
+} sths34pf80_ctrl2_t;
+
+#define STHS34PF80_CTRL3    0x22U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ien  : 2;
+  uint8_t int_latched  : 1;
+  uint8_t int_msk  : 3;
+  uint8_t pp_od  : 1;
+  uint8_t int_h_l  : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t int_h_l  : 1;
+  uint8_t pp_od  : 1;
+  uint8_t int_msk  : 3;
+  uint8_t int_latched  : 1;
+  uint8_t ien  : 2;
+#endif /* DRV_BYTE_ORDER */
+} sths34pf80_ctrl3_t;
+
+#define STHS34PF80_STATUS    0x23U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0  : 2;
+  uint8_t drdy  : 1;
+  uint8_t not_used1  : 5;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1  : 5;
+  uint8_t drdy  : 1;
+  uint8_t not_used0  : 2;
+#endif /* DRV_BYTE_ORDER */
+} sths34pf80_status_t;
+
+#define STHS34PF80_FUNC_STATUS    0x25U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t tamb_shock_flag  : 1;
+  uint8_t mot_flag  : 1;
+  uint8_t pres_flag  : 1;
+  uint8_t not_used0  : 5;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0  : 5;
+  uint8_t pres_flag  : 1;
+  uint8_t mot_flag  : 1;
+  uint8_t tamb_shock_flag  : 1;
+#endif /* DRV_BYTE_ORDER */
+} sths34pf80_func_status_t;
+
+#define STHS34PF80_TOBJECT_L    0x26U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t tobject  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t tobject  : 8;
+#endif /* DRV_BYTE_ORDER */
+} sths34pf80_tobject_l_t;
+
+#define STHS34PF80_TOBJECT_H    0x27U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t tobject  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t tobject  : 8;
+#endif /* DRV_BYTE_ORDER */
+} sths34pf80_tobject_h_t;
+
+#define STHS34PF80_TAMBIENT_L    0x28U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t tambient  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t tambient  : 8;
+#endif /* DRV_BYTE_ORDER */
+} sths34pf80_tambient_l_t;
+
+#define STHS34PF80_TAMBIENT_H    0x29U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t tambient  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t tambient  : 8;
+#endif /* DRV_BYTE_ORDER */
+} sths34pf80_tambient_h_t;
+
+#define STHS34PF80_TOBJ_COMP_L    0x38U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t tobj_comp  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t tobj_comp  : 8;
+#endif /* DRV_BYTE_ORDER */
+} sths34pf80_tobj_comp_l_t;
+
+#define STHS34PF80_TOBJ_COMP_H    0x39U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t tobj_comp  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t tobj_comp  : 8;
+#endif /* DRV_BYTE_ORDER */
+} sths34pf80_tobj_comp_h_t;
+
+#define STHS34PF80_TPRESENCE_L    0x3AU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t tpresence  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t tpresence  : 8;
+#endif /* DRV_BYTE_ORDER */
+} sths34pf80_tpresence_l_t;
+
+#define STHS34PF80_TPRESENCE_H    0x3BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t tpresence  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t tpresence  : 8;
+#endif /* DRV_BYTE_ORDER */
+} sths34pf80_tpresence_h_t;
+
+#define STHS34PF80_TMOTION_L    0x3CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t tmotion  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t tmotion  : 8;
+#endif /* DRV_BYTE_ORDER */
+} sths34pf80_tmotion_l_t;
+
+#define STHS34PF80_TMOTION_H    0x3DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t tmotion  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t tmotion  : 8;
+#endif /* DRV_BYTE_ORDER */
+} sths34pf80_tmotion_h_t;
+
+#define STHS34PF80_TAMB_SHOCK_L    0x3EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t tamb_shock  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t tamb_shock  : 8;
+#endif /* DRV_BYTE_ORDER */
+} sths34pf80_tamb_shock_l_t;
+
+#define STHS34PF80_TAMB_SHOCK_H    0x3FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t tamb_shock  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t tamb_shock  : 8;
+#endif /* DRV_BYTE_ORDER */
+} sths34pf80_tamb_shock_h_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup bitfields page embedded
+  * @{
+  *
+  */
+
+#define STHS34PF80_FUNC_CFG_ADDR    0x08U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t func_cfg_addr  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t func_cfg_addr  : 8;
+#endif /* DRV_BYTE_ORDER */
+} sths34pf80_func_cfg_addr_t;
+
+#define STHS34PF80_FUNC_CFG_DATA    0x09U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t func_cfg_data  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t func_cfg_data  : 8;
+#endif /* DRV_BYTE_ORDER */
+} sths34pf80_func_cfg_data_t;
+
+#define STHS34PF80_PAGE_RW    0x11U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0  : 5;
+  uint8_t func_cfg_read  : 1;
+  uint8_t func_cfg_write  : 1;
+  uint8_t not_used1  : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1  : 1;
+  uint8_t func_cfg_write  : 1;
+  uint8_t func_cfg_read  : 1;
+  uint8_t not_used0  : 5;
+#endif /* DRV_BYTE_ORDER */
+} sths34pf80_page_rw_t;
+
+#define STHS34PF80_PRESENCE_THS       0x20U
+#define STHS34PF80_MOTION_THS         0x22U
+#define STHS34PF80_TAMB_SHOCK_THS     0x24U
+#define STHS34PF80_HYST_MOTION        0x26U
+#define STHS34PF80_HYST_PRESENCE      0x27U
+#define STHS34PF80_ALGO_CONFIG        0x28U
+#define STHS34PF80_HYST_TAMB_SHOCK    0x29U
+#define STHS34PF80_RESET_ALGO         0x2AU
+
+/**
+  * @}
+  *
+  */
+
+typedef union
+{
+  sths34pf80_lpf1_t    lpf1;
+  sths34pf80_lpf2_t    lpf2;
+  sths34pf80_who_am_i_t    who_am_i;
+  sths34pf80_avg_trim_t    avg_trim;
+  sths34pf80_ctrl1_t    ctrl1;
+  sths34pf80_ctrl2_t    ctrl2;
+  sths34pf80_ctrl3_t    ctrl3;
+  sths34pf80_status_t    status;
+  sths34pf80_func_status_t    func_status;
+  sths34pf80_tobject_l_t    tobject_l;
+  sths34pf80_tobject_h_t    tobject_h;
+  sths34pf80_tambient_l_t    tambient_l;
+  sths34pf80_tambient_h_t    tambient_h;
+  sths34pf80_tpresence_l_t    tpresence_l;
+  sths34pf80_tpresence_h_t    tpresence_h;
+  sths34pf80_tmotion_l_t    tmotion_l;
+  sths34pf80_tmotion_h_t    tmotion_h;
+  sths34pf80_tamb_shock_l_t    tamb_shock_l;
+  sths34pf80_tamb_shock_h_t    tamb_shock_h;
+  bitwise_t    bitwise;
+  uint8_t    byte;
+} prefix_lowmain_t;
+
+typedef union
+{
+  sths34pf80_func_cfg_addr_t    func_cfg_addr;
+  sths34pf80_func_cfg_data_t    func_cfg_data;
+  sths34pf80_page_rw_t    page_rw;
+  bitwise_t    bitwise;
+  uint8_t    byte;
+} prefix_lowembedded_t;
+
+/**
+  * @}
+  *
+  */
+
+#ifndef __weak
+#define __weak __attribute__((weak))
+#endif /* __weak */
+
+/*
+ * These are the basic platform dependent I/O routines to read
+ * and write device registers connected on a standard bus.
+ * The driver keeps offering a default implementation based on function
+ * pointers to read/write routines for backward compatibility.
+ * The default implementation is declared with a __weak directive to
+ * allow the final application to overwrite it with a custom implementation.
+ */
+int32_t sths34pf80_read_reg(stmdev_ctx_t *ctx, uint8_t reg,
+                            uint8_t *data,
+                            uint16_t len);
+int32_t sths34pf80_write_reg(stmdev_ctx_t *ctx, uint8_t reg,
+                             uint8_t *data,
+                             uint16_t len);
+
+int32_t sths34pf80_device_id_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  STHS34PF80_AVG_TMOS_2 = 0x0,
+  STHS34PF80_AVG_TMOS_8 = 0x1,
+  STHS34PF80_AVG_TMOS_32 = 0x2,
+  STHS34PF80_AVG_TMOS_128 = 0x3,
+  STHS34PF80_AVG_TMOS_256 = 0x4,
+  STHS34PF80_AVG_TMOS_512 = 0x5,
+  STHS34PF80_AVG_TMOS_1024 = 0x6,
+  STHS34PF80_AVG_TMOS_2048 = 0x7,
+} sths34pf80_avg_tobject_num_t;
+int32_t sths34pf80_avg_tobject_num_set(stmdev_ctx_t *ctx, sths34pf80_avg_tobject_num_t val);
+int32_t sths34pf80_avg_tobject_num_get(stmdev_ctx_t *ctx, sths34pf80_avg_tobject_num_t *val);
+
+typedef enum
+{
+  STHS34PF80_AVG_T_8 = 0x0,
+  STHS34PF80_AVG_T_4 = 0x1,
+  STHS34PF80_AVG_T_2 = 0x2,
+  STHS34PF80_AVG_T_1 = 0x3,
+} sths34pf80_avg_tambient_num_t;
+int32_t sths34pf80_avg_tambient_num_set(stmdev_ctx_t *ctx, sths34pf80_avg_tambient_num_t val);
+int32_t sths34pf80_avg_tambient_num_get(stmdev_ctx_t *ctx, sths34pf80_avg_tambient_num_t *val);
+
+typedef enum
+{
+  STHS34PF80_GAIN_WIDE_MODE = 0x0,
+  STHS34PF80_GAIN_DEFAULT_MODE = 0x7,
+} sths34pf80_gain_mode_t;
+
+int32_t sths34pf80_gain_mode_set(stmdev_ctx_t *ctx, sths34pf80_gain_mode_t val);
+int32_t sths34pf80_gain_mode_get(stmdev_ctx_t *ctx, sths34pf80_gain_mode_t *val);
+
+int32_t sths34pf80_tmos_sensitivity_set(stmdev_ctx_t *ctx, uint16_t *val);
+int32_t sths34pf80_tmos_sensitivity_get(stmdev_ctx_t *ctx, uint16_t *val);
+
+typedef enum
+{
+  STHS34PF80_TMOS_ODR_OFF = 0x0,
+  STHS34PF80_TMOS_ODR_AT_0Hz25 = 0x1,
+  STHS34PF80_TMOS_ODR_AT_0Hz50 = 0x2,
+  STHS34PF80_TMOS_ODR_AT_1Hz = 0x3,
+  STHS34PF80_TMOS_ODR_AT_2Hz = 0x4,
+  STHS34PF80_TMOS_ODR_AT_4Hz = 0x5,
+  STHS34PF80_TMOS_ODR_AT_8Hz = 0x6,
+  STHS34PF80_TMOS_ODR_AT_15Hz = 0x7,
+  STHS34PF80_TMOS_ODR_AT_30Hz = 0x8,
+} sths34pf80_tmos_odr_t;
+int32_t sths34pf80_tmos_odr_set(stmdev_ctx_t *ctx, sths34pf80_tmos_odr_t val);
+int32_t sths34pf80_tmos_odr_get(stmdev_ctx_t *ctx, sths34pf80_tmos_odr_t *val);
+
+int32_t sths34pf80_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t sths34pf80_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  STHS34PF80_TMOS_IDLE_MODE = 0x0,
+  STHS34PF80_TMOS_ONE_SHOT = 0x1,
+} sths34pf80_tmos_one_shot_t;
+int32_t sths34pf80_tmos_one_shot_set(stmdev_ctx_t *ctx, sths34pf80_tmos_one_shot_t val);
+int32_t sths34pf80_tmos_one_shot_get(stmdev_ctx_t *ctx, sths34pf80_tmos_one_shot_t *val);
+
+typedef enum
+{
+  STHS34PF80_MAIN_MEM_BANK = 0x0,
+  STHS34PF80_EMBED_FUNC_MEM_BANK = 0x1,
+} sths34pf80_mem_bank_t;
+int32_t sths34pf80_mem_bank_set(stmdev_ctx_t *ctx, sths34pf80_mem_bank_t val);
+int32_t sths34pf80_mem_bank_get(stmdev_ctx_t *ctx, sths34pf80_mem_bank_t *val);
+
+int32_t sths34pf80_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t sths34pf80_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef struct
+{
+  uint8_t drdy : 1;
+} sths34pf80_tmos_drdy_status_t;
+int32_t sths34pf80_tmos_drdy_status_get(stmdev_ctx_t *ctx, sths34pf80_tmos_drdy_status_t *val);
+
+typedef struct
+{
+  uint8_t tamb_shock_flag : 1;
+  uint8_t mot_flag : 1;
+  uint8_t pres_flag : 1;
+} sths34pf80_tmos_func_status_t;
+int32_t sths34pf80_tmos_func_status_get(stmdev_ctx_t *ctx, sths34pf80_tmos_func_status_t *val);
+
+int32_t sths34pf80_tobject_raw_get(stmdev_ctx_t *ctx, int16_t *val);
+int32_t sths34pf80_tambient_raw_get(stmdev_ctx_t *ctx, int16_t *val);
+int32_t sths34pf80_tobj_comp_raw_get(stmdev_ctx_t *ctx, int16_t *val);
+int32_t sths34pf80_tpresence_raw_get(stmdev_ctx_t *ctx, int16_t *val);
+int32_t sths34pf80_tmotion_raw_get(stmdev_ctx_t *ctx, int16_t *val);
+int32_t sths34pf80_tamb_shock_raw_get(stmdev_ctx_t *ctx, int16_t *val);
+
+typedef enum
+{
+  STHS34PF80_LPF_ODR_DIV_9 = 0x0,
+  STHS34PF80_LPF_ODR_DIV_20 = 0x1,
+  STHS34PF80_LPF_ODR_DIV_50 = 0x2,
+  STHS34PF80_LPF_ODR_DIV_100 = 0x3,
+  STHS34PF80_LPF_ODR_DIV_200 = 0x4,
+  STHS34PF80_LPF_ODR_DIV_400 = 0x5,
+  STHS34PF80_LPF_ODR_DIV_800 = 0x6,
+} sths34pf80_lpf_bandwidth_t;
+int32_t sths34pf80_lpf_m_bandwidth_set(stmdev_ctx_t *ctx, sths34pf80_lpf_bandwidth_t val);
+int32_t sths34pf80_lpf_m_bandwidth_get(stmdev_ctx_t *ctx, sths34pf80_lpf_bandwidth_t *val);
+int32_t sths34pf80_lpf_p_m_bandwidth_set(stmdev_ctx_t *ctx, sths34pf80_lpf_bandwidth_t val);
+int32_t sths34pf80_lpf_p_m_bandwidth_get(stmdev_ctx_t *ctx, sths34pf80_lpf_bandwidth_t *val);
+int32_t sths34pf80_lpf_a_t_bandwidth_set(stmdev_ctx_t *ctx, sths34pf80_lpf_bandwidth_t val);
+int32_t sths34pf80_lpf_a_t_bandwidth_get(stmdev_ctx_t *ctx, sths34pf80_lpf_bandwidth_t *val);
+int32_t sths34pf80_lpf_p_bandwidth_set(stmdev_ctx_t *ctx, sths34pf80_lpf_bandwidth_t val);
+int32_t sths34pf80_lpf_p_bandwidth_get(stmdev_ctx_t *ctx, sths34pf80_lpf_bandwidth_t *val);
+
+typedef enum
+{
+  STHS34PF80_TMOS_INT_HIZ = 0x0,
+  STHS34PF80_TMOS_INT_DRDY = 0x1,
+  STHS34PF80_TMOS_INT_OR = 0x2,
+} sths34pf80_tmos_route_int_t;
+int32_t sths34pf80_tmos_route_int_set(stmdev_ctx_t *ctx, sths34pf80_tmos_route_int_t val);
+int32_t sths34pf80_tmos_route_int_get(stmdev_ctx_t *ctx, sths34pf80_tmos_route_int_t *val);
+
+typedef enum
+{
+  STHS34PF80_TMOS_INT_NONE = 0x0,
+  STHS34PF80_TMOS_INT_TSHOCK = 0x1,
+  STHS34PF80_TMOS_INT_MOTION = 0x2,
+  STHS34PF80_TMOS_INT_TSHOCK_MOTION = 0x3,
+  STHS34PF80_TMOS_INT_PRESENCE = 0x4,
+  STHS34PF80_TMOS_INT_TSHOCK_PRESENCE = 0x5,
+  STHS34PF80_TMOS_INT_MOTION_PRESENCE = 0x6,
+  STHS34PF80_TMOS_INT_ALL = 0x7,
+} sths34pf80_tmos_int_or_t;
+int32_t sths34pf80_tmos_int_or_set(stmdev_ctx_t *ctx, sths34pf80_tmos_int_or_t val);
+int32_t sths34pf80_tmos_int_or_get(stmdev_ctx_t *ctx, sths34pf80_tmos_int_or_t *val);
+
+typedef struct
+{
+  enum {
+    STHS34PF80_PUSH_PULL = 0x0,
+    STHS34PF80_OPEN_DRAIN = 0x1,
+  } pin;
+
+  enum {
+    STHS34PF80_ACTIVE_HIGH = 0x0,
+    STHS34PF80_ACTIVE_LOW = 0x1,
+  } polarity;
+} sths34pf80_int_mode_t;
+int32_t sths34pf80_int_mode_set(stmdev_ctx_t *ctx, sths34pf80_int_mode_t val);
+int32_t sths34pf80_int_mode_get(stmdev_ctx_t *ctx, sths34pf80_int_mode_t *val);
+
+typedef enum {
+  STHS34PF80_DRDY_PULSED = 0x0,
+  STHS34PF80_DRDY_LATCHED = 0x1,
+} sths34pf80_drdy_mode_t;
+int32_t sths34pf80_drdy_mode_set(stmdev_ctx_t *ctx, sths34pf80_drdy_mode_t val);
+int32_t sths34pf80_drdy_mode_get(stmdev_ctx_t *ctx, sths34pf80_drdy_mode_t *val);
+
+int32_t sths34pf80_func_cfg_write(stmdev_ctx_t *ctx, uint8_t addr, uint8_t *data, uint8_t len);
+int32_t sths34pf80_func_cfg_read(stmdev_ctx_t *ctx, uint8_t addr, uint8_t *data, uint8_t len);
+
+int32_t sths34pf80_presence_threshold_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t sths34pf80_presence_threshold_get(stmdev_ctx_t *ctx, uint16_t *val);
+
+int32_t sths34pf80_motion_threshold_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t sths34pf80_motion_threshold_get(stmdev_ctx_t *ctx, uint16_t *val);
+
+int32_t sths34pf80_tambient_shock_threshold_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t sths34pf80_tambient_shock_threshold_get(stmdev_ctx_t *ctx, uint16_t *val);
+
+int32_t sths34pf80_motion_hysteresis_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t sths34pf80_motion_hysteresis_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t sths34pf80_presence_hysteresis_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t sths34pf80_presence_hysteresis_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t sths34pf80_tambient_shock_hysteresis_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t sths34pf80_tambient_shock_hysteresis_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t sths34pf80_int_or_pulsed_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t sths34pf80_int_or_pulsed_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t sths34pf80_tobject_algo_compensation_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t sths34pf80_tobject_algo_compensation_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t sths34pf80_presence_abs_value_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t sths34pf80_presence_abs_value_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t sths34pf80_algo_reset(stmdev_ctx_t *ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*STHS34PF80_DRIVER_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/


### PR DESCRIPTION
Align stmemsc HAL i/f to v2.3
Purpose is to be able to better handle ST sensor drivers in zephyr