### PR TITLE
Kconfig doesn't allow dashes in variable names

### DIFF
--- a/sensor/stmemsc/CMakeLists.txt
+++ b/sensor/stmemsc/CMakeLists.txt
@@ -86,7 +86,8 @@ set(stmems_pids
 
 foreach(stmems_pid ${stmems_pids})
   string(TOUPPER ${stmems_pid} pid_to_upper)
-  if(CONFIG_USE_STDC_${pid_to_upper})
+  string(REPLACE - _ pid_replace_dash_underscore ${pid_to_upper})
+  if(CONFIG_USE_STDC_${pid_replace_dash_underscore})
     zephyr_include_directories(
         ${stmems_pid}_STdC/driver/
         )

--- a/sensor/stmemsc/CMakeLists.txt
+++ b/sensor/stmemsc/CMakeLists.txt
@@ -86,7 +86,7 @@ set(stmems_pids
 
 foreach(stmems_pid ${stmems_pids})
   string(TOUPPER ${stmems_pid} pid_to_upper)
-  string(REPLACE - _ pid_replace_dash_underscore ${pid_to_upper})
+  string(REPLACE "-" "_" pid_replace_dash_underscore ${pid_to_upper})
   if(CONFIG_USE_STDC_${pid_replace_dash_underscore})
     zephyr_include_directories(
         ${stmems_pid}_STdC/driver/


### PR DESCRIPTION
Kconfig doesn't allow dashes in variable names so convert them to underscore. Affects lsm6ds3tr-c
Also the zephyr repos needs a change in modules/hal_st/Kconfig to align with the variable reference here.
I could make that change if this PR is approved.