### PR TITLE
zephyr/module.yml: enable use of kconfig-ext

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,2 +1,4 @@
+name: hal_st
 build:
   cmake: .
+  kconfig-ext: True


### PR DESCRIPTION
Change to using kconfig-ext which means we'll look in the zephyr repo for kconfig files. Change also module name to 'hal_st' for the sake of understandability.

This is required to be able to properly use hal_st module in zephyr
Please see zephyr issue https://github.com/zephyrproject-rtos/zephyr/issues/67242