### PR TITLE
zephyr/module.yaml: add ble f/w blobs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,3 +40,6 @@ endif()
 
 # STMEMSC - Hardware Abstraction Layer for ST sensor
 add_subdirectory_ifdef(CONFIG_HAS_STMEMSC sensor/stmemsc)
+
+# Add BT firmware images upgrade support
+add_subdirectory_ifdef(CONFIG_BT ble_firmware)

--- a/ble_firmware/CMakeLists.txt
+++ b/ble_firmware/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright (c) 2024 STMicroelectronics
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set(hal_dir            ${ZEPHYR_HAL_ST_MODULE_DIR})
+set(hal_blobs_dir      ${hal_dir}/zephyr/blobs/img/bluetooth/steval-mkboxpro)
+set(blob_gen_inc_file  ${ZEPHYR_BINARY_DIR}/include/generated/dtm.bin.inc)
+
+# bluenrg-lp
+set(blob_hcd_file      ${hal_blobs_dir}/dtm.bin)
+
+# generate Bluetooth include blob from .bin
+if(EXISTS ${blob_hcd_file})
+  message(INFO " generate include of blob Bluetooth file: ${blob_hcd_file}")
+
+  generate_inc_file_for_target(app ${blob_hcd_file} ${blob_gen_inc_file})
+  zephyr_library_sources(${CMAKE_CURRENT_SOURCE_DIR}/ble_fw.c)
+endif()

--- a/ble_firmware/ble_fw.c
+++ b/ble_firmware/ble_fw.c
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+
+const uint8_t ble_fw_img[] = {
+	#include <dtm.bin.inc>
+};
+
+const uint32_t ble_fw_img_len = sizeof(ble_fw_img);

--- a/zephyr/blobs/license.md
+++ b/zephyr/blobs/license.md
@@ -1,0 +1,80 @@
+SLA0044 Rev5/February 2018
+
+## Software license agreement
+
+### __ULTIMATE LIBERTY SOFTWARE LICENSE AGREEMENT__
+
+BY INSTALLING, COPYING, DOWNLOADING, ACCESSING OR OTHERWISE USING THIS SOFTWARE
+OR ANY PART THEREOF (AND THE RELATED DOCUMENTATION) FROM STMICROELECTRONICS
+INTERNATIONAL N.V, SWISS BRANCH AND/OR ITS AFFILIATED COMPANIES
+(STMICROELECTRONICS), THE RECIPIENT, ON BEHALF OF HIMSELF OR HERSELF, OR ON
+BEHALF OF ANY ENTITY BY WHICH SUCH RECIPIENT IS EMPLOYED AND/OR ENGAGED AGREES
+TO BE BOUND BY THIS SOFTWARE LICENSE AGREEMENT.
+
+Under STMicroelectronics’ intellectual property rights, the redistribution,
+reproduction and use in source and binary forms of the software or any part
+thereof, with or without modification, are permitted provided that the following
+conditions are met:
+
+1. Redistribution of source code (modified or not) must retain any copyright
+notice, this list of conditions and the disclaimer set forth below as items 10
+and 11.
+
+2. Redistributions in binary form, except as embedded into microcontroller or
+microprocessor device manufactured by or for STMicroelectronics or a software
+update for such device, must reproduce any copyright notice provided with the
+binary code, this list of conditions, and the disclaimer set forth below as
+items 10 and 11, in documentation and/or other materials provided with the
+distribution.
+
+3. Neither the name of STMicroelectronics nor the names of other contributors to
+this software may be used to endorse or promote products derived from this
+software or part thereof without specific written permission.
+
+4. This software or any part thereof, including modifications and/or derivative
+works of this software, must be used and execute solely and exclusively on or in
+combination with a microcontroller or microprocessor device manufactured by or
+for STMicroelectronics.
+
+5. No use, reproduction or redistribution of this software partially or totally
+may be done in any manner that would subject this software to any Open Source
+Terms. “Open Source Terms” shall mean any open source license which requires as
+part of distribution of software that the source code of such software is
+distributed therewith or otherwise made available, or open source license that
+substantially complies with the Open Source definition specified at
+www.opensource.org and any other comparable open source license such as for
+example GNU General Public License (GPL), Eclipse Public License (EPL), Apache
+Software License, BSD license or MIT license.
+
+6. STMicroelectronics has no obligation to provide any maintenance, support or
+updates for the software.
+
+7. The software is and will remain the exclusive property of STMicroelectronics
+and its licensors. The recipient will not take any action that jeopardizes
+STMicroelectronics and its licensors' proprietary rights or acquire any rights
+in the software, except the limited rights specified hereunder.
+
+8. The recipient shall comply with all applicable laws and regulations affecting
+the use of the software or any part thereof including any applicable export
+control law or regulation.
+
+9. Redistribution and use of this software or any part thereof other than as
+permitted under this license is void and will automatically terminate your
+rights under this license.
+
+10. THIS SOFTWARE IS PROVIDED BY STMICROELECTRONICS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS, IMPLIED OR STATUTORY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NON-INFRINGEMENT OF THIRD PARTY INTELLECTUAL PROPERTY RIGHTS, WHICH ARE
+DISCLAIMED TO THE FULLEST EXTENT PERMITTED BY LAW. IN NO EVENT SHALL
+STMICROELECTRONICS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+11. EXCEPT AS EXPRESSLY PERMITTED HEREUNDER, NO LICENSE OR OTHER RIGHTS, WHETHER
+EXPRESS OR IMPLIED, ARE GRANTED UNDER ANY PATENT OR OTHER INTELLECTUAL PROPERTY
+RIGHTS OF STMICROELECTRONICS OR ANY THIRD PARTY.

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -2,3 +2,11 @@ name: hal_st
 build:
   cmake: .
   kconfig-ext: True
+blobs:
+  - path: img/bluetooth/steval-mkboxpro/dtm.bin
+    sha256: f65b59363482a1122d4155ceb843b1fe7bb5612496f81feb50746f110fc27ebf
+    type: img
+    version: '1.0.0'
+    license-path: zephyr/blobs/license.md
+    url: https://github.com/STMicroelectronics/stsw-mkbox-bleco/raw/v1.0.0/img/steval-mkboxpro/DTM_SPI_WITH_UPDATER_CONTROLLER.bin
+    description: "controller-only BLE f/w image for the STEVAL-MKBOXPRO board"


### PR DESCRIPTION
Configure zephyr/module.yaml to allow importation of BLE controller-only firmware required to work with zephyr bluetooth stack.