### PR TITLE
sensor/stmemsc: Align stmemsc i/f to v2.8

### DIFF
--- a/sensor/stmemsc/CMakeLists.txt
+++ b/sensor/stmemsc/CMakeLists.txt
@@ -78,6 +78,7 @@ set(stmems_pids
   lsm6dsv32x
   lsm6dsv
   lsm9ds1
+  st1vafe3bx
   st1vafe6ax
   sths34pf80
   stts22h

--- a/sensor/stmemsc/README
+++ b/sensor/stmemsc/README
@@ -6,7 +6,7 @@ Origin:
    https://www.st.com/en/embedded-software/c-driver-mems.html
 
 Status:
-   version v2.6
+   version v2.8
 
 Purpose:
    ST Microelectronics standard C platform-independent drivers for MEMS
@@ -25,7 +25,7 @@ Description:
 
    The driver is platform-independent, you only need to define the two
    functions for read and write transactions from the sensor hardware bus
-   (ie. SPI or I2C). In addition you may define a mdelay (milliseconds) 
+   (i.e. SPI or I2C/I3C). In addition you may define a mdelay (milliseconds)
    routine.
 
    Define in your 'xyz' driver code the read and write functions that use the
@@ -55,10 +55,10 @@ Description:
      - ais2ih_STdC          v2.0.1
      - ais328dq_STdC        v2.0.1
      - ais3624dq_STdC       v2.0.1
-     - asm330lhb_STdC       v2.0.1
-     - asm330lhbg1_STdC     v1.0.0
-     - asm330lhh_STdC       v3.1.0
-     - asm330lhhx_STdC      v2.0.0
+     - asm330lhb_STdC       v2.1.0
+     - asm330lhbg1_STdC     v1.1.0
+     - asm330lhh_STdC       v3.2.0
+     - asm330lhhx_STdC      v2.1.0
      - asm330lhhxg1_STdC    v2.0.1
      - h3lis100dl_STdC      v2.0.1
      - h3lis331dl_STdC      v2.0.1
@@ -71,11 +71,11 @@ Description:
      - iis328dq_STdC        v2.0.1
      - iis3dhhc_STdC        v2.0.1
      - iis3dwb_STdC         v2.0.1
-     - ilps22qs_STdC        v3.1.0
-     - ilps28qsw_STdC       v2.1.0
+     - ilps22qs_STdC        v3.1.1
+     - ilps28qsw_STdC       v2.2.0
      - ism303dac_STdC       v2.0.1
-     - ism330bx_STdC        v3.0.0
-     - ism330dhcx_STdC      v2.0.2
+     - ism330bx_STdC        v3.0.1
+     - ism330dhcx_STdC      v2.1.0
      - ism330dlc_STdC       v2.0.1
      - ism330is_STdC        v3.0.1
      - l3gd20h_STdC         v2.0.1
@@ -85,8 +85,8 @@ Description:
      - lis2ds12_STdC        v2.0.1
      - lis2dtw12_STdC       v2.0.1
      - lis2du12_STdC        v2.0.1
-     - lis2dux12_STdC       v2.2.0
-     - lis2duxs12_STdC      v2.2.0
+     - lis2dux12_STdC       v2.3.0
+     - lis2duxs12_STdC      v2.3.0
      - lis2dw12_STdC        v2.0.1
      - lis2hh12_STdC        v2.0.1
      - lis2mdl_STdC         v2.0.1
@@ -96,13 +96,13 @@ Description:
      - lis3dhh_STdC         v2.0.1
      - lis3mdl_STdC         v2.0.1
      - lps22ch_STdC         v2.0.1
-     - lps22df_STdC         v2.1.0
+     - lps22df_STdC         v2.2.0
      - lps22hb_STdC         v2.0.1
      - lps22hh_STdC         v3.0.1
      - lps25hb_STdC         v2.0.1
      - lps27hhtw_STdC       v2.0.1
      - lps27hhw_STdC        v2.0.1
-     - lps28dfw_STdC        v2.1.0
+     - lps28dfw_STdC        v2.2.0
      - lps33k_STdC          v2.0.1
      - lsm303agr_STdC       v2.0.1
      - lsm303ah_STdC        v2.0.1
@@ -110,19 +110,20 @@ Description:
      - lsm6dsl_STdC         v2.0.1
      - lsm6dsm_STdC         v2.0.1
      - lsm6dso16is_STdC     v3.0.1
-     - lsm6dso32_STdC       v2.0.1
-     - lsm6dso32x_STdC      v2.0.1
-     - lsm6dso_STdC         v3.0.2
-     - lsm6dsox_STdC        v3.0.1
-     - lsm6dsr_STdC         v2.0.1
-     - lsm6dsrx_STdC        v2.0.1
+     - lsm6dso32_STdC       v2.1.0
+     - lsm6dso32x_STdC      v2.1.0
+     - lsm6dso_STdC         v3.1.0
+     - lsm6dsox_STdC        v3.1.0
+     - lsm6dsr_STdC         v2.1.0
+     - lsm6dsrx_STdC        v2.1.0
      - lsm6dsv16b_STdC      v3.0.0
-     - lsm6dsv16bx_STdC     v5.0.0
-     - lsm6dsv16x_STdC      v4.0.0
-     - lsm6dsv32x_STdC      v2.0.0
-     - lsm6dsv_STdC         v3.0.0
+     - lsm6dsv16bx_STdC     v5.0.1
+     - lsm6dsv16x_STdC      v4.3.0
+     - lsm6dsv32x_STdC      v2.3.0
+     - lsm6dsv_STdC         v3.3.0
      - lsm9ds1_STdC         v2.0.1
-     - st1vafe6ax_STdC      v2.0.0
+     - st1vafe3bx_STdC      v2.0.0
+     - st1vafe6ax_STdC      v2.0.1
      - sths34pf80_STdC      v3.0.1
      - stts22h_STdC         v2.1.0
      - stts751_STdC         v2.0.1
@@ -132,9 +133,10 @@ Dependencies:
 
 URL:
    https://www.st.com/en/embedded-software/c-driver-mems.html
+   https://github.com/STMicroelectronics/STMems_Standard_C_drivers/tree/v2.8
 
 commit:
-   version v2.3
+   1609395 (tag v2.8)
 
 Maintained-by:
    ST Microelectronics
@@ -144,7 +146,3 @@ License:
 
 License Link:
    https://opensource.org/licenses/BSD-3-Clause
-
-Patch List:
-   * sensor: lsm6dso: Disable -Wmaybe-uninitialized for lsm6dso_mode_set
-     - Modified sensor/stmemsc/lsm6dso_STdC/driver/lsm6dso_reg.c

--- a/sensor/stmemsc/asm330lhb_STdC/driver/asm330lhb_reg.h
+++ b/sensor/stmemsc/asm330lhb_STdC/driver/asm330lhb_reg.h
@@ -2372,7 +2372,7 @@ int32_t asm330lhb_fifo_stop_on_wtm_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum
 {
-  ASM330LHB_XL_NOT_BATCHED       =  0,
+  ASM330LHB_XL_NOT_BATCHED        =  0,
   ASM330LHB_XL_BATCHED_AT_12Hz5   =  1,
   ASM330LHB_XL_BATCHED_AT_26Hz    =  2,
   ASM330LHB_XL_BATCHED_AT_52Hz    =  3,
@@ -2399,7 +2399,7 @@ typedef enum
   ASM330LHB_GY_BATCHED_AT_417Hz    = 6,
   ASM330LHB_GY_BATCHED_AT_833Hz    = 7,
   ASM330LHB_GY_BATCHED_AT_1667Hz   = 8,
-  ASM330LHB_GY_BATCHED_AT_6Hz5    = 11,
+  ASM330LHB_GY_BATCHED_AT_6Hz5     = 11,
 } asm330lhb_bdr_gy_t;
 int32_t asm330lhb_fifo_gy_batch_set(const stmdev_ctx_t *ctx,
                                     asm330lhb_bdr_gy_t val);

--- a/sensor/stmemsc/asm330lhbg1_STdC/driver/asm330lhbg1_reg.c
+++ b/sensor/stmemsc/asm330lhbg1_STdC/driver/asm330lhbg1_reg.c
@@ -3254,6 +3254,7 @@ int32_t asm330lhbg1_pin_int1_route_set(const stmdev_ctx_t *ctx,
   {
     ret = asm330lhbg1_write_reg(ctx, ASM330LHBG1_MD1_CFG, (uint8_t *)&val->md1_cfg, 1);
   }
+
   if (ret == 0)
   {
     ret = asm330lhbg1_read_reg(ctx, ASM330LHBG1_INT_CFG1, (uint8_t *) &int_cfg1, 1);
@@ -4493,19 +4494,15 @@ int32_t asm330lhbg1_fifo_watermark_set(const stmdev_ctx_t *ctx, uint16_t val)
   asm330lhbg1_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
 
-  ret = asm330lhbg1_read_reg(ctx, ASM330LHBG1_FIFO_CTRL2,
-                             (uint8_t *)&fifo_ctrl2, 1);
+  ret = asm330lhbg1_read_reg(ctx, ASM330LHBG1_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
+  ret += asm330lhbg1_read_reg(ctx, ASM330LHBG1_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+
   if (ret == 0)
   {
+    fifo_ctrl1.wtm = (uint8_t)(val  & 0xFFU);
     fifo_ctrl2.wtm = (uint8_t)((val / 256U) & 0x01U);
-    ret = asm330lhbg1_write_reg(ctx, ASM330LHBG1_FIFO_CTRL2,
-                                (uint8_t *)&fifo_ctrl2, 1);
-  }
-  if (ret == 0)
-  {
-    fifo_ctrl1.wtm = (uint8_t)(val - (fifo_ctrl2.wtm * 256U));
-    ret = asm330lhbg1_write_reg(ctx, ASM330LHBG1_FIFO_CTRL1,
-                                (uint8_t *)&fifo_ctrl1, 1);
+    ret = asm330lhbg1_write_reg(ctx, ASM330LHBG1_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
+    ret += asm330lhbg1_write_reg(ctx, ASM330LHBG1_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
   }
 
   return ret;
@@ -5170,26 +5167,25 @@ int32_t asm330lhbg1_batch_counter_threshold_get(const stmdev_ctx_t *ctx,
   * @brief  Number of unread sensor data (TAG + 6 bytes) stored in FIFO.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of diff_fifo in reg FIFO_STATUS1
+  * @param  val    Read the value of diff_fifo in reg FIFO_STATUS1 and FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t asm330lhbg1_fifo_data_level_get(const stmdev_ctx_t *ctx, uint16_t *val)
 {
-  asm330lhbg1_fifo_status1_t fifo_status1;
-  asm330lhbg1_fifo_status2_t fifo_status2;
+  uint8_t reg[2];
+  asm330lhbg1_fifo_status1_t *fifo_status1 = (asm330lhbg1_fifo_status1_t *)&reg[0];
+  asm330lhbg1_fifo_status2_t *fifo_status2 = (asm330lhbg1_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = asm330lhbg1_read_reg(ctx, ASM330LHBG1_FIFO_STATUS1,
-                             (uint8_t *)&fifo_status1, 1);
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = asm330lhbg1_read_reg(ctx, ASM330LHBG1_FIFO_STATUS1, (uint8_t *)reg, 2);
   if (ret == 0)
   {
-    ret = asm330lhbg1_read_reg(ctx, ASM330LHBG1_FIFO_STATUS2,
-                               (uint8_t *)&fifo_status2, 1);
-
-    *val = fifo_status2.diff_fifo;
-    *val = (*val * 256U) + fifo_status1.diff_fifo;
+    *val = fifo_status2->diff_fifo;
+    *val = (*val * 256U) + fifo_status1->diff_fifo;
   }
+
   return ret;
 }
 
@@ -5197,15 +5193,24 @@ int32_t asm330lhbg1_fifo_data_level_get(const stmdev_ctx_t *ctx, uint16_t *val)
   * @brief  Smart FIFO status.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Registers FIFO_STATUS2
+  * @param  val    Read registers FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t asm330lhbg1_fifo_status_get(const stmdev_ctx_t *ctx,
                                     asm330lhbg1_fifo_status2_t *val)
 {
+  uint8_t reg[2];
+  asm330lhbg1_fifo_status2_t *fifo_status2 = (asm330lhbg1_fifo_status2_t *)&reg[1];
   int32_t ret;
-  ret = asm330lhbg1_read_reg(ctx, ASM330LHBG1_FIFO_STATUS2, (uint8_t *)val, 1);
+
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = asm330lhbg1_read_reg(ctx, ASM330LHBG1_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = *fifo_status2;
+  }
+
   return ret;
 }
 
@@ -5213,18 +5218,22 @@ int32_t asm330lhbg1_fifo_status_get(const stmdev_ctx_t *ctx,
   * @brief  Smart FIFO full status.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of fifo_full_ia in reg FIFO_STATUS2
+  * @param  val    Read the values of fifo_full_ia in reg FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t asm330lhbg1_fifo_full_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  asm330lhbg1_fifo_status2_t fifo_status2;
+  uint8_t reg[2];
+  asm330lhbg1_fifo_status2_t *fifo_status2 = (asm330lhbg1_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = asm330lhbg1_read_reg(ctx, ASM330LHBG1_FIFO_STATUS2,
-                             (uint8_t *)&fifo_status2, 1);
-  *val = fifo_status2.fifo_full_ia;
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = asm330lhbg1_read_reg(ctx, ASM330LHBG1_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_full_ia;
+  }
 
   return ret;
 }
@@ -5233,19 +5242,23 @@ int32_t asm330lhbg1_fifo_full_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @brief  FIFO overrun status.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of  fifo_over_run_latched in
+  * @param  val    Read the values of  fifo_over_run_latched in
   *                reg FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t asm330lhbg1_fifo_ovr_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  asm330lhbg1_fifo_status2_t fifo_status2;
+  uint8_t reg[2];
+  asm330lhbg1_fifo_status2_t *fifo_status2 = (asm330lhbg1_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = asm330lhbg1_read_reg(ctx, ASM330LHBG1_FIFO_STATUS2,
-                             (uint8_t *)&fifo_status2, 1);
-  *val = fifo_status2. fifo_ovr_ia;
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = asm330lhbg1_read_reg(ctx, ASM330LHBG1_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_ovr_ia;
+  }
 
   return ret;
 }
@@ -5254,18 +5267,22 @@ int32_t asm330lhbg1_fifo_ovr_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @brief  FIFO watermark status.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of fifo_wtm_ia in reg FIFO_STATUS2
+  * @param  val    Read the values of fifo_wtm_ia in reg FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t asm330lhbg1_fifo_wtm_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  asm330lhbg1_fifo_status2_t fifo_status2;
+  uint8_t reg[2];
+  asm330lhbg1_fifo_status2_t *fifo_status2 = (asm330lhbg1_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = asm330lhbg1_read_reg(ctx, ASM330LHBG1_FIFO_STATUS2,
-                             (uint8_t *)&fifo_status2, 1);
-  *val = fifo_status2.fifo_wtm_ia;
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = asm330lhbg1_read_reg(ctx, ASM330LHBG1_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_wtm_ia;
+  }
 
   return ret;
 }

--- a/sensor/stmemsc/asm330lhbg1_STdC/driver/asm330lhbg1_reg.h
+++ b/sensor/stmemsc/asm330lhbg1_STdC/driver/asm330lhbg1_reg.h
@@ -2372,7 +2372,7 @@ int32_t asm330lhbg1_fifo_stop_on_wtm_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum
 {
-  ASM330LHBG1_XL_NOT_BATCHED       =  0,
+  ASM330LHBG1_XL_NOT_BATCHED        =  0,
   ASM330LHBG1_XL_BATCHED_AT_12Hz5   =  1,
   ASM330LHBG1_XL_BATCHED_AT_26Hz    =  2,
   ASM330LHBG1_XL_BATCHED_AT_52Hz    =  3,
@@ -2399,7 +2399,7 @@ typedef enum
   ASM330LHBG1_GY_BATCHED_AT_417Hz    = 6,
   ASM330LHBG1_GY_BATCHED_AT_833Hz    = 7,
   ASM330LHBG1_GY_BATCHED_AT_1667Hz   = 8,
-  ASM330LHBG1_GY_BATCHED_AT_6Hz5    = 11,
+  ASM330LHBG1_GY_BATCHED_AT_6Hz5     = 11,
 } asm330lhbg1_bdr_gy_t;
 int32_t asm330lhbg1_fifo_gy_batch_set(const stmdev_ctx_t *ctx,
                                       asm330lhbg1_bdr_gy_t val);

--- a/sensor/stmemsc/asm330lhh_STdC/driver/asm330lhh_reg.c
+++ b/sensor/stmemsc/asm330lhh_STdC/driver/asm330lhh_reg.c
@@ -1,21 +1,21 @@
-/**
-  ******************************************************************************
-  * @file    asm330lhh_reg.c
-  * @author  Sensors Software Solution Team
-  * @brief   ASM330LHH driver file
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2021 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
-  ******************************************************************************
-  */
+/*
+ ******************************************************************************
+ * @file    asm330lhh_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   ASM330LHH driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; Copyright (c) 2023 STMicroelectronics.
+ * All rights reserved.</center></h2>
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+ */
 
 #include "asm330lhh_reg.h"
 
@@ -46,13 +46,15 @@
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t __weak asm330lhh_read_reg(const stmdev_ctx_t *ctx, uint8_t reg,
-                                  uint8_t *data,
+int32_t __weak asm330lhh_read_reg(const stmdev_ctx_t *ctx, uint8_t reg, uint8_t *data,
                                   uint16_t len)
 {
   int32_t ret;
 
-  if (ctx == NULL) return -1;
+  if (ctx == NULL)
+  {
+    return -1;
+  }
 
   ret = ctx->read_reg(ctx->handle, reg, data, len);
 
@@ -69,13 +71,15 @@ int32_t __weak asm330lhh_read_reg(const stmdev_ctx_t *ctx, uint8_t reg,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t __weak asm330lhh_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
-                                   uint8_t *data,
+int32_t __weak asm330lhh_write_reg(const stmdev_ctx_t *ctx, uint8_t reg, uint8_t *data,
                                    uint16_t len)
 {
   int32_t ret;
 
-  if (ctx == NULL) return -1;
+  if (ctx == NULL)
+  {
+    return -1;
+  }
 
   ret = ctx->write_reg(ctx->handle, reg, data, len);
 
@@ -181,16 +185,13 @@ int32_t asm330lhh_xl_full_scale_set(const stmdev_ctx_t *ctx,
   asm330lhh_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL1_XL,
-                           (uint8_t *)&ctrl1_xl, 1);
-
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL1_XL, (uint8_t *)&ctrl1_xl, 1);
   if (ret == 0)
   {
     ctrl1_xl.fs_xl = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL1_XL,
                               (uint8_t *)&ctrl1_xl, 1);
   }
-
   return ret;
 }
 
@@ -208,32 +209,25 @@ int32_t asm330lhh_xl_full_scale_get(const stmdev_ctx_t *ctx,
   asm330lhh_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL1_XL,
-                           (uint8_t *)&ctrl1_xl, 1);
-
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL1_XL, (uint8_t *)&ctrl1_xl, 1);
   switch (ctrl1_xl.fs_xl)
   {
     case ASM330LHH_2g:
       *val = ASM330LHH_2g;
       break;
-
     case ASM330LHH_16g:
       *val = ASM330LHH_16g;
       break;
-
     case ASM330LHH_4g:
       *val = ASM330LHH_4g;
       break;
-
     case ASM330LHH_8g:
       *val = ASM330LHH_8g;
       break;
-
     default:
       *val = ASM330LHH_2g;
       break;
   }
-
   return ret;
 }
 
@@ -248,19 +242,20 @@ int32_t asm330lhh_xl_full_scale_get(const stmdev_ctx_t *ctx,
 int32_t asm330lhh_xl_data_rate_set(const stmdev_ctx_t *ctx,
                                    asm330lhh_odr_xl_t val)
 {
+  asm330lhh_odr_xl_t odr_xl =  val;
   asm330lhh_ctrl1_xl_t ctrl1_xl;
-  int32_t ret;
-
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL1_XL,
-                           (uint8_t *)&ctrl1_xl, 1);
+  int32_t ret = 0;
 
   if (ret == 0)
   {
-    ctrl1_xl.odr_xl = (uint8_t)val;
+    ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL1_XL, (uint8_t *)&ctrl1_xl, 1);
+  }
+  if (ret == 0)
+  {
+    ctrl1_xl.odr_xl = (uint8_t)odr_xl;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL1_XL,
                               (uint8_t *)&ctrl1_xl, 1);
   }
-
   return ret;
 }
 
@@ -278,60 +273,46 @@ int32_t asm330lhh_xl_data_rate_get(const stmdev_ctx_t *ctx,
   asm330lhh_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL1_XL,
-                           (uint8_t *)&ctrl1_xl, 1);
-
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL1_XL, (uint8_t *)&ctrl1_xl, 1);
   switch (ctrl1_xl.odr_xl)
   {
     case ASM330LHH_XL_ODR_OFF:
       *val = ASM330LHH_XL_ODR_OFF;
       break;
-
     case ASM330LHH_XL_ODR_12Hz5:
       *val = ASM330LHH_XL_ODR_12Hz5;
       break;
-
     case ASM330LHH_XL_ODR_26Hz:
       *val = ASM330LHH_XL_ODR_26Hz;
       break;
-
     case ASM330LHH_XL_ODR_52Hz:
       *val = ASM330LHH_XL_ODR_52Hz;
       break;
-
     case ASM330LHH_XL_ODR_104Hz:
       *val = ASM330LHH_XL_ODR_104Hz;
       break;
-
     case ASM330LHH_XL_ODR_208Hz:
       *val = ASM330LHH_XL_ODR_208Hz;
       break;
-
     case ASM330LHH_XL_ODR_417Hz:
       *val = ASM330LHH_XL_ODR_417Hz;
       break;
-
     case ASM330LHH_XL_ODR_833Hz:
       *val = ASM330LHH_XL_ODR_833Hz;
       break;
-
     case ASM330LHH_XL_ODR_1667Hz:
       *val = ASM330LHH_XL_ODR_1667Hz;
       break;
-
     case ASM330LHH_XL_ODR_3333Hz:
       *val = ASM330LHH_XL_ODR_3333Hz;
       break;
-
     case ASM330LHH_XL_ODR_6667Hz:
       *val = ASM330LHH_XL_ODR_6667Hz;
       break;
-
     default:
       *val = ASM330LHH_XL_ODR_OFF;
       break;
   }
-
   return ret;
 }
 
@@ -350,13 +331,11 @@ int32_t asm330lhh_gy_full_scale_set(const stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL2_G, (uint8_t *)&ctrl2_g, 1);
-
   if (ret == 0)
   {
     ctrl2_g.fs_g = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL2_G, (uint8_t *)&ctrl2_g, 1);
   }
-
   return ret;
 }
 
@@ -375,38 +354,30 @@ int32_t asm330lhh_gy_full_scale_get(const stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL2_G, (uint8_t *)&ctrl2_g, 1);
-
   switch (ctrl2_g.fs_g)
   {
     case ASM330LHH_125dps:
       *val = ASM330LHH_125dps;
       break;
-
     case ASM330LHH_250dps:
       *val = ASM330LHH_250dps;
       break;
-
     case ASM330LHH_500dps:
       *val = ASM330LHH_500dps;
       break;
-
     case ASM330LHH_1000dps:
       *val = ASM330LHH_1000dps;
       break;
-
     case ASM330LHH_2000dps:
       *val = ASM330LHH_2000dps;
       break;
-
     case ASM330LHH_4000dps:
       *val = ASM330LHH_4000dps;
       break;
-
     default:
       *val = ASM330LHH_125dps;
       break;
   }
-
   return ret;
 }
 
@@ -421,17 +392,19 @@ int32_t asm330lhh_gy_full_scale_get(const stmdev_ctx_t *ctx,
 int32_t asm330lhh_gy_data_rate_set(const stmdev_ctx_t *ctx,
                                    asm330lhh_odr_g_t val)
 {
+  asm330lhh_odr_g_t odr_gy =  val;
   asm330lhh_ctrl2_g_t ctrl2_g;
-  int32_t ret;
-
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL2_G, (uint8_t *)&ctrl2_g, 1);
+  int32_t ret = 0;
 
   if (ret == 0)
   {
-    ctrl2_g.odr_g = (uint8_t)val;
+    ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL2_G, (uint8_t *)&ctrl2_g, 1);
+  }
+  if (ret == 0)
+  {
+    ctrl2_g.odr_g = (uint8_t)odr_gy;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL2_G, (uint8_t *)&ctrl2_g, 1);
   }
-
   return ret;
 }
 
@@ -450,58 +423,45 @@ int32_t asm330lhh_gy_data_rate_get(const stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL2_G, (uint8_t *)&ctrl2_g, 1);
-
   switch (ctrl2_g.odr_g)
   {
     case ASM330LHH_GY_ODR_OFF:
       *val = ASM330LHH_GY_ODR_OFF;
       break;
-
     case ASM330LHH_GY_ODR_12Hz5:
       *val = ASM330LHH_GY_ODR_12Hz5;
       break;
-
     case ASM330LHH_GY_ODR_26Hz:
       *val = ASM330LHH_GY_ODR_26Hz;
       break;
-
     case ASM330LHH_GY_ODR_52Hz:
       *val = ASM330LHH_GY_ODR_52Hz;
       break;
-
     case ASM330LHH_GY_ODR_104Hz:
       *val = ASM330LHH_GY_ODR_104Hz;
       break;
-
     case ASM330LHH_GY_ODR_208Hz:
       *val = ASM330LHH_GY_ODR_208Hz;
       break;
-
     case ASM330LHH_GY_ODR_417Hz:
       *val = ASM330LHH_GY_ODR_417Hz;
       break;
-
     case ASM330LHH_GY_ODR_833Hz:
       *val = ASM330LHH_GY_ODR_833Hz;
       break;
-
     case ASM330LHH_GY_ODR_1667Hz:
       *val = ASM330LHH_GY_ODR_1667Hz;
       break;
-
     case ASM330LHH_GY_ODR_3333Hz:
       *val = ASM330LHH_GY_ODR_3333Hz;
       break;
-
     case ASM330LHH_GY_ODR_6667Hz:
       *val = ASM330LHH_GY_ODR_6667Hz;
       break;
-
     default:
       *val = ASM330LHH_GY_ODR_OFF;
       break;
   }
-
   return ret;
 }
 
@@ -513,20 +473,17 @@ int32_t asm330lhh_gy_data_rate_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_block_data_update_set(const stmdev_ctx_t *ctx,
-                                        uint8_t val)
+int32_t asm330lhh_block_data_update_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_ctrl3_c_t ctrl3_c;
   int32_t ret;
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
-
   if (ret == 0)
   {
     ctrl3_c.bdu = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
   }
-
   return ret;
 }
 
@@ -538,8 +495,7 @@ int32_t asm330lhh_block_data_update_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_block_data_update_get(const stmdev_ctx_t *ctx,
-                                        uint8_t *val)
+int32_t asm330lhh_block_data_update_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -566,13 +522,11 @@ int32_t asm330lhh_xl_offset_weight_set(const stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
-
   if (ret == 0)
   {
     ctrl6_c.usr_off_w = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
   }
-
   return ret;
 }
 
@@ -598,16 +552,13 @@ int32_t asm330lhh_xl_offset_weight_get(const stmdev_ctx_t *ctx,
     case ASM330LHH_LSb_1mg:
       *val = ASM330LHH_LSb_1mg;
       break;
-
     case ASM330LHH_LSb_16mg:
       *val = ASM330LHH_LSb_16mg;
       break;
-
     default:
       *val = ASM330LHH_LSb_1mg;
       break;
   }
-
   return ret;
 }
 
@@ -616,7 +567,7 @@ int32_t asm330lhh_xl_offset_weight_get(const stmdev_ctx_t *ctx,
   *[get]
   * @param  ctx    Read / write interface definitions.(ptr)
   * @param  val    Get registers ALL_INT_SRC; WAKE_UP_SRC;
-  *                              D6D_SRC; STATUS_REG;
+  *                              TAP_SRC; D6D_SRC; STATUS_REG;
   *                              EMB_FUNC_STATUS; FSM_STATUS_A/B
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
@@ -628,19 +579,16 @@ int32_t asm330lhh_all_sources_get(const stmdev_ctx_t *ctx,
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_ALL_INT_SRC,
                            (uint8_t *)&val->all_int_src, 1);
-
   if (ret == 0)
   {
     ret = asm330lhh_read_reg(ctx, ASM330LHH_WAKE_UP_SRC,
                              (uint8_t *)&val->wake_up_src, 1);
   }
-
   if (ret == 0)
   {
     ret = asm330lhh_read_reg(ctx, ASM330LHH_D6D_SRC,
                              (uint8_t *)&val->d6d_src, 1);
   }
-
   if (ret == 0)
   {
     ret = asm330lhh_read_reg(ctx, ASM330LHH_STATUS_REG,
@@ -662,9 +610,7 @@ int32_t asm330lhh_status_reg_get(const stmdev_ctx_t *ctx,
                                  asm330lhh_status_reg_t *val)
 {
   int32_t ret;
-
   ret = asm330lhh_read_reg(ctx, ASM330LHH_STATUS_REG, (uint8_t *) val, 1);
-
   return ret;
 }
 
@@ -672,12 +618,11 @@ int32_t asm330lhh_status_reg_get(const stmdev_ctx_t *ctx,
   * @brief  Accelerometer new data available.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of xlda in reg STATUS_REG
+  * @param  val    Get the values of xlda in reg STATUS_REG
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_flag_data_ready_get(const stmdev_ctx_t *ctx,
-                                         uint8_t *val)
+int32_t asm330lhh_xl_flag_data_ready_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_status_reg_t status_reg;
   int32_t ret;
@@ -693,12 +638,11 @@ int32_t asm330lhh_xl_flag_data_ready_get(const stmdev_ctx_t *ctx,
   * @brief  Gyroscope new data available.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of gda in reg STATUS_REG
+  * @param  val    Get the values of gda in reg STATUS_REG
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_gy_flag_data_ready_get(const stmdev_ctx_t *ctx,
-                                         uint8_t *val)
+int32_t asm330lhh_gy_flag_data_ready_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_status_reg_t status_reg;
   int32_t ret;
@@ -714,12 +658,11 @@ int32_t asm330lhh_gy_flag_data_ready_get(const stmdev_ctx_t *ctx,
   * @brief  Temperature new data available.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of tda in reg STATUS_REG
+  * @param  val    Get the values of tda in reg STATUS_REG
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_temp_flag_data_ready_get(const stmdev_ctx_t *ctx,
-                                           uint8_t *val)
+int32_t asm330lhh_temp_flag_data_ready_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_status_reg_t status_reg;
   int32_t ret;
@@ -741,13 +684,10 @@ int32_t asm330lhh_temp_flag_data_ready_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_usr_offset_x_set(const stmdev_ctx_t *ctx,
-                                      uint8_t *buff)
+int32_t asm330lhh_xl_usr_offset_x_set(const stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
-
   ret = asm330lhh_write_reg(ctx, ASM330LHH_X_OFS_USR, buff, 1);
-
   return ret;
 }
 
@@ -761,13 +701,10 @@ int32_t asm330lhh_xl_usr_offset_x_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_usr_offset_x_get(const stmdev_ctx_t *ctx,
-                                      uint8_t *buff)
+int32_t asm330lhh_xl_usr_offset_x_get(const stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
-
   ret = asm330lhh_read_reg(ctx, ASM330LHH_X_OFS_USR, buff, 1);
-
   return ret;
 }
 
@@ -781,13 +718,10 @@ int32_t asm330lhh_xl_usr_offset_x_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_usr_offset_y_set(const stmdev_ctx_t *ctx,
-                                      uint8_t *buff)
+int32_t asm330lhh_xl_usr_offset_y_set(const stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
-
   ret = asm330lhh_write_reg(ctx, ASM330LHH_Y_OFS_USR, buff, 1);
-
   return ret;
 }
 
@@ -801,13 +735,10 @@ int32_t asm330lhh_xl_usr_offset_y_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_usr_offset_y_get(const stmdev_ctx_t *ctx,
-                                      uint8_t *buff)
+int32_t asm330lhh_xl_usr_offset_y_get(const stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
-
   ret = asm330lhh_read_reg(ctx, ASM330LHH_Y_OFS_USR, buff, 1);
-
   return ret;
 }
 
@@ -821,13 +752,10 @@ int32_t asm330lhh_xl_usr_offset_y_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_usr_offset_z_set(const stmdev_ctx_t *ctx,
-                                      uint8_t *buff)
+int32_t asm330lhh_xl_usr_offset_z_set(const stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
-
   ret = asm330lhh_write_reg(ctx, ASM330LHH_Z_OFS_USR, buff, 1);
-
   return ret;
 }
 
@@ -841,13 +769,10 @@ int32_t asm330lhh_xl_usr_offset_z_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_usr_offset_z_get(const stmdev_ctx_t *ctx,
-                                      uint8_t *buff)
+int32_t asm330lhh_xl_usr_offset_z_get(const stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
-
   ret = asm330lhh_read_reg(ctx, ASM330LHH_Z_OFS_USR, buff, 1);
-
   return ret;
 }
 
@@ -865,13 +790,11 @@ int32_t asm330lhh_xl_usr_offset_set(const stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
-
   if (ret == 0)
   {
     ctrl7_g.usr_off_on_out = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
   }
-
   return ret;
 }
 
@@ -917,6 +840,7 @@ int32_t asm330lhh_xl_usr_offset_get(const stmdev_ctx_t *ctx, uint8_t *val)
 int32_t asm330lhh_timestamp_rst(const stmdev_ctx_t *ctx)
 {
   uint8_t rst_val = 0xAA;
+
   return asm330lhh_write_reg(ctx, ASM330LHH_TIMESTAMP2, &rst_val, 1);
 }
 
@@ -933,16 +857,13 @@ int32_t asm330lhh_timestamp_set(const stmdev_ctx_t *ctx, uint8_t val)
   asm330lhh_ctrl10_c_t ctrl10_c;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL10_C,
-                           (uint8_t *)&ctrl10_c, 1);
-
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL10_C, (uint8_t *)&ctrl10_c, 1);
   if (ret == 0)
   {
     ctrl10_c.timestamp_en = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL10_C,
                               (uint8_t *)&ctrl10_c, 1);
   }
-
   return ret;
 }
 
@@ -959,8 +880,7 @@ int32_t asm330lhh_timestamp_get(const stmdev_ctx_t *ctx, uint8_t *val)
   asm330lhh_ctrl10_c_t ctrl10_c;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL10_C,
-                           (uint8_t *)&ctrl10_c, 1);
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL10_C, (uint8_t *)&ctrl10_c, 1);
   *val = ctrl10_c.timestamp_en;
 
   return ret;
@@ -1017,13 +937,11 @@ int32_t asm330lhh_rounding_mode_set(const stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL5_C, (uint8_t *)&ctrl5_c, 1);
-
   if (ret == 0)
   {
     ctrl5_c.rounding = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL5_C, (uint8_t *)&ctrl5_c, 1);
   }
-
   return ret;
 }
 
@@ -1042,30 +960,24 @@ int32_t asm330lhh_rounding_mode_get(const stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL5_C, (uint8_t *)&ctrl5_c, 1);
-
   switch (ctrl5_c.rounding)
   {
     case ASM330LHH_NO_ROUND:
       *val = ASM330LHH_NO_ROUND;
       break;
-
     case ASM330LHH_ROUND_XL:
       *val = ASM330LHH_ROUND_XL;
       break;
-
     case ASM330LHH_ROUND_GY:
       *val = ASM330LHH_ROUND_GY;
       break;
-
     case ASM330LHH_ROUND_GY_XL:
       *val = ASM330LHH_ROUND_GY_XL;
       break;
-
     default:
       *val = ASM330LHH_NO_ROUND;
       break;
   }
-
   return ret;
 }
 
@@ -1100,13 +1012,12 @@ int32_t asm330lhh_temperature_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_angular_rate_raw_get(const stmdev_ctx_t *ctx,
-                                       int16_t *val)
+int32_t asm330lhh_angular_rate_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
 {
   uint8_t buff[6];
   int32_t ret;
-
   ret = asm330lhh_read_reg(ctx, ASM330LHH_OUTX_L_G, buff, 6);
+
   val[0] = (int16_t)buff[1];
   val[0] = (val[0] * 256) + (int16_t)buff[0];
   val[1] = (int16_t)buff[3];
@@ -1126,13 +1037,12 @@ int32_t asm330lhh_angular_rate_raw_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_acceleration_raw_get(const stmdev_ctx_t *ctx,
-                                       int16_t *val)
+int32_t asm330lhh_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
 {
   uint8_t buff[6];
   int32_t ret;
-
   ret = asm330lhh_read_reg(ctx, ASM330LHH_OUTX_L_A, buff, 6);
+
   val[0] = (int16_t)buff[1];
   val[0] = (val[0] * 256) + (int16_t)buff[0];
   val[1] = (int16_t)buff[3];
@@ -1154,9 +1064,7 @@ int32_t asm330lhh_acceleration_raw_get(const stmdev_ctx_t *ctx,
 int32_t asm330lhh_fifo_out_raw_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   int32_t ret;
-
   ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_DATA_OUT_X_L, val, 6);
-
   return ret;
 }
 
@@ -1235,14 +1143,12 @@ int32_t asm330lhh_odr_cal_reg_set(const stmdev_ctx_t *ctx, uint8_t val)
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_INTERNAL_FREQ_FINE,
                            (uint8_t *)&internal_freq_fine, 1);
-
   if (ret == 0)
   {
     internal_freq_fine.freq_fine = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_INTERNAL_FREQ_FINE,
                               (uint8_t *)&internal_freq_fine, 1);
   }
-
   return ret;
 }
 
@@ -1285,14 +1191,12 @@ int32_t asm330lhh_data_ready_mode_set(const stmdev_ctx_t *ctx,
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_COUNTER_BDR_REG1,
                            (uint8_t *)&counter_bdr_reg1, 1);
-
   if (ret == 0)
   {
     counter_bdr_reg1.dataready_pulsed = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_COUNTER_BDR_REG1,
                               (uint8_t *)&counter_bdr_reg1, 1);
   }
-
   return ret;
 }
 
@@ -1313,22 +1217,18 @@ int32_t asm330lhh_data_ready_mode_get(const stmdev_ctx_t *ctx,
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_COUNTER_BDR_REG1,
                            (uint8_t *)&counter_bdr_reg1, 1);
-
   switch (counter_bdr_reg1.dataready_pulsed)
   {
     case ASM330LHH_DRDY_LATCHED:
       *val = ASM330LHH_DRDY_LATCHED;
       break;
-
     case ASM330LHH_DRDY_PULSED:
       *val = ASM330LHH_DRDY_PULSED;
       break;
-
     default:
       *val = ASM330LHH_DRDY_LATCHED;
       break;
   }
-
   return ret;
 }
 
@@ -1343,9 +1243,7 @@ int32_t asm330lhh_data_ready_mode_get(const stmdev_ctx_t *ctx,
 int32_t asm330lhh_device_id_get(const stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
-
   ret = asm330lhh_read_reg(ctx, ASM330LHH_WHO_AM_I, buff, 1);
-
   return ret;
 }
 
@@ -1363,13 +1261,11 @@ int32_t asm330lhh_reset_set(const stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
-
   if (ret == 0)
   {
     ctrl3_c.sw_reset = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
   }
-
   return ret;
 }
 
@@ -1407,13 +1303,11 @@ int32_t asm330lhh_auto_increment_set(const stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
-
   if (ret == 0)
   {
     ctrl3_c.if_inc = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
   }
-
   return ret;
 }
 
@@ -1451,13 +1345,11 @@ int32_t asm330lhh_boot_set(const stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
-
   if (ret == 0)
   {
     ctrl3_c.boot = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
   }
-
   return ret;
 }
 
@@ -1497,13 +1389,11 @@ int32_t asm330lhh_xl_self_test_set(const stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL5_C, (uint8_t *)&ctrl5_c, 1);
-
   if (ret == 0)
   {
     ctrl5_c.st_xl = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL5_C, (uint8_t *)&ctrl5_c, 1);
   }
-
   return ret;
 }
 
@@ -1528,20 +1418,16 @@ int32_t asm330lhh_xl_self_test_get(const stmdev_ctx_t *ctx,
     case ASM330LHH_XL_ST_DISABLE:
       *val = ASM330LHH_XL_ST_DISABLE;
       break;
-
     case ASM330LHH_XL_ST_POSITIVE:
       *val = ASM330LHH_XL_ST_POSITIVE;
       break;
-
     case ASM330LHH_XL_ST_NEGATIVE:
       *val = ASM330LHH_XL_ST_NEGATIVE;
       break;
-
     default:
       *val = ASM330LHH_XL_ST_DISABLE;
       break;
   }
-
   return ret;
 }
 
@@ -1560,13 +1446,11 @@ int32_t asm330lhh_gy_self_test_set(const stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL5_C, (uint8_t *)&ctrl5_c, 1);
-
   if (ret == 0)
   {
     ctrl5_c.st_g = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL5_C, (uint8_t *)&ctrl5_c, 1);
   }
-
   return ret;
 }
 
@@ -1591,20 +1475,16 @@ int32_t asm330lhh_gy_self_test_get(const stmdev_ctx_t *ctx,
     case ASM330LHH_GY_ST_DISABLE:
       *val = ASM330LHH_GY_ST_DISABLE;
       break;
-
     case ASM330LHH_GY_ST_POSITIVE:
       *val = ASM330LHH_GY_ST_POSITIVE;
       break;
-
     case ASM330LHH_GY_ST_NEGATIVE:
       *val = ASM330LHH_GY_ST_NEGATIVE;
       break;
-
     default:
       *val = ASM330LHH_GY_ST_DISABLE;
       break;
   }
-
   return ret;
 }
 
@@ -1634,16 +1514,13 @@ int32_t asm330lhh_xl_filter_lp2_set(const stmdev_ctx_t *ctx, uint8_t val)
   asm330lhh_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL1_XL,
-                           (uint8_t *)&ctrl1_xl, 1);
-
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL1_XL, (uint8_t *)&ctrl1_xl, 1);
   if (ret == 0)
   {
     ctrl1_xl.lpf2_xl_en = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL1_XL,
                               (uint8_t *)&ctrl1_xl, 1);
   }
-
   return ret;
 }
 
@@ -1660,8 +1537,7 @@ int32_t asm330lhh_xl_filter_lp2_get(const stmdev_ctx_t *ctx, uint8_t *val)
   asm330lhh_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL1_XL,
-                           (uint8_t *)&ctrl1_xl, 1);
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL1_XL, (uint8_t *)&ctrl1_xl, 1);
   *val = ctrl1_xl.lpf2_xl_en;
 
   return ret;
@@ -1682,13 +1558,11 @@ int32_t asm330lhh_gy_filter_lp1_set(const stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
-
   if (ret == 0)
   {
     ctrl4_c.lpf1_sel_g = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
   }
-
   return ret;
 }
 
@@ -1721,20 +1595,17 @@ int32_t asm330lhh_gy_filter_lp1_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_filter_settling_mask_set(const stmdev_ctx_t *ctx,
-                                           uint8_t val)
+int32_t asm330lhh_filter_settling_mask_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_ctrl4_c_t ctrl4_c;
   int32_t ret;
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
-
   if (ret == 0)
   {
     ctrl4_c.drdy_mask = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
   }
-
   return ret;
 }
 
@@ -1774,13 +1645,11 @@ int32_t asm330lhh_gy_lp1_bandwidth_set(const stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
-
   if (ret == 0)
   {
     ctrl6_c.ftype = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
   }
-
   return ret;
 }
 
@@ -1805,40 +1674,31 @@ int32_t asm330lhh_gy_lp1_bandwidth_get(const stmdev_ctx_t *ctx,
     case ASM330LHH_ULTRA_LIGHT:
       *val = ASM330LHH_ULTRA_LIGHT;
       break;
-
     case ASM330LHH_VERY_LIGHT:
       *val = ASM330LHH_VERY_LIGHT;
       break;
-
     case ASM330LHH_LIGHT:
       *val = ASM330LHH_LIGHT;
       break;
-
     case ASM330LHH_MEDIUM:
       *val = ASM330LHH_MEDIUM;
       break;
-
     case ASM330LHH_STRONG:
       *val = ASM330LHH_STRONG;
       break;
-
     case ASM330LHH_VERY_STRONG:
       *val = ASM330LHH_VERY_STRONG;
       break;
-
     case ASM330LHH_AGGRESSIVE:
       *val = ASM330LHH_AGGRESSIVE;
       break;
-
     case ASM330LHH_XTREME:
       *val = ASM330LHH_XTREME;
       break;
-
     default:
       *val = ASM330LHH_ULTRA_LIGHT;
       break;
   }
-
   return ret;
 }
 
@@ -1855,16 +1715,13 @@ int32_t asm330lhh_xl_lp2_on_6d_set(const stmdev_ctx_t *ctx, uint8_t val)
   asm330lhh_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL8_XL,
-                           (uint8_t *)&ctrl8_xl, 1);
-
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL8_XL, (uint8_t *)&ctrl8_xl, 1);
   if (ret == 0)
   {
     ctrl8_xl.low_pass_on_6d = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL8_XL,
                               (uint8_t *)&ctrl8_xl, 1);
   }
-
   return ret;
 }
 
@@ -1881,8 +1738,7 @@ int32_t asm330lhh_xl_lp2_on_6d_get(const stmdev_ctx_t *ctx, uint8_t *val)
   asm330lhh_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL8_XL,
-                           (uint8_t *)&ctrl8_xl, 1);
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL8_XL, (uint8_t *)&ctrl8_xl, 1);
   *val = ctrl8_xl.low_pass_on_6d;
 
   return ret;
@@ -1903,9 +1759,7 @@ int32_t asm330lhh_xl_hp_path_on_out_set(const stmdev_ctx_t *ctx,
   asm330lhh_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL8_XL,
-                           (uint8_t *)&ctrl8_xl, 1);
-
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL8_XL, (uint8_t *)&ctrl8_xl, 1);
   if (ret == 0)
   {
     ctrl8_xl.hp_slope_xl_en = (((uint8_t)val & 0x10U) >> 4);
@@ -1914,7 +1768,6 @@ int32_t asm330lhh_xl_hp_path_on_out_set(const stmdev_ctx_t *ctx,
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL8_XL,
                               (uint8_t *)&ctrl8_xl, 1);
   }
-
   return ret;
 }
 
@@ -1933,110 +1786,83 @@ int32_t asm330lhh_xl_hp_path_on_out_get(const stmdev_ctx_t *ctx,
   asm330lhh_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL8_XL,
-                           (uint8_t *)&ctrl8_xl, 1);
-
-  switch (((ctrl8_xl.hp_ref_mode_xl << 5) + (ctrl8_xl.hp_slope_xl_en <<
-                                             4) +
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL8_XL, (uint8_t *)&ctrl8_xl, 1);
+  switch (((ctrl8_xl.hp_ref_mode_xl << 5) + (ctrl8_xl.hp_slope_xl_en << 4) +
            ctrl8_xl.hpcf_xl))
   {
     case ASM330LHH_HP_PATH_DISABLE_ON_OUT:
       *val = ASM330LHH_HP_PATH_DISABLE_ON_OUT;
       break;
-
     case ASM330LHH_SLOPE_ODR_DIV_4:
       *val = ASM330LHH_SLOPE_ODR_DIV_4;
       break;
-
     case ASM330LHH_HP_ODR_DIV_10:
       *val = ASM330LHH_HP_ODR_DIV_10;
       break;
-
     case ASM330LHH_HP_ODR_DIV_20:
       *val = ASM330LHH_HP_ODR_DIV_20;
       break;
-
     case ASM330LHH_HP_ODR_DIV_45:
       *val = ASM330LHH_HP_ODR_DIV_45;
       break;
-
     case ASM330LHH_HP_ODR_DIV_100:
       *val = ASM330LHH_HP_ODR_DIV_100;
       break;
-
     case ASM330LHH_HP_ODR_DIV_200:
       *val = ASM330LHH_HP_ODR_DIV_200;
       break;
-
     case ASM330LHH_HP_ODR_DIV_400:
       *val = ASM330LHH_HP_ODR_DIV_400;
       break;
-
     case ASM330LHH_HP_ODR_DIV_800:
       *val = ASM330LHH_HP_ODR_DIV_800;
       break;
-
     case ASM330LHH_HP_REF_MD_ODR_DIV_10:
       *val = ASM330LHH_HP_REF_MD_ODR_DIV_10;
       break;
-
     case ASM330LHH_HP_REF_MD_ODR_DIV_20:
       *val = ASM330LHH_HP_REF_MD_ODR_DIV_20;
       break;
-
     case ASM330LHH_HP_REF_MD_ODR_DIV_45:
       *val = ASM330LHH_HP_REF_MD_ODR_DIV_45;
       break;
-
     case ASM330LHH_HP_REF_MD_ODR_DIV_100:
       *val = ASM330LHH_HP_REF_MD_ODR_DIV_100;
       break;
-
     case ASM330LHH_HP_REF_MD_ODR_DIV_200:
       *val = ASM330LHH_HP_REF_MD_ODR_DIV_200;
       break;
-
     case ASM330LHH_HP_REF_MD_ODR_DIV_400:
       *val = ASM330LHH_HP_REF_MD_ODR_DIV_400;
       break;
-
     case ASM330LHH_HP_REF_MD_ODR_DIV_800:
       *val = ASM330LHH_HP_REF_MD_ODR_DIV_800;
       break;
-
     case ASM330LHH_LP_ODR_DIV_10:
       *val = ASM330LHH_LP_ODR_DIV_10;
       break;
-
     case ASM330LHH_LP_ODR_DIV_20:
       *val = ASM330LHH_LP_ODR_DIV_20;
       break;
-
     case ASM330LHH_LP_ODR_DIV_45:
       *val = ASM330LHH_LP_ODR_DIV_45;
       break;
-
     case ASM330LHH_LP_ODR_DIV_100:
       *val = ASM330LHH_LP_ODR_DIV_100;
       break;
-
     case ASM330LHH_LP_ODR_DIV_200:
       *val = ASM330LHH_LP_ODR_DIV_200;
       break;
-
     case ASM330LHH_LP_ODR_DIV_400:
       *val = ASM330LHH_LP_ODR_DIV_400;
       break;
-
     case ASM330LHH_LP_ODR_DIV_800:
       *val = ASM330LHH_LP_ODR_DIV_800;
       break;
-
     default:
       *val = ASM330LHH_HP_PATH_DISABLE_ON_OUT;
       break;
   }
-
   return ret;
 }
 
@@ -2055,16 +1881,13 @@ int32_t asm330lhh_xl_fast_settling_set(const stmdev_ctx_t *ctx, uint8_t val)
   asm330lhh_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL8_XL,
-                           (uint8_t *)&ctrl8_xl, 1);
-
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL8_XL, (uint8_t *)&ctrl8_xl, 1);
   if (ret == 0)
   {
     ctrl8_xl.fastsettl_mode_xl = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL8_XL,
                               (uint8_t *)&ctrl8_xl, 1);
   }
-
   return ret;
 }
 
@@ -2078,14 +1901,12 @@ int32_t asm330lhh_xl_fast_settling_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_fast_settling_get(const stmdev_ctx_t *ctx,
-                                       uint8_t *val)
+int32_t asm330lhh_xl_fast_settling_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL8_XL,
-                           (uint8_t *)&ctrl8_xl, 1);
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL8_XL, (uint8_t *)&ctrl8_xl, 1);
   *val = ctrl8_xl.fastsettl_mode_xl;
 
   return ret;
@@ -2106,16 +1927,13 @@ int32_t asm330lhh_xl_hp_path_internal_set(const stmdev_ctx_t *ctx,
   asm330lhh_int_cfg0_t int_cfg0;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG0,
-                           (uint8_t *)&int_cfg0, 1);
-
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG0, (uint8_t *)&int_cfg0, 1);
   if (ret == 0)
   {
     int_cfg0.slope_fds = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_INT_CFG0,
                               (uint8_t *)&int_cfg0, 1);
   }
-
   return ret;
 }
 
@@ -2134,24 +1952,19 @@ int32_t asm330lhh_xl_hp_path_internal_get(const stmdev_ctx_t *ctx,
   asm330lhh_int_cfg0_t int_cfg0;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG0,
-                           (uint8_t *)&int_cfg0, 1);
-
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG0, (uint8_t *)&int_cfg0, 1);
   switch (int_cfg0.slope_fds)
   {
     case ASM330LHH_USE_SLOPE:
       *val = ASM330LHH_USE_SLOPE;
       break;
-
     case ASM330LHH_USE_HPF:
       *val = ASM330LHH_USE_HPF;
       break;
-
     default:
       *val = ASM330LHH_USE_SLOPE;
       break;
   }
-
   return ret;
 }
 
@@ -2171,14 +1984,12 @@ int32_t asm330lhh_gy_hp_path_internal_set(const stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
-
   if (ret == 0)
   {
     ctrl7_g.hp_en_g = (((uint8_t)val & 0x80U) >> 7);
     ctrl7_g.hpm_g = (uint8_t)val & 0x03U;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
   }
-
   return ret;
 }
 
@@ -2204,28 +2015,22 @@ int32_t asm330lhh_gy_hp_path_internal_get(const stmdev_ctx_t *ctx,
     case ASM330LHH_HP_FILTER_NONE:
       *val = ASM330LHH_HP_FILTER_NONE;
       break;
-
     case ASM330LHH_HP_FILTER_16mHz:
       *val = ASM330LHH_HP_FILTER_16mHz;
       break;
-
     case ASM330LHH_HP_FILTER_65mHz:
       *val = ASM330LHH_HP_FILTER_65mHz;
       break;
-
     case ASM330LHH_HP_FILTER_260mHz:
       *val = ASM330LHH_HP_FILTER_260mHz;
       break;
-
     case ASM330LHH_HP_FILTER_1Hz04:
       *val = ASM330LHH_HP_FILTER_1Hz04;
       break;
-
     default:
       *val = ASM330LHH_HP_FILTER_NONE;
       break;
   }
-
   return ret;
 }
 
@@ -2256,16 +2061,12 @@ int32_t asm330lhh_sdo_sa0_mode_set(const stmdev_ctx_t *ctx,
   asm330lhh_pin_ctrl_t pin_ctrl;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_PIN_CTRL,
-                           (uint8_t *)&pin_ctrl, 1);
-
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
   if (ret == 0)
   {
     pin_ctrl.sdo_pu_en = (uint8_t)val;
-    ret = asm330lhh_write_reg(ctx, ASM330LHH_PIN_CTRL,
-                              (uint8_t *)&pin_ctrl, 1);
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
   }
-
   return ret;
 }
 
@@ -2283,24 +2084,20 @@ int32_t asm330lhh_sdo_sa0_mode_get(const stmdev_ctx_t *ctx,
   asm330lhh_pin_ctrl_t pin_ctrl;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_PIN_CTRL,
-                           (uint8_t *)&pin_ctrl, 1);
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
 
   switch (pin_ctrl.sdo_pu_en)
   {
     case ASM330LHH_PULL_UP_DISC:
       *val = ASM330LHH_PULL_UP_DISC;
       break;
-
     case ASM330LHH_PULL_UP_CONNECT:
       *val = ASM330LHH_PULL_UP_CONNECT;
       break;
-
     default:
       *val = ASM330LHH_PULL_UP_DISC;
       break;
   }
-
   return ret;
 }
 
@@ -2318,13 +2115,11 @@ int32_t asm330lhh_spi_mode_set(const stmdev_ctx_t *ctx, asm330lhh_sim_t val)
   int32_t ret;
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
-
   if (ret == 0)
   {
     ctrl3_c.sim = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
   }
-
   return ret;
 }
 
@@ -2336,8 +2131,7 @@ int32_t asm330lhh_spi_mode_set(const stmdev_ctx_t *ctx, asm330lhh_sim_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_spi_mode_get(const stmdev_ctx_t *ctx,
-                               asm330lhh_sim_t *val)
+int32_t asm330lhh_spi_mode_get(const stmdev_ctx_t *ctx, asm330lhh_sim_t *val)
 {
   asm330lhh_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -2349,16 +2143,13 @@ int32_t asm330lhh_spi_mode_get(const stmdev_ctx_t *ctx,
     case ASM330LHH_SPI_4_WIRE:
       *val = ASM330LHH_SPI_4_WIRE;
       break;
-
     case ASM330LHH_SPI_3_WIRE:
       *val = ASM330LHH_SPI_3_WIRE;
       break;
-
     default:
       *val = ASM330LHH_SPI_4_WIRE;
       break;
   }
-
   return ret;
 }
 
@@ -2377,13 +2168,11 @@ int32_t asm330lhh_i2c_interface_set(const stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
-
   if (ret == 0)
   {
     ctrl4_c.i2c_disable = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
   }
-
   return ret;
 }
 
@@ -2408,16 +2197,13 @@ int32_t asm330lhh_i2c_interface_get(const stmdev_ctx_t *ctx,
     case ASM330LHH_I2C_ENABLE:
       *val = ASM330LHH_I2C_ENABLE;
       break;
-
     case ASM330LHH_I2C_DISABLE:
       *val = ASM330LHH_I2C_DISABLE;
       break;
-
     default:
       *val = ASM330LHH_I2C_ENABLE;
       break;
   }
-
   return ret;
 }
 
@@ -2437,70 +2223,57 @@ int32_t asm330lhh_i2c_interface_get(const stmdev_ctx_t *ctx,
 /**
   * @brief  Select the signal that need to route on int1 pad.[set]
   *
-  * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Structure of registers: INT1_CTRL,MD1_CFG,
-  *                EMB_FUNC_INT1, FSM_INT1_A, FSM_INT1_B
-  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  * @param  ctx      read / write interface definitions
+  * @param  val      struct of registers: INT1_CTRL,
+  *                  MD1_CFG, EMB_FUNC_INT1, FSM_INT1_A,
+  *                  FSM_INT1_B
   *
   */
 int32_t asm330lhh_pin_int1_route_set(const stmdev_ctx_t *ctx,
                                      asm330lhh_pin_int1_route_t *val)
 {
-  asm330lhh_int_cfg1_t tap_cfg2;
+  asm330lhh_int_cfg1_t int_cfg1;
   int32_t ret;
 
-  ret = asm330lhh_write_reg(ctx, ASM330LHH_INT1_CTRL,
-                            (uint8_t *)&val->int1_ctrl, 1);
+  ret = asm330lhh_write_reg(ctx, ASM330LHH_MD1_CFG, (uint8_t *)&val->md1_cfg, 1);
 
   if (ret == 0)
   {
-    ret = asm330lhh_write_reg(ctx, ASM330LHH_MD1_CFG,
-                              (uint8_t *)&val->md1_cfg, 1);
+    ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG1, (uint8_t *) &int_cfg1, 1);
   }
 
   if (ret == 0)
   {
-    ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG1,
-                             (uint8_t *)&tap_cfg2, 1);
-
-    if ((val->int1_ctrl.den_drdy_flag |
-         val->int1_ctrl.int1_boot |
-         val->int1_ctrl.int1_cnt_bdr |
-         val->int1_ctrl.int1_drdy_g |
-         val->int1_ctrl.int1_drdy_xl |
-         val->int1_ctrl.int1_fifo_full |
-         val->int1_ctrl.int1_fifo_ovr |
-         val->int1_ctrl.int1_fifo_th |
-         val->md1_cfg.int1_6d |
-         val->md1_cfg.int1_ff |
-         val->md1_cfg.int1_wu |
-         val->md1_cfg.int1_sleep_change) != PROPERTY_DISABLE)
+    if ((val->int1_ctrl.den_drdy_flag
+         | val->int1_ctrl.int1_boot
+         | val->int1_ctrl.int1_cnt_bdr
+         | val->int1_ctrl.int1_drdy_g
+         | val->int1_ctrl.int1_drdy_xl
+         | val->int1_ctrl.int1_fifo_full
+         | val->int1_ctrl.int1_fifo_ovr
+         | val->int1_ctrl.int1_fifo_th
+         | val->md1_cfg.int1_6d
+         | val->md1_cfg.int1_ff
+         | val->md1_cfg.int1_wu
+         | val->md1_cfg.int1_sleep_change) != PROPERTY_DISABLE)
     {
-      tap_cfg2.interrupts_enable = PROPERTY_ENABLE;
+      int_cfg1.interrupts_enable = PROPERTY_ENABLE;
     }
-
     else
     {
-      tap_cfg2.interrupts_enable = PROPERTY_DISABLE;
+      int_cfg1.interrupts_enable = PROPERTY_DISABLE;
     }
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_INT_CFG1, (uint8_t *) &int_cfg1, 1);
   }
-
-  if (ret == 0)
-  {
-    ret = asm330lhh_write_reg(ctx, ASM330LHH_INT_CFG1,
-                              (uint8_t *)&tap_cfg2, 1);
-  }
-
   return ret;
 }
 
 /**
   * @brief  Select the signal that need to route on int1 pad.[get]
   *
-  * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Structure of registers: INT1_CTRL, MD1_CFG,
-  *                EMB_FUNC_INT1, FSM_INT1_A, FSM_INT1_B.(ptr)
-  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  * @param  ctx      read / write interface definitions
+  * @param  val      struct of registers: INT1_CTRL, MD1_CFG,
+  *                  EMB_FUNC_INT1, FSM_INT1_A, FSM_INT1_B
   *
   */
 int32_t asm330lhh_pin_int1_route_get(const stmdev_ctx_t *ctx,
@@ -2510,82 +2283,88 @@ int32_t asm330lhh_pin_int1_route_get(const stmdev_ctx_t *ctx,
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_INT1_CTRL,
                            (uint8_t *)&val->int1_ctrl, 1);
-
   if (ret == 0)
   {
-    ret = asm330lhh_read_reg(ctx, ASM330LHH_MD1_CFG,
-                             (uint8_t *)&val->md1_cfg, 1);
+    ret = asm330lhh_read_reg(ctx, ASM330LHH_MD1_CFG, (uint8_t *)&val->md1_cfg, 1);
   }
 
   return ret;
 }
 
 /**
-  * @brief  Select the signal that need to route on int2 pad[set]
+  * @brief  Select the signal that need to route on int2 pad.[set]
   *
-  * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Structure of registers INT2_CTRL,  MD2_CFG,
-  *                EMB_FUNC_INT2, FSM_INT2_A, FSM_INT2_B
-  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  * @param  ctx      read / write interface definitions
+  * @param  val      union of registers INT2_CTRL,  MD2_CFG,
+  *                  EMB_FUNC_INT2, FSM_INT2_A, FSM_INT2_B
   *
   */
 int32_t asm330lhh_pin_int2_route_set(const stmdev_ctx_t *ctx,
                                      asm330lhh_pin_int2_route_t *val)
 {
-  asm330lhh_int_cfg1_t tap_cfg2;
+  asm330lhh_pin_int1_route_t pin_int1_route;
+  asm330lhh_int_cfg1_t int_cfg1;
   int32_t ret;
 
   ret = asm330lhh_write_reg(ctx, ASM330LHH_INT2_CTRL,
                             (uint8_t *)&val->int2_ctrl, 1);
-
   if (ret == 0)
   {
-    ret = asm330lhh_write_reg(ctx, ASM330LHH_MD2_CFG,
-                              (uint8_t *)&val->md2_cfg, 1);
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_MD2_CFG, (uint8_t *)&val->md2_cfg, 1);
+  }
+  if (ret == 0)
+  {
+    ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG1, (uint8_t *) &int_cfg1, 1);
   }
 
   if (ret == 0)
   {
-    ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG1,
-                             (uint8_t *)&tap_cfg2, 1);
+    ret = asm330lhh_pin_int1_route_get(ctx, &pin_int1_route);
   }
 
   if (ret == 0)
   {
-    if ((val->int2_ctrl.int2_drdy_xl |
-         val->int2_ctrl.int2_drdy_g |
-         val->int2_ctrl.int2_drdy_temp |
-         val->int2_ctrl.int2_fifo_th |
-         val->int2_ctrl.int2_fifo_ovr |
-         val->int2_ctrl.int2_fifo_full |
-         val->int2_ctrl.int2_cnt_bdr |
-         val->md2_cfg.int2_6d |
-         val->md2_cfg.int2_ff |
-         val->md2_cfg.int2_wu |
-         val->md2_cfg.int2_sleep_change) != PROPERTY_DISABLE)
+    if ((val->int2_ctrl.int2_cnt_bdr
+         | val->int2_ctrl.int2_drdy_g
+         | val->int2_ctrl.int2_drdy_temp
+         | val->int2_ctrl.int2_drdy_xl
+         | val->int2_ctrl.int2_fifo_full
+         | val->int2_ctrl.int2_fifo_ovr
+         | val->int2_ctrl.int2_fifo_th
+         | val->md2_cfg.int2_6d
+         | val->md2_cfg.int2_ff
+         | val->md2_cfg.int2_wu
+         | val->md2_cfg.int2_sleep_change
+         | pin_int1_route.int1_ctrl.den_drdy_flag
+         | pin_int1_route.int1_ctrl.int1_boot
+         | pin_int1_route.int1_ctrl.int1_cnt_bdr
+         | pin_int1_route.int1_ctrl.int1_drdy_g
+         | pin_int1_route.int1_ctrl.int1_drdy_xl
+         | pin_int1_route.int1_ctrl.int1_fifo_full
+         | pin_int1_route.int1_ctrl.int1_fifo_ovr
+         | pin_int1_route.int1_ctrl.int1_fifo_th
+         | pin_int1_route.md1_cfg.int1_6d
+         | pin_int1_route.md1_cfg.int1_ff
+         | pin_int1_route.md1_cfg.int1_wu
+         | pin_int1_route.md1_cfg.int1_sleep_change) != PROPERTY_DISABLE)
     {
-      tap_cfg2.interrupts_enable = PROPERTY_ENABLE;
+      int_cfg1.interrupts_enable = PROPERTY_ENABLE;
     }
-
     else
     {
-      tap_cfg2.interrupts_enable = PROPERTY_DISABLE;
+      int_cfg1.interrupts_enable = PROPERTY_DISABLE;
     }
-
-    ret = asm330lhh_write_reg(ctx, ASM330LHH_INT_CFG1,
-                              (uint8_t *)&tap_cfg2, 1);
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_INT_CFG1, (uint8_t *) &int_cfg1, 1);
   }
-
   return ret;
 }
 
 /**
   * @brief  Select the signal that need to route on int2 pad.[get]
   *
-  * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Structure of registers INT2_CTRL,  MD2_CFG,
-  *                EMB_FUNC_INT2, FSM_INT2_A, FSM_INT2_B.[get]
-  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  * @param  ctx      read / write interface definitions
+  * @param  val      union of registers INT2_CTRL,  MD2_CFG,
+  *                  EMB_FUNC_INT2, FSM_INT2_A, FSM_INT2_B
   *
   */
 int32_t asm330lhh_pin_int2_route_get(const stmdev_ctx_t *ctx,
@@ -2595,13 +2374,10 @@ int32_t asm330lhh_pin_int2_route_get(const stmdev_ctx_t *ctx,
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_INT2_CTRL,
                            (uint8_t *)&val->int2_ctrl, 1);
-
   if (ret == 0)
   {
-    ret = asm330lhh_read_reg(ctx, ASM330LHH_MD2_CFG,
-                             (uint8_t *)&val->md2_cfg, 1);
+    ret = asm330lhh_read_reg(ctx, ASM330LHH_MD2_CFG, (uint8_t *)&val->md2_cfg, 1);
   }
-
   return ret;
 }
 
@@ -2613,20 +2389,17 @@ int32_t asm330lhh_pin_int2_route_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_pin_mode_set(const stmdev_ctx_t *ctx,
-                               asm330lhh_pp_od_t val)
+int32_t asm330lhh_pin_mode_set(const stmdev_ctx_t *ctx, asm330lhh_pp_od_t val)
 {
   asm330lhh_ctrl3_c_t ctrl3_c;
   int32_t ret;
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
-
   if (ret == 0)
   {
     ctrl3_c.pp_od = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
   }
-
   return ret;
 }
 
@@ -2638,8 +2411,7 @@ int32_t asm330lhh_pin_mode_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_pin_mode_get(const stmdev_ctx_t *ctx,
-                               asm330lhh_pp_od_t *val)
+int32_t asm330lhh_pin_mode_get(const stmdev_ctx_t *ctx, asm330lhh_pp_od_t *val)
 {
   asm330lhh_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -2651,16 +2423,13 @@ int32_t asm330lhh_pin_mode_get(const stmdev_ctx_t *ctx,
     case ASM330LHH_PUSH_PULL:
       *val = ASM330LHH_PUSH_PULL;
       break;
-
     case ASM330LHH_OPEN_DRAIN:
       *val = ASM330LHH_OPEN_DRAIN;
       break;
-
     default:
       *val = ASM330LHH_PUSH_PULL;
       break;
   }
-
   return ret;
 }
 
@@ -2679,13 +2448,11 @@ int32_t asm330lhh_pin_polarity_set(const stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
-
   if (ret == 0)
   {
     ctrl3_c.h_lactive = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
   }
-
   return ret;
 }
 
@@ -2710,16 +2477,13 @@ int32_t asm330lhh_pin_polarity_get(const stmdev_ctx_t *ctx,
     case ASM330LHH_ACTIVE_HIGH:
       *val = ASM330LHH_ACTIVE_HIGH;
       break;
-
     case ASM330LHH_ACTIVE_LOW:
       *val = ASM330LHH_ACTIVE_LOW;
       break;
-
     default:
       *val = ASM330LHH_ACTIVE_HIGH;
       break;
   }
-
   return ret;
 }
 
@@ -2737,13 +2501,11 @@ int32_t asm330lhh_all_on_int1_set(const stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
-
   if (ret == 0)
   {
     ctrl4_c.int2_on_int1 = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
   }
-
   return ret;
 }
 
@@ -2780,9 +2542,7 @@ int32_t asm330lhh_int_notification_set(const stmdev_ctx_t *ctx,
   asm330lhh_int_cfg0_t int_cfg0;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG0,
-                           (uint8_t *)&int_cfg0, 1);
-
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG0, (uint8_t *)&int_cfg0, 1);
   if (ret == 0)
   {
     int_cfg0.lir = (uint8_t)val & 0x01U;
@@ -2790,7 +2550,6 @@ int32_t asm330lhh_int_notification_set(const stmdev_ctx_t *ctx,
     ret = asm330lhh_write_reg(ctx, ASM330LHH_INT_CFG0,
                               (uint8_t *)&int_cfg0, 1);
   }
-
   return ret;
 }
 
@@ -2809,24 +2568,26 @@ int32_t asm330lhh_int_notification_get(const stmdev_ctx_t *ctx,
   int32_t ret;
 
   *val = ASM330LHH_ALL_INT_PULSED;
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG0,
-                           (uint8_t *)&int_cfg0, 1);
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG0, (uint8_t *)&int_cfg0, 1);
 
   switch ((int_cfg0.lir << 1) + int_cfg0.int_clr_on_read)
   {
     case ASM330LHH_ALL_INT_PULSED:
       *val = ASM330LHH_ALL_INT_PULSED;
       break;
-
+    case ASM330LHH_BASE_LATCHED_EMB_PULSED:
+      *val = ASM330LHH_BASE_LATCHED_EMB_PULSED;
+      break;
+    case ASM330LHH_BASE_PULSED_EMB_LATCHED:
+      *val = ASM330LHH_BASE_PULSED_EMB_LATCHED;
+      break;
     case ASM330LHH_ALL_INT_LATCHED:
       *val = ASM330LHH_ALL_INT_LATCHED;
       break;
-
     default:
       *val = ASM330LHH_ALL_INT_PULSED;
       break;
   }
-
   return ret;
 }
 
@@ -2861,14 +2622,12 @@ int32_t asm330lhh_wkup_ths_weight_set(const stmdev_ctx_t *ctx,
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_WAKE_UP_DUR,
                            (uint8_t *)&wake_up_dur, 1);
-
   if (ret == 0)
   {
     wake_up_dur.wake_ths_w = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_WAKE_UP_DUR,
                               (uint8_t *)&wake_up_dur, 1);
   }
-
   return ret;
 }
 
@@ -2896,16 +2655,13 @@ int32_t asm330lhh_wkup_ths_weight_get(const stmdev_ctx_t *ctx,
     case ASM330LHH_LSb_FS_DIV_64:
       *val = ASM330LHH_LSb_FS_DIV_64;
       break;
-
     case ASM330LHH_LSb_FS_DIV_256:
       *val = ASM330LHH_LSb_FS_DIV_256;
       break;
-
     default:
       *val = ASM330LHH_LSb_FS_DIV_64;
       break;
   }
-
   return ret;
 }
 
@@ -2925,14 +2681,12 @@ int32_t asm330lhh_wkup_threshold_set(const stmdev_ctx_t *ctx, uint8_t val)
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_WAKE_UP_THS,
                            (uint8_t *)&wake_up_ths, 1);
-
   if (ret == 0)
   {
     wake_up_ths.wk_ths = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_WAKE_UP_THS,
                               (uint8_t *)&wake_up_ths, 1);
   }
-
   return ret;
 }
 
@@ -2965,22 +2719,19 @@ int32_t asm330lhh_wkup_threshold_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_usr_offset_on_wkup_set(const stmdev_ctx_t *ctx,
-                                            uint8_t val)
+int32_t asm330lhh_xl_usr_offset_on_wkup_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_wake_up_ths_t wake_up_ths;
   int32_t ret;
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_WAKE_UP_THS,
                            (uint8_t *)&wake_up_ths, 1);
-
   if (ret == 0)
   {
     wake_up_ths.usr_off_on_wu = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_WAKE_UP_THS,
                               (uint8_t *)&wake_up_ths, 1);
   }
-
   return ret;
 }
 
@@ -3020,14 +2771,12 @@ int32_t asm330lhh_wkup_dur_set(const stmdev_ctx_t *ctx, uint8_t val)
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_WAKE_UP_DUR,
                            (uint8_t *)&wake_up_dur, 1);
-
   if (ret == 0)
   {
     wake_up_dur.wake_dur = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_WAKE_UP_DUR,
                               (uint8_t *)&wake_up_dur, 1);
   }
-
   return ret;
 }
 
@@ -3078,13 +2827,11 @@ int32_t asm330lhh_gy_sleep_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
-
   if (ret == 0)
   {
     ctrl4_c.sleep_g = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
   }
-
   return ret;
 }
 
@@ -3123,16 +2870,13 @@ int32_t asm330lhh_act_pin_notification_set(const stmdev_ctx_t *ctx,
   asm330lhh_int_cfg0_t int_cfg0;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG0,
-                           (uint8_t *)&int_cfg0, 1);
-
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG0, (uint8_t *)&int_cfg0, 1);
   if (ret == 0)
   {
     int_cfg0. sleep_status_on_int = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_INT_CFG0,
                               (uint8_t *)&int_cfg0, 1);
   }
-
   return ret;
 }
 
@@ -3152,24 +2896,19 @@ int32_t asm330lhh_act_pin_notification_get(const stmdev_ctx_t *ctx,
   asm330lhh_int_cfg0_t int_cfg0;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG0,
-                           (uint8_t *)&int_cfg0, 1);
-
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG0, (uint8_t *)&int_cfg0, 1);
   switch (int_cfg0. sleep_status_on_int)
   {
     case ASM330LHH_DRIVE_SLEEP_CHG_EVENT:
       *val = ASM330LHH_DRIVE_SLEEP_CHG_EVENT;
       break;
-
     case ASM330LHH_DRIVE_SLEEP_STATUS:
       *val = ASM330LHH_DRIVE_SLEEP_STATUS;
       break;
-
     default:
       *val = ASM330LHH_DRIVE_SLEEP_CHG_EVENT;
       break;
   }
-
   return ret;
 }
 
@@ -3181,22 +2920,17 @@ int32_t asm330lhh_act_pin_notification_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_act_mode_set(const stmdev_ctx_t *ctx,
-                               asm330lhh_inact_en_t val)
+int32_t asm330lhh_act_mode_set(const stmdev_ctx_t *ctx, asm330lhh_inact_en_t val)
 {
   asm330lhh_int_cfg1_t int_cfg1;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG1,
-                           (uint8_t *)&int_cfg1, 1);
-
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG1, (uint8_t *)&int_cfg1, 1);
   if (ret == 0)
   {
     int_cfg1.inact_en = (uint8_t)val;
-    ret = asm330lhh_write_reg(ctx, ASM330LHH_INT_CFG1,
-                              (uint8_t *)&int_cfg1, 1);
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_INT_CFG1, (uint8_t *)&int_cfg1, 1);
   }
-
   return ret;
 }
 
@@ -3214,32 +2948,26 @@ int32_t asm330lhh_act_mode_get(const stmdev_ctx_t *ctx,
   asm330lhh_int_cfg1_t int_cfg1;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG1,
-                           (uint8_t *)&int_cfg1, 1);
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG1, (uint8_t *)&int_cfg1, 1);
 
   switch (int_cfg1.inact_en)
   {
     case ASM330LHH_XL_AND_GY_NOT_AFFECTED:
       *val = ASM330LHH_XL_AND_GY_NOT_AFFECTED;
       break;
-
     case ASM330LHH_XL_12Hz5_GY_NOT_AFFECTED:
       *val = ASM330LHH_XL_12Hz5_GY_NOT_AFFECTED;
       break;
-
     case ASM330LHH_XL_12Hz5_GY_SLEEP:
       *val = ASM330LHH_XL_12Hz5_GY_SLEEP;
       break;
-
     case ASM330LHH_XL_12Hz5_GY_PD:
       *val = ASM330LHH_XL_12Hz5_GY_PD;
       break;
-
     default:
       *val = ASM330LHH_XL_AND_GY_NOT_AFFECTED;
       break;
   }
-
   return ret;
 }
 
@@ -3258,14 +2986,12 @@ int32_t asm330lhh_act_sleep_dur_set(const stmdev_ctx_t *ctx, uint8_t val)
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_WAKE_UP_DUR,
                            (uint8_t *)&wake_up_dur, 1);
-
   if (ret == 0)
   {
     wake_up_dur.sleep_dur = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_WAKE_UP_DUR,
                               (uint8_t *)&wake_up_dur, 1);
   }
-
   return ret;
 }
 
@@ -3318,14 +3044,12 @@ int32_t asm330lhh_6d_threshold_set(const stmdev_ctx_t *ctx,
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_THS_6D,
                            (uint8_t *)&ths_6d, 1);
-
   if (ret == 0)
   {
     ths_6d.sixd_ths = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_THS_6D,
                               (uint8_t *)&ths_6d, 1);
   }
-
   return ret;
 }
 
@@ -3351,24 +3075,19 @@ int32_t asm330lhh_6d_threshold_get(const stmdev_ctx_t *ctx,
     case ASM330LHH_DEG_80:
       *val = ASM330LHH_DEG_80;
       break;
-
     case ASM330LHH_DEG_70:
       *val = ASM330LHH_DEG_70;
       break;
-
     case ASM330LHH_DEG_60:
       *val = ASM330LHH_DEG_60;
       break;
-
     case ASM330LHH_DEG_50:
       *val = ASM330LHH_DEG_50;
       break;
-
     default:
       *val = ASM330LHH_DEG_80;
       break;
   }
-
   return ret;
 }
 
@@ -3387,14 +3106,12 @@ int32_t asm330lhh_4d_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_THS_6D,
                            (uint8_t *)&ths_6d, 1);
-
   if (ret == 0)
   {
     ths_6d.d4d_en = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_THS_6D,
                               (uint8_t *)&ths_6d, 1);
   }
-
   return ret;
 }
 
@@ -3445,16 +3162,13 @@ int32_t asm330lhh_ff_threshold_set(const stmdev_ctx_t *ctx,
   asm330lhh_free_fall_t free_fall;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_FREE_FALL,
-                           (uint8_t *)&free_fall, 1);
-
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FREE_FALL, (uint8_t *)&free_fall, 1);
   if (ret == 0)
   {
     free_fall.ff_ths = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_FREE_FALL,
                               (uint8_t *)&free_fall, 1);
   }
-
   return ret;
 }
 
@@ -3472,48 +3186,38 @@ int32_t asm330lhh_ff_threshold_get(const stmdev_ctx_t *ctx,
   asm330lhh_free_fall_t free_fall;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_FREE_FALL,
-                           (uint8_t *)&free_fall, 1);
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FREE_FALL, (uint8_t *)&free_fall, 1);
 
   switch (free_fall.ff_ths)
   {
     case ASM330LHH_FF_TSH_156mg:
       *val = ASM330LHH_FF_TSH_156mg;
       break;
-
     case ASM330LHH_FF_TSH_219mg:
       *val = ASM330LHH_FF_TSH_219mg;
       break;
-
     case ASM330LHH_FF_TSH_250mg:
       *val = ASM330LHH_FF_TSH_250mg;
       break;
-
     case ASM330LHH_FF_TSH_312mg:
       *val = ASM330LHH_FF_TSH_312mg;
       break;
-
     case ASM330LHH_FF_TSH_344mg:
       *val = ASM330LHH_FF_TSH_344mg;
       break;
-
     case ASM330LHH_FF_TSH_406mg:
       *val = ASM330LHH_FF_TSH_406mg;
       break;
-
     case ASM330LHH_FF_TSH_469mg:
       *val = ASM330LHH_FF_TSH_469mg;
       break;
-
     case ASM330LHH_FF_TSH_500mg:
       *val = ASM330LHH_FF_TSH_500mg;
       break;
-
     default:
       *val = ASM330LHH_FF_TSH_156mg;
       break;
   }
-
   return ret;
 }
 
@@ -3533,27 +3237,23 @@ int32_t asm330lhh_ff_dur_set(const stmdev_ctx_t *ctx, uint8_t val)
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_WAKE_UP_DUR,
                            (uint8_t *)&wake_up_dur, 1);
-
   if (ret == 0)
   {
     wake_up_dur.ff_dur = (val & 0x20U) >> 5;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_WAKE_UP_DUR,
                               (uint8_t *)&wake_up_dur, 1);
   }
-
   if (ret == 0)
   {
     ret = asm330lhh_read_reg(ctx, ASM330LHH_FREE_FALL,
                              (uint8_t *)&free_fall, 1);
   }
-
   if (ret == 0)
   {
     free_fall.ff_dur = val & 0x1FU;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_FREE_FALL,
                               (uint8_t *)&free_fall, 1);
   }
-
   return ret;
 }
 
@@ -3579,7 +3279,6 @@ int32_t asm330lhh_ff_dur_get(const stmdev_ctx_t *ctx, uint8_t *val)
     ret = asm330lhh_read_reg(ctx, ASM330LHH_FREE_FALL,
                              (uint8_t *)&free_fall, 1);
   }
-
   *val = (wake_up_dur.ff_dur << 5) + free_fall.ff_dur;
 
   return ret;
@@ -3612,21 +3311,15 @@ int32_t asm330lhh_fifo_watermark_set(const stmdev_ctx_t *ctx, uint16_t val)
   asm330lhh_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL2,
-                           (uint8_t *)&fifo_ctrl2, 1);
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
+  ret += asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
 
   if (ret == 0)
   {
+    fifo_ctrl1.wtm = (uint8_t)(val  & 0xFFU);
     fifo_ctrl2.wtm = (uint8_t)((val / 256U) & 0x01U);
-    ret = asm330lhh_write_reg(ctx, ASM330LHH_FIFO_CTRL2,
-                              (uint8_t *)&fifo_ctrl2, 1);
-  }
-
-  if (ret == 0)
-  {
-    fifo_ctrl1.wtm = (uint8_t)(val - (fifo_ctrl2.wtm * 256U));
-    ret = asm330lhh_write_reg(ctx, ASM330LHH_FIFO_CTRL1,
-                              (uint8_t *)&fifo_ctrl1, 1);
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
+    ret += asm330lhh_write_reg(ctx, ASM330LHH_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
   }
 
   return ret;
@@ -3648,18 +3341,16 @@ int32_t asm330lhh_fifo_watermark_get(const stmdev_ctx_t *ctx, uint16_t *val)
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL2,
                            (uint8_t *)&fifo_ctrl2, 1);
-
   if (ret == 0)
   {
     ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL1,
                              (uint8_t *)&fifo_ctrl1, 1);
   }
-
   *val = fifo_ctrl2.wtm;
   *val = (*val * 256U) +  fifo_ctrl1.wtm;
-
   return ret;
 }
+
 /**
   * @brief  Enables ODR CHANGE virtual sensor to be batched in FIFO.[set]
   *
@@ -3676,7 +3367,6 @@ int32_t asm330lhh_fifo_virtual_sens_odr_chg_set(const stmdev_ctx_t *ctx,
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL2,
                            (uint8_t *)&fifo_ctrl2, 1);
-
   if (ret == 0)
   {
     fifo_ctrl2.odrchg_en = (uint8_t)val;
@@ -3724,14 +3414,12 @@ int32_t asm330lhh_fifo_stop_on_wtm_set(const stmdev_ctx_t *ctx, uint8_t val)
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL2,
                            (uint8_t *)&fifo_ctrl2, 1);
-
   if (ret == 0)
   {
     fifo_ctrl2.stop_on_wtm = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_FIFO_CTRL2,
                               (uint8_t *)&fifo_ctrl2, 1);
   }
-
   return ret;
 }
 
@@ -3744,8 +3432,7 @@ int32_t asm330lhh_fifo_stop_on_wtm_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_fifo_stop_on_wtm_get(const stmdev_ctx_t *ctx,
-                                       uint8_t *val)
+int32_t asm330lhh_fifo_stop_on_wtm_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
@@ -3774,14 +3461,12 @@ int32_t asm330lhh_fifo_xl_batch_set(const stmdev_ctx_t *ctx,
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL3,
                            (uint8_t *)&fifo_ctrl3, 1);
-
   if (ret == 0)
   {
     fifo_ctrl3.bdr_xl = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_FIFO_CTRL3,
                               (uint8_t *)&fifo_ctrl3, 1);
   }
-
   return ret;
 }
 
@@ -3808,56 +3493,40 @@ int32_t asm330lhh_fifo_xl_batch_get(const stmdev_ctx_t *ctx,
     case ASM330LHH_XL_NOT_BATCHED:
       *val = ASM330LHH_XL_NOT_BATCHED;
       break;
-
     case ASM330LHH_XL_BATCHED_AT_12Hz5:
       *val = ASM330LHH_XL_BATCHED_AT_12Hz5;
       break;
-
     case ASM330LHH_XL_BATCHED_AT_26Hz:
       *val = ASM330LHH_XL_BATCHED_AT_26Hz;
       break;
-
     case ASM330LHH_XL_BATCHED_AT_52Hz:
       *val = ASM330LHH_XL_BATCHED_AT_52Hz;
       break;
-
     case ASM330LHH_XL_BATCHED_AT_104Hz:
       *val = ASM330LHH_XL_BATCHED_AT_104Hz;
       break;
-
     case ASM330LHH_XL_BATCHED_AT_208Hz:
       *val = ASM330LHH_XL_BATCHED_AT_208Hz;
       break;
-
     case ASM330LHH_XL_BATCHED_AT_417Hz:
       *val = ASM330LHH_XL_BATCHED_AT_417Hz;
       break;
-
     case ASM330LHH_XL_BATCHED_AT_833Hz:
       *val = ASM330LHH_XL_BATCHED_AT_833Hz;
       break;
-
     case ASM330LHH_XL_BATCHED_AT_1667Hz:
       *val = ASM330LHH_XL_BATCHED_AT_1667Hz;
       break;
-
     case ASM330LHH_XL_BATCHED_AT_3333Hz:
       *val = ASM330LHH_XL_BATCHED_AT_3333Hz;
       break;
-
     case ASM330LHH_XL_BATCHED_AT_6667Hz:
       *val = ASM330LHH_XL_BATCHED_AT_6667Hz;
       break;
-
-    case ASM330LHH_XL_BATCHED_AT_6Hz5:
-      *val = ASM330LHH_XL_BATCHED_AT_6Hz5;
-      break;
-
     default:
       *val = ASM330LHH_XL_NOT_BATCHED;
       break;
   }
-
   return ret;
 }
 
@@ -3878,14 +3547,12 @@ int32_t asm330lhh_fifo_gy_batch_set(const stmdev_ctx_t *ctx,
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL3,
                            (uint8_t *)&fifo_ctrl3, 1);
-
   if (ret == 0)
   {
     fifo_ctrl3.bdr_gy = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_FIFO_CTRL3,
                               (uint8_t *)&fifo_ctrl3, 1);
   }
-
   return ret;
 }
 
@@ -3912,56 +3579,43 @@ int32_t asm330lhh_fifo_gy_batch_get(const stmdev_ctx_t *ctx,
     case ASM330LHH_GY_NOT_BATCHED:
       *val = ASM330LHH_GY_NOT_BATCHED;
       break;
-
     case ASM330LHH_GY_BATCHED_AT_12Hz5:
       *val = ASM330LHH_GY_BATCHED_AT_12Hz5;
       break;
-
     case ASM330LHH_GY_BATCHED_AT_26Hz:
       *val = ASM330LHH_GY_BATCHED_AT_26Hz;
       break;
-
     case ASM330LHH_GY_BATCHED_AT_52Hz:
       *val = ASM330LHH_GY_BATCHED_AT_52Hz;
       break;
-
     case ASM330LHH_GY_BATCHED_AT_104Hz:
       *val = ASM330LHH_GY_BATCHED_AT_104Hz;
       break;
-
     case ASM330LHH_GY_BATCHED_AT_208Hz:
       *val = ASM330LHH_GY_BATCHED_AT_208Hz;
       break;
-
     case ASM330LHH_GY_BATCHED_AT_417Hz:
       *val = ASM330LHH_GY_BATCHED_AT_417Hz;
       break;
-
     case ASM330LHH_GY_BATCHED_AT_833Hz:
       *val = ASM330LHH_GY_BATCHED_AT_833Hz;
       break;
-
     case ASM330LHH_GY_BATCHED_AT_1667Hz:
       *val = ASM330LHH_GY_BATCHED_AT_1667Hz;
       break;
-
     case ASM330LHH_GY_BATCHED_AT_3333Hz:
       *val = ASM330LHH_GY_BATCHED_AT_3333Hz;
       break;
-
     case ASM330LHH_GY_BATCHED_AT_6667Hz:
       *val = ASM330LHH_GY_BATCHED_AT_6667Hz;
       break;
-
     case ASM330LHH_GY_BATCHED_AT_6Hz5:
       *val = ASM330LHH_GY_BATCHED_AT_6Hz5;
       break;
-
     default:
       *val = ASM330LHH_GY_NOT_BATCHED;
       break;
   }
-
   return ret;
 }
 
@@ -3981,14 +3635,12 @@ int32_t asm330lhh_fifo_mode_set(const stmdev_ctx_t *ctx,
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL4,
                            (uint8_t *)&fifo_ctrl4, 1);
-
   if (ret == 0)
   {
     fifo_ctrl4.fifo_mode = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_FIFO_CTRL4,
                               (uint8_t *)&fifo_ctrl4, 1);
   }
-
   return ret;
 }
 
@@ -4014,32 +3666,25 @@ int32_t asm330lhh_fifo_mode_get(const stmdev_ctx_t *ctx,
     case ASM330LHH_BYPASS_MODE:
       *val = ASM330LHH_BYPASS_MODE;
       break;
-
     case ASM330LHH_FIFO_MODE:
       *val = ASM330LHH_FIFO_MODE;
       break;
-
     case ASM330LHH_STREAM_TO_FIFO_MODE:
       *val = ASM330LHH_STREAM_TO_FIFO_MODE;
       break;
-
     case ASM330LHH_BYPASS_TO_STREAM_MODE:
       *val = ASM330LHH_BYPASS_TO_STREAM_MODE;
       break;
-
     case ASM330LHH_STREAM_MODE:
       *val = ASM330LHH_STREAM_MODE;
       break;
-
     case ASM330LHH_BYPASS_TO_FIFO_MODE:
       *val = ASM330LHH_BYPASS_TO_FIFO_MODE;
       break;
-
     default:
       *val = ASM330LHH_BYPASS_MODE;
       break;
   }
-
   return ret;
 }
 
@@ -4060,14 +3705,12 @@ int32_t asm330lhh_fifo_temp_batch_set(const stmdev_ctx_t *ctx,
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL4,
                            (uint8_t *)&fifo_ctrl4, 1);
-
   if (ret == 0)
   {
     fifo_ctrl4.odr_t_batch = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_FIFO_CTRL4,
                               (uint8_t *)&fifo_ctrl4, 1);
   }
-
   return ret;
 }
 
@@ -4094,24 +3737,19 @@ int32_t asm330lhh_fifo_temp_batch_get(const stmdev_ctx_t *ctx,
     case ASM330LHH_TEMP_NOT_BATCHED:
       *val = ASM330LHH_TEMP_NOT_BATCHED;
       break;
-
     case ASM330LHH_TEMP_BATCHED_AT_52Hz:
       *val = ASM330LHH_TEMP_BATCHED_AT_52Hz;
       break;
-
     case ASM330LHH_TEMP_BATCHED_AT_12Hz5:
       *val = ASM330LHH_TEMP_BATCHED_AT_12Hz5;
       break;
-
     case ASM330LHH_TEMP_BATCHED_AT_1Hz6:
       *val = ASM330LHH_TEMP_BATCHED_AT_1Hz6;
       break;
-
     default:
       *val = ASM330LHH_TEMP_NOT_BATCHED;
       break;
   }
-
   return ret;
 }
 
@@ -4121,26 +3759,24 @@ int32_t asm330lhh_fifo_temp_batch_get(const stmdev_ctx_t *ctx,
   *         GYRO BDR divided by decimation decoder.[set]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of odr_ts_batch in reg FIFO_CTRL4
+  * @param  val    Change the values of dec_ts_batch in reg FIFO_CTRL4
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t asm330lhh_fifo_timestamp_decimation_set(const stmdev_ctx_t *ctx,
-                                                asm330lhh_odr_ts_batch_t val)
+                                                asm330lhh_dec_ts_batch_t val)
 {
   asm330lhh_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL4,
                            (uint8_t *)&fifo_ctrl4, 1);
-
   if (ret == 0)
   {
     fifo_ctrl4.dec_ts_batch = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_FIFO_CTRL4,
                               (uint8_t *)&fifo_ctrl4, 1);
   }
-
   return ret;
 }
 
@@ -4150,13 +3786,13 @@ int32_t asm330lhh_fifo_timestamp_decimation_set(const stmdev_ctx_t *ctx,
   *         GYRO BDR divided by decimation decoder.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Get the values of odr_ts_batch in reg
+  * @param  val    Get the values of dec_ts_batch in reg
   *                                 FIFO_CTRL4
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t asm330lhh_fifo_timestamp_decimation_get(const stmdev_ctx_t *ctx,
-                                                asm330lhh_odr_ts_batch_t *val)
+                                                asm330lhh_dec_ts_batch_t *val)
 {
   asm330lhh_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
@@ -4169,24 +3805,19 @@ int32_t asm330lhh_fifo_timestamp_decimation_get(const stmdev_ctx_t *ctx,
     case ASM330LHH_NO_DECIMATION:
       *val = ASM330LHH_NO_DECIMATION;
       break;
-
     case ASM330LHH_DEC_1:
       *val = ASM330LHH_DEC_1;
       break;
-
     case ASM330LHH_DEC_8:
       *val = ASM330LHH_DEC_8;
       break;
-
     case ASM330LHH_DEC_32:
       *val = ASM330LHH_DEC_32;
       break;
-
     default:
       *val = ASM330LHH_NO_DECIMATION;
       break;
   }
-
   return ret;
 }
 
@@ -4208,14 +3839,12 @@ int32_t asm330lhh_fifo_cnt_event_batch_set(const stmdev_ctx_t *ctx,
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_COUNTER_BDR_REG1,
                            (uint8_t *)&counter_bdr_reg1, 1);
-
   if (ret == 0)
   {
     counter_bdr_reg1.trig_counter_bdr = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_COUNTER_BDR_REG1,
                               (uint8_t *)&counter_bdr_reg1, 1);
   }
-
   return ret;
 }
 
@@ -4243,16 +3872,13 @@ int32_t asm330lhh_fifo_cnt_event_batch_get(const stmdev_ctx_t *ctx,
     case ASM330LHH_XL_BATCH_EVENT:
       *val = ASM330LHH_XL_BATCH_EVENT;
       break;
-
     case ASM330LHH_GYRO_BATCH_EVENT:
       *val = ASM330LHH_GYRO_BATCH_EVENT;
       break;
-
     default:
       *val = ASM330LHH_XL_BATCH_EVENT;
       break;
   }
-
   return ret;
 }
 
@@ -4265,22 +3891,19 @@ int32_t asm330lhh_fifo_cnt_event_batch_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_rst_batch_counter_set(const stmdev_ctx_t *ctx,
-                                        uint8_t val)
+int32_t asm330lhh_rst_batch_counter_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_counter_bdr_reg1_t counter_bdr_reg1;
   int32_t ret;
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_COUNTER_BDR_REG1,
                            (uint8_t *)&counter_bdr_reg1, 1);
-
   if (ret == 0)
   {
     counter_bdr_reg1.rst_counter_bdr = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_COUNTER_BDR_REG1,
                               (uint8_t *)&counter_bdr_reg1, 1);
   }
-
   return ret;
 }
 
@@ -4293,8 +3916,7 @@ int32_t asm330lhh_rst_batch_counter_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_rst_batch_counter_get(const stmdev_ctx_t *ctx,
-                                        uint8_t *val)
+int32_t asm330lhh_rst_batch_counter_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_counter_bdr_reg1_t counter_bdr_reg1;
   int32_t ret;
@@ -4315,8 +3937,7 @@ int32_t asm330lhh_rst_batch_counter_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_batch_counter_threshold_set(const stmdev_ctx_t *ctx,
-                                              uint16_t val)
+int32_t asm330lhh_batch_counter_threshold_set(const stmdev_ctx_t *ctx, uint16_t val)
 {
   asm330lhh_counter_bdr_reg2_t counter_bdr_reg1;
   asm330lhh_counter_bdr_reg2_t counter_bdr_reg2;
@@ -4324,22 +3945,18 @@ int32_t asm330lhh_batch_counter_threshold_set(const stmdev_ctx_t *ctx,
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_COUNTER_BDR_REG1,
                            (uint8_t *)&counter_bdr_reg1, 1);
-
   if (ret == 0)
   {
-    counter_bdr_reg1.cnt_bdr_th = (uint8_t)((val / 256U) & 0x03U);
+    counter_bdr_reg1.cnt_bdr_th = (uint8_t)((val / 256U) & 0x07U);
     ret = asm330lhh_write_reg(ctx, ASM330LHH_COUNTER_BDR_REG1,
                               (uint8_t *)&counter_bdr_reg1, 1);
   }
-
   if (ret == 0)
   {
-    counter_bdr_reg2.cnt_bdr_th = (uint8_t)(val -
-                                            (counter_bdr_reg1.cnt_bdr_th * 256U));
+    counter_bdr_reg2.cnt_bdr_th = (uint8_t)(val - (counter_bdr_reg1.cnt_bdr_th * 256U));
     ret = asm330lhh_write_reg(ctx, ASM330LHH_COUNTER_BDR_REG2,
                               (uint8_t *)&counter_bdr_reg2, 1);
   }
-
   return ret;
 }
 
@@ -4361,7 +3978,6 @@ int32_t asm330lhh_batch_counter_threshold_get(const stmdev_ctx_t *ctx,
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_COUNTER_BDR_REG1,
                            (uint8_t *)&counter_bdr_reg1, 1);
-
   if (ret == 0)
   {
     ret = asm330lhh_read_reg(ctx, ASM330LHH_COUNTER_BDR_REG2,
@@ -4370,7 +3986,6 @@ int32_t asm330lhh_batch_counter_threshold_get(const stmdev_ctx_t *ctx,
 
   *val = counter_bdr_reg1.cnt_bdr_th;
   *val = (*val * 256U) +  counter_bdr_reg2.cnt_bdr_th;
-
   return ret;
 }
 
@@ -4378,26 +3993,23 @@ int32_t asm330lhh_batch_counter_threshold_get(const stmdev_ctx_t *ctx,
   * @brief  Number of unread sensor data (TAG + 6 bytes) stored in FIFO.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of diff_fifo in reg FIFO_STATUS1
+  * @param  val    Read the value of diff_fifo in reg FIFO_STATUS1 and FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_fifo_data_level_get(const stmdev_ctx_t *ctx,
-                                      uint16_t *val)
+int32_t asm330lhh_fifo_data_level_get(const stmdev_ctx_t *ctx, uint16_t *val)
 {
-  asm330lhh_fifo_status1_t fifo_status1;
-  asm330lhh_fifo_status2_t fifo_status2;
+  uint8_t reg[2];
+  asm330lhh_fifo_status1_t *fifo_status1 = (asm330lhh_fifo_status1_t *)&reg[0];
+  asm330lhh_fifo_status2_t *fifo_status2 = (asm330lhh_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_STATUS1,
-                           (uint8_t *)&fifo_status1, 1);
-
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_STATUS1, (uint8_t *)reg, 2);
   if (ret == 0)
   {
-    ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_STATUS2,
-                             (uint8_t *)&fifo_status2, 1);
-    *val = fifo_status2.diff_fifo;
-    *val = (*val * 256U) + fifo_status1.diff_fifo;
+    *val = fifo_status2->diff_fifo;
+    *val = (*val * 256U) + fifo_status1->diff_fifo;
   }
 
   return ret;
@@ -4407,16 +4019,23 @@ int32_t asm330lhh_fifo_data_level_get(const stmdev_ctx_t *ctx,
   * @brief  Smart FIFO status.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Registers FIFO_STATUS2
+  * @param  val    Read registers FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t asm330lhh_fifo_status_get(const stmdev_ctx_t *ctx,
                                   asm330lhh_fifo_status2_t *val)
 {
+  uint8_t reg[2];
+  asm330lhh_fifo_status2_t *fifo_status2 = (asm330lhh_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_STATUS2, (uint8_t *)val, 1);
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = *fifo_status2;
+  }
 
   return ret;
 }
@@ -4425,18 +4044,22 @@ int32_t asm330lhh_fifo_status_get(const stmdev_ctx_t *ctx,
   * @brief  Smart FIFO full status.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of fifo_full_ia in reg FIFO_STATUS2
+  * @param  val    Read the values of fifo_full_ia in reg FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t asm330lhh_fifo_full_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  asm330lhh_fifo_status2_t fifo_status2;
+  uint8_t reg[2];
+  asm330lhh_fifo_status2_t *fifo_status2 = (asm330lhh_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_STATUS2,
-                           (uint8_t *)&fifo_status2, 1);
-  *val = fifo_status2.fifo_full_ia;
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_full_ia;
+  }
 
   return ret;
 }
@@ -4445,19 +4068,23 @@ int32_t asm330lhh_fifo_full_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @brief  FIFO overrun status.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of  fifo_over_run_latched in
+  * @param  val    Read the values of  fifo_over_run_latched in
   *                reg FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t asm330lhh_fifo_ovr_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  asm330lhh_fifo_status2_t fifo_status2;
+  uint8_t reg[2];
+  asm330lhh_fifo_status2_t *fifo_status2 = (asm330lhh_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_STATUS2,
-                           (uint8_t *)&fifo_status2, 1);
-  *val = fifo_status2. fifo_ovr_ia;
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_ovr_ia;
+  }
 
   return ret;
 }
@@ -4466,18 +4093,22 @@ int32_t asm330lhh_fifo_ovr_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @brief  FIFO watermark status.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of fifo_wtm_ia in reg FIFO_STATUS2
+  * @param  val    Read the values of fifo_wtm_ia in reg FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t asm330lhh_fifo_wtm_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  asm330lhh_fifo_status2_t fifo_status2;
+  uint8_t reg[2];
+  asm330lhh_fifo_status2_t *fifo_status2 = (asm330lhh_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_STATUS2,
-                           (uint8_t *)&fifo_status2, 1);
-  *val = fifo_status2.fifo_wtm_ia;
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_wtm_ia;
+  }
 
   return ret;
 }
@@ -4504,28 +4135,22 @@ int32_t asm330lhh_fifo_sensor_tag_get(const stmdev_ctx_t *ctx,
     case ASM330LHH_GYRO_NC_TAG:
       *val = ASM330LHH_GYRO_NC_TAG;
       break;
-
     case ASM330LHH_XL_NC_TAG:
       *val = ASM330LHH_XL_NC_TAG;
       break;
-
     case ASM330LHH_TEMPERATURE_TAG:
       *val = ASM330LHH_TEMPERATURE_TAG;
       break;
-
     case ASM330LHH_TIMESTAMP_TAG:
       *val = ASM330LHH_TIMESTAMP_TAG;
       break;
-
     case ASM330LHH_CFG_CHANGE_TAG:
       *val = ASM330LHH_CFG_CHANGE_TAG;
       break;
-
     default:
-      *val = ASM330LHH_CFG_CHANGE_TAG;
+      *val = ASM330LHH_XL_NC_TAG;
       break;
   }
-
   return ret;
 }
 
@@ -4550,20 +4175,17 @@ int32_t asm330lhh_fifo_sensor_tag_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_den_mode_set(const stmdev_ctx_t *ctx,
-                               asm330lhh_den_mode_t val)
+int32_t asm330lhh_den_mode_set(const stmdev_ctx_t *ctx, asm330lhh_den_mode_t val)
 {
   asm330lhh_ctrl6_c_t ctrl6_c;
   int32_t ret;
 
   ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
-
   if (ret == 0)
   {
     ctrl6_c.den_mode = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
   }
-
   return ret;
 }
 
@@ -4588,28 +4210,22 @@ int32_t asm330lhh_den_mode_get(const stmdev_ctx_t *ctx,
     case ASM330LHH_DEN_DISABLE:
       *val = ASM330LHH_DEN_DISABLE;
       break;
-
     case ASM330LHH_LEVEL_FIFO:
       *val = ASM330LHH_LEVEL_FIFO;
       break;
-
     case ASM330LHH_LEVEL_LETCHED:
       *val = ASM330LHH_LEVEL_LETCHED;
       break;
-
     case ASM330LHH_LEVEL_TRIGGER:
       *val = ASM330LHH_LEVEL_TRIGGER;
       break;
-
     case ASM330LHH_EDGE_TRIGGER:
       *val = ASM330LHH_EDGE_TRIGGER;
       break;
-
     default:
       *val = ASM330LHH_DEN_DISABLE;
       break;
   }
-
   return ret;
 }
 
@@ -4627,16 +4243,13 @@ int32_t asm330lhh_den_polarity_set(const stmdev_ctx_t *ctx,
   asm330lhh_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL,
-                           (uint8_t *)&ctrl9_xl, 1);
-
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
   if (ret == 0)
   {
     ctrl9_xl.den_lh = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL9_XL,
                               (uint8_t *)&ctrl9_xl, 1);
   }
-
   return ret;
 }
 
@@ -4654,24 +4267,20 @@ int32_t asm330lhh_den_polarity_get(const stmdev_ctx_t *ctx,
   asm330lhh_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL,
-                           (uint8_t *)&ctrl9_xl, 1);
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
 
   switch (ctrl9_xl.den_lh)
   {
     case ASM330LHH_DEN_ACT_LOW:
       *val = ASM330LHH_DEN_ACT_LOW;
       break;
-
     case ASM330LHH_DEN_ACT_HIGH:
       *val = ASM330LHH_DEN_ACT_HIGH;
       break;
-
     default:
       *val = ASM330LHH_DEN_ACT_LOW;
       break;
   }
-
   return ret;
 }
 
@@ -4689,16 +4298,13 @@ int32_t asm330lhh_den_enable_set(const stmdev_ctx_t *ctx,
   asm330lhh_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL,
-                           (uint8_t *)&ctrl9_xl, 1);
-
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
   if (ret == 0)
   {
     ctrl9_xl.den_xl_g = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL9_XL,
                               (uint8_t *)&ctrl9_xl, 1);
   }
-
   return ret;
 }
 
@@ -4716,28 +4322,23 @@ int32_t asm330lhh_den_enable_get(const stmdev_ctx_t *ctx,
   asm330lhh_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL,
-                           (uint8_t *)&ctrl9_xl, 1);
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
 
   switch (ctrl9_xl.den_xl_g)
   {
     case ASM330LHH_STAMP_IN_GY_DATA:
       *val = ASM330LHH_STAMP_IN_GY_DATA;
       break;
-
     case ASM330LHH_STAMP_IN_XL_DATA:
       *val = ASM330LHH_STAMP_IN_XL_DATA;
       break;
-
     case ASM330LHH_STAMP_IN_GY_XL_DATA:
       *val = ASM330LHH_STAMP_IN_GY_XL_DATA;
       break;
-
     default:
       *val = ASM330LHH_STAMP_IN_GY_DATA;
       break;
   }
-
   return ret;
 }
 
@@ -4754,16 +4355,13 @@ int32_t asm330lhh_den_mark_axis_x_set(const stmdev_ctx_t *ctx, uint8_t val)
   asm330lhh_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL,
-                           (uint8_t *)&ctrl9_xl, 1);
-
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
   if (ret == 0)
   {
     ctrl9_xl.den_z = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL9_XL,
                               (uint8_t *)&ctrl9_xl, 1);
   }
-
   return ret;
 }
 
@@ -4780,8 +4378,7 @@ int32_t asm330lhh_den_mark_axis_x_get(const stmdev_ctx_t *ctx, uint8_t *val)
   asm330lhh_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL,
-                           (uint8_t *)&ctrl9_xl, 1);
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
   *val = ctrl9_xl.den_z;
 
   return ret;
@@ -4800,16 +4397,13 @@ int32_t asm330lhh_den_mark_axis_y_set(const stmdev_ctx_t *ctx, uint8_t val)
   asm330lhh_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL,
-                           (uint8_t *)&ctrl9_xl, 1);
-
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
   if (ret == 0)
   {
     ctrl9_xl.den_y = (uint8_t)val;
     ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL9_XL,
                               (uint8_t *)&ctrl9_xl, 1);
   }
-
   return ret;
 }
 
@@ -4826,8 +4420,7 @@ int32_t asm330lhh_den_mark_axis_y_get(const stmdev_ctx_t *ctx, uint8_t *val)
   asm330lhh_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL,
-                           (uint8_t *)&ctrl9_xl, 1);
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
   *val = ctrl9_xl.den_y;
 
   return ret;
@@ -4846,16 +4439,12 @@ int32_t asm330lhh_den_mark_axis_z_set(const stmdev_ctx_t *ctx, uint8_t val)
   asm330lhh_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL,
-                           (uint8_t *)&ctrl9_xl, 1);
-
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
   if (ret == 0)
   {
     ctrl9_xl.den_x = (uint8_t)val;
-    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL9_XL,
-                              (uint8_t *)&ctrl9_xl, 1);
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
   }
-
   return ret;
 }
 
@@ -4872,8 +4461,7 @@ int32_t asm330lhh_den_mark_axis_z_get(const stmdev_ctx_t *ctx, uint8_t *val)
   asm330lhh_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL,
-                           (uint8_t *)&ctrl9_xl, 1);
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
   *val = ctrl9_xl.den_x;
 
   return ret;

--- a/sensor/stmemsc/asm330lhh_STdC/driver/asm330lhh_reg.h
+++ b/sensor/stmemsc/asm330lhh_STdC/driver/asm330lhh_reg.h
@@ -1,13 +1,13 @@
-/**
+/*
   ******************************************************************************
   * @file    asm330lhh_reg.h
-  * @author  Sensors Software Solution Team
+  * @author  Sensor Solutions Software Team
   * @brief   This file contains all the functions prototypes for the
   *          asm330lhh_reg.c driver.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2021 STMicroelectronics.
+  * <h2><center>&copy; Copyright (c) 2023 STMicroelectronics.
   * All rights reserved.</center></h2>
   *
   * This software component is licensed by ST under BSD 3-Clause license,
@@ -319,6 +319,7 @@ typedef struct
 } asm330lhh_int2_ctrl_t;
 
 #define ASM330LHH_WHO_AM_I                     0x0FU
+
 #define ASM330LHH_CTRL1_XL                     0x10U
 typedef struct
 {
@@ -433,19 +434,19 @@ typedef struct
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t not_used_01              : 1;
+  uint8_t not_used_00              : 1;
   uint8_t usr_off_on_out           : 1;
-  uint8_t not_used_02              : 2;
+  uint8_t not_used_01              : 2;
   uint8_t hpm_g                    : 2;
   uint8_t hp_en_g                  : 1;
-  uint8_t not_used_03              : 1;
+  uint8_t not_used_02              : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t not_used_03              : 1;
+  uint8_t not_used_02              : 1;
   uint8_t hp_en_g                  : 1;
   uint8_t hpm_g                    : 2;
-  uint8_t not_used_02              : 2;
+  uint8_t not_used_01              : 2;
   uint8_t usr_off_on_out           : 1;
-  uint8_t not_used_01              : 1;
+  uint8_t not_used_00              : 1;
 #endif /* DRV_BYTE_ORDER */
 } asm330lhh_ctrl7_g_t;
 
@@ -511,17 +512,17 @@ typedef struct
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ff_ia                    : 1;
   uint8_t wu_ia                    : 1;
-  uint8_t not_used_01              : 2;
+  uint8_t not_used_00              : 2;
   uint8_t d6d_ia                   : 1;
   uint8_t sleep_change_ia          : 1;
-  uint8_t not_used_02              : 1;
+  uint8_t not_used_01              : 1;
   uint8_t timestamp_endcount       : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t timestamp_endcount       : 1;
-  uint8_t not_used_02              : 1;
+  uint8_t not_used_01              : 1;
   uint8_t sleep_change_ia          : 1;
   uint8_t d6d_ia                   : 1;
-  uint8_t not_used_01              : 2;
+  uint8_t not_used_00              : 2;
   uint8_t wu_ia                    : 1;
   uint8_t ff_ia                    : 1;
 #endif /* DRV_BYTE_ORDER */
@@ -605,6 +606,7 @@ typedef struct
 #define ASM330LHH_OUTY_H_A                     0x2BU
 #define ASM330LHH_OUTZ_L_A                     0x2CU
 #define ASM330LHH_OUTZ_H_A                     0x2DU
+
 #define ASM330LHH_FIFO_STATUS1                 0x3AU
 typedef struct
 {
@@ -617,7 +619,7 @@ typedef struct
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t diff_fifo                : 2;
   uint8_t not_used_01              : 1;
-  uint8_t fifo_ovr_latched         : 1;
+  uint8_t over_run_latched         : 1;
   uint8_t counter_bdr_ia           : 1;
   uint8_t fifo_full_ia             : 1;
   uint8_t fifo_ovr_ia              : 1;
@@ -627,7 +629,7 @@ typedef struct
   uint8_t fifo_ovr_ia              : 1;
   uint8_t fifo_full_ia             : 1;
   uint8_t counter_bdr_ia           : 1;
-  uint8_t fifo_ovr_latched         : 1;
+  uint8_t over_run_latched         : 1;
   uint8_t not_used_01              : 1;
   uint8_t diff_fifo                : 2;
 #endif /* DRV_BYTE_ORDER */
@@ -671,7 +673,7 @@ typedef struct
 #endif /* DRV_BYTE_ORDER */
 } asm330lhh_int_cfg1_t;
 
-#define ASM330LHH_THS_6D                       0x59U
+#define ASM330LHH_THS_6D                   0x59U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -731,21 +733,21 @@ typedef struct
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t not_used_01              : 2;
+  uint8_t not_used_00              : 2;
   uint8_t int1_6d                  : 1;
-  uint8_t not_used_02              : 1;
+  uint8_t not_used_01              : 1;
   uint8_t int1_ff                  : 1;
   uint8_t int1_wu                  : 1;
-  uint8_t not_used_03              : 1;
+  uint8_t not_used_02              : 1;
   uint8_t int1_sleep_change        : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t int1_sleep_change        : 1;
-  uint8_t not_used_03              : 1;
+  uint8_t not_used_02              : 1;
   uint8_t int1_wu                  : 1;
   uint8_t int1_ff                  : 1;
-  uint8_t not_used_02              : 1;
+  uint8_t not_used_01              : 1;
   uint8_t int1_6d                  : 1;
-  uint8_t not_used_01              : 2;
+  uint8_t not_used_00              : 2;
 #endif /* DRV_BYTE_ORDER */
 } asm330lhh_md1_cfg_t;
 
@@ -754,21 +756,21 @@ typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t int2_timestamp           : 1;
-  uint8_t not_used_01              : 1;
+  uint8_t int2_emb_func            : 1;
   uint8_t int2_6d                  : 1;
-  uint8_t not_used_02              : 1;
+  uint8_t not_used_01              : 1;
   uint8_t int2_ff                  : 1;
   uint8_t int2_wu                  : 1;
-  uint8_t not_used_03              : 1;
+  uint8_t not_used_02              : 1;
   uint8_t int2_sleep_change        : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t int2_sleep_change        : 1;
-  uint8_t not_used_03              : 1;
+  uint8_t not_used_02              : 1;
   uint8_t int2_wu                  : 1;
   uint8_t int2_ff                  : 1;
-  uint8_t not_used_02              : 1;
-  uint8_t int2_6d                  : 1;
   uint8_t not_used_01              : 1;
+  uint8_t int2_6d                  : 1;
+  uint8_t int2_emb_func            : 1;
   uint8_t int2_timestamp           : 1;
 #endif /* DRV_BYTE_ORDER */
 } asm330lhh_md2_cfg_t;
@@ -805,9 +807,9 @@ typedef struct
 
 /**
   * @defgroup ASM330LHH_Register_Union
-  * @brief    This union group all the registers having a bit-field
+  * @brief    This union group all the registers that has a bit-field
   *           description.
-  *           This union is useful but it's not needed by the driver.
+  *           This union is useful but not need by the driver.
   *
   *           REMOVING this union you are compliant with:
   *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
@@ -852,8 +854,8 @@ typedef union
   asm330lhh_md2_cfg_t                       md2_cfg;
   asm330lhh_internal_freq_fine_t            internal_freq_fine;
   asm330lhh_fifo_data_out_tag_t             fifo_data_out_tag;
-  bitwise_t                                 bitwise;
-  uint8_t                                   byte;
+  bitwise_t                                  bitwise;
+  uint8_t                                    byte;
 } asm330lhh_reg_t;
 
 /**
@@ -874,27 +876,22 @@ typedef union
  * them with a custom implementation.
  */
 
-int32_t asm330lhh_read_reg(const stmdev_ctx_t *ctx, uint8_t reg,
-                           uint8_t *data,
+int32_t asm330lhh_read_reg(const stmdev_ctx_t *ctx, uint8_t reg, uint8_t *data,
                            uint16_t len);
-int32_t asm330lhh_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
-                            uint8_t *data,
+int32_t asm330lhh_write_reg(const stmdev_ctx_t *ctx, uint8_t reg, uint8_t *data,
                             uint16_t len);
 
 float_t asm330lhh_from_fs2g_to_mg(int16_t lsb);
 float_t asm330lhh_from_fs4g_to_mg(int16_t lsb);
 float_t asm330lhh_from_fs8g_to_mg(int16_t lsb);
 float_t asm330lhh_from_fs16g_to_mg(int16_t lsb);
-
 float_t asm330lhh_from_fs125dps_to_mdps(int16_t lsb);
 float_t asm330lhh_from_fs250dps_to_mdps(int16_t lsb);
 float_t asm330lhh_from_fs500dps_to_mdps(int16_t lsb);
 float_t asm330lhh_from_fs1000dps_to_mdps(int16_t lsb);
 float_t asm330lhh_from_fs2000dps_to_mdps(int16_t lsb);
 float_t asm330lhh_from_fs4000dps_to_mdps(int16_t lsb);
-
 float_t asm330lhh_from_lsb_to_celsius(int16_t lsb);
-
 float_t asm330lhh_from_lsb_to_nsec(int32_t lsb);
 
 typedef enum
@@ -904,8 +901,7 @@ typedef enum
   ASM330LHH_4g   = 2,
   ASM330LHH_8g   = 3,
 } asm330lhh_fs_xl_t;
-int32_t asm330lhh_xl_full_scale_set(const stmdev_ctx_t *ctx,
-                                    asm330lhh_fs_xl_t val);
+int32_t asm330lhh_xl_full_scale_set(const stmdev_ctx_t *ctx, asm330lhh_fs_xl_t val);
 int32_t asm330lhh_xl_full_scale_get(const stmdev_ctx_t *ctx,
                                     asm330lhh_fs_xl_t *val);
 
@@ -920,11 +916,10 @@ typedef enum
   ASM330LHH_XL_ODR_417Hz  = 6,
   ASM330LHH_XL_ODR_833Hz  = 7,
   ASM330LHH_XL_ODR_1667Hz = 8,
-  ASM330LHH_XL_ODR_3333Hz = 9,
+  ASM330LHH_XL_ODR_3333Hz =  9,
   ASM330LHH_XL_ODR_6667Hz = 10,
 } asm330lhh_odr_xl_t;
-int32_t asm330lhh_xl_data_rate_set(const stmdev_ctx_t *ctx,
-                                   asm330lhh_odr_xl_t val);
+int32_t asm330lhh_xl_data_rate_set(const stmdev_ctx_t *ctx, asm330lhh_odr_xl_t val);
 int32_t asm330lhh_xl_data_rate_get(const stmdev_ctx_t *ctx,
                                    asm330lhh_odr_xl_t *val);
 
@@ -937,10 +932,8 @@ typedef enum
   ASM330LHH_2000dps = 12,
   ASM330LHH_4000dps = 1,
 } asm330lhh_fs_g_t;
-int32_t asm330lhh_gy_full_scale_set(const stmdev_ctx_t *ctx,
-                                    asm330lhh_fs_g_t val);
-int32_t asm330lhh_gy_full_scale_get(const stmdev_ctx_t *ctx,
-                                    asm330lhh_fs_g_t *val);
+int32_t asm330lhh_gy_full_scale_set(const stmdev_ctx_t *ctx, asm330lhh_fs_g_t val);
+int32_t asm330lhh_gy_full_scale_get(const stmdev_ctx_t *ctx, asm330lhh_fs_g_t *val);
 
 typedef enum
 {
@@ -953,7 +946,7 @@ typedef enum
   ASM330LHH_GY_ODR_417Hz  = 6,
   ASM330LHH_GY_ODR_833Hz  = 7,
   ASM330LHH_GY_ODR_1667Hz = 8,
-  ASM330LHH_GY_ODR_3333Hz = 9,
+  ASM330LHH_GY_ODR_3333Hz =  9,
   ASM330LHH_GY_ODR_6667Hz = 10,
 } asm330lhh_odr_g_t;
 int32_t asm330lhh_gy_data_rate_set(const stmdev_ctx_t *ctx,
@@ -961,10 +954,8 @@ int32_t asm330lhh_gy_data_rate_set(const stmdev_ctx_t *ctx,
 int32_t asm330lhh_gy_data_rate_get(const stmdev_ctx_t *ctx,
                                    asm330lhh_odr_g_t *val);
 
-int32_t asm330lhh_block_data_update_set(const stmdev_ctx_t *ctx,
-                                        uint8_t val);
-int32_t asm330lhh_block_data_update_get(const stmdev_ctx_t *ctx,
-                                        uint8_t *val);
+int32_t asm330lhh_block_data_update_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_block_data_update_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum
 {
@@ -978,10 +969,10 @@ int32_t asm330lhh_xl_offset_weight_get(const stmdev_ctx_t *ctx,
 
 typedef struct
 {
-  asm330lhh_all_int_src_t       all_int_src;
-  asm330lhh_wake_up_src_t       wake_up_src;
-  asm330lhh_d6d_src_t           d6d_src;
-  asm330lhh_status_reg_t        status_reg;
+  asm330lhh_all_int_src_t           all_int_src;
+  asm330lhh_wake_up_src_t           wake_up_src;
+  asm330lhh_d6d_src_t               d6d_src;
+  asm330lhh_status_reg_t            status_reg;
 } asm330lhh_all_sources_t;
 int32_t asm330lhh_all_sources_get(const stmdev_ctx_t *ctx,
                                   asm330lhh_all_sources_t *val);
@@ -989,29 +980,20 @@ int32_t asm330lhh_all_sources_get(const stmdev_ctx_t *ctx,
 int32_t asm330lhh_status_reg_get(const stmdev_ctx_t *ctx,
                                  asm330lhh_status_reg_t *val);
 
-int32_t asm330lhh_xl_flag_data_ready_get(const stmdev_ctx_t *ctx,
-                                         uint8_t *val);
+int32_t asm330lhh_xl_flag_data_ready_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t asm330lhh_gy_flag_data_ready_get(const stmdev_ctx_t *ctx,
-                                         uint8_t *val);
+int32_t asm330lhh_gy_flag_data_ready_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t asm330lhh_temp_flag_data_ready_get(const stmdev_ctx_t *ctx,
-                                           uint8_t *val);
+int32_t asm330lhh_temp_flag_data_ready_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t asm330lhh_xl_usr_offset_x_set(const stmdev_ctx_t *ctx,
-                                      uint8_t *buff);
-int32_t asm330lhh_xl_usr_offset_x_get(const stmdev_ctx_t *ctx,
-                                      uint8_t *buff);
+int32_t asm330lhh_xl_usr_offset_x_set(const stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t asm330lhh_xl_usr_offset_x_get(const stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t asm330lhh_xl_usr_offset_y_set(const stmdev_ctx_t *ctx,
-                                      uint8_t *buff);
-int32_t asm330lhh_xl_usr_offset_y_get(const stmdev_ctx_t *ctx,
-                                      uint8_t *buff);
+int32_t asm330lhh_xl_usr_offset_y_set(const stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t asm330lhh_xl_usr_offset_y_get(const stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t asm330lhh_xl_usr_offset_z_set(const stmdev_ctx_t *ctx,
-                                      uint8_t *buff);
-int32_t asm330lhh_xl_usr_offset_z_get(const stmdev_ctx_t *ctx,
-                                      uint8_t *buff);
+int32_t asm330lhh_xl_usr_offset_z_set(const stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t asm330lhh_xl_usr_offset_z_get(const stmdev_ctx_t *ctx, uint8_t *buff);
 
 int32_t asm330lhh_xl_usr_offset_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t asm330lhh_xl_usr_offset_get(const stmdev_ctx_t *ctx, uint8_t *val);
@@ -1035,14 +1017,11 @@ int32_t asm330lhh_rounding_mode_set(const stmdev_ctx_t *ctx,
 int32_t asm330lhh_rounding_mode_get(const stmdev_ctx_t *ctx,
                                     asm330lhh_rounding_t *val);
 
-int32_t asm330lhh_temperature_raw_get(const stmdev_ctx_t *ctx,
-                                      int16_t *val);
+int32_t asm330lhh_temperature_raw_get(const stmdev_ctx_t *ctx, int16_t *val);
 
-int32_t asm330lhh_angular_rate_raw_get(const stmdev_ctx_t *ctx,
-                                       int16_t *val);
+int32_t asm330lhh_angular_rate_raw_get(const stmdev_ctx_t *ctx, int16_t *val);
 
-int32_t asm330lhh_acceleration_raw_get(const stmdev_ctx_t *ctx,
-                                       int16_t *val);
+int32_t asm330lhh_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *val);
 
 int32_t asm330lhh_fifo_out_raw_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
@@ -1079,10 +1058,8 @@ typedef enum
   ASM330LHH_XL_ST_POSITIVE = 1,
   ASM330LHH_XL_ST_NEGATIVE = 2,
 } asm330lhh_st_xl_t;
-int32_t asm330lhh_xl_self_test_set(const stmdev_ctx_t *ctx,
-                                   asm330lhh_st_xl_t val);
-int32_t asm330lhh_xl_self_test_get(const stmdev_ctx_t *ctx,
-                                   asm330lhh_st_xl_t *val);
+int32_t asm330lhh_xl_self_test_set(const stmdev_ctx_t *ctx, asm330lhh_st_xl_t val);
+int32_t asm330lhh_xl_self_test_get(const stmdev_ctx_t *ctx, asm330lhh_st_xl_t *val);
 
 typedef enum
 {
@@ -1090,10 +1067,8 @@ typedef enum
   ASM330LHH_GY_ST_POSITIVE = 1,
   ASM330LHH_GY_ST_NEGATIVE = 3,
 } asm330lhh_st_g_t;
-int32_t asm330lhh_gy_self_test_set(const stmdev_ctx_t *ctx,
-                                   asm330lhh_st_g_t val);
-int32_t asm330lhh_gy_self_test_get(const stmdev_ctx_t *ctx,
-                                   asm330lhh_st_g_t *val);
+int32_t asm330lhh_gy_self_test_set(const stmdev_ctx_t *ctx, asm330lhh_st_g_t val);
+int32_t asm330lhh_gy_self_test_get(const stmdev_ctx_t *ctx, asm330lhh_st_g_t *val);
 
 int32_t asm330lhh_xl_filter_lp2_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t asm330lhh_xl_filter_lp2_get(const stmdev_ctx_t *ctx, uint8_t *val);
@@ -1101,10 +1076,8 @@ int32_t asm330lhh_xl_filter_lp2_get(const stmdev_ctx_t *ctx, uint8_t *val);
 int32_t asm330lhh_gy_filter_lp1_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t asm330lhh_gy_filter_lp1_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t asm330lhh_filter_settling_mask_set(const stmdev_ctx_t *ctx,
-                                           uint8_t val);
-int32_t asm330lhh_filter_settling_mask_get(const stmdev_ctx_t *ctx,
-                                           uint8_t *val);
+int32_t asm330lhh_filter_settling_mask_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_filter_settling_mask_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum
 {
@@ -1156,10 +1129,8 @@ int32_t asm330lhh_xl_hp_path_on_out_set(const stmdev_ctx_t *ctx,
 int32_t asm330lhh_xl_hp_path_on_out_get(const stmdev_ctx_t *ctx,
                                         asm330lhh_hp_slope_xl_en_t *val);
 
-int32_t asm330lhh_xl_fast_settling_set(const stmdev_ctx_t *ctx,
-                                       uint8_t val);
-int32_t asm330lhh_xl_fast_settling_get(const stmdev_ctx_t *ctx,
-                                       uint8_t *val);
+int32_t asm330lhh_xl_fast_settling_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_xl_fast_settling_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum
 {
@@ -1199,10 +1170,8 @@ typedef enum
   ASM330LHH_SPI_4_WIRE = 0,
   ASM330LHH_SPI_3_WIRE = 1,
 } asm330lhh_sim_t;
-int32_t asm330lhh_spi_mode_set(const stmdev_ctx_t *ctx,
-                               asm330lhh_sim_t val);
-int32_t asm330lhh_spi_mode_get(const stmdev_ctx_t *ctx,
-                               asm330lhh_sim_t *val);
+int32_t asm330lhh_spi_mode_set(const stmdev_ctx_t *ctx, asm330lhh_sim_t val);
+int32_t asm330lhh_spi_mode_get(const stmdev_ctx_t *ctx, asm330lhh_sim_t *val);
 
 typedef enum
 {
@@ -1239,10 +1208,8 @@ typedef enum
   ASM330LHH_PUSH_PULL   = 0,
   ASM330LHH_OPEN_DRAIN  = 1,
 } asm330lhh_pp_od_t;
-int32_t asm330lhh_pin_mode_set(const stmdev_ctx_t *ctx,
-                               asm330lhh_pp_od_t val);
-int32_t asm330lhh_pin_mode_get(const stmdev_ctx_t *ctx,
-                               asm330lhh_pp_od_t *val);
+int32_t asm330lhh_pin_mode_set(const stmdev_ctx_t *ctx, asm330lhh_pp_od_t val);
+int32_t asm330lhh_pin_mode_get(const stmdev_ctx_t *ctx, asm330lhh_pp_od_t *val);
 
 typedef enum
 {
@@ -1260,6 +1227,8 @@ int32_t asm330lhh_all_on_int1_get(const stmdev_ctx_t *ctx, uint8_t *val);
 typedef enum
 {
   ASM330LHH_ALL_INT_PULSED            = 0,
+  ASM330LHH_BASE_LATCHED_EMB_PULSED   = 1,
+  ASM330LHH_BASE_PULSED_EMB_LATCHED   = 2,
   ASM330LHH_ALL_INT_LATCHED           = 3,
 } asm330lhh_lir_t;
 int32_t asm330lhh_int_notification_set(const stmdev_ctx_t *ctx,
@@ -1351,18 +1320,15 @@ int32_t asm330lhh_ff_dur_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t asm330lhh_ff_dur_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 int32_t asm330lhh_fifo_watermark_set(const stmdev_ctx_t *ctx, uint16_t val);
-int32_t asm330lhh_fifo_watermark_get(const stmdev_ctx_t *ctx,
-                                     uint16_t *val);
+int32_t asm330lhh_fifo_watermark_get(const stmdev_ctx_t *ctx, uint16_t *val);
 
 int32_t asm330lhh_fifo_virtual_sens_odr_chg_set(const stmdev_ctx_t *ctx,
                                                 uint8_t val);
 int32_t asm330lhh_fifo_virtual_sens_odr_chg_get(const stmdev_ctx_t *ctx,
                                                 uint8_t *val);
 
-int32_t asm330lhh_fifo_stop_on_wtm_set(const stmdev_ctx_t *ctx,
-                                       uint8_t val);
-int32_t asm330lhh_fifo_stop_on_wtm_get(const stmdev_ctx_t *ctx,
-                                       uint8_t *val);
+int32_t asm330lhh_fifo_stop_on_wtm_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_fifo_stop_on_wtm_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum
 {
@@ -1377,7 +1343,6 @@ typedef enum
   ASM330LHH_XL_BATCHED_AT_1667Hz  =  8,
   ASM330LHH_XL_BATCHED_AT_3333Hz  =  9,
   ASM330LHH_XL_BATCHED_AT_6667Hz  = 10,
-  ASM330LHH_XL_BATCHED_AT_6Hz5    = 11,
 } asm330lhh_bdr_xl_t;
 int32_t asm330lhh_fifo_xl_batch_set(const stmdev_ctx_t *ctx,
                                     asm330lhh_bdr_xl_t val);
@@ -1413,8 +1378,7 @@ typedef enum
   ASM330LHH_STREAM_MODE             = 6,
   ASM330LHH_BYPASS_TO_FIFO_MODE     = 7,
 } asm330lhh_fifo_mode_t;
-int32_t asm330lhh_fifo_mode_set(const stmdev_ctx_t *ctx,
-                                asm330lhh_fifo_mode_t val);
+int32_t asm330lhh_fifo_mode_set(const stmdev_ctx_t *ctx, asm330lhh_fifo_mode_t val);
 int32_t asm330lhh_fifo_mode_get(const stmdev_ctx_t *ctx,
                                 asm330lhh_fifo_mode_t *val);
 
@@ -1436,11 +1400,11 @@ typedef enum
   ASM330LHH_DEC_1         = 1,
   ASM330LHH_DEC_8         = 2,
   ASM330LHH_DEC_32        = 3,
-} asm330lhh_odr_ts_batch_t;
+} asm330lhh_dec_ts_batch_t;
 int32_t asm330lhh_fifo_timestamp_decimation_set(const stmdev_ctx_t *ctx,
-                                                asm330lhh_odr_ts_batch_t val);
+                                                asm330lhh_dec_ts_batch_t val);
 int32_t asm330lhh_fifo_timestamp_decimation_get(const stmdev_ctx_t *ctx,
-                                                asm330lhh_odr_ts_batch_t *val);
+                                                asm330lhh_dec_ts_batch_t *val);
 
 typedef enum
 {
@@ -1452,18 +1416,15 @@ int32_t asm330lhh_fifo_cnt_event_batch_set(const stmdev_ctx_t *ctx,
 int32_t asm330lhh_fifo_cnt_event_batch_get(const stmdev_ctx_t *ctx,
                                            asm330lhh_trig_counter_bdr_t *val);
 
-int32_t asm330lhh_rst_batch_counter_set(const stmdev_ctx_t *ctx,
-                                        uint8_t val);
-int32_t asm330lhh_rst_batch_counter_get(const stmdev_ctx_t *ctx,
-                                        uint8_t *val);
+int32_t asm330lhh_rst_batch_counter_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_rst_batch_counter_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 int32_t asm330lhh_batch_counter_threshold_set(const stmdev_ctx_t *ctx,
                                               uint16_t val);
 int32_t asm330lhh_batch_counter_threshold_get(const stmdev_ctx_t *ctx,
                                               uint16_t *val);
 
-int32_t asm330lhh_fifo_data_level_get(const stmdev_ctx_t *ctx,
-                                      uint16_t *val);
+int32_t asm330lhh_fifo_data_level_get(const stmdev_ctx_t *ctx, uint16_t *val);
 
 int32_t asm330lhh_fifo_status_get(const stmdev_ctx_t *ctx,
                                   asm330lhh_fifo_status2_t *val);
@@ -1476,11 +1437,11 @@ int32_t asm330lhh_fifo_wtm_flag_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum
 {
-  ASM330LHH_GYRO_NC_TAG    = 1,
-  ASM330LHH_XL_NC_TAG,
-  ASM330LHH_TEMPERATURE_TAG,
-  ASM330LHH_TIMESTAMP_TAG,
-  ASM330LHH_CFG_CHANGE_TAG,
+  ASM330LHH_GYRO_NC_TAG          = 0x01,
+  ASM330LHH_XL_NC_TAG            = 0x02,
+  ASM330LHH_TEMPERATURE_TAG      = 0x03,
+  ASM330LHH_TIMESTAMP_TAG        = 0x04,
+  ASM330LHH_CFG_CHANGE_TAG       = 0x05,
 } asm330lhh_fifo_tag_t;
 int32_t asm330lhh_fifo_sensor_tag_get(const stmdev_ctx_t *ctx,
                                       asm330lhh_fifo_tag_t *val);
@@ -1520,16 +1481,13 @@ int32_t asm330lhh_den_enable_get(const stmdev_ctx_t *ctx,
                                  asm330lhh_den_xl_g_t *val);
 
 int32_t asm330lhh_den_mark_axis_x_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t asm330lhh_den_mark_axis_x_get(const stmdev_ctx_t *ctx,
-                                      uint8_t *val);
+int32_t asm330lhh_den_mark_axis_x_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 int32_t asm330lhh_den_mark_axis_y_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t asm330lhh_den_mark_axis_y_get(const stmdev_ctx_t *ctx,
-                                      uint8_t *val);
+int32_t asm330lhh_den_mark_axis_y_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 int32_t asm330lhh_den_mark_axis_z_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t asm330lhh_den_mark_axis_z_get(const stmdev_ctx_t *ctx,
-                                      uint8_t *val);
+int32_t asm330lhh_den_mark_axis_z_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 /**
   *@}

--- a/sensor/stmemsc/asm330lhhx_STdC/driver/asm330lhhx_reg.c
+++ b/sensor/stmemsc/asm330lhhx_STdC/driver/asm330lhhx_reg.c
@@ -6,7 +6,7 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; Copyright (c) 2020 STMicroelectronics.
+ * <h2><center>&copy; Copyright (c) 2023 STMicroelectronics.
  * All rights reserved.</center></h2>
  *
  * This software component is licensed by ST under BSD 3-Clause license,
@@ -51,7 +51,10 @@ int32_t __weak asm330lhhx_read_reg(const stmdev_ctx_t *ctx, uint8_t reg, uint8_t
 {
   int32_t ret;
 
-  if (ctx == NULL) return -1;
+  if (ctx == NULL)
+  {
+    return -1;
+  }
 
   ret = ctx->read_reg(ctx->handle, reg, data, len);
 
@@ -73,7 +76,10 @@ int32_t __weak asm330lhhx_write_reg(const stmdev_ctx_t *ctx, uint8_t reg, uint8_
 {
   int32_t ret;
 
-  if (ctx == NULL) return -1;
+  if (ctx == NULL)
+  {
+    return -1;
+  }
 
   ret = ctx->write_reg(ctx->handle, reg, data, len);
 
@@ -3242,6 +3248,7 @@ int32_t asm330lhhx_pin_int1_route_set(const stmdev_ctx_t *ctx,
   {
     ret = asm330lhhx_write_reg(ctx, ASM330LHHX_MD1_CFG, (uint8_t *)&val->md1_cfg, 1);
   }
+
   if (ret == 0)
   {
     ret = asm330lhhx_read_reg(ctx, ASM330LHHX_INT_CFG1, (uint8_t *) &int_cfg1, 1);
@@ -4482,19 +4489,15 @@ int32_t asm330lhhx_fifo_watermark_set(const stmdev_ctx_t *ctx, uint16_t val)
   asm330lhhx_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
 
-  ret = asm330lhhx_read_reg(ctx, ASM330LHHX_FIFO_CTRL2,
-                            (uint8_t *)&fifo_ctrl2, 1);
+  ret = asm330lhhx_read_reg(ctx, ASM330LHHX_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
+  ret += asm330lhhx_read_reg(ctx, ASM330LHHX_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+
   if (ret == 0)
   {
+    fifo_ctrl1.wtm = (uint8_t)(val  & 0xFFU);
     fifo_ctrl2.wtm = (uint8_t)((val / 256U) & 0x01U);
-    ret = asm330lhhx_write_reg(ctx, ASM330LHHX_FIFO_CTRL2,
-                               (uint8_t *)&fifo_ctrl2, 1);
-  }
-  if (ret == 0)
-  {
-    fifo_ctrl1.wtm = (uint8_t)(val - (fifo_ctrl2.wtm * 256U));
-    ret = asm330lhhx_write_reg(ctx, ASM330LHHX_FIFO_CTRL1,
-                               (uint8_t *)&fifo_ctrl1, 1);
+    ret = asm330lhhx_write_reg(ctx, ASM330LHHX_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
+    ret += asm330lhhx_write_reg(ctx, ASM330LHHX_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
   }
 
   return ret;
@@ -5171,26 +5174,25 @@ int32_t asm330lhhx_batch_counter_threshold_get(const stmdev_ctx_t *ctx,
   * @brief  Number of unread sensor data (TAG + 6 bytes) stored in FIFO.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of diff_fifo in reg FIFO_STATUS1
+  * @param  val    Read the value of diff_fifo in reg FIFO_STATUS1 and FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t asm330lhhx_fifo_data_level_get(const stmdev_ctx_t *ctx, uint16_t *val)
 {
-  asm330lhhx_fifo_status1_t fifo_status1;
-  asm330lhhx_fifo_status2_t fifo_status2;
+  uint8_t reg[2];
+  asm330lhhx_fifo_status1_t *fifo_status1 = (asm330lhhx_fifo_status1_t *)&reg[0];
+  asm330lhhx_fifo_status2_t *fifo_status2 = (asm330lhhx_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = asm330lhhx_read_reg(ctx, ASM330LHHX_FIFO_STATUS1,
-                            (uint8_t *)&fifo_status1, 1);
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = asm330lhhx_read_reg(ctx, ASM330LHHX_FIFO_STATUS1, (uint8_t *)reg, 2);
   if (ret == 0)
   {
-    ret = asm330lhhx_read_reg(ctx, ASM330LHHX_FIFO_STATUS2,
-                              (uint8_t *)&fifo_status2, 1);
-
-    *val = fifo_status2.diff_fifo;
-    *val = (*val * 256U) + fifo_status1.diff_fifo;
+    *val = fifo_status2->diff_fifo;
+    *val = (*val * 256U) + fifo_status1->diff_fifo;
   }
+
   return ret;
 }
 
@@ -5198,15 +5200,24 @@ int32_t asm330lhhx_fifo_data_level_get(const stmdev_ctx_t *ctx, uint16_t *val)
   * @brief  Smart FIFO status.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Registers FIFO_STATUS2
+  * @param  val    Read registers FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t asm330lhhx_fifo_status_get(const stmdev_ctx_t *ctx,
                                    asm330lhhx_fifo_status2_t *val)
 {
+  uint8_t reg[2];
+  asm330lhhx_fifo_status2_t *fifo_status2 = (asm330lhhx_fifo_status2_t *)&reg[1];
   int32_t ret;
-  ret = asm330lhhx_read_reg(ctx, ASM330LHHX_FIFO_STATUS2, (uint8_t *)val, 1);
+
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = asm330lhhx_read_reg(ctx, ASM330LHHX_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = *fifo_status2;
+  }
+
   return ret;
 }
 
@@ -5214,18 +5225,22 @@ int32_t asm330lhhx_fifo_status_get(const stmdev_ctx_t *ctx,
   * @brief  Smart FIFO full status.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of fifo_full_ia in reg FIFO_STATUS2
+  * @param  val    Read the values of fifo_full_ia in reg FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t asm330lhhx_fifo_full_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  asm330lhhx_fifo_status2_t fifo_status2;
+  uint8_t reg[2];
+  asm330lhhx_fifo_status2_t *fifo_status2 = (asm330lhhx_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = asm330lhhx_read_reg(ctx, ASM330LHHX_FIFO_STATUS2,
-                            (uint8_t *)&fifo_status2, 1);
-  *val = fifo_status2.fifo_full_ia;
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = asm330lhhx_read_reg(ctx, ASM330LHHX_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_full_ia;
+  }
 
   return ret;
 }
@@ -5234,19 +5249,23 @@ int32_t asm330lhhx_fifo_full_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @brief  FIFO overrun status.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of  fifo_over_run_latched in
+  * @param  val    Read the values of  fifo_over_run_latched in
   *                reg FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t asm330lhhx_fifo_ovr_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  asm330lhhx_fifo_status2_t fifo_status2;
+  uint8_t reg[2];
+  asm330lhhx_fifo_status2_t *fifo_status2 = (asm330lhhx_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = asm330lhhx_read_reg(ctx, ASM330LHHX_FIFO_STATUS2,
-                            (uint8_t *)&fifo_status2, 1);
-  *val = fifo_status2. fifo_ovr_ia;
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = asm330lhhx_read_reg(ctx, ASM330LHHX_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_ovr_ia;
+  }
 
   return ret;
 }
@@ -5255,18 +5274,22 @@ int32_t asm330lhhx_fifo_ovr_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @brief  FIFO watermark status.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of fifo_wtm_ia in reg FIFO_STATUS2
+  * @param  val    Read the values of fifo_wtm_ia in reg FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t asm330lhhx_fifo_wtm_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  asm330lhhx_fifo_status2_t fifo_status2;
+  uint8_t reg[2];
+  asm330lhhx_fifo_status2_t *fifo_status2 = (asm330lhhx_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = asm330lhhx_read_reg(ctx, ASM330LHHX_FIFO_STATUS2,
-                            (uint8_t *)&fifo_status2, 1);
-  *val = fifo_status2.fifo_wtm_ia;
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = asm330lhhx_read_reg(ctx, ASM330LHHX_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_wtm_ia;
+  }
 
   return ret;
 }
@@ -5321,7 +5344,7 @@ int32_t asm330lhhx_fifo_sensor_tag_get(const stmdev_ctx_t *ctx,
       *val = ASM330LHHX_SENSORHUB_NACK_TAG;
       break;
     default:
-      *val = ASM330LHHX_SENSORHUB_NACK_TAG;
+      *val = ASM330LHHX_XL_NC_TAG;
       break;
   }
   return ret;

--- a/sensor/stmemsc/asm330lhhx_STdC/driver/asm330lhhx_reg.h
+++ b/sensor/stmemsc/asm330lhhx_STdC/driver/asm330lhhx_reg.h
@@ -7,7 +7,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2020 STMicroelectronics.
+  * <h2><center>&copy; Copyright (c) 2023 STMicroelectronics.
   * All rights reserved.</center></h2>
   *
   * This software component is licensed by ST under BSD 3-Clause license,
@@ -2418,6 +2418,12 @@ typedef struct
 #endif /* DRV_BYTE_ORDER */
 } asm330lhhx_status_master_t;
 
+#define ASM330LHHX_FSM_LC_TIMEOUT_L             0x17AU
+#define ASM330LHHX_FSM_LC_TIMEOUT_H             0x17BU
+#define ASM330LHHX_FSM_PROGRAMS                 0x17CU
+#define ASM330LHHX_FSM_START_ADD_L              0x17EU
+#define ASM330LHHX_FSM_START_ADD_H              0x17FU
+
 /**
   * @defgroup ASM330LHHX_Register_Union
   * @brief    This union group all the registers that has a bit-field
@@ -2605,7 +2611,7 @@ typedef enum
   ASM330LHHX_XL_ODR_417Hz  = 6,
   ASM330LHHX_XL_ODR_833Hz  = 7,
   ASM330LHHX_XL_ODR_1667Hz = 8,
-  ASM330LHHX_XL_ODR_3333Hz = 9,
+  ASM330LHHX_XL_ODR_3333Hz =  9,
   ASM330LHHX_XL_ODR_6667Hz = 10,
   ASM330LHHX_XL_ODR_1Hz6   = 11, /* (low power only) */
 } asm330lhhx_odr_xl_t;
@@ -2636,7 +2642,7 @@ typedef enum
   ASM330LHHX_GY_ODR_417Hz  = 6,
   ASM330LHHX_GY_ODR_833Hz  = 7,
   ASM330LHHX_GY_ODR_1667Hz = 8,
-  ASM330LHHX_GY_ODR_3333Hz = 9,
+  ASM330LHHX_GY_ODR_3333Hz =  9,
   ASM330LHHX_GY_ODR_6667Hz = 10,
 } asm330lhhx_odr_g_t;
 int32_t asm330lhhx_gy_data_rate_set(const stmdev_ctx_t *ctx,
@@ -3093,7 +3099,7 @@ int32_t asm330lhhx_fifo_stop_on_wtm_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum
 {
-  ASM330LHHX_XL_NOT_BATCHED       =  0,
+  ASM330LHHX_XL_NOT_BATCHED        =  0,
   ASM330LHHX_XL_BATCHED_AT_12Hz5   =  1,
   ASM330LHHX_XL_BATCHED_AT_26Hz    =  2,
   ASM330LHHX_XL_BATCHED_AT_52Hz    =  3,
@@ -3426,7 +3432,6 @@ int32_t asm330lhhx_mlc_out_get(const stmdev_ctx_t *ctx, uint8_t *buff);
 
 int32_t asm330lhhx_mlc_mag_sensitivity_set(const stmdev_ctx_t *ctx, uint16_t val);
 int32_t asm330lhhx_mlc_mag_sensitivity_get(const stmdev_ctx_t *ctx, uint16_t *val);
-
 typedef struct
 {
   asm330lhhx_sensor_hub_1_t   sh_byte_1;

--- a/sensor/stmemsc/ilps22qs_STdC/driver/ilps22qs_reg.h
+++ b/sensor/stmemsc/ilps22qs_STdC/driver/ilps22qs_reg.h
@@ -1,4 +1,4 @@
-/*
+/**
   ******************************************************************************
   * @file    ilps22qs_reg.h
   * @author  Sensors Software Solution Team
@@ -235,7 +235,7 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t not_used_03      : 1;
   uint8_t i2c_i3c_dis      : 1;
-  uint8_t sim              : 1;
+  uint8_t en_spi_read      : 1;
   uint8_t sda_pu_en        : 1;
   uint8_t not_used_02      : 2;
   uint8_t cs_pu_dis        : 1;
@@ -286,17 +286,17 @@ typedef struct
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t if_add_inc             : 1;
-  uint8_t not_used_01            : 4;
-  uint8_t ah_qvar_p_auto_en      : 1;
-  uint8_t not_used_02            : 1;
-  uint8_t ah_qvar_en             : 1;
+  uint8_t if_add_inc       : 1;
+  uint8_t not_used_01      : 4;
+  uint8_t ah_qvar_p_auto_en: 1;
+  uint8_t not_used_02      : 1;
+  uint8_t ah_qvar_en       : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t ah_qvar_en             : 1;
-  uint8_t not_used_02            : 1;
-  uint8_t ah_qvar_p_auto_en      : 1;
-  uint8_t not_used_01            : 4;
-  uint8_t if_add_inc             : 1;
+  uint8_t ah_qvar_en       : 1;
+  uint8_t not_used_02      : 1;
+  uint8_t ah_qvar_p_auto_en: 1;
+  uint8_t not_used_01      : 4;
+  uint8_t if_add_inc       : 1;
 #endif /* DRV_BYTE_ORDER */
 } ilps22qs_ctrl_reg3_t;
 
@@ -304,17 +304,17 @@ typedef struct
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t f_mode                 : 2;
-  uint8_t trig_modes             : 1;
-  uint8_t stop_on_wtm            : 1;
-  uint8_t ah_qvar_p_fifo_en      : 1;
-  uint8_t not_used_01            : 3;
+  uint8_t f_mode           : 2;
+  uint8_t trig_modes       : 1;
+  uint8_t stop_on_wtm      : 1;
+  uint8_t ah_qvar_p_fifo_en: 1;
+  uint8_t not_used_01      : 3;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t not_used_01            : 3;
-  uint8_t ah_qvar_p_fifo_en      : 1;
-  uint8_t stop_on_wtm            : 1;
-  uint8_t trig_modes             : 1;
-  uint8_t f_mode                 : 2;
+  uint8_t not_used_01      : 3;
+  uint8_t ah_qvar_p_fifo_en: 1;
+  uint8_t stop_on_wtm      : 1;
+  uint8_t trig_modes       : 1;
+  uint8_t f_mode           : 2;
 #endif /* DRV_BYTE_ORDER */
 } ilps22qs_fifo_ctrl_t;
 
@@ -483,9 +483,7 @@ int32_t ilps22qs_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
 
 extern float_t ilps22qs_from_fs1260_to_hPa(int32_t lsb);
 extern float_t ilps22qs_from_fs4000_to_hPa(int32_t lsb);
-
 extern float_t ilps22qs_from_lsb_to_celsius(int16_t lsb);
-
 extern float_t ilps22qs_from_lsb_to_mv(int32_t lsb);
 
 typedef struct
@@ -496,14 +494,14 @@ int32_t ilps22qs_id_get(const stmdev_ctx_t *ctx, ilps22qs_id_t *val);
 
 typedef enum
 {
-  ILPS22QS_SEL_BY_HW = 0x00, /* bus mode select by HW (SPI 3W disable) */
-  ILPS22QS_SPI_3W    = 0x03, /* bus mode select by HW (SPI 3W enable) */
+  ILPS22QS_SEL_BY_HW      = 0x00, /* bus mode select by HW (SPI 3W disable) */
+  ILPS22QS_SPI_3W         = 0x03, /* Only SPI: SDO / SDI share the same pin */
 } ilps22qs_interface_t;
 
 typedef enum
 {
-  ILPS22QS_AUTO      = 0x00, /* bus mode select by HW (SPI 3W disable) */
-  ILPS22QS_ALWAYS_ON = 0x01, /* Only SPI: SDO / SDI separated pins */
+  ILPS22QS_FILTER_AUTO      = 0x00, /* Disable anti-spike filters */
+  ILPS22QS_FILTER_ALWAYS_ON = 0x01, /* Enable anti-spike filters */
 } ilps22qs_filter_t;
 
 typedef struct
@@ -537,8 +535,8 @@ int32_t ilps22qs_status_get(const stmdev_ctx_t *ctx, ilps22qs_stat_t *val);
 
 typedef struct
 {
-  uint8_t sda_pull_up : 1; /* 1 = pull-up always disabled */
-  uint8_t cs_pull_up  : 1; /* 1 = pull-up always disabled */
+  uint8_t sda_pull_up : 1; /* 1 = pull-up enabled */
+  uint8_t cs_pull_up  : 1; /* 1 = pull-up enabled */
 } ilps22qs_pin_conf_t;
 int32_t ilps22qs_pin_conf_set(const stmdev_ctx_t *ctx, ilps22qs_pin_conf_t *val);
 int32_t ilps22qs_pin_conf_get(const stmdev_ctx_t *ctx, ilps22qs_pin_conf_t *val);
@@ -554,8 +552,7 @@ typedef struct
   uint8_t fifo_ovr    :  1; /* FIFO overrun */
   uint8_t fifo_th     :  1; /* FIFO threshold reached */
 } ilps22qs_all_sources_t;
-int32_t ilps22qs_all_sources_get(const stmdev_ctx_t *ctx,
-                                 ilps22qs_all_sources_t *val);
+int32_t ilps22qs_all_sources_get(const stmdev_ctx_t *ctx, ilps22qs_all_sources_t *val);
 
 typedef enum
 {
@@ -597,11 +594,11 @@ typedef enum
 
 typedef struct
 {
+  uint8_t interleaved_mode;
   ilps22qs_fs_t fs;
   ilps22qs_odr_t odr;
   ilps22qs_avg_t avg;
   ilps22qs_lpf_t lpf;
-  uint8_t interleaved_mode;
 } ilps22qs_md_t;
 int32_t ilps22qs_mode_set(const stmdev_ctx_t *ctx, ilps22qs_md_t *val);
 int32_t ilps22qs_mode_get(const stmdev_ctx_t *ctx, ilps22qs_md_t *val);
@@ -673,10 +670,8 @@ typedef struct
 {
   uint8_t int_latched  : 1; /* int events are: int on threshold, FIFO */
 } ilps22qs_int_mode_t;
-int32_t ilps22qs_interrupt_mode_set(const stmdev_ctx_t *ctx,
-                                    ilps22qs_int_mode_t *val);
-int32_t ilps22qs_interrupt_mode_get(const stmdev_ctx_t *ctx,
-                                    ilps22qs_int_mode_t *val);
+int32_t ilps22qs_interrupt_mode_set(const stmdev_ctx_t *ctx, ilps22qs_int_mode_t *val);
+int32_t ilps22qs_interrupt_mode_get(const stmdev_ctx_t *ctx, ilps22qs_int_mode_t *val);
 
 int32_t ilps22qs_ah_qvar_disable(const stmdev_ctx_t *ctx);
 int32_t ilps22qs_ah_qvar_en_set(const stmdev_ctx_t *ctx, uint8_t val);

--- a/sensor/stmemsc/ilps28qsw_STdC/driver/ilps28qsw_reg.c
+++ b/sensor/stmemsc/ilps28qsw_STdC/driver/ilps28qsw_reg.c
@@ -6,7 +6,7 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; Copyright (c) 2023 STMicroelectronics.
+ * <h2><center>&copy; Copyright (c) 2024 STMicroelectronics.
  * All rights reserved.</center></h2>
  *
  * This software component is licensed by ST under BSD 3-Clause license,
@@ -71,8 +71,7 @@ int32_t __weak ilps28qsw_read_reg(const stmdev_ctx_t *ctx, uint8_t reg, uint8_t 
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t __weak ilps28qsw_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
-                                   uint8_t *data,
+int32_t __weak ilps28qsw_write_reg(const stmdev_ctx_t *ctx, uint8_t reg, uint8_t *data,
                                    uint16_t len)
 {
   int32_t ret;
@@ -124,7 +123,7 @@ float_t ilps28qsw_from_fs1260_to_hPa(int32_t lsb)
   return ((float_t)lsb / 1048576.0f);   /* 4096.0f * 256 */
 }
 
-float_t ilps28qsw_from_fs4000_to_hPa(int32_t lsb)
+float_t ilps28qsw_from_fs4060_to_hPa(int32_t lsb)
 {
   return ((float_t)lsb /  524288.0f);   /* 2048.0f * 256 */
 }
@@ -189,9 +188,11 @@ int32_t ilps28qsw_bus_mode_set(const stmdev_ctx_t *ctx, ilps28qsw_bus_mode_t *va
   if (ret == 0)
   {
     i3c_if_ctrl.asf_on = (uint8_t)val->filter & 0x01U;
+    i3c_if_ctrl.I3C_Bus_Avb_Sel = (uint8_t)val->bus_avb_time & 0x03U;
     ret = ilps28qsw_write_reg(ctx, ILPS28QSW_I3C_IF_CTRL,
                               (uint8_t *)&i3c_if_ctrl, 1);
   }
+
   return ret;
 }
 
@@ -208,8 +209,7 @@ int32_t ilps28qsw_bus_mode_get(const stmdev_ctx_t *ctx, ilps28qsw_bus_mode_t *va
   ilps28qsw_i3c_if_ctrl_t i3c_if_ctrl;
   int32_t ret;
 
-  ret = ilps28qsw_read_reg(ctx, ILPS28QSW_I3C_IF_CTRL,
-                           (uint8_t *)&i3c_if_ctrl, 1);
+  ret = ilps28qsw_read_reg(ctx, ILPS28QSW_I3C_IF_CTRL, (uint8_t *)&i3c_if_ctrl, 1);
   if (ret == 0)
   {
     switch (i3c_if_ctrl.asf_on)
@@ -224,7 +224,27 @@ int32_t ilps28qsw_bus_mode_get(const stmdev_ctx_t *ctx, ilps28qsw_bus_mode_t *va
         val->filter = ILPS28QSW_AUTO;
         break;
     }
+
+    switch (i3c_if_ctrl.I3C_Bus_Avb_Sel)
+    {
+      case ILPS28QSW_BUS_AVB_TIME_50us:
+        val->bus_avb_time = ILPS28QSW_BUS_AVB_TIME_50us;
+        break;
+      case ILPS28QSW_BUS_AVB_TIME_2us:
+        val->bus_avb_time = ILPS28QSW_BUS_AVB_TIME_2us;
+        break;
+      case ILPS28QSW_BUS_AVB_TIME_1ms:
+        val->bus_avb_time = ILPS28QSW_BUS_AVB_TIME_1ms;
+        break;
+      case ILPS28QSW_BUS_AVB_TIME_25ms:
+        val->bus_avb_time = ILPS28QSW_BUS_AVB_TIME_25ms;
+        break;
+      default:
+        val->bus_avb_time = ILPS28QSW_BUS_AVB_TIME_50us;
+        break;
+    }
   }
+
   return ret;
 }
 
@@ -275,7 +295,6 @@ int32_t ilps28qsw_init_set(const stmdev_ctx_t *ctx, ilps28qsw_init_t val)
         break;
     }
   }
-
   return ret;
 }
 
@@ -360,7 +379,6 @@ int32_t ilps28qsw_pin_conf_get(const stmdev_ctx_t *ctx, ilps28qsw_pin_conf_t *va
   int32_t ret;
 
   ret = ilps28qsw_read_reg(ctx, ILPS28QSW_IF_CTRL, (uint8_t *)&if_ctrl, 1);
-
   val->sda_pull_up  = if_ctrl.sda_pu_en;
 
   return ret;
@@ -474,7 +492,7 @@ int32_t ilps28qsw_mode_set(const stmdev_ctx_t *ctx, ilps28qsw_md_t *val)
     ctrl_reg1.odr = (uint8_t)val->odr;
     ctrl_reg1.avg = (uint8_t)val->avg;
     ctrl_reg2.en_lpfp = (uint8_t)val->lpf & 0x01U;
-    ctrl_reg2.lfpf_cfg = ((uint8_t)val->lpf & 0x02U) >> 2;
+    ctrl_reg2.lfpf_cfg = ((uint8_t)val->lpf & 0x02U) >> 1;
     ctrl_reg2.fs_mode = (uint8_t)val->fs;
 
     bytecpy(&reg[0], (uint8_t *)&ctrl_reg1);
@@ -678,7 +696,7 @@ int32_t ilps28qsw_ah_qvar_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
 }
 
 /**
-  * @brief  Software trigger for One-Shot.[get]
+  * @brief  Retrieve sensor data.[get]
   *
   * @param  ctx   communication interface handler.(ptr)
   * @param  md    the sensor conversion parameters.(ptr)
@@ -711,7 +729,7 @@ int32_t ilps28qsw_data_get(const stmdev_ctx_t *ctx, ilps28qsw_md_t *md,
           data->pressure.hpa = ilps28qsw_from_fs1260_to_hPa(data->pressure.raw);
           break;
         case ILPS28QSW_4060hPa:
-          data->pressure.hpa = ilps28qsw_from_fs4000_to_hPa(data->pressure.raw);
+          data->pressure.hpa = ilps28qsw_from_fs4060_to_hPa(data->pressure.raw);
           break;
         default:
           data->pressure.hpa = 0.0f;
@@ -734,7 +752,7 @@ int32_t ilps28qsw_data_get(const stmdev_ctx_t *ctx, ilps28qsw_md_t *md,
         data->pressure.hpa = ilps28qsw_from_fs1260_to_hPa(data->pressure.raw);
         break;
       case ILPS28QSW_4060hPa:
-        data->pressure.hpa = ilps28qsw_from_fs4000_to_hPa(data->pressure.raw);
+        data->pressure.hpa = ilps28qsw_from_fs4060_to_hPa(data->pressure.raw);
         break;
       default:
         data->pressure.hpa = 0.0f;
@@ -987,7 +1005,7 @@ int32_t ilps28qsw_fifo_data_get(const stmdev_ctx_t *ctx, uint8_t samp,
             data[i].hpa = ilps28qsw_from_fs1260_to_hPa(data[i].raw);
             break;
           case ILPS28QSW_4060hPa:
-            data[i].hpa = ilps28qsw_from_fs4000_to_hPa(data[i].raw);
+            data[i].hpa = ilps28qsw_from_fs4060_to_hPa(data[i].raw);
             break;
           default:
             data[i].hpa = 0.0f;
@@ -1010,7 +1028,7 @@ int32_t ilps28qsw_fifo_data_get(const stmdev_ctx_t *ctx, uint8_t samp,
           data[i].hpa = ilps28qsw_from_fs1260_to_hPa(data[i].raw);
           break;
         case ILPS28QSW_4060hPa:
-          data[i].hpa = ilps28qsw_from_fs4000_to_hPa(data[i].raw);
+          data[i].hpa = ilps28qsw_from_fs4060_to_hPa(data[i].raw);
           break;
         default:
           data[i].hpa = 0.0f;
@@ -1018,7 +1036,6 @@ int32_t ilps28qsw_fifo_data_get(const stmdev_ctx_t *ctx, uint8_t samp,
       }
       data[i].lsb = 0;
     }
-
   }
 
   return ret;
@@ -1078,25 +1095,7 @@ int32_t ilps28qsw_interrupt_mode_get(const stmdev_ctx_t *ctx,
 
   ret = ilps28qsw_read_reg(ctx, ILPS28QSW_INTERRUPT_CFG,
                            (uint8_t *)&interrupt_cfg, 1);
-
   val->int_latched = interrupt_cfg.lir;
-
-  return ret;
-}
-
-/**
-  * @brief  AH function disable
-  *
-  * @param  ctx   communication interface handler.(ptr)
-  * @retval       interface status (MANDATORY: return 0 -> no Error)
-  *
-  */
-int32_t ilps28qsw_ah_qvar_disable(const stmdev_ctx_t *ctx)
-{
-  uint32_t val = 0;
-  int32_t ret;
-
-  ret = ilps28qsw_write_reg(ctx, ILPS28QSW_ANALOGIC_HUB_DISABLE, (uint8_t *)&val, 1);
 
   return ret;
 }
@@ -1147,7 +1146,7 @@ int32_t ilps28qsw_int_on_threshold_mode_set(const stmdev_ctx_t *ctx,
     bytecpy(&reg[1], (uint8_t *)&ths_p_l);
     bytecpy(&reg[2], (uint8_t *)&ths_p_h);
 
-    ret = ilps28qsw_read_reg(ctx, ILPS28QSW_INTERRUPT_CFG, reg, 3);
+    ret = ilps28qsw_write_reg(ctx, ILPS28QSW_INTERRUPT_CFG, reg, 3);
   }
   return ret;
 }
@@ -1220,8 +1219,8 @@ int32_t ilps28qsw_reference_mode_set(const stmdev_ctx_t *ctx, ilps28qsw_ref_md_t
     interrupt_cfg.reset_az  = ((uint8_t)val->apply_ref & 0x02U) >> 1;
     interrupt_cfg.reset_arp = ((uint8_t)val->apply_ref & 0x02U) >> 1;
 
-    ret = ilps28qsw_read_reg(ctx, ILPS28QSW_INTERRUPT_CFG,
-                             (uint8_t *)&interrupt_cfg, 1);
+    ret = ilps28qsw_write_reg(ctx, ILPS28QSW_INTERRUPT_CFG,
+                              (uint8_t *)&interrupt_cfg, 1);
   }
   return ret;
 }
@@ -1260,6 +1259,26 @@ int32_t ilps28qsw_reference_mode_get(const stmdev_ctx_t *ctx, ilps28qsw_ref_md_t
   return ret;
 }
 
+/**
+  * @brief  Reference Pressure LSB data .[get]
+  *
+  * @param  ctx   communication interface handler.(ptr)
+  * @param  val   parameters of configuration.(ptr)
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ilps28qsw_refp_get(const stmdev_ctx_t *ctx, int16_t *val)
+{
+  uint8_t reg[2];
+  int32_t ret;
+
+  ret = ilps28qsw_read_reg(ctx, ILPS28QSW_REF_P_L, reg, 2);
+
+  *val = (int16_t)reg[1];
+  *val = *val * 256 + (int16_t)reg[0];
+
+  return ret;
+}
 
 /**
   * @brief  Configuration of Wake-up and Wake-up to Sleep .[set]
@@ -1303,6 +1322,11 @@ int32_t ilps28qsw_opc_get(const stmdev_ctx_t *ctx, int16_t *val)
   return ret;
 }
 
+
+/**
+  * @}
+  *
+  */
 
 /**
   * @}

--- a/sensor/stmemsc/ilps28qsw_STdC/driver/ilps28qsw_reg.h
+++ b/sensor/stmemsc/ilps28qsw_STdC/driver/ilps28qsw_reg.h
@@ -7,7 +7,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2023 STMicroelectronics.
+  * <h2><center>&copy; Copyright (c) 2024 STMicroelectronics.
   * All rights reserved.</center></h2>
   *
   * This software component is licensed by ST under BSD 3-Clause license,
@@ -338,13 +338,15 @@ typedef struct
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t not_used_02      : 5;
+  uint8_t I3C_Bus_Avb_Sel  : 2;
+  uint8_t not_used_02      : 3;
   uint8_t asf_on           : 1;
   uint8_t not_used_01      : 2;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t not_used_01      : 2;
   uint8_t asf_on           : 1;
-  uint8_t not_used_02      : 5;
+  uint8_t not_used_02      : 3;
+  uint8_t I3C_Bus_Avb_Sel  : 2;
 #endif /* DRV_BYTE_ORDER */
 } ilps28qsw_i3c_if_ctrl_t;
 
@@ -415,7 +417,7 @@ typedef struct
 #define ILPS28QSW_PRESS_OUT_H             0x2AU
 #define ILPS28QSW_TEMP_OUT_L              0x2BU
 #define ILPS28QSW_TEMP_OUT_H              0x2CU
-#define ILPS28QSW_ANALOGIC_HUB_DISABLE    0x5FU
+
 #define ILPS28QSW_FIFO_DATA_OUT_PRESS_XL  0x78U
 #define ILPS28QSW_FIFO_DATA_OUT_PRESS_L   0x79U
 #define ILPS28QSW_FIFO_DATA_OUT_PRESS_H   0x7AU
@@ -474,7 +476,7 @@ int32_t ilps28qsw_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
                             uint8_t *data, uint16_t len);
 
 extern float_t ilps28qsw_from_fs1260_to_hPa(int32_t lsb);
-extern float_t ilps28qsw_from_fs4000_to_hPa(int32_t lsb);
+extern float_t ilps28qsw_from_fs4060_to_hPa(int32_t lsb);
 
 extern float_t ilps28qsw_from_lsb_to_celsius(int16_t lsb);
 
@@ -492,9 +494,18 @@ typedef enum
   ILPS28QSW_ALWAYS_ON = 0x01, /* anti-spike filters always on */
 } ilps28qsw_filter_t;
 
+typedef enum
+{
+  ILPS28QSW_BUS_AVB_TIME_50us      = 0x00, /* bus available time equal to 50 us */
+  ILPS28QSW_BUS_AVB_TIME_2us       = 0x01, /* bus available time equal to 2 us */
+  ILPS28QSW_BUS_AVB_TIME_1ms       = 0x02, /* bus available time equal to 1 ms */
+  ILPS28QSW_BUS_AVB_TIME_25ms      = 0x03, /* bus available time equal to 25 ms */
+} ilps28qsw_bus_avb_time_t;
+
 typedef struct
 {
   ilps28qsw_filter_t filter;
+  ilps28qsw_bus_avb_time_t bus_avb_time;
 } ilps28qsw_bus_mode_t;
 int32_t ilps28qsw_bus_mode_set(const stmdev_ctx_t *ctx, ilps28qsw_bus_mode_t *val);
 int32_t ilps28qsw_bus_mode_get(const stmdev_ctx_t *ctx, ilps28qsw_bus_mode_t *val);
@@ -523,7 +534,6 @@ int32_t ilps28qsw_status_get(const stmdev_ctx_t *ctx, ilps28qsw_stat_t *val);
 typedef struct
 {
   uint8_t sda_pull_up : 1; /* 1 = pull-up always disabled */
-  uint8_t cs_pull_up  : 1; /* 1 = pull-up always disabled */
 } ilps28qsw_pin_conf_t;
 int32_t ilps28qsw_pin_conf_set(const stmdev_ctx_t *ctx, ilps28qsw_pin_conf_t *val);
 int32_t ilps28qsw_pin_conf_get(const stmdev_ctx_t *ctx, ilps28qsw_pin_conf_t *val);
@@ -696,6 +706,8 @@ int32_t ilps28qsw_reference_mode_set(const stmdev_ctx_t *ctx,
                                      ilps28qsw_ref_md_t *val);
 int32_t ilps28qsw_reference_mode_get(const stmdev_ctx_t *ctx,
                                      ilps28qsw_ref_md_t *val);
+
+int32_t ilps28qsw_refp_get(const stmdev_ctx_t *ctx, int16_t *val);
 
 int32_t ilps28qsw_opc_set(const stmdev_ctx_t *ctx, int16_t val);
 int32_t ilps28qsw_opc_get(const stmdev_ctx_t *ctx, int16_t *val);

--- a/sensor/stmemsc/ism330bx_STdC/driver/ism330bx_reg.c
+++ b/sensor/stmemsc/ism330bx_STdC/driver/ism330bx_reg.c
@@ -7487,7 +7487,7 @@ int32_t ism330bx_mlc_out_get(const stmdev_ctx_t *ctx, ism330bx_mlc_out_t *val)
   ret = ism330bx_mem_bank_set(ctx, ISM330BX_EMBED_FUNC_MEM_BANK);
   if (ret == 0)
   {
-    ret = ism330bx_read_reg(ctx, ISM330BX_MLC1_SRC, (uint8_t *)&val, 4);
+    ret = ism330bx_read_reg(ctx, ISM330BX_MLC1_SRC, (uint8_t *)val, 4);
   }
 
   ret += ism330bx_mem_bank_set(ctx, ISM330BX_MAIN_MEM_BANK);

--- a/sensor/stmemsc/ism330dhcx_STdC/driver/ism330dhcx_reg.c
+++ b/sensor/stmemsc/ism330dhcx_STdC/driver/ism330dhcx_reg.c
@@ -155,9 +155,9 @@ float_t ism330dhcx_from_lsb_to_celsius(int16_t lsb)
   return (((float_t)lsb / 256.0f) + 25.0f);
 }
 
-float_t ism330dhcx_from_lsb_to_nsec(int32_t lsb)
+uint64_t ism330dhcx_from_lsb_to_nsec(uint32_t lsb)
 {
-  return ((float_t)lsb * 25000.0f);
+  return ((uint64_t)lsb * 25000ULL);
 }
 
 /**
@@ -259,6 +259,7 @@ int32_t ism330dhcx_xl_data_rate_set(const stmdev_ctx_t *ctx,
   ism330dhcx_mlc_odr_t mlc_odr;
   ism330dhcx_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
+
   /* Check the Finite State Machine data rate constraints */
   ret =  ism330dhcx_fsm_enable_get(ctx, &fsm_enable);
 
@@ -666,6 +667,7 @@ int32_t ism330dhcx_gy_data_rate_set(const stmdev_ctx_t *ctx,
   ism330dhcx_mlc_odr_t mlc_odr;
   ism330dhcx_ctrl2_g_t ctrl2_g;
   int32_t ret;
+
   /* Check the Finite State Machine data rate constraints */
   ret =  ism330dhcx_fsm_enable_get(ctx, &fsm_enable);
 
@@ -1217,6 +1219,7 @@ int32_t ism330dhcx_all_sources_get(const stmdev_ctx_t *ctx,
                                    ism330dhcx_all_sources_t *val)
 {
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_ALL_INT_SRC,
                             (uint8_t *)&val->all_int_src, 1);
 
@@ -1287,6 +1290,7 @@ int32_t ism330dhcx_status_reg_get(const stmdev_ctx_t *ctx,
                                   ism330dhcx_status_reg_t *val)
 {
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_STATUS_REG, (uint8_t *) val, 1);
 
   return ret;
@@ -1305,6 +1309,7 @@ int32_t ism330dhcx_xl_flag_data_ready_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_status_reg_t status_reg;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_STATUS_REG,
                             (uint8_t *)&status_reg, 1);
   *val = status_reg.xlda;
@@ -1325,6 +1330,7 @@ int32_t ism330dhcx_gy_flag_data_ready_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_status_reg_t status_reg;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_STATUS_REG,
                             (uint8_t *)&status_reg, 1);
   *val = status_reg.gda;
@@ -1345,6 +1351,7 @@ int32_t ism330dhcx_temp_flag_data_ready_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_status_reg_t status_reg;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_STATUS_REG,
                             (uint8_t *)&status_reg, 1);
   *val = status_reg.tda;
@@ -1366,6 +1373,7 @@ int32_t ism330dhcx_xl_usr_offset_x_set(const stmdev_ctx_t *ctx,
                                        uint8_t *buff)
 {
   int32_t ret;
+
   ret = ism330dhcx_write_reg(ctx, ISM330DHCX_X_OFS_USR, buff, 1);
 
   return ret;
@@ -1385,6 +1393,7 @@ int32_t ism330dhcx_xl_usr_offset_x_get(const stmdev_ctx_t *ctx,
                                        uint8_t *buff)
 {
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_X_OFS_USR, buff, 1);
 
   return ret;
@@ -1404,6 +1413,7 @@ int32_t ism330dhcx_xl_usr_offset_y_set(const stmdev_ctx_t *ctx,
                                        uint8_t *buff)
 {
   int32_t ret;
+
   ret = ism330dhcx_write_reg(ctx, ISM330DHCX_Y_OFS_USR, buff, 1);
 
   return ret;
@@ -1423,6 +1433,7 @@ int32_t ism330dhcx_xl_usr_offset_y_get(const stmdev_ctx_t *ctx,
                                        uint8_t *buff)
 {
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_Y_OFS_USR, buff, 1);
 
   return ret;
@@ -1442,6 +1453,7 @@ int32_t ism330dhcx_xl_usr_offset_z_set(const stmdev_ctx_t *ctx,
                                        uint8_t *buff)
 {
   int32_t ret;
+
   ret = ism330dhcx_write_reg(ctx, ISM330DHCX_Z_OFS_USR, buff, 1);
 
   return ret;
@@ -1461,6 +1473,7 @@ int32_t ism330dhcx_xl_usr_offset_z_get(const stmdev_ctx_t *ctx,
                                        uint8_t *buff)
 {
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_Z_OFS_USR, buff, 1);
 
   return ret;
@@ -1478,6 +1491,7 @@ int32_t ism330dhcx_xl_usr_offset_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_ctrl7_g_t ctrl7_g;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL7_G,
                             (uint8_t *)&ctrl7_g, 1);
 
@@ -1503,6 +1517,7 @@ int32_t ism330dhcx_xl_usr_offset_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_ctrl7_g_t ctrl7_g;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL7_G,
                             (uint8_t *)&ctrl7_g, 1);
   *val = ctrl7_g.usr_off_on_out;
@@ -1548,6 +1563,7 @@ int32_t ism330dhcx_timestamp_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_ctrl10_c_t ctrl10_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL10_C,
                             (uint8_t *)&ctrl10_c, 1);
 
@@ -1573,6 +1589,7 @@ int32_t ism330dhcx_timestamp_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_ctrl10_c_t ctrl10_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL10_C,
                             (uint8_t *)&ctrl10_c, 1);
   *val = ctrl10_c.timestamp_en;
@@ -1594,6 +1611,7 @@ int32_t ism330dhcx_timestamp_raw_get(const stmdev_ctx_t *ctx, uint32_t *val)
 {
   uint8_t buff[4];
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TIMESTAMP0, buff, 4);
   *val = buff[3];
   *val = (*val * 256U) +  buff[2];
@@ -1628,6 +1646,7 @@ int32_t ism330dhcx_rounding_mode_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl5_c_t ctrl5_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL5_C,
                             (uint8_t *)&ctrl5_c, 1);
 
@@ -1654,6 +1673,7 @@ int32_t ism330dhcx_rounding_mode_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl5_c_t ctrl5_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL5_C,
                             (uint8_t *)&ctrl5_c, 1);
 
@@ -1698,6 +1718,7 @@ int32_t ism330dhcx_temperature_raw_get(const stmdev_ctx_t *ctx,
 {
   uint8_t buff[2];
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_OUT_TEMP_L, buff, 2);
   *val = (int16_t)buff[1];
   *val = (*val * 256) + (int16_t)buff[0];
@@ -1719,6 +1740,7 @@ int32_t ism330dhcx_angular_rate_raw_get(const stmdev_ctx_t *ctx,
 {
   uint8_t buff[6];
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_OUTX_L_G, buff, 6);
   val[0] = (int16_t)buff[1];
   val[0] = (val[0] * 256) + (int16_t)buff[0];
@@ -1744,6 +1766,7 @@ int32_t ism330dhcx_acceleration_raw_get(const stmdev_ctx_t *ctx,
 {
   uint8_t buff[6];
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_OUTX_L_A, buff, 6);
   val[0] = (int16_t)buff[1];
   val[0] = (val[0] * 256) + (int16_t)buff[0];
@@ -1766,6 +1789,7 @@ int32_t ism330dhcx_acceleration_raw_get(const stmdev_ctx_t *ctx,
 int32_t ism330dhcx_fifo_out_raw_get(const stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_DATA_OUT_X_L, buff, 6);
 
   return ret;
@@ -1784,6 +1808,7 @@ int32_t ism330dhcx_number_of_steps_get(const stmdev_ctx_t *ctx,
 {
   uint8_t buff[2];
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -1812,6 +1837,7 @@ int32_t ism330dhcx_steps_reset(const stmdev_ctx_t *ctx)
 {
   ism330dhcx_emb_func_src_t emb_func_src;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -1825,31 +1851,6 @@ int32_t ism330dhcx_steps_reset(const stmdev_ctx_t *ctx)
     emb_func_src.pedo_rst_step = PROPERTY_ENABLE;
     ret = ism330dhcx_write_reg(ctx, ISM330DHCX_EMB_FUNC_SRC,
                                (uint8_t *)&emb_func_src, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
-  }
-
-  return ret;
-}
-
-/**
-  * @brief  prgsens_out: [get] Output value of all MLCx decision trees.
-  *
-  * @param  ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
-  *
-  */
-int32_t ism330dhcx_mlc_out_get(const stmdev_ctx_t *ctx, uint8_t *buff)
-{
-  int32_t ret;
-  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
-
-  if (ret == 0)
-  {
-    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_MLC0_SRC, buff, 8);
   }
 
   if (ret == 0)
@@ -1884,6 +1885,7 @@ int32_t ism330dhcx_device_conf_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL9_XL,
                             (uint8_t *)&ctrl9_xl, 1);
 
@@ -1909,6 +1911,7 @@ int32_t ism330dhcx_device_conf_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL9_XL,
                             (uint8_t *)&ctrl9_xl, 1);
   *val = ctrl9_xl.device_conf;
@@ -1930,6 +1933,7 @@ int32_t ism330dhcx_odr_cal_reg_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_internal_freq_fine_t internal_freq_fine;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INTERNAL_FREQ_FINE,
                             (uint8_t *)&internal_freq_fine, 1);
 
@@ -1957,6 +1961,7 @@ int32_t ism330dhcx_odr_cal_reg_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_internal_freq_fine_t internal_freq_fine;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INTERNAL_FREQ_FINE,
                             (uint8_t *)&internal_freq_fine, 1);
   *val = internal_freq_fine.freq_fine;
@@ -1978,6 +1983,7 @@ int32_t ism330dhcx_mem_bank_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_func_cfg_access_t func_cfg_access;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FUNC_CFG_ACCESS,
                             (uint8_t *)&func_cfg_access, 1);
 
@@ -2005,6 +2011,7 @@ int32_t ism330dhcx_mem_bank_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_func_cfg_access_t func_cfg_access;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FUNC_CFG_ACCESS,
                             (uint8_t *)&func_cfg_access, 1);
 
@@ -2046,6 +2053,7 @@ int32_t ism330dhcx_ln_pg_write_byte(const stmdev_ctx_t *ctx, uint16_t add,
   ism330dhcx_page_sel_t page_sel;
   ism330dhcx_page_address_t page_address;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -2128,6 +2136,7 @@ int32_t ism330dhcx_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t add,
   uint8_t lsb;
   int32_t ret;
   uint8_t i ;
+
   msb = (uint8_t)((add / 256U) & 0x0FU);
   lsb = (uint8_t)(add - (msb * 256U));
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
@@ -2240,6 +2249,7 @@ int32_t ism330dhcx_ln_pg_read_byte(const stmdev_ctx_t *ctx, uint16_t add,
   ism330dhcx_page_sel_t page_sel;
   ism330dhcx_page_address_t page_address;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -2316,6 +2326,7 @@ int32_t ism330dhcx_data_ready_mode_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_counter_bdr_reg1_t counter_bdr_reg1;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_COUNTER_BDR_REG1,
                             (uint8_t *)&counter_bdr_reg1, 1);
 
@@ -2343,6 +2354,7 @@ int32_t ism330dhcx_data_ready_mode_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_counter_bdr_reg1_t counter_bdr_reg1;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_COUNTER_BDR_REG1,
                             (uint8_t *)&counter_bdr_reg1, 1);
 
@@ -2375,6 +2387,7 @@ int32_t ism330dhcx_data_ready_mode_get(const stmdev_ctx_t *ctx,
 int32_t ism330dhcx_device_id_get(const stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WHO_AM_I, buff, 1);
 
   return ret;
@@ -2392,6 +2405,7 @@ int32_t ism330dhcx_reset_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_ctrl3_c_t ctrl3_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_C,
                             (uint8_t *)&ctrl3_c, 1);
 
@@ -2417,6 +2431,7 @@ int32_t ism330dhcx_reset_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_ctrl3_c_t ctrl3_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_C,
                             (uint8_t *)&ctrl3_c, 1);
   *val = ctrl3_c.sw_reset;
@@ -2437,6 +2452,7 @@ int32_t ism330dhcx_auto_increment_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_ctrl3_c_t ctrl3_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_C,
                             (uint8_t *)&ctrl3_c, 1);
 
@@ -2463,6 +2479,7 @@ int32_t ism330dhcx_auto_increment_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_ctrl3_c_t ctrl3_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_C,
                             (uint8_t *)&ctrl3_c, 1);
   *val = ctrl3_c.if_inc;
@@ -2482,6 +2499,7 @@ int32_t ism330dhcx_boot_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_ctrl3_c_t ctrl3_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_C,
                             (uint8_t *)&ctrl3_c, 1);
 
@@ -2507,6 +2525,7 @@ int32_t ism330dhcx_boot_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_ctrl3_c_t ctrl3_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_C,
                             (uint8_t *)&ctrl3_c, 1);
   *val = ctrl3_c.boot;
@@ -2529,6 +2548,7 @@ int32_t ism330dhcx_xl_self_test_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl5_c_t ctrl5_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL5_C,
                             (uint8_t *)&ctrl5_c, 1);
 
@@ -2555,6 +2575,7 @@ int32_t ism330dhcx_xl_self_test_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl5_c_t ctrl5_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL5_C,
                             (uint8_t *)&ctrl5_c, 1);
 
@@ -2593,6 +2614,7 @@ int32_t ism330dhcx_gy_self_test_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl5_c_t ctrl5_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL5_C,
                             (uint8_t *)&ctrl5_c, 1);
 
@@ -2619,6 +2641,7 @@ int32_t ism330dhcx_gy_self_test_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl5_c_t ctrl5_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL5_C,
                             (uint8_t *)&ctrl5_c, 1);
 
@@ -2669,6 +2692,7 @@ int32_t ism330dhcx_xl_filter_lp2_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL1_XL,
                             (uint8_t *)&ctrl1_xl, 1);
 
@@ -2694,6 +2718,7 @@ int32_t ism330dhcx_xl_filter_lp2_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL1_XL,
                             (uint8_t *)&ctrl1_xl, 1);
   *val = ctrl1_xl.lpf2_xl_en;
@@ -2714,6 +2739,7 @@ int32_t ism330dhcx_gy_filter_lp1_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_ctrl4_c_t ctrl4_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL4_C,
                             (uint8_t *)&ctrl4_c, 1);
 
@@ -2740,6 +2766,7 @@ int32_t ism330dhcx_gy_filter_lp1_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_ctrl4_c_t ctrl4_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL4_C,
                             (uint8_t *)&ctrl4_c, 1);
   *val = ctrl4_c.lpf1_sel_g;
@@ -2761,6 +2788,7 @@ int32_t ism330dhcx_filter_settling_mask_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl4_c_t ctrl4_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL4_C,
                             (uint8_t *)&ctrl4_c, 1);
 
@@ -2788,6 +2816,7 @@ int32_t ism330dhcx_filter_settling_mask_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl4_c_t ctrl4_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL4_C,
                             (uint8_t *)&ctrl4_c, 1);
   *val = ctrl4_c.drdy_mask;
@@ -2808,6 +2837,7 @@ int32_t ism330dhcx_gy_lp1_bandwidth_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl6_c_t ctrl6_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL6_C,
                             (uint8_t *)&ctrl6_c, 1);
 
@@ -2834,6 +2864,7 @@ int32_t ism330dhcx_gy_lp1_bandwidth_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl6_c_t ctrl6_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL6_C,
                             (uint8_t *)&ctrl6_c, 1);
 
@@ -2891,6 +2922,7 @@ int32_t ism330dhcx_xl_lp2_on_6d_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL8_XL,
                             (uint8_t *)&ctrl8_xl, 1);
 
@@ -2916,6 +2948,7 @@ int32_t ism330dhcx_xl_lp2_on_6d_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL8_XL,
                             (uint8_t *)&ctrl8_xl, 1);
   *val = ctrl8_xl.low_pass_on_6d;
@@ -2937,6 +2970,7 @@ int32_t ism330dhcx_xl_hp_path_on_out_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL8_XL,
                             (uint8_t *)&ctrl8_xl, 1);
 
@@ -2966,6 +3000,7 @@ int32_t ism330dhcx_xl_hp_path_on_out_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL8_XL,
                             (uint8_t *)&ctrl8_xl, 1);
 
@@ -3088,6 +3123,7 @@ int32_t ism330dhcx_xl_fast_settling_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL8_XL,
                             (uint8_t *)&ctrl8_xl, 1);
 
@@ -3116,6 +3152,7 @@ int32_t ism330dhcx_xl_fast_settling_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL8_XL,
                             (uint8_t *)&ctrl8_xl, 1);
   *val = ctrl8_xl.fastsettl_mode_xl;
@@ -3137,6 +3174,7 @@ int32_t ism330dhcx_xl_hp_path_internal_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_tap_cfg0_t tap_cfg0;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG0,
                             (uint8_t *)&tap_cfg0, 1);
 
@@ -3164,6 +3202,7 @@ int32_t ism330dhcx_xl_hp_path_internal_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_tap_cfg0_t tap_cfg0;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG0,
                             (uint8_t *)&tap_cfg0, 1);
 
@@ -3199,6 +3238,7 @@ int32_t ism330dhcx_gy_hp_path_internal_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl7_g_t ctrl7_g;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL7_G,
                             (uint8_t *)&ctrl7_g, 1);
 
@@ -3227,6 +3267,7 @@ int32_t ism330dhcx_gy_hp_path_internal_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl7_g_t ctrl7_g;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL7_G,
                             (uint8_t *)&ctrl7_g, 1);
 
@@ -3287,6 +3328,7 @@ int32_t ism330dhcx_aux_sdo_ocs_mode_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_pin_ctrl_t pin_ctrl;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_PIN_CTRL,
                             (uint8_t *)&pin_ctrl, 1);
 
@@ -3314,6 +3356,7 @@ int32_t ism330dhcx_aux_sdo_ocs_mode_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_pin_ctrl_t pin_ctrl;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_PIN_CTRL,
                             (uint8_t *)&pin_ctrl, 1);
 
@@ -3348,6 +3391,7 @@ int32_t ism330dhcx_aux_pw_on_ctrl_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl7_g_t ctrl7_g;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL7_G,
                             (uint8_t *)&ctrl7_g, 1);
 
@@ -3375,6 +3419,7 @@ int32_t ism330dhcx_aux_pw_on_ctrl_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl7_g_t ctrl7_g;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL7_G,
                             (uint8_t *)&ctrl7_g, 1);
 
@@ -3408,6 +3453,7 @@ int32_t ism330dhcx_aux_status_reg_get(const stmdev_ctx_t *ctx,
                                       ism330dhcx_status_spiaux_t *val)
 {
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_STATUS_SPIAUX,
                             (uint8_t *)val, 1);
 
@@ -3427,6 +3473,7 @@ int32_t ism330dhcx_aux_xl_flag_data_ready_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_status_spiaux_t status_spiaux;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_STATUS_SPIAUX,
                             (uint8_t *)&status_spiaux, 1);
   *val = status_spiaux.xlda;
@@ -3447,6 +3494,7 @@ int32_t ism330dhcx_aux_gy_flag_data_ready_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_status_spiaux_t status_spiaux;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_STATUS_SPIAUX,
                             (uint8_t *)&status_spiaux, 1);
   *val = status_spiaux.gda;
@@ -3467,6 +3515,7 @@ int32_t ism330dhcx_aux_gy_flag_settling_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_status_spiaux_t status_spiaux;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_STATUS_SPIAUX,
                             (uint8_t *)&status_spiaux, 1);
   *val = status_spiaux.gyro_settling;
@@ -3488,6 +3537,7 @@ int32_t ism330dhcx_aux_xl_self_test_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_int_ois_t int_ois;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT_OIS,
                             (uint8_t *)&int_ois, 1);
 
@@ -3515,6 +3565,7 @@ int32_t ism330dhcx_aux_xl_self_test_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_int_ois_t int_ois;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT_OIS,
                             (uint8_t *)&int_ois, 1);
 
@@ -3553,6 +3604,7 @@ int32_t ism330dhcx_aux_den_polarity_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_int_ois_t int_ois;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT_OIS,
                             (uint8_t *)&int_ois, 1);
 
@@ -3579,6 +3631,7 @@ int32_t ism330dhcx_aux_den_polarity_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_int_ois_t int_ois;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT_OIS,
                             (uint8_t *)&int_ois, 1);
 
@@ -3614,6 +3667,7 @@ int32_t ism330dhcx_aux_den_mode_set(const stmdev_ctx_t *ctx,
   ism330dhcx_int_ois_t int_ois;
   ism330dhcx_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT_OIS,
                             (uint8_t *)&int_ois, 1);
 
@@ -3654,6 +3708,7 @@ int32_t ism330dhcx_aux_den_mode_get(const stmdev_ctx_t *ctx,
   ism330dhcx_int_ois_t int_ois;
   ism330dhcx_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT_OIS,
                             (uint8_t *)&int_ois, 1);
 
@@ -3699,6 +3754,7 @@ int32_t ism330dhcx_aux_drdy_on_int2_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_int_ois_t int_ois;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT_OIS,
                             (uint8_t *)&int_ois, 1);
 
@@ -3726,6 +3782,7 @@ int32_t ism330dhcx_aux_drdy_on_int2_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_int_ois_t int_ois;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT_OIS,
                             (uint8_t *)&int_ois, 1);
   *val = int_ois.int2_drdy_ois;
@@ -3751,6 +3808,7 @@ int32_t ism330dhcx_aux_mode_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL1_OIS,
                             (uint8_t *)&ctrl1_ois, 1);
 
@@ -3784,6 +3842,7 @@ int32_t ism330dhcx_aux_mode_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL1_OIS,
                             (uint8_t *)&ctrl1_ois, 1);
 
@@ -3822,6 +3881,7 @@ int32_t ism330dhcx_aux_gy_full_scale_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL1_OIS,
                             (uint8_t *)&ctrl1_ois, 1);
 
@@ -3849,6 +3909,7 @@ int32_t ism330dhcx_aux_gy_full_scale_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL1_OIS,
                             (uint8_t *)&ctrl1_ois, 1);
 
@@ -3895,6 +3956,7 @@ int32_t ism330dhcx_aux_spi_mode_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL1_OIS,
                             (uint8_t *)&ctrl1_ois, 1);
 
@@ -3921,6 +3983,7 @@ int32_t ism330dhcx_aux_spi_mode_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL1_OIS,
                             (uint8_t *)&ctrl1_ois, 1);
 
@@ -3955,6 +4018,7 @@ int32_t ism330dhcx_aux_gy_lp1_bandwidth_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl2_ois_t ctrl2_ois;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL2_OIS,
                             (uint8_t *)&ctrl2_ois, 1);
 
@@ -3981,6 +4045,7 @@ int32_t ism330dhcx_aux_gy_lp1_bandwidth_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl2_ois_t ctrl2_ois;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL2_OIS,
                             (uint8_t *)&ctrl2_ois, 1);
 
@@ -4023,6 +4088,7 @@ int32_t ism330dhcx_aux_gy_hp_bandwidth_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl2_ois_t ctrl2_ois;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL2_OIS,
                             (uint8_t *)&ctrl2_ois, 1);
 
@@ -4050,6 +4116,7 @@ int32_t ism330dhcx_aux_gy_hp_bandwidth_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl2_ois_t ctrl2_ois;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL2_OIS,
                             (uint8_t *)&ctrl2_ois, 1);
 
@@ -4098,6 +4165,7 @@ int32_t ism330dhcx_aux_gy_clamp_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl3_ois_t ctrl3_ois;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_OIS,
                             (uint8_t *)&ctrl3_ois, 1);
 
@@ -4126,6 +4194,7 @@ int32_t ism330dhcx_aux_gy_clamp_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl3_ois_t ctrl3_ois;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_OIS,
                             (uint8_t *)&ctrl3_ois, 1);
 
@@ -4160,6 +4229,7 @@ int32_t ism330dhcx_aux_gy_self_test_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl3_ois_t ctrl3_ois;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_OIS,
                             (uint8_t *)&ctrl3_ois, 1);
 
@@ -4186,6 +4256,7 @@ int32_t ism330dhcx_aux_gy_self_test_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl3_ois_t ctrl3_ois;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_OIS,
                             (uint8_t *)&ctrl3_ois, 1);
 
@@ -4224,6 +4295,7 @@ int32_t ism330dhcx_aux_xl_bandwidth_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl3_ois_t ctrl3_ois;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_OIS,
                             (uint8_t *)&ctrl3_ois, 1);
 
@@ -4250,6 +4322,7 @@ int32_t ism330dhcx_aux_xl_bandwidth_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl3_ois_t ctrl3_ois;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_OIS,
                             (uint8_t *)&ctrl3_ois, 1);
 
@@ -4308,6 +4381,7 @@ int32_t ism330dhcx_aux_xl_full_scale_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl3_ois_t ctrl3_ois;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_OIS,
                             (uint8_t *)&ctrl3_ois, 1);
 
@@ -4334,6 +4408,7 @@ int32_t ism330dhcx_aux_xl_full_scale_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl3_ois_t ctrl3_ois;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_OIS,
                             (uint8_t *)&ctrl3_ois, 1);
 
@@ -4389,6 +4464,7 @@ int32_t ism330dhcx_sdo_sa0_mode_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_pin_ctrl_t pin_ctrl;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_PIN_CTRL,
                             (uint8_t *)&pin_ctrl, 1);
 
@@ -4415,6 +4491,7 @@ int32_t ism330dhcx_sdo_sa0_mode_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_pin_ctrl_t pin_ctrl;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_PIN_CTRL,
                             (uint8_t *)&pin_ctrl, 1);
 
@@ -4449,6 +4526,7 @@ int32_t ism330dhcx_spi_mode_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl3_c_t ctrl3_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_C,
                             (uint8_t *)&ctrl3_c, 1);
 
@@ -4475,6 +4553,7 @@ int32_t ism330dhcx_spi_mode_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl3_c_t ctrl3_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_C,
                             (uint8_t *)&ctrl3_c, 1);
 
@@ -4509,6 +4588,7 @@ int32_t ism330dhcx_i2c_interface_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl4_c_t ctrl4_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL4_C,
                             (uint8_t *)&ctrl4_c, 1);
 
@@ -4535,6 +4615,7 @@ int32_t ism330dhcx_i2c_interface_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl4_c_t ctrl4_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL4_C,
                             (uint8_t *)&ctrl4_c, 1);
 
@@ -4583,6 +4664,7 @@ int32_t ism330dhcx_pin_int1_route_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_tap_cfg2_t tap_cfg2;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -4647,7 +4729,6 @@ int32_t ism330dhcx_pin_int1_route_set(const stmdev_ctx_t *ctx,
     {
       val->md1_cfg.int1_emb_func = PROPERTY_ENABLE;
     }
-
     else
     {
       val->md1_cfg.int1_emb_func = PROPERTY_DISABLE;
@@ -4715,6 +4796,7 @@ int32_t ism330dhcx_pin_int1_route_get(const stmdev_ctx_t *ctx,
                                       ism330dhcx_pin_int1_route_t *val)
 {
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -4775,6 +4857,7 @@ int32_t ism330dhcx_pin_int2_route_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_tap_cfg2_t tap_cfg2;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -4839,7 +4922,6 @@ int32_t ism330dhcx_pin_int2_route_set(const stmdev_ctx_t *ctx,
     {
       val->md2_cfg.int2_emb_func = PROPERTY_ENABLE;
     }
-
     else
     {
       val->md2_cfg.int2_emb_func = PROPERTY_DISABLE;
@@ -4905,6 +4987,7 @@ int32_t ism330dhcx_pin_int2_route_get(const stmdev_ctx_t *ctx,
                                       ism330dhcx_pin_int2_route_t *val)
 {
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -4964,6 +5047,7 @@ int32_t ism330dhcx_pin_mode_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl3_c_t ctrl3_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_C,
                             (uint8_t *)&ctrl3_c, 1);
 
@@ -4990,6 +5074,7 @@ int32_t ism330dhcx_pin_mode_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl3_c_t ctrl3_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_C,
                             (uint8_t *)&ctrl3_c, 1);
 
@@ -5024,6 +5109,7 @@ int32_t ism330dhcx_pin_polarity_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl3_c_t ctrl3_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_C,
                             (uint8_t *)&ctrl3_c, 1);
 
@@ -5050,6 +5136,7 @@ int32_t ism330dhcx_pin_polarity_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl3_c_t ctrl3_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_C,
                             (uint8_t *)&ctrl3_c, 1);
 
@@ -5083,6 +5170,7 @@ int32_t ism330dhcx_all_on_int1_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_ctrl4_c_t ctrl4_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL4_C,
                             (uint8_t *)&ctrl4_c, 1);
 
@@ -5108,6 +5196,7 @@ int32_t ism330dhcx_all_on_int1_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_ctrl4_c_t ctrl4_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL4_C,
                             (uint8_t *)&ctrl4_c, 1);
   *val = ctrl4_c.int2_on_int1;
@@ -5129,6 +5218,7 @@ int32_t ism330dhcx_int_notification_set(const stmdev_ctx_t *ctx,
   ism330dhcx_tap_cfg0_t tap_cfg0;
   ism330dhcx_page_rw_t page_rw;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG0,
                             (uint8_t *)&tap_cfg0, 1);
 
@@ -5180,6 +5270,7 @@ int32_t ism330dhcx_int_notification_get(const stmdev_ctx_t *ctx,
   ism330dhcx_tap_cfg0_t tap_cfg0;
   ism330dhcx_page_rw_t page_rw;
   int32_t ret;
+
   *val = ISM330DHCX_ALL_INT_PULSED;
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG0,
                             (uint8_t *)&tap_cfg0, 1);
@@ -5254,6 +5345,7 @@ int32_t ism330dhcx_wkup_ths_weight_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_wake_up_dur_t wake_up_dur;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_DUR,
                             (uint8_t *)&wake_up_dur, 1);
 
@@ -5282,6 +5374,7 @@ int32_t ism330dhcx_wkup_ths_weight_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_wake_up_dur_t wake_up_dur;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_DUR,
                             (uint8_t *)&wake_up_dur, 1);
 
@@ -5316,6 +5409,7 @@ int32_t ism330dhcx_wkup_threshold_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_wake_up_ths_t wake_up_ths;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_THS,
                             (uint8_t *)&wake_up_ths, 1);
 
@@ -5342,6 +5436,7 @@ int32_t ism330dhcx_wkup_threshold_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_wake_up_ths_t wake_up_ths;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_THS,
                             (uint8_t *)&wake_up_ths, 1);
   *val = wake_up_ths.wk_ths;
@@ -5362,6 +5457,7 @@ int32_t ism330dhcx_xl_usr_offset_on_wkup_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_wake_up_ths_t wake_up_ths;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_THS,
                             (uint8_t *)&wake_up_ths, 1);
 
@@ -5388,6 +5484,7 @@ int32_t ism330dhcx_xl_usr_offset_on_wkup_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_wake_up_ths_t wake_up_ths;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_THS,
                             (uint8_t *)&wake_up_ths, 1);
   *val = wake_up_ths.usr_off_on_wu;
@@ -5407,6 +5504,7 @@ int32_t ism330dhcx_wkup_dur_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_wake_up_dur_t wake_up_dur;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_DUR,
                             (uint8_t *)&wake_up_dur, 1);
 
@@ -5432,6 +5530,7 @@ int32_t ism330dhcx_wkup_dur_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_wake_up_dur_t wake_up_dur;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_DUR,
                             (uint8_t *)&wake_up_dur, 1);
   *val = wake_up_dur.wake_dur;
@@ -5464,6 +5563,7 @@ int32_t ism330dhcx_gy_sleep_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_ctrl4_c_t ctrl4_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL4_C,
                             (uint8_t *)&ctrl4_c, 1);
 
@@ -5489,6 +5589,7 @@ int32_t ism330dhcx_gy_sleep_mode_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_ctrl4_c_t ctrl4_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL4_C,
                             (uint8_t *)&ctrl4_c, 1);
   *val = ctrl4_c.sleep_g;
@@ -5511,6 +5612,7 @@ int32_t ism330dhcx_act_pin_notification_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_tap_cfg0_t tap_cfg0;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG0,
                             (uint8_t *)&tap_cfg0, 1);
 
@@ -5539,6 +5641,7 @@ int32_t ism330dhcx_act_pin_notification_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_tap_cfg0_t tap_cfg0;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG0,
                             (uint8_t *)&tap_cfg0, 1);
 
@@ -5573,6 +5676,7 @@ int32_t ism330dhcx_act_mode_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_tap_cfg2_t tap_cfg2;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG2,
                             (uint8_t *)&tap_cfg2, 1);
 
@@ -5599,6 +5703,7 @@ int32_t ism330dhcx_act_mode_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_tap_cfg2_t tap_cfg2;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG2,
                             (uint8_t *)&tap_cfg2, 1);
 
@@ -5640,6 +5745,7 @@ int32_t ism330dhcx_act_sleep_dur_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_wake_up_dur_t wake_up_dur;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_DUR,
                             (uint8_t *)&wake_up_dur, 1);
 
@@ -5665,6 +5771,7 @@ int32_t ism330dhcx_act_sleep_dur_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_wake_up_dur_t wake_up_dur;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_DUR,
                             (uint8_t *)&wake_up_dur, 1);
   *val = wake_up_dur.sleep_dur;
@@ -5698,6 +5805,7 @@ int32_t ism330dhcx_tap_detection_on_z_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_tap_cfg0_t tap_cfg0;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG0,
                             (uint8_t *)&tap_cfg0, 1);
 
@@ -5724,6 +5832,7 @@ int32_t ism330dhcx_tap_detection_on_z_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_tap_cfg0_t tap_cfg0;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG0,
                             (uint8_t *)&tap_cfg0, 1);
   *val = tap_cfg0.tap_z_en;
@@ -5744,6 +5853,7 @@ int32_t ism330dhcx_tap_detection_on_y_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_tap_cfg0_t tap_cfg0;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG0,
                             (uint8_t *)&tap_cfg0, 1);
 
@@ -5770,6 +5880,7 @@ int32_t ism330dhcx_tap_detection_on_y_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_tap_cfg0_t tap_cfg0;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG0,
                             (uint8_t *)&tap_cfg0, 1);
   *val = tap_cfg0.tap_y_en;
@@ -5790,6 +5901,7 @@ int32_t ism330dhcx_tap_detection_on_x_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_tap_cfg0_t tap_cfg0;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG0,
                             (uint8_t *)&tap_cfg0, 1);
 
@@ -5816,6 +5928,7 @@ int32_t ism330dhcx_tap_detection_on_x_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_tap_cfg0_t tap_cfg0;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG0,
                             (uint8_t *)&tap_cfg0, 1);
   *val = tap_cfg0.tap_x_en;
@@ -5835,6 +5948,7 @@ int32_t ism330dhcx_tap_threshold_x_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_tap_cfg1_t tap_cfg1;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG1,
                             (uint8_t *)&tap_cfg1, 1);
 
@@ -5861,6 +5975,7 @@ int32_t ism330dhcx_tap_threshold_x_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_tap_cfg1_t tap_cfg1;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG1,
                             (uint8_t *)&tap_cfg1, 1);
   *val = tap_cfg1.tap_ths_x;
@@ -5881,6 +5996,7 @@ int32_t ism330dhcx_tap_axis_priority_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_tap_cfg1_t tap_cfg1;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG1,
                             (uint8_t *)&tap_cfg1, 1);
 
@@ -5907,6 +6023,7 @@ int32_t ism330dhcx_tap_axis_priority_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_tap_cfg1_t tap_cfg1;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG1,
                             (uint8_t *)&tap_cfg1, 1);
 
@@ -5956,6 +6073,7 @@ int32_t ism330dhcx_tap_threshold_y_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_tap_cfg2_t tap_cfg2;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG2,
                             (uint8_t *)&tap_cfg2, 1);
 
@@ -5982,6 +6100,7 @@ int32_t ism330dhcx_tap_threshold_y_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_tap_cfg2_t tap_cfg2;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG2,
                             (uint8_t *)&tap_cfg2, 1);
   *val = tap_cfg2.tap_ths_y;
@@ -6001,6 +6120,7 @@ int32_t ism330dhcx_tap_threshold_z_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_THS_6D,
                             (uint8_t *)&tap_ths_6d, 1);
 
@@ -6027,6 +6147,7 @@ int32_t ism330dhcx_tap_threshold_z_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_THS_6D,
                             (uint8_t *)&tap_ths_6d, 1);
   *val = tap_ths_6d.tap_ths_z;
@@ -6050,6 +6171,7 @@ int32_t ism330dhcx_tap_shock_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_int_dur2_t int_dur2;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT_DUR2,
                             (uint8_t *)&int_dur2, 1);
 
@@ -6079,6 +6201,7 @@ int32_t ism330dhcx_tap_shock_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_int_dur2_t int_dur2;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT_DUR2,
                             (uint8_t *)&int_dur2, 1);
   *val = int_dur2.shock;
@@ -6102,6 +6225,7 @@ int32_t ism330dhcx_tap_quiet_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_int_dur2_t int_dur2;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT_DUR2,
                             (uint8_t *)&int_dur2, 1);
 
@@ -6131,6 +6255,7 @@ int32_t ism330dhcx_tap_quiet_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_int_dur2_t int_dur2;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT_DUR2,
                             (uint8_t *)&int_dur2, 1);
   *val = int_dur2.quiet;
@@ -6156,6 +6281,7 @@ int32_t ism330dhcx_tap_dur_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_int_dur2_t int_dur2;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT_DUR2,
                             (uint8_t *)&int_dur2, 1);
 
@@ -6185,6 +6311,7 @@ int32_t ism330dhcx_tap_dur_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_int_dur2_t int_dur2;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT_DUR2,
                             (uint8_t *)&int_dur2, 1);
   *val = int_dur2.dur;
@@ -6205,6 +6332,7 @@ int32_t ism330dhcx_tap_mode_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_wake_up_ths_t wake_up_ths;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_THS,
                             (uint8_t *)&wake_up_ths, 1);
 
@@ -6231,6 +6359,7 @@ int32_t ism330dhcx_tap_mode_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_wake_up_ths_t wake_up_ths;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_THS,
                             (uint8_t *)&wake_up_ths, 1);
 
@@ -6278,6 +6407,7 @@ int32_t ism330dhcx_6d_threshold_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_THS_6D,
                             (uint8_t *)&tap_ths_6d, 1);
 
@@ -6304,6 +6434,7 @@ int32_t ism330dhcx_6d_threshold_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_THS_6D,
                             (uint8_t *)&tap_ths_6d, 1);
 
@@ -6345,6 +6476,7 @@ int32_t ism330dhcx_4d_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_THS_6D,
                             (uint8_t *)&tap_ths_6d, 1);
 
@@ -6370,6 +6502,7 @@ int32_t ism330dhcx_4d_mode_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_THS_6D,
                             (uint8_t *)&tap_ths_6d, 1);
   *val = tap_ths_6d.d4d_en;
@@ -6403,6 +6536,7 @@ int32_t ism330dhcx_ff_threshold_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_free_fall_t free_fall;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FREE_FALL,
                             (uint8_t *)&free_fall, 1);
 
@@ -6429,6 +6563,7 @@ int32_t ism330dhcx_ff_threshold_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_free_fall_t free_fall;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FREE_FALL,
                             (uint8_t *)&free_fall, 1);
 
@@ -6487,6 +6622,7 @@ int32_t ism330dhcx_ff_dur_set(const stmdev_ctx_t *ctx, uint8_t val)
   ism330dhcx_wake_up_dur_t wake_up_dur;
   ism330dhcx_free_fall_t free_fall;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_DUR,
                             (uint8_t *)&wake_up_dur, 1);
 
@@ -6526,6 +6662,7 @@ int32_t ism330dhcx_ff_dur_get(const stmdev_ctx_t *ctx, uint8_t *val)
   ism330dhcx_wake_up_dur_t wake_up_dur;
   ism330dhcx_free_fall_t free_fall;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_DUR,
                             (uint8_t *)&wake_up_dur, 1);
 
@@ -6566,21 +6703,17 @@ int32_t ism330dhcx_fifo_watermark_set(const stmdev_ctx_t *ctx, uint16_t val)
   ism330dhcx_fifo_ctrl1_t fifo_ctrl1;
   ism330dhcx_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
-  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL2,
-                            (uint8_t *)&fifo_ctrl2, 1);
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
+  ret += ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
 
   if (ret == 0)
   {
+    fifo_ctrl1.wtm = (uint8_t)(val  & 0xFFU);
     fifo_ctrl2.wtm = (uint8_t)(val / 256U) & 0x01U;
-    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_FIFO_CTRL2,
-                               (uint8_t *)&fifo_ctrl2, 1);
-  }
 
-  if (ret == 0)
-  {
-    fifo_ctrl1.wtm = (uint8_t)(val - (fifo_ctrl2.wtm * 256U));
-    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_FIFO_CTRL1,
-                               (uint8_t *)&fifo_ctrl1, 1);
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
+    ret += ism330dhcx_write_reg(ctx, ISM330DHCX_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
   }
 
   return ret;
@@ -6600,14 +6733,9 @@ int32_t ism330dhcx_fifo_watermark_get(const stmdev_ctx_t *ctx,
   ism330dhcx_fifo_ctrl1_t fifo_ctrl1;
   ism330dhcx_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
-  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL2,
-                            (uint8_t *)&fifo_ctrl2, 1);
 
-  if (ret == 0)
-  {
-    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL1,
-                              (uint8_t *)&fifo_ctrl1, 1);
-  }
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
+  ret += ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
 
   *val = fifo_ctrl2.wtm;
   *val = (*val * 256U) +  fifo_ctrl1.wtm;;
@@ -6628,6 +6756,7 @@ int32_t ism330dhcx_compression_algo_init_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_emb_func_init_b_t emb_func_init_b;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -6665,6 +6794,7 @@ int32_t ism330dhcx_compression_algo_init_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_emb_func_init_b_t emb_func_init_b;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -6696,6 +6826,7 @@ int32_t ism330dhcx_compression_algo_set(const stmdev_ctx_t *ctx,
   ism330dhcx_fifo_ctrl2_t fifo_ctrl2;
   ism330dhcx_emb_func_en_b_t emb_func_en_b;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -6750,6 +6881,7 @@ int32_t ism330dhcx_compression_algo_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL2,
                             (uint8_t *)&fifo_ctrl2, 1);
 
@@ -6797,6 +6929,7 @@ int32_t ism330dhcx_fifo_virtual_sens_odr_chg_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL2,
                             (uint8_t *)&fifo_ctrl2, 1);
 
@@ -6823,6 +6956,7 @@ int32_t ism330dhcx_fifo_virtual_sens_odr_chg_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL2,
                             (uint8_t *)&fifo_ctrl2, 1);
   *val = fifo_ctrl2.odrchg_en;
@@ -6843,6 +6977,7 @@ int32_t ism330dhcx_compression_algo_real_time_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL2,
                             (uint8_t *)&fifo_ctrl2, 1);
 
@@ -6869,6 +7004,7 @@ int32_t ism330dhcx_compression_algo_real_time_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL2,
                             (uint8_t *)&fifo_ctrl2, 1);
   *val = fifo_ctrl2.fifo_compr_rt_en;
@@ -6890,6 +7026,7 @@ int32_t ism330dhcx_fifo_stop_on_wtm_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL2,
                             (uint8_t *)&fifo_ctrl2, 1);
 
@@ -6917,6 +7054,7 @@ int32_t ism330dhcx_fifo_stop_on_wtm_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL2,
                             (uint8_t *)&fifo_ctrl2, 1);
   *val = fifo_ctrl2.stop_on_wtm;
@@ -6938,6 +7076,7 @@ int32_t ism330dhcx_fifo_xl_batch_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_fifo_ctrl3_t fifo_ctrl3;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL3,
                             (uint8_t *)&fifo_ctrl3, 1);
 
@@ -6965,6 +7104,7 @@ int32_t ism330dhcx_fifo_xl_batch_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_fifo_ctrl3_t fifo_ctrl3;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL3,
                             (uint8_t *)&fifo_ctrl3, 1);
 
@@ -7040,6 +7180,7 @@ int32_t ism330dhcx_fifo_gy_batch_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_fifo_ctrl3_t fifo_ctrl3;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL3,
                             (uint8_t *)&fifo_ctrl3, 1);
 
@@ -7067,6 +7208,7 @@ int32_t ism330dhcx_fifo_gy_batch_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_fifo_ctrl3_t fifo_ctrl3;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL3,
                             (uint8_t *)&fifo_ctrl3, 1);
 
@@ -7141,6 +7283,7 @@ int32_t ism330dhcx_fifo_mode_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL4,
                             (uint8_t *)&fifo_ctrl4, 1);
 
@@ -7167,6 +7310,7 @@ int32_t ism330dhcx_fifo_mode_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL4,
                             (uint8_t *)&fifo_ctrl4, 1);
 
@@ -7218,6 +7362,7 @@ int32_t ism330dhcx_fifo_temp_batch_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL4,
                             (uint8_t *)&fifo_ctrl4, 1);
 
@@ -7245,6 +7390,7 @@ int32_t ism330dhcx_fifo_temp_batch_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL4,
                             (uint8_t *)&fifo_ctrl4, 1);
 
@@ -7289,6 +7435,7 @@ int32_t ism330dhcx_fifo_timestamp_decimation_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL4,
                             (uint8_t *)&fifo_ctrl4, 1);
 
@@ -7318,6 +7465,7 @@ int32_t ism330dhcx_fifo_timestamp_decimation_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL4,
                             (uint8_t *)&fifo_ctrl4, 1);
 
@@ -7362,6 +7510,7 @@ int32_t ism330dhcx_fifo_cnt_event_batch_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_counter_bdr_reg1_t counter_bdr_reg1;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_COUNTER_BDR_REG1,
                             (uint8_t *)&counter_bdr_reg1, 1);
 
@@ -7390,6 +7539,7 @@ int32_t ism330dhcx_fifo_cnt_event_batch_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_counter_bdr_reg1_t counter_bdr_reg1;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_COUNTER_BDR_REG1,
                             (uint8_t *)&counter_bdr_reg1, 1);
 
@@ -7425,6 +7575,7 @@ int32_t ism330dhcx_rst_batch_counter_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_counter_bdr_reg1_t counter_bdr_reg1;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_COUNTER_BDR_REG1,
                             (uint8_t *)&counter_bdr_reg1, 1);
 
@@ -7452,6 +7603,7 @@ int32_t ism330dhcx_rst_batch_counter_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_counter_bdr_reg1_t counter_bdr_reg1;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_COUNTER_BDR_REG1,
                             (uint8_t *)&counter_bdr_reg1, 1);
   *val = counter_bdr_reg1.rst_counter_bdr;
@@ -7474,6 +7626,7 @@ int32_t ism330dhcx_batch_counter_threshold_set(const stmdev_ctx_t *ctx,
   ism330dhcx_counter_bdr_reg2_t counter_bdr_reg1;
   ism330dhcx_counter_bdr_reg2_t counter_bdr_reg2;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_COUNTER_BDR_REG1,
                             (uint8_t *)&counter_bdr_reg1, 1);
 
@@ -7510,6 +7663,7 @@ int32_t ism330dhcx_batch_counter_threshold_get(const stmdev_ctx_t *ctx,
   ism330dhcx_counter_bdr_reg1_t counter_bdr_reg1;
   ism330dhcx_counter_bdr_reg2_t counter_bdr_reg2;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_COUNTER_BDR_REG1,
                             (uint8_t *)&counter_bdr_reg1, 1);
 
@@ -7529,25 +7683,24 @@ int32_t ism330dhcx_batch_counter_threshold_get(const stmdev_ctx_t *ctx,
   * @brief  Number of unread sensor data (TAG + 6 bytes) stored in FIFO.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of diff_fifo in reg FIFO_STATUS1
+  * @param  val    Read the value of diff_fifo in reg FIFO_STATUS1 and FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t ism330dhcx_fifo_data_level_get(const stmdev_ctx_t *ctx,
                                        uint16_t *val)
 {
-  ism330dhcx_fifo_status1_t fifo_status1;
-  ism330dhcx_fifo_status2_t fifo_status2;
+  uint8_t reg[2];
+  ism330dhcx_fifo_status1_t *fifo_status1 = (ism330dhcx_fifo_status1_t *)&reg[0];
+  ism330dhcx_fifo_status2_t *fifo_status2 = (ism330dhcx_fifo_status2_t *)&reg[1];
   int32_t ret;
-  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_STATUS1,
-                            (uint8_t *)&fifo_status1, 1);
 
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_STATUS1, (uint8_t *)reg, 2);
   if (ret == 0)
   {
-    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_STATUS2,
-                              (uint8_t *)&fifo_status2, 1);
-    *val = fifo_status2.diff_fifo;
-    *val = (*val * 256U) +  fifo_status1.diff_fifo;
+    *val = fifo_status2->diff_fifo;
+    *val = (*val * 256U) + fifo_status1->diff_fifo;
   }
 
   return ret;
@@ -7557,16 +7710,23 @@ int32_t ism330dhcx_fifo_data_level_get(const stmdev_ctx_t *ctx,
   * @brief  Smart FIFO status.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Registers FIFO_STATUS2
+  * @param  val    Read registers FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t ism330dhcx_fifo_status_get(const stmdev_ctx_t *ctx,
                                    ism330dhcx_fifo_status2_t *val)
 {
+  uint8_t reg[2];
+  ism330dhcx_fifo_status2_t *fifo_status2 = (ism330dhcx_fifo_status2_t *)&reg[1];
   int32_t ret;
-  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_STATUS2,
-                            (uint8_t *)val, 1);
+
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = *fifo_status2;
+  }
 
   return ret;
 }
@@ -7575,17 +7735,22 @@ int32_t ism330dhcx_fifo_status_get(const stmdev_ctx_t *ctx,
   * @brief  Smart FIFO full status.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of fifo_full_ia in reg FIFO_STATUS2
+  * @param  val    Read the values of fifo_full_ia in reg FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t ism330dhcx_fifo_full_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism330dhcx_fifo_status2_t fifo_status2;
+  uint8_t reg[2];
+  ism330dhcx_fifo_status2_t *fifo_status2 = (ism330dhcx_fifo_status2_t *)&reg[1];
   int32_t ret;
-  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_STATUS2,
-                            (uint8_t *)&fifo_status2, 1);
-  *val = fifo_status2.fifo_full_ia;
+
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_full_ia;
+  }
 
   return ret;
 }
@@ -7594,18 +7759,23 @@ int32_t ism330dhcx_fifo_full_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @brief  FIFO overrun status.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of  fifo_over_run_latched in
+  * @param  val    Read the values of  fifo_over_run_latched in
   *                reg FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t ism330dhcx_fifo_ovr_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism330dhcx_fifo_status2_t fifo_status2;
+  uint8_t reg[2];
+  ism330dhcx_fifo_status2_t *fifo_status2 = (ism330dhcx_fifo_status2_t *)&reg[1];
   int32_t ret;
-  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_STATUS2,
-                            (uint8_t *)&fifo_status2, 1);
-  *val = fifo_status2. fifo_ovr_ia;
+
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_ovr_ia;
+  }
 
   return ret;
 }
@@ -7614,17 +7784,22 @@ int32_t ism330dhcx_fifo_ovr_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @brief  FIFO watermark status.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of fifo_wtm_ia in reg FIFO_STATUS2
+  * @param  val    Read the values of fifo_wtm_ia in reg FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t ism330dhcx_fifo_wtm_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism330dhcx_fifo_status2_t fifo_status2;
+  uint8_t reg[2];
+  ism330dhcx_fifo_status2_t *fifo_status2 = (ism330dhcx_fifo_status2_t *)&reg[1];
   int32_t ret;
-  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_STATUS2,
-                            (uint8_t *)&fifo_status2, 1);
-  *val = fifo_status2.fifo_wtm_ia;
+
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_wtm_ia;
+  }
 
   return ret;
 }
@@ -7642,6 +7817,7 @@ int32_t ism330dhcx_fifo_sensor_tag_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_fifo_data_out_tag_t fifo_data_out_tag;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_DATA_OUT_TAG,
                             (uint8_t *)&fifo_data_out_tag, 1);
 
@@ -7756,6 +7932,7 @@ int32_t ism330dhcx_fifo_pedo_batch_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_emb_func_fifo_cfg_t emb_func_fifo_cfg;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -7793,6 +7970,7 @@ int32_t ism330dhcx_fifo_pedo_batch_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_emb_func_fifo_cfg_t emb_func_fifo_cfg;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -7823,6 +8001,7 @@ int32_t ism330dhcx_sh_batch_slave_0_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_slv0_config_t slv0_config;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -7860,6 +8039,7 @@ int32_t ism330dhcx_sh_batch_slave_0_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_slv0_config_t slv0_config;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -7891,6 +8071,7 @@ int32_t ism330dhcx_sh_batch_slave_1_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_slv1_config_t slv1_config;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -7928,6 +8109,7 @@ int32_t ism330dhcx_sh_batch_slave_1_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_slv1_config_t slv1_config;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -7959,6 +8141,7 @@ int32_t ism330dhcx_sh_batch_slave_2_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_slv2_config_t slv2_config;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -7996,6 +8179,7 @@ int32_t ism330dhcx_sh_batch_slave_2_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_slv2_config_t slv2_config;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -8027,6 +8211,7 @@ int32_t ism330dhcx_sh_batch_slave_3_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_slv3_config_t slv3_config;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -8064,6 +8249,7 @@ int32_t ism330dhcx_sh_batch_slave_3_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_slv3_config_t slv3_config;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -8107,6 +8293,7 @@ int32_t ism330dhcx_den_mode_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl6_c_t ctrl6_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL6_C,
                             (uint8_t *)&ctrl6_c, 1);
 
@@ -8133,6 +8320,7 @@ int32_t ism330dhcx_den_mode_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl6_c_t ctrl6_c;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL6_C,
                             (uint8_t *)&ctrl6_c, 1);
 
@@ -8179,6 +8367,7 @@ int32_t ism330dhcx_den_polarity_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL9_XL,
                             (uint8_t *)&ctrl9_xl, 1);
 
@@ -8205,6 +8394,7 @@ int32_t ism330dhcx_den_polarity_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL9_XL,
                             (uint8_t *)&ctrl9_xl, 1);
 
@@ -8239,6 +8429,7 @@ int32_t ism330dhcx_den_enable_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL9_XL,
                             (uint8_t *)&ctrl9_xl, 1);
 
@@ -8265,6 +8456,7 @@ int32_t ism330dhcx_den_enable_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL9_XL,
                             (uint8_t *)&ctrl9_xl, 1);
 
@@ -8302,6 +8494,7 @@ int32_t ism330dhcx_den_mark_axis_x_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL9_XL,
                             (uint8_t *)&ctrl9_xl, 1);
 
@@ -8328,6 +8521,7 @@ int32_t ism330dhcx_den_mark_axis_x_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL9_XL,
                             (uint8_t *)&ctrl9_xl, 1);
   *val = ctrl9_xl.den_z;
@@ -8347,6 +8541,7 @@ int32_t ism330dhcx_den_mark_axis_y_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL9_XL,
                             (uint8_t *)&ctrl9_xl, 1);
 
@@ -8373,6 +8568,7 @@ int32_t ism330dhcx_den_mark_axis_y_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL9_XL,
                             (uint8_t *)&ctrl9_xl, 1);
   *val = ctrl9_xl.den_y;
@@ -8392,6 +8588,7 @@ int32_t ism330dhcx_den_mark_axis_z_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL9_XL,
                             (uint8_t *)&ctrl9_xl, 1);
 
@@ -8418,6 +8615,7 @@ int32_t ism330dhcx_den_mark_axis_z_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
+
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL9_XL,
                             (uint8_t *)&ctrl9_xl, 1);
   *val = ctrl9_xl.den_x;
@@ -8449,6 +8647,7 @@ int32_t ism330dhcx_pedo_sens_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_emb_func_en_a_t emb_func_en_a;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -8484,6 +8683,7 @@ int32_t ism330dhcx_pedo_sens_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_emb_func_en_a_t emb_func_en_a;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -8514,6 +8714,7 @@ int32_t ism330dhcx_pedo_step_detect_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_emb_func_status_t emb_func_status;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -8543,6 +8744,7 @@ int32_t ism330dhcx_pedo_debounce_steps_set(const stmdev_ctx_t *ctx,
                                            uint8_t *buff)
 {
   int32_t ret;
+
   ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_PEDO_DEB_STEPS_CONF,
                                     buff);
 
@@ -8561,6 +8763,7 @@ int32_t ism330dhcx_pedo_debounce_steps_get(const stmdev_ctx_t *ctx,
                                            uint8_t *buff)
 {
   int32_t ret;
+
   ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_PEDO_DEB_STEPS_CONF,
                                    buff);
 
@@ -8580,6 +8783,7 @@ int32_t ism330dhcx_pedo_steps_period_set(const stmdev_ctx_t *ctx,
 {
   uint8_t buff[2];
   int32_t ret;
+
   buff[1] = (uint8_t)(val / 256U);
   buff[0] = (uint8_t)(val - (buff[1] * 256U));
   ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_PEDO_SC_DELTAT_L,
@@ -8607,6 +8811,7 @@ int32_t ism330dhcx_pedo_steps_period_get(const stmdev_ctx_t *ctx,
 {
   uint8_t buff[2];
   int32_t ret;
+
   ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_PEDO_SC_DELTAT_L,
                                    &buff[0]);
 
@@ -8635,6 +8840,7 @@ int32_t ism330dhcx_pedo_int_mode_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_pedo_cmd_reg_t pedo_cmd_reg;
   int32_t ret;
+
   ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_PEDO_CMD_REG,
                                    (uint8_t *)&pedo_cmd_reg);
 
@@ -8662,6 +8868,7 @@ int32_t ism330dhcx_pedo_int_mode_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_pedo_cmd_reg_t pedo_cmd_reg;
   int32_t ret;
+
   ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_PEDO_CMD_REG,
                                    (uint8_t *)&pedo_cmd_reg);
 
@@ -8708,6 +8915,7 @@ int32_t ism330dhcx_motion_sens_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_emb_func_en_a_t emb_func_en_a;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -8743,6 +8951,7 @@ int32_t ism330dhcx_motion_sens_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_emb_func_en_a_t emb_func_en_a;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -8773,6 +8982,7 @@ int32_t ism330dhcx_motion_flag_data_ready_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_emb_func_status_t emb_func_status;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -8815,6 +9025,7 @@ int32_t ism330dhcx_tilt_sens_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_emb_func_en_a_t emb_func_en_a;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -8850,6 +9061,7 @@ int32_t ism330dhcx_tilt_sens_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_emb_func_en_a_t emb_func_en_a;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -8880,6 +9092,7 @@ int32_t ism330dhcx_tilt_flag_data_ready_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_emb_func_status_t emb_func_status;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -8923,6 +9136,7 @@ int32_t ism330dhcx_mag_sensitivity_set(const stmdev_ctx_t *ctx,
 {
   uint8_t buff[2];
   int32_t ret;
+
   buff[1] = (uint8_t)(val / 256U);
   buff[0] = (uint8_t)(val - (buff[1] * 256U));
   ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_SENSITIVITY_L,
@@ -8950,6 +9164,7 @@ int32_t ism330dhcx_mag_sensitivity_get(const stmdev_ctx_t *ctx,
 {
   uint8_t buff[2];
   int32_t ret;
+
   ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_SENSITIVITY_L,
                                    &buff[0]);
 
@@ -8977,6 +9192,7 @@ int32_t ism330dhcx_mag_offset_set(const stmdev_ctx_t *ctx, int16_t *val)
   uint8_t buff[6];
   int32_t ret;
   uint8_t i;
+
   buff[1] = (uint8_t)((uint16_t)val[0] / 256U);
   buff[0] = (uint8_t)((uint16_t)val[0] - (buff[1] * 256U));
   buff[3] = (uint8_t)((uint16_t)val[1] / 256U);
@@ -8984,42 +9200,36 @@ int32_t ism330dhcx_mag_offset_set(const stmdev_ctx_t *ctx, int16_t *val)
   buff[5] = (uint8_t)((uint16_t)val[2] / 256U);
   buff[4] = (uint8_t)((uint16_t)val[2] - (buff[5] * 256U));
   i = 0x00U;
-  ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_OFFX_L,
-                                    &buff[i]);
+  ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_OFFX_L, &buff[i]);
 
   if (ret == 0)
   {
     i++;
-    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_OFFX_H,
-                                      &buff[i]);
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_OFFX_H, &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_OFFY_L,
-                                      &buff[i]);
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_OFFY_L, &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_OFFY_H,
-                                      &buff[i]);
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_OFFY_H, &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_OFFZ_L,
-                                      &buff[i]);
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_OFFZ_L, &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_OFFZ_H,
-                                      &buff[i]);
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_OFFZ_H, &buff[i]);
   }
 
   return ret;
@@ -9038,51 +9248,46 @@ int32_t ism330dhcx_mag_offset_get(const stmdev_ctx_t *ctx, int16_t *val)
   uint8_t buff[6];
   int32_t ret;
   uint8_t i;
+
   i = 0x00U;
-  ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_OFFX_L,
-                                   &buff[i]);
+  ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_OFFX_L, &buff[i]);
 
   if (ret == 0)
   {
     i++;
-    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_OFFX_H,
-                                     &buff[i]);
+    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_OFFX_H, &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_OFFY_L,
-                                     &buff[i]);
+    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_OFFY_L, &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_OFFY_H,
-                                     &buff[i]);
+    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_OFFY_H, &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_OFFZ_L,
-                                     &buff[i]);
+    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_OFFZ_L, &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_OFFZ_H,
-                                     &buff[i]);
-  }
+    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_OFFZ_H, &buff[i]);
 
-  val[0] = (int16_t)buff[1];
-  val[0] = (val[0] * 256) + (int16_t)buff[0];
-  val[1] = (int16_t)buff[3];
-  val[1] = (val[1] * 256) + (int16_t)buff[2];
-  val[2] = (int16_t)buff[5];
-  val[2] = (val[2] * 256) + (int16_t)buff[4];
+    val[0] = (int16_t)buff[1];
+    val[0] = (val[0] * 256) + (int16_t)buff[0];
+    val[1] = (int16_t)buff[3];
+    val[1] = (val[1] * 256) + (int16_t)buff[2];
+    val[2] = (int16_t)buff[5];
+    val[2] = (val[2] * 256) + (int16_t)buff[4];
+  }
 
   return ret;
 }
@@ -9105,6 +9310,7 @@ int32_t ism330dhcx_mag_soft_iron_set(const stmdev_ctx_t *ctx, uint16_t *val)
   uint8_t buff[12];
   int32_t ret;
   uint8_t i;
+
   buff[1] = (uint8_t)(val[0] / 256U);
   buff[0] = (uint8_t)(val[0] - (buff[1] * 256U));
   buff[3] = (uint8_t)(val[1] / 256U);
@@ -9219,6 +9425,7 @@ int32_t ism330dhcx_mag_soft_iron_get(const stmdev_ctx_t *ctx, uint16_t *val)
   uint8_t buff[12];
   int32_t ret;
   uint8_t i;
+
   i = 0x00U;
   ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_SI_XX_L,
                                    &buff[i]);
@@ -9330,6 +9537,7 @@ int32_t ism330dhcx_mag_z_orient_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_mag_cfg_a_t mag_cfg_a;
   int32_t ret;
+
   ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_CFG_A,
                                    (uint8_t *)&mag_cfg_a);
 
@@ -9357,6 +9565,7 @@ int32_t ism330dhcx_mag_z_orient_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_mag_cfg_a_t mag_cfg_a;
   int32_t ret;
+
   ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_CFG_A,
                                    (uint8_t *)&mag_cfg_a);
 
@@ -9409,6 +9618,7 @@ int32_t ism330dhcx_mag_y_orient_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_mag_cfg_a_t mag_cfg_a;
   int32_t ret;
+
   ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_CFG_A,
                                    (uint8_t *)&mag_cfg_a);
 
@@ -9436,6 +9646,7 @@ int32_t ism330dhcx_mag_y_orient_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_mag_cfg_a_t mag_cfg_a;
   int32_t ret;
+
   ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_CFG_A,
                                    (uint8_t *)&mag_cfg_a);
 
@@ -9487,6 +9698,7 @@ int32_t ism330dhcx_mag_x_orient_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_mag_cfg_b_t mag_cfg_b;
   int32_t ret;
+
   ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_CFG_B,
                                    (uint8_t *)&mag_cfg_b);
 
@@ -9514,6 +9726,7 @@ int32_t ism330dhcx_mag_x_orient_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_mag_cfg_b_t mag_cfg_b;
   int32_t ret;
+
   ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_CFG_B,
                                    (uint8_t *)&mag_cfg_b);
 
@@ -9578,6 +9791,7 @@ int32_t ism330dhcx_long_cnt_flag_data_ready_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_emb_func_status_t emb_func_status;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -9606,6 +9820,7 @@ int32_t ism330dhcx_long_cnt_flag_data_ready_get(const stmdev_ctx_t *ctx,
 int32_t ism330dhcx_emb_fsm_en_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   int32_t ret;
+
   ism330dhcx_emb_func_en_b_t emb_func_en_b;
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
@@ -9642,6 +9857,7 @@ int32_t ism330dhcx_emb_fsm_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   int32_t ret;
   ism330dhcx_emb_func_en_b_t emb_func_en_b;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -9678,6 +9894,7 @@ int32_t ism330dhcx_fsm_enable_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_emb_func_en_b_t emb_func_en_b;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -9752,6 +9969,7 @@ int32_t ism330dhcx_fsm_enable_get(const stmdev_ctx_t *ctx,
                                   ism330dhcx_emb_fsm_enable_t *val)
 {
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -9787,6 +10005,7 @@ int32_t ism330dhcx_long_cnt_set(const stmdev_ctx_t *ctx, uint16_t val)
 {
   uint8_t buff[2];
   int32_t ret;
+
   buff[1] = (uint8_t)(val / 256U);
   buff[0] = (uint8_t)(val - (buff[1] * 256U));
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
@@ -9818,6 +10037,7 @@ int32_t ism330dhcx_long_cnt_get(const stmdev_ctx_t *ctx, uint16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -9850,6 +10070,7 @@ int32_t ism330dhcx_long_clr_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_fsm_long_counter_clear_t fsm_long_counter_clear;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -9886,6 +10107,7 @@ int32_t ism330dhcx_long_clr_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_fsm_long_counter_clear_t fsm_long_counter_clear;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -9933,6 +10155,7 @@ int32_t ism330dhcx_fsm_out_get(const stmdev_ctx_t *ctx,
                                ism330dhcx_fsm_out_t *val)
 {
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -9962,6 +10185,7 @@ int32_t ism330dhcx_fsm_data_rate_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_emb_func_odr_cfg_b_t emb_func_odr_cfg_b;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -10000,6 +10224,7 @@ int32_t ism330dhcx_fsm_data_rate_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_emb_func_odr_cfg_b_t emb_func_odr_cfg_b;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -10051,6 +10276,7 @@ int32_t ism330dhcx_fsm_init_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_emb_func_init_b_t emb_func_init_b;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -10086,6 +10312,7 @@ int32_t ism330dhcx_fsm_init_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_emb_func_init_b_t emb_func_init_b;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -10119,18 +10346,16 @@ int32_t ism330dhcx_long_cnt_int_value_set(const stmdev_ctx_t *ctx,
 {
   uint8_t buff[2];
   int32_t ret;
-  uint8_t i;
+
   buff[1] = (uint8_t)(val / 256U);
   buff[0] = (uint8_t)(val - (buff[1] * 256U));
-  i = 0x00U;
   ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_FSM_LC_TIMEOUT_L,
-                                    &buff[i]);
+                                    &buff[0]);
 
   if (ret == 0)
   {
-    i++;
     ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_FSM_LC_TIMEOUT_H,
-                                      &buff[i]);
+                                      &buff[1]);
   }
 
   return ret;
@@ -10152,16 +10377,14 @@ int32_t ism330dhcx_long_cnt_int_value_get(const stmdev_ctx_t *ctx,
 {
   uint8_t buff[2];
   int32_t ret;
-  uint8_t i;
-  i = 0x00U;
+
   ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_FSM_LC_TIMEOUT_L,
-                                   &buff[i]);
+                                   &buff[0]);
 
   if (ret == 0)
   {
-    i++;
     ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_FSM_LC_TIMEOUT_H,
-                                     &buff[i]);
+                                     &buff[1]);
     *val = buff[1];
     *val = (*val * 256U) +  buff[0];
   }
@@ -10181,6 +10404,7 @@ int32_t ism330dhcx_fsm_number_of_programs_set(const stmdev_ctx_t *ctx,
                                               uint8_t *buff)
 {
   int32_t ret;
+
   ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_FSM_PROGRAMS, buff);
 
   if (ret == 0)
@@ -10205,6 +10429,7 @@ int32_t ism330dhcx_fsm_number_of_programs_get(const stmdev_ctx_t *ctx,
                                               uint8_t *buff)
 {
   int32_t ret;
+
   ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_FSM_PROGRAMS, buff);
 
   return ret;
@@ -10224,18 +10449,16 @@ int32_t ism330dhcx_fsm_start_address_set(const stmdev_ctx_t *ctx,
 {
   uint8_t buff[2];
   int32_t ret;
-  uint8_t i;
+
   buff[1] = (uint8_t)(val / 256U);
   buff[0] = (uint8_t)(val - (buff[1] * 256U));
-  i = 0x00U;
   ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_FSM_START_ADD_L,
-                                    &buff[i]);
+                                    &buff[0]);
 
   if (ret == 0)
   {
-    i++;
     ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_FSM_START_ADD_H,
-                                      &buff[i]);
+                                      &buff[1]);
   }
 
   return ret;
@@ -10255,16 +10478,14 @@ int32_t ism330dhcx_fsm_start_address_get(const stmdev_ctx_t *ctx,
 {
   uint8_t buff[2];
   int32_t ret;
-  uint8_t i;
-  i = 0x00U;
+
   ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_FSM_START_ADD_L,
-                                   &buff[i]);
+                                   &buff[0]);
 
   if (ret == 0)
   {
-    i++;
     ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_FSM_START_ADD_H,
-                                     &buff[i]);
+                                     &buff[1]);
     *val = buff[1];
     *val = (*val * 256U) +  buff[0];
   }
@@ -10298,6 +10519,7 @@ int32_t ism330dhcx_mlc_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_emb_func_en_b_t reg;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -10346,6 +10568,7 @@ int32_t ism330dhcx_mlc_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_emb_func_en_b_t reg;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -10390,6 +10613,7 @@ int32_t ism330dhcx_mlc_data_rate_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_emb_func_odr_cfg_c_t reg;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -10426,6 +10650,7 @@ int32_t ism330dhcx_mlc_data_rate_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_emb_func_odr_cfg_c_t reg;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -10466,6 +10691,88 @@ int32_t ism330dhcx_mlc_data_rate_get(const stmdev_ctx_t *ctx,
 }
 
 /**
+  * @brief  prgsens_out: [get] Output value of all MLCx decision trees.
+  *
+  * @param  ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t ism330dhcx_mlc_out_get(const stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+
+  if (ret == 0)
+  {
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_MLC0_SRC, buff, 8);
+  }
+
+  if (ret == 0)
+  {
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  External magnetometer sensitivity value register for
+  *         Machine Learning Core.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  *
+  */
+int32_t ism330dhcx_mlc_mag_sensitivity_set(const stmdev_ctx_t *ctx,
+                                           uint16_t val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  buff[1] = (uint8_t)(val / 256U);
+  buff[0] = (uint8_t)(val - (buff[1] * 256U));
+  ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MLC_MAG_SENSITIVITY_L,
+                                    &buff[0]);
+
+  if (ret == 0)
+  {
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MLC_MAG_SENSITIVITY_H,
+                                      &buff[1]);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  External magnetometer sensitivity value register for
+  *         Machine Learning Core.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t ism330dhcx_mlc_mag_sensitivity_get(const stmdev_ctx_t *ctx,
+                                           uint16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MLC_MAG_SENSITIVITY_L,
+                                   &buff[0]);
+
+  if (ret == 0)
+  {
+    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MLC_MAG_SENSITIVITY_H,
+                                     &buff[1]);
+    *val = buff[1];
+    *val = (*val * 256U) +  buff[0];
+  }
+
+  return ret;
+}
+
+/**
   * @}
   *
   */
@@ -10491,6 +10798,7 @@ int32_t ism330dhcx_sh_read_data_raw_get(const stmdev_ctx_t *ctx,
                                         uint8_t len)
 {
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -10520,6 +10828,7 @@ int32_t ism330dhcx_sh_slave_connected_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_master_config_t master_config;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -10556,6 +10865,7 @@ int32_t ism330dhcx_sh_slave_connected_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_master_config_t master_config;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -10607,6 +10917,7 @@ int32_t ism330dhcx_sh_master_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_master_config_t master_config;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -10642,6 +10953,7 @@ int32_t ism330dhcx_sh_master_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_master_config_t master_config;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -10672,6 +10984,7 @@ int32_t ism330dhcx_sh_pin_mode_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_master_config_t master_config;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -10708,6 +11021,7 @@ int32_t ism330dhcx_sh_pin_mode_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_master_config_t master_config;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -10751,6 +11065,7 @@ int32_t ism330dhcx_sh_pass_through_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_master_config_t master_config;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -10787,6 +11102,7 @@ int32_t ism330dhcx_sh_pass_through_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_master_config_t master_config;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -10817,6 +11133,7 @@ int32_t ism330dhcx_sh_syncro_mode_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_master_config_t master_config;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -10853,6 +11170,7 @@ int32_t ism330dhcx_sh_syncro_mode_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_master_config_t master_config;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -10898,6 +11216,7 @@ int32_t ism330dhcx_sh_write_mode_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_master_config_t master_config;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -10935,6 +11254,7 @@ int32_t ism330dhcx_sh_write_mode_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_master_config_t master_config;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -10977,6 +11297,7 @@ int32_t ism330dhcx_sh_reset_set(const stmdev_ctx_t *ctx)
 {
   ism330dhcx_master_config_t master_config;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -11019,6 +11340,7 @@ int32_t ism330dhcx_sh_reset_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_master_config_t master_config;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -11049,6 +11371,7 @@ int32_t ism330dhcx_sh_data_rate_set(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_slv0_config_t slv0_config;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -11085,6 +11408,7 @@ int32_t ism330dhcx_sh_data_rate_get(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_slv0_config_t slv0_config;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -11140,6 +11464,7 @@ int32_t ism330dhcx_sh_cfg_write(const stmdev_ctx_t *ctx,
 {
   ism330dhcx_slv0_add_t slv0_add;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -11187,6 +11512,7 @@ int32_t ism330dhcx_sh_slv0_cfg_read(const stmdev_ctx_t *ctx,
   ism330dhcx_slv0_config_t slv0_config;
   ism330dhcx_slv0_add_t slv0_add;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -11241,6 +11567,7 @@ int32_t ism330dhcx_sh_slv1_cfg_read(const stmdev_ctx_t *ctx,
   ism330dhcx_slv1_config_t slv1_config;
   ism330dhcx_slv1_add_t slv1_add;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -11295,6 +11622,7 @@ int32_t ism330dhcx_sh_slv2_cfg_read(const stmdev_ctx_t *ctx,
   ism330dhcx_slv2_config_t slv2_config;
   ism330dhcx_slv2_add_t slv2_add;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -11349,6 +11677,7 @@ int32_t ism330dhcx_sh_slv3_cfg_read(const stmdev_ctx_t *ctx,
   ism330dhcx_slv3_config_t slv3_config;
   ism330dhcx_slv3_add_t slv3_add;
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)
@@ -11398,6 +11727,7 @@ int32_t ism330dhcx_sh_status_get(const stmdev_ctx_t *ctx,
                                  ism330dhcx_status_master_t *val)
 {
   int32_t ret;
+
   ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
 
   if (ret == 0)

--- a/sensor/stmemsc/ism330dhcx_STdC/driver/ism330dhcx_reg.h
+++ b/sensor/stmemsc/ism330dhcx_STdC/driver/ism330dhcx_reg.h
@@ -665,6 +665,7 @@ typedef struct
 #define ISM330DHCX_OUTY_H_A                     0x2BU
 #define ISM330DHCX_OUTZ_L_A                     0x2CU
 #define ISM330DHCX_OUTZ_H_A                     0x2DU
+
 #define ISM330DHCX_EMB_FUNC_STATUS_MAINPAGE     0x35U
 typedef struct
 {
@@ -733,27 +734,27 @@ typedef struct
 #endif /* DRV_BYTE_ORDER */
 } ism330dhcx_fsm_status_b_mainpage_t;
 
-#define ISM330DHCX_MLC_STATUS_MAINPAGE     0x38U
+#define ISM330DHCX_MLC_STATUS_MAINPAGE          0x38U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t is_mlc1             : 1;
-  uint8_t is_mlc2             : 1;
-  uint8_t is_mlc3             : 1;
-  uint8_t is_mlc4             : 1;
-  uint8_t is_mlc5             : 1;
-  uint8_t is_mlc6             : 1;
-  uint8_t is_mlc7             : 1;
-  uint8_t is_mlc8             : 1;
+  uint8_t is_mlc1                 : 1;
+  uint8_t is_mlc2                 : 1;
+  uint8_t is_mlc3                 : 1;
+  uint8_t is_mlc4                 : 1;
+  uint8_t is_mlc5                 : 1;
+  uint8_t is_mlc6                 : 1;
+  uint8_t is_mlc7                 : 1;
+  uint8_t is_mlc8                 : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t is_mlc8             : 1;
-  uint8_t is_mlc7             : 1;
-  uint8_t is_mlc6             : 1;
-  uint8_t is_mlc5             : 1;
-  uint8_t is_mlc4             : 1;
-  uint8_t is_mlc3             : 1;
-  uint8_t is_mlc2             : 1;
-  uint8_t is_mlc1             : 1;
+  uint8_t is_mlc8                 : 1;
+  uint8_t is_mlc7                 : 1;
+  uint8_t is_mlc6                 : 1;
+  uint8_t is_mlc5                 : 1;
+  uint8_t is_mlc4                 : 1;
+  uint8_t is_mlc3                 : 1;
+  uint8_t is_mlc2                 : 1;
+  uint8_t is_mlc1                 : 1;
 #endif /* DRV_BYTE_ORDER */
 } ism330dhcx_mlc_status_mainpage_t;
 
@@ -1988,6 +1989,11 @@ typedef struct
 #define ISM330DHCX_MLC5_SRC                     0x75U
 #define ISM330DHCX_MLC6_SRC                     0x76U
 #define ISM330DHCX_MLC7_SRC                     0x77U
+
+/** @defgroup bitfields page 0 and 1
+  * @{
+  *
+  */
 #define ISM330DHCX_MAG_SENSITIVITY_L            0xBAU
 #define ISM330DHCX_MAG_SENSITIVITY_H            0xBBU
 #define ISM330DHCX_MAG_OFFX_L                   0xC0U
@@ -2060,6 +2066,17 @@ typedef struct
 #define ISM330DHCX_PEDO_SC_DELTAT_H             0x1D1U
 #define ISM330DHCX_MLC_MAG_SENSITIVITY_L        0x1E8U
 #define ISM330DHCX_MLC_MAG_SENSITIVITY_H        0x1E9U
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup bitfields page sensor_hub
+  * @{
+  *
+  */
+
 #define ISM330DHCX_SENSOR_HUB_1                 0x02U
 typedef struct
 {
@@ -2512,7 +2529,6 @@ typedef struct
   uint8_t master_on                : 1;
   uint8_t aux_sens_on              : 2;
 #endif /* DRV_BYTE_ORDER */
-
 } ism330dhcx_master_config_t;
 
 #define ISM330DHCX_SLV0_ADD                     0x15U
@@ -2525,7 +2541,6 @@ typedef struct
   uint8_t slave0                   : 7;
   uint8_t rw_0                     : 1;
 #endif /* DRV_BYTE_ORDER */
-
 } ism330dhcx_slv0_add_t;
 
 #define ISM330DHCX_SLV0_SUBADD                  0x16U
@@ -2548,7 +2563,6 @@ typedef struct
   uint8_t batch_ext_sens_0_en      : 1;
   uint8_t slave0_numop             : 3;
 #endif /* DRV_BYTE_ORDER */
-
 } ism330dhcx_slv0_config_t;
 
 #define ISM330DHCX_SLV1_ADD                     0x18U
@@ -2676,6 +2690,11 @@ typedef struct
 } ism330dhcx_status_master_t;
 
 /**
+  * @}
+  *
+  */
+
+/**
   * @defgroup ISM330DHCX_Register_Union
   * @brief    This union group all the registers having a bit-field
   *           description.
@@ -2741,14 +2760,17 @@ typedef union
   ism330dhcx_emb_func_int1_t                 emb_func_int1;
   ism330dhcx_fsm_int1_a_t                    fsm_int1_a;
   ism330dhcx_fsm_int1_b_t                    fsm_int1_b;
+  ism330dhcx_mlc_int1_t                      mlc_int1;
   ism330dhcx_emb_func_int2_t                 emb_func_int2;
   ism330dhcx_fsm_int2_a_t                    fsm_int2_a;
   ism330dhcx_fsm_int2_b_t                    fsm_int2_b;
+  ism330dhcx_mlc_int2_t                      mlc_int2;
   ism330dhcx_emb_func_status_t               emb_func_status;
   ism330dhcx_fsm_status_a_t                  fsm_status_a;
   ism330dhcx_fsm_status_b_t                  fsm_status_b;
+  ism330dhcx_mlc_status_mainpage_t           mlc_status_mainpage;
   ism330dhcx_page_rw_t                       page_rw;
-  ism330dhcx_emb_func_fifo_cfg_t              emb_func_fifo_cfg;
+  ism330dhcx_emb_func_fifo_cfg_t             emb_func_fifo_cfg;
   ism330dhcx_fsm_enable_a_t                  fsm_enable_a;
   ism330dhcx_fsm_enable_b_t                  fsm_enable_b;
   ism330dhcx_fsm_long_counter_clear_t        fsm_long_counter_clear;
@@ -2851,7 +2873,7 @@ float_t ism330dhcx_from_fs4000dps_to_mdps(int16_t lsb);
 
 float_t ism330dhcx_from_lsb_to_celsius(int16_t lsb);
 
-float_t ism330dhcx_from_lsb_to_nsec(int32_t lsb);
+uint64_t ism330dhcx_from_lsb_to_nsec(uint32_t lsb);
 
 typedef enum
 {
@@ -2955,14 +2977,15 @@ int32_t ism330dhcx_gy_power_mode_get(const stmdev_ctx_t *ctx,
 
 typedef struct
 {
-  ism330dhcx_all_int_src_t       all_int_src;
-  ism330dhcx_wake_up_src_t       wake_up_src;
-  ism330dhcx_tap_src_t           tap_src;
-  ism330dhcx_d6d_src_t           d6d_src;
-  ism330dhcx_status_reg_t        status_reg;
-  ism330dhcx_emb_func_status_t   emb_func_status;
-  ism330dhcx_fsm_status_a_t      fsm_status_a;
-  ism330dhcx_fsm_status_b_t      fsm_status_b;
+  ism330dhcx_all_int_src_t           all_int_src;
+  ism330dhcx_wake_up_src_t           wake_up_src;
+  ism330dhcx_tap_src_t               tap_src;
+  ism330dhcx_d6d_src_t               d6d_src;
+  ism330dhcx_status_reg_t            status_reg;
+  ism330dhcx_emb_func_status_t       emb_func_status;
+  ism330dhcx_fsm_status_a_t          fsm_status_a;
+  ism330dhcx_fsm_status_b_t          fsm_status_b;
+  ism330dhcx_mlc_status_mainpage_t   mlc_status;
 } ism330dhcx_all_sources_t;
 int32_t ism330dhcx_all_sources_get(const stmdev_ctx_t *ctx,
                                    ism330dhcx_all_sources_t *val);
@@ -2980,19 +3003,19 @@ int32_t ism330dhcx_temp_flag_data_ready_get(const stmdev_ctx_t *ctx,
                                             uint8_t *val);
 
 int32_t ism330dhcx_xl_usr_offset_x_set(const stmdev_ctx_t *ctx,
-                                       uint8_t *buff);
+                                       uint8_t *val);
 int32_t ism330dhcx_xl_usr_offset_x_get(const stmdev_ctx_t *ctx,
-                                       uint8_t *buff);
+                                       uint8_t *val);
 
 int32_t ism330dhcx_xl_usr_offset_y_set(const stmdev_ctx_t *ctx,
-                                       uint8_t *buff);
+                                       uint8_t *val);
 int32_t ism330dhcx_xl_usr_offset_y_get(const stmdev_ctx_t *ctx,
-                                       uint8_t *buff);
+                                       uint8_t *val);
 
 int32_t ism330dhcx_xl_usr_offset_z_set(const stmdev_ctx_t *ctx,
-                                       uint8_t *buff);
+                                       uint8_t *val);
 int32_t ism330dhcx_xl_usr_offset_z_get(const stmdev_ctx_t *ctx,
-                                       uint8_t *buff);
+                                       uint8_t *val);
 
 int32_t ism330dhcx_xl_usr_offset_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t ism330dhcx_xl_usr_offset_get(const stmdev_ctx_t *ctx, uint8_t *val);
@@ -3002,8 +3025,7 @@ int32_t ism330dhcx_timestamp_rst(const stmdev_ctx_t *ctx);
 int32_t ism330dhcx_timestamp_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t ism330dhcx_timestamp_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dhcx_timestamp_raw_get(const stmdev_ctx_t *ctx,
-                                     uint32_t *val);
+int32_t ism330dhcx_timestamp_raw_get(const stmdev_ctx_t *ctx, uint32_t *val);
 
 typedef enum
 {
@@ -3017,18 +3039,15 @@ int32_t ism330dhcx_rounding_mode_set(const stmdev_ctx_t *ctx,
 int32_t ism330dhcx_rounding_mode_get(const stmdev_ctx_t *ctx,
                                      ism330dhcx_rounding_t *val);
 
-int32_t ism330dhcx_temperature_raw_get(const stmdev_ctx_t *ctx,
-                                       int16_t *val);
+int32_t ism330dhcx_temperature_raw_get(const stmdev_ctx_t *ctx, int16_t *val);
 
-int32_t ism330dhcx_angular_rate_raw_get(const stmdev_ctx_t *ctx,
-                                        int16_t *val);
+int32_t ism330dhcx_angular_rate_raw_get(const stmdev_ctx_t *ctx, int16_t *val);
 
-int32_t ism330dhcx_acceleration_raw_get(const stmdev_ctx_t *ctx,
-                                        int16_t *val);
+int32_t ism330dhcx_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *val);
 
-int32_t ism330dhcx_fifo_out_raw_get(const stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dhcx_fifo_out_raw_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dhcx_mlc_out_get(const stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dhcx_mlc_out_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 int32_t ism330dhcx_device_conf_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t ism330dhcx_device_conf_get(const stmdev_ctx_t *ctx, uint8_t *val);
@@ -3036,8 +3055,7 @@ int32_t ism330dhcx_device_conf_get(const stmdev_ctx_t *ctx, uint8_t *val);
 int32_t ism330dhcx_odr_cal_reg_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t ism330dhcx_odr_cal_reg_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dhcx_number_of_steps_get(const stmdev_ctx_t *ctx,
-                                       uint16_t *val);
+int32_t ism330dhcx_number_of_steps_get(const stmdev_ctx_t *ctx, uint16_t *val);
 
 int32_t ism330dhcx_steps_reset(const stmdev_ctx_t *ctx);
 
@@ -3052,8 +3070,7 @@ int32_t ism330dhcx_mem_bank_set(const stmdev_ctx_t *ctx,
 int32_t ism330dhcx_mem_bank_get(const stmdev_ctx_t *ctx,
                                 ism330dhcx_reg_access_t *val);
 
-int32_t ism330dhcx_ln_pg_write_byte(const stmdev_ctx_t *ctx,
-                                    uint16_t address,
+int32_t ism330dhcx_ln_pg_write_byte(const stmdev_ctx_t *ctx, uint16_t address,
                                     uint8_t *val);
 int32_t ism330dhcx_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t address,
                                uint8_t *buf, uint8_t len);
@@ -3072,14 +3089,13 @@ int32_t ism330dhcx_data_ready_mode_set(const stmdev_ctx_t *ctx,
 int32_t ism330dhcx_data_ready_mode_get(const stmdev_ctx_t *ctx,
                                        ism330dhcx_dataready_pulsed_t *val);
 
-int32_t ism330dhcx_device_id_get(const stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dhcx_device_id_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 int32_t ism330dhcx_reset_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t ism330dhcx_reset_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 int32_t ism330dhcx_auto_increment_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t ism330dhcx_auto_increment_get(const stmdev_ctx_t *ctx,
-                                      uint8_t *val);
+int32_t ism330dhcx_auto_increment_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 int32_t ism330dhcx_boot_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t ism330dhcx_boot_get(const stmdev_ctx_t *ctx, uint8_t *val);
@@ -3112,10 +3128,8 @@ int32_t ism330dhcx_xl_filter_lp2_get(const stmdev_ctx_t *ctx, uint8_t *val);
 int32_t ism330dhcx_gy_filter_lp1_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t ism330dhcx_gy_filter_lp1_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dhcx_filter_settling_mask_set(const stmdev_ctx_t *ctx,
-                                            uint8_t val);
-int32_t ism330dhcx_filter_settling_mask_get(const stmdev_ctx_t *ctx,
-                                            uint8_t *val);
+int32_t ism330dhcx_filter_settling_mask_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_filter_settling_mask_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum
 {
@@ -3167,10 +3181,8 @@ int32_t ism330dhcx_xl_hp_path_on_out_set(const stmdev_ctx_t *ctx,
 int32_t ism330dhcx_xl_hp_path_on_out_get(const stmdev_ctx_t *ctx,
                                          ism330dhcx_hp_slope_xl_en_t *val);
 
-int32_t ism330dhcx_xl_fast_settling_set(const stmdev_ctx_t *ctx,
-                                        uint8_t val);
-int32_t ism330dhcx_xl_fast_settling_get(const stmdev_ctx_t *ctx,
-                                        uint8_t *val);
+int32_t ism330dhcx_xl_fast_settling_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_xl_fast_settling_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum
 {
@@ -3259,10 +3271,8 @@ int32_t ism330dhcx_aux_den_mode_set(const stmdev_ctx_t *ctx,
 int32_t ism330dhcx_aux_den_mode_get(const stmdev_ctx_t *ctx,
                                     ism330dhcx_lvl2_ois_t *val);
 
-int32_t ism330dhcx_aux_drdy_on_int2_set(const stmdev_ctx_t *ctx,
-                                        uint8_t val);
-int32_t ism330dhcx_aux_drdy_on_int2_get(const stmdev_ctx_t *ctx,
-                                        uint8_t *val);
+int32_t ism330dhcx_aux_drdy_on_int2_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_aux_drdy_on_int2_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum
 {
@@ -3870,9 +3880,9 @@ int32_t ism330dhcx_pedo_step_detect_get(const stmdev_ctx_t *ctx,
                                         uint8_t *val);
 
 int32_t ism330dhcx_pedo_debounce_steps_set(const stmdev_ctx_t *ctx,
-                                           uint8_t *buff);
+                                           uint8_t *val);
 int32_t ism330dhcx_pedo_debounce_steps_get(const stmdev_ctx_t *ctx,
-                                           uint8_t *buff);
+                                           uint8_t *val);
 
 int32_t ism330dhcx_pedo_steps_period_set(const stmdev_ctx_t *ctx,
                                          uint16_t val);
@@ -4029,9 +4039,9 @@ int32_t ism330dhcx_long_cnt_int_value_get(const stmdev_ctx_t *ctx,
                                           uint16_t *val);
 
 int32_t ism330dhcx_fsm_number_of_programs_set(const stmdev_ctx_t *ctx,
-                                              uint8_t *buff);
+                                              uint8_t *val);
 int32_t ism330dhcx_fsm_number_of_programs_get(const stmdev_ctx_t *ctx,
-                                              uint8_t *buff);
+                                              uint8_t *val);
 
 int32_t ism330dhcx_fsm_start_address_set(const stmdev_ctx_t *ctx,
                                          uint16_t val);
@@ -4055,6 +4065,10 @@ int32_t ism330dhcx_mlc_data_rate_set(const stmdev_ctx_t *ctx,
                                      ism330dhcx_mlc_odr_t val);
 int32_t ism330dhcx_mlc_data_rate_get(const stmdev_ctx_t *ctx,
                                      ism330dhcx_mlc_odr_t *val);
+
+int32_t ism330dhcx_mlc_out_get(const stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dhcx_mlc_mag_sensitivity_set(const stmdev_ctx_t *ctx, uint16_t val);
+int32_t ism330dhcx_mlc_mag_sensitivity_get(const stmdev_ctx_t *ctx, uint16_t *val);
 
 typedef struct
 {

--- a/sensor/stmemsc/lis2dux12_STdC/driver/lis2dux12_reg.h
+++ b/sensor/stmemsc/lis2dux12_STdC/driver/lis2dux12_reg.h
@@ -251,9 +251,9 @@ typedef struct
   uint8_t if_add_inc                   : 1;
   uint8_t sw_reset                     : 1;
   uint8_t int1_on_res                  : 1;
-  uint8_t not_used0                    : 1;
+  uint8_t smart_power_en               : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t not_used0                    : 1;
+  uint8_t smart_power_en               : 1;
   uint8_t int1_on_res                  : 1;
   uint8_t sw_reset                     : 1;
   uint8_t if_add_inc                   : 1;
@@ -1909,6 +1909,18 @@ typedef struct
 #endif /* DRV_BYTE_ORDER */
 } lis2dux12_t_sensitivity_h_t;
 
+#define LIS2DUX12_SMART_POWER_CTRL                     0xD2U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t smart_power_ctrl_win         : 4;
+  uint8_t smart_power_ctrl_dur         : 4;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t smart_power_ctrl_dur         : 4;
+  uint8_t smart_power_ctrl_win         : 4;
+#endif /* DRV_BYTE_ORDER */
+} lis2dux12_smart_power_ctrl_t;
+
 /**
   * @}
   *
@@ -2026,6 +2038,7 @@ typedef union
   lis2dux12_pedo_sc_deltat_h_t    pedo_sc_deltat_h;
   lis2dux12_t_sensitivity_l_t    t_sensitivity_l;
   lis2dux12_t_sensitivity_h_t    t_sensitivity_h;
+  lis2dux12_smart_power_ctrl_t   smart_power_ctrl;
   bitwise_t    bitwise;
   uint8_t    byte;
 } lis2dux12_reg_t;
@@ -2466,6 +2479,15 @@ int32_t lis2dux12_stpcnt_debounce_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 int32_t lis2dux12_stpcnt_period_set(const stmdev_ctx_t *ctx, uint16_t val);
 int32_t lis2dux12_stpcnt_period_get(const stmdev_ctx_t *ctx, uint16_t *val);
+
+typedef struct
+{
+  uint8_t enable                       : 1;
+  uint8_t window                       : 1;
+  uint8_t duration                     : 1;
+} lis2dux12_smart_power_cfg_t;
+int32_t lis2dux12_smart_power_set(const stmdev_ctx_t *ctx, lis2dux12_smart_power_cfg_t val);
+int32_t lis2dux12_smart_power_get(const stmdev_ctx_t *ctx, lis2dux12_smart_power_cfg_t *val);
 
 int32_t lis2dux12_tilt_mode_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t lis2dux12_tilt_mode_get(const stmdev_ctx_t *ctx, uint8_t *val);

--- a/sensor/stmemsc/lis2duxs12_STdC/driver/lis2duxs12_reg.c
+++ b/sensor/stmemsc/lis2duxs12_STdC/driver/lis2duxs12_reg.c
@@ -184,7 +184,7 @@ int32_t lis2duxs12_init_set(const stmdev_ctx_t *ctx, lis2duxs12_init_t val)
           break;
         }
 
-        /* boot procedue ended correctly */
+        /* boot procedure ended correctly */
         if (ctrl4.boot == 0U)
         {
           break;
@@ -217,7 +217,7 @@ int32_t lis2duxs12_init_set(const stmdev_ctx_t *ctx, lis2duxs12_init_t val)
           break;
         }
 
-        /* sw-reset procedue ended correctly */
+        /* sw-reset procedure ended correctly */
         if (status.sw_reset == 0U)
         {
           break;
@@ -400,13 +400,13 @@ int32_t lis2duxs12_mode_set(const stmdev_ctx_t *ctx, const lis2duxs12_md_t *val)
       switch (val->bw)
       {
         default:
+        case LIS2DUXS12_ODR_div_2:
         case LIS2DUXS12_ODR_div_4:
         case LIS2DUXS12_ODR_div_8:
-        case LIS2DUXS12_ODR_div_16:
           /* value not allowed */
           ret = -1;
           break;
-        case LIS2DUXS12_ODR_div_2:
+        case LIS2DUXS12_ODR_div_16:
           ctrl5.bw = 0x3;
           break;
       }
@@ -415,15 +415,15 @@ int32_t lis2duxs12_mode_set(const stmdev_ctx_t *ctx, const lis2duxs12_md_t *val)
       switch (val->bw)
       {
         default:
-        case LIS2DUXS12_ODR_div_8:
-        case LIS2DUXS12_ODR_div_16:
+        case LIS2DUXS12_ODR_div_2:
+        case LIS2DUXS12_ODR_div_4:
           /* value not allowed */
           ret = -1;
           break;
-        case LIS2DUXS12_ODR_div_2:
+        case LIS2DUXS12_ODR_div_8:
           ctrl5.bw = 0x2;
           break;
-        case LIS2DUXS12_ODR_div_4:
+        case LIS2DUXS12_ODR_div_16:
           ctrl5.bw = 0x3;
           break;
       }
@@ -432,17 +432,17 @@ int32_t lis2duxs12_mode_set(const stmdev_ctx_t *ctx, const lis2duxs12_md_t *val)
       switch (val->bw)
       {
         default:
-        case LIS2DUXS12_ODR_div_16:
+        case LIS2DUXS12_ODR_div_2:
           /* value not allowed */
           ret = -1;
           break;
-        case LIS2DUXS12_ODR_div_2:
+        case LIS2DUXS12_ODR_div_4:
           ctrl5.bw = 0x1;
           break;
-        case LIS2DUXS12_ODR_div_4:
+        case LIS2DUXS12_ODR_div_8:
           ctrl5.bw = 0x2;
           break;
-        case LIS2DUXS12_ODR_div_8:
+        case LIS2DUXS12_ODR_div_16:
           ctrl5.bw = 0x3;
           break;
       }
@@ -519,7 +519,7 @@ int32_t lis2duxs12_mode_get(const stmdev_ctx_t *ctx, lis2duxs12_md_t *val)
       val->odr = LIS2DUXS12_25Hz_ULP;
       break;
     case 0x04:
-      val->odr = LIS2DUXS12_6Hz_LP;
+      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUXS12_6Hz_HP : LIS2DUXS12_6Hz_LP;
       break;
     case 0x05:
       val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUXS12_12Hz5_HP : LIS2DUXS12_12Hz5_LP;
@@ -1089,53 +1089,59 @@ int32_t lis2duxs12_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t address, uint8_
   lsb = (uint8_t)address & 0xFFU;
 
   ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
-
-  if (ret == 0)
+  if (ret != 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_RW, (uint8_t *)&page_rw, 1);
-    page_rw.page_read = PROPERTY_DISABLE;
-    page_rw.page_write = PROPERTY_ENABLE;
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_RW, (uint8_t *)&page_rw, 1);
-
-    ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
-    page_sel.page_sel = msb;
-    page_sel.not_used0 = 1; // Default value
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
-
-    page_address.page_addr = lsb;
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_ADDRESS, (uint8_t *)&page_address, 1);
-
-    for (i = 0; i < len; i++)
-    {
-      ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_VALUE, &buf[i], 1);
-      lsb++;
-
-      /* Check if page wrap */
-      if (((lsb & 0xFFU) == 0x00U) && (ret == 0))
-      {
-        msb++;
-        ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
-        page_sel.page_sel = msb;
-        page_sel.not_used0 = 1; // Default value
-        ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
-      }
-
-      if (ret != 0)
-      {
-        break;
-      }
-    }
-
-    page_sel.page_sel = 0;
-    page_sel.not_used0 = 1;// Default value
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
-
-    ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_RW, (uint8_t *)&page_rw, 1);
-    page_rw.page_read = PROPERTY_DISABLE;
-    page_rw.page_write = PROPERTY_DISABLE;
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_RW, (uint8_t *)&page_rw, 1);
+    goto exit;
   }
 
+  /* page write */
+  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_RW, (uint8_t *)&page_rw, 1);
+  page_rw.page_read = PROPERTY_DISABLE;
+  page_rw.page_write = PROPERTY_ENABLE;
+  ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_RW, (uint8_t *)&page_rw, 1);
+
+  /* set page num */
+  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  page_sel.page_sel = msb;
+  page_sel.not_used0 = 1; // Default value
+  ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
+
+  /* set page addr */
+  page_address.page_addr = lsb;
+  ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_ADDRESS, (uint8_t *)&page_address, 1);
+
+  for (i = 0; i < len; i++)
+  {
+    /* read value */
+    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_VALUE, &buf[i], 1);
+    lsb++;
+
+    /* Check if page wrap */
+    if (((lsb & 0xFFU) == 0x00U) && (ret == 0))
+    {
+      msb++;
+      ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
+      page_sel.page_sel = msb;
+      page_sel.not_used0 = 1; // Default value
+      ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
+    }
+
+    if (ret != 0)
+    {
+      break;
+    }
+  }
+
+  page_sel.page_sel = 0;
+  page_sel.not_used0 = 1;// Default value
+  ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
+
+  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_RW, (uint8_t *)&page_rw, 1);
+  page_rw.page_read = PROPERTY_DISABLE;
+  page_rw.page_write = PROPERTY_DISABLE;
+  ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_RW, (uint8_t *)&page_rw, 1);
+
+exit:
   ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
 
   return ret;
@@ -1166,53 +1172,69 @@ int32_t lis2duxs12_ln_pg_read(const stmdev_ctx_t *ctx, uint16_t address, uint8_t
   lsb = (uint8_t)address & 0xFFU;
 
   ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
-
-  if (ret == 0)
+  if (ret != 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_RW, (uint8_t *)&page_rw, 1);
-    page_rw.page_read = PROPERTY_ENABLE;
-    page_rw.page_write = PROPERTY_DISABLE;
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_RW, (uint8_t *)&page_rw, 1);
-
-    ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
-    page_sel.page_sel = msb;
-    page_sel.not_used0 = 1; // Default value
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
-
-    page_address.page_addr = lsb;
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_ADDRESS, (uint8_t *)&page_address, 1);
-
-    for (i = 0; i < len; i++)
-    {
-      ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_VALUE, &buf[i], 1);
-      lsb++;
-
-      /* Check if page wrap */
-      if (((lsb & 0xFFU) == 0x00U) && (ret == 0))
-      {
-        msb++;
-        ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
-        page_sel.page_sel = msb;
-        page_sel.not_used0 = 1; // Default value
-        ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
-      }
-
-      if (ret != 0)
-      {
-        break;
-      }
-    }
-
-    page_sel.page_sel = 0;
-    page_sel.not_used0 = 1;// Default value
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
-
-    ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_RW, (uint8_t *)&page_rw, 1);
-    page_rw.page_read = PROPERTY_DISABLE;
-    page_rw.page_write = PROPERTY_DISABLE;
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_RW, (uint8_t *)&page_rw, 1);
+    goto exit;
   }
 
+  /* page read */
+  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_RW, (uint8_t *)&page_rw, 1);
+  page_rw.page_read = PROPERTY_ENABLE;
+  page_rw.page_write = PROPERTY_DISABLE;
+  ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_RW, (uint8_t *)&page_rw, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  /* set page num */
+  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  page_sel.page_sel = msb;
+  page_sel.not_used0 = 1; // Default value
+  ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  for (i = 0; i < len; i++)
+  {
+    /* Sequential readings are not allowed. Set page address every loop */
+    page_address.page_addr = lsb++;
+    ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_ADDRESS, (uint8_t *)&page_address, 1);
+
+    /* read value */
+    ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_VALUE, &buf[i], 1);
+
+    /* Check if page wrap */
+    if (((lsb & 0xFFU) == 0x00U) && (ret == 0))
+    {
+      msb++;
+      lsb = 0;
+
+      /* set page */
+      ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
+      page_sel.page_sel = msb;
+      page_sel.not_used0 = 1; // Default value
+      ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
+    }
+
+    if (ret != 0)
+    {
+      goto exit;
+    }
+  }
+
+  page_sel.page_sel = 0;
+  page_sel.not_used0 = 1;// Default value
+  ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
+
+  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_RW, (uint8_t *)&page_rw, 1);
+  page_rw.page_read = PROPERTY_DISABLE;
+  page_rw.page_write = PROPERTY_DISABLE;
+  ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_RW, (uint8_t *)&page_rw, 1);
+
+exit:
   ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
 
   return ret;
@@ -1419,7 +1441,7 @@ int32_t lis2duxs12_spi_mode_get(const stmdev_ctx_t *ctx, lis2duxs12_spi_mode *va
 
   ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
 
-  switch ((pin_ctrl.h_lactive))
+  switch ((pin_ctrl.sim))
   {
     case 0x0:
       *val = LIS2DUXS12_SPI_4_WIRE;
@@ -2139,7 +2161,7 @@ int32_t lis2duxs12_fifo_data_get(const stmdev_ctx_t *ctx, const lis2duxs12_md_t 
         data->xl[0].raw[1] = (int16_t)fifo_raw[1] / 16;
         data->xl[0].raw[1] = (data->xl[0].raw[1] + ((int16_t)fifo_raw[2] * 16)) * 16;
         data->xl[0].raw[2] = (int16_t)fifo_raw[3];
-        data->xl[0].raw[2] = data->xl[0].raw[2] + ((int16_t)fifo_raw[4] * 256) * 16;
+        data->xl[0].raw[2] = (data->xl[0].raw[2] + (int16_t)fifo_raw[4] * 256) * 16;
         data->heat.raw = (int16_t)fifo_raw[4] / 16;
         data->heat.raw = (data->heat.raw + ((int16_t)fifo_raw[5] * 16)) * 16;
         if (fifo_tag.tag_sensor == (uint8_t)LIS2DUXS12_XL_TEMP_TAG)
@@ -2156,8 +2178,8 @@ int32_t lis2duxs12_fifo_data_get(const stmdev_ctx_t *ctx, const lis2duxs12_md_t 
       {
         /* A FIFO sample consists of 16-bits 3-axis XL at ODR  */
         data->xl[0].raw[0] = (int16_t)fifo_raw[0] + (int16_t)fifo_raw[1] * 256;
-        data->xl[0].raw[1] = (int16_t)fifo_raw[1] + (int16_t)fifo_raw[3] * 256;
-        data->xl[0].raw[2] = (int16_t)fifo_raw[2] + (int16_t)fifo_raw[5] * 256;
+        data->xl[0].raw[1] = (int16_t)fifo_raw[2] + (int16_t)fifo_raw[3] * 256;
+        data->xl[0].raw[2] = (int16_t)fifo_raw[4] + (int16_t)fifo_raw[5] * 256;
       }
       break;
     case 0x4:
@@ -2536,6 +2558,61 @@ int32_t lis2duxs12_stpcnt_period_get(const stmdev_ctx_t *ctx, uint16_t *val)
                               (uint8_t *)buff, 2);
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
+
+  return ret;
+}
+
+/**
+  * @brief  smart_power functionality configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lis2duxs12_smart_power_cfg_t structure.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  */
+int32_t lis2duxs12_smart_power_set(const stmdev_ctx_t *ctx, lis2duxs12_smart_power_cfg_t val)
+{
+  lis2duxs12_ctrl1_t ctrl1;
+  lis2duxs12_smart_power_ctrl_t smart_power_ctrl;
+  int32_t ret;
+
+  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL1, (uint8_t *)&ctrl1, 1);
+  ctrl1.smart_power_en = val.enable;
+  ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_CTRL1, (uint8_t *)&ctrl1, 1);
+
+  if (val.enable == 0)
+  {
+    /* if disabling smart_power no need to set win/dur fields */
+    return ret;
+  }
+
+  smart_power_ctrl.smart_power_ctrl_win = val.window;
+  smart_power_ctrl.smart_power_ctrl_dur = val.duration;
+  ret += lis2duxs12_ln_pg_write(ctx, LIS2DUXS12_EMB_ADV_PG_0 + LIS2DUXS12_SMART_POWER_CTRL,
+                                (uint8_t *)&smart_power_ctrl, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  smart_power functionality configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lis2duxs12_smart_power_cfg_t structure.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  */
+int32_t lis2duxs12_smart_power_get(const stmdev_ctx_t *ctx, lis2duxs12_smart_power_cfg_t *val)
+{
+  lis2duxs12_ctrl1_t ctrl1;
+  lis2duxs12_smart_power_ctrl_t smart_power_ctrl;
+  int32_t ret;
+
+  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL1, (uint8_t *)&ctrl1, 1);
+  val->enable = ctrl1.smart_power_en;
+
+  ret += lis2duxs12_ln_pg_read(ctx, LIS2DUXS12_EMB_ADV_PG_0 + LIS2DUXS12_SMART_POWER_CTRL,
+                               (uint8_t *)&smart_power_ctrl, 1);
+  val->window = smart_power_ctrl.smart_power_ctrl_win;
+  val->duration = smart_power_ctrl.smart_power_ctrl_dur;
 
   return ret;
 }

--- a/sensor/stmemsc/lps22df_STdC/driver/lps22df_reg.c
+++ b/sensor/stmemsc/lps22df_STdC/driver/lps22df_reg.c
@@ -170,29 +170,29 @@ int32_t lps22df_id_get(const stmdev_ctx_t *ctx, lps22df_id_t *val)
   */
 int32_t lps22df_bus_mode_set(const stmdev_ctx_t *ctx, lps22df_bus_mode_t *val)
 {
-  lps22df_i3c_if_ctrl_add_t i3c_if_ctrl_add;
+  lps22df_i3c_if_ctrl_t i3c_if_ctrl;
   lps22df_if_ctrl_t if_ctrl;
   int32_t ret;
 
   ret = lps22df_read_reg(ctx, LPS22DF_IF_CTRL, (uint8_t *)&if_ctrl, 1);
   if (ret == 0)
   {
-    if_ctrl.int_en_i3c = ((uint8_t)val->interface & 0x04U) >> 2;
     if_ctrl.i2c_i3c_dis = ((uint8_t)val->interface & 0x02U) >> 1;
+    if_ctrl.int_en_i3c = ((uint8_t)val->interface & 0x04U) >> 2;
     if_ctrl.sim = ((uint8_t)val->interface & 0x01U);
     ret = lps22df_write_reg(ctx, LPS22DF_IF_CTRL, (uint8_t *)&if_ctrl, 1);
   }
   if (ret == 0)
   {
-    ret = lps22df_read_reg(ctx, LPS22DF_I3C_IF_CTRL_ADD,
-                           (uint8_t *)&i3c_if_ctrl_add, 1);
+    ret = lps22df_read_reg(ctx, LPS22DF_I3C_IF_CTRL,
+                           (uint8_t *)&i3c_if_ctrl, 1);
   }
   if (ret == 0)
   {
-    i3c_if_ctrl_add.asf_on = (uint8_t)val->filter & 0x01U;
-    i3c_if_ctrl_add.i3c_bus_avb_sel = (uint8_t)val->i3c_ibi_time & 0x03U;
-    ret = lps22df_write_reg(ctx, LPS22DF_I3C_IF_CTRL_ADD,
-                            (uint8_t *)&i3c_if_ctrl_add, 1);
+    i3c_if_ctrl.asf_on = (uint8_t)val->filter & 0x01U;
+    i3c_if_ctrl.i3c_bus_avb_sel = (uint8_t)val->i3c_ibi_time & 0x03U;
+    ret = lps22df_write_reg(ctx, LPS22DF_I3C_IF_CTRL,
+                            (uint8_t *)&i3c_if_ctrl, 1);
   }
   return ret;
 }
@@ -207,15 +207,15 @@ int32_t lps22df_bus_mode_set(const stmdev_ctx_t *ctx, lps22df_bus_mode_t *val)
   */
 int32_t lps22df_bus_mode_get(const stmdev_ctx_t *ctx, lps22df_bus_mode_t *val)
 {
-  lps22df_i3c_if_ctrl_add_t i3c_if_ctrl_add;
+  lps22df_i3c_if_ctrl_t i3c_if_ctrl;
   lps22df_if_ctrl_t if_ctrl;
   int32_t ret;
 
   ret = lps22df_read_reg(ctx, LPS22DF_IF_CTRL, (uint8_t *)&if_ctrl, 1);
   if (ret == 0)
   {
-    ret = lps22df_read_reg(ctx, LPS22DF_I3C_IF_CTRL_ADD,
-                           (uint8_t *)&i3c_if_ctrl_add, 1);
+    ret = lps22df_read_reg(ctx, LPS22DF_I3C_IF_CTRL,
+                           (uint8_t *)&i3c_if_ctrl, 1);
 
     switch ((if_ctrl.int_en_i3c << 2) | (if_ctrl.i2c_i3c_dis << 1) |
             if_ctrl.sim)
@@ -237,20 +237,20 @@ int32_t lps22df_bus_mode_get(const stmdev_ctx_t *ctx, lps22df_bus_mode_t *val)
         break;
     }
 
-    switch (i3c_if_ctrl_add.asf_on)
+    switch (i3c_if_ctrl.asf_on)
     {
-      case LPS22DF_AUTO:
-        val->filter = LPS22DF_AUTO;
+      case LPS22DF_FILTER_AUTO:
+        val->filter = LPS22DF_FILTER_AUTO;
         break;
-      case LPS22DF_ALWAYS_ON:
-        val->filter = LPS22DF_ALWAYS_ON;
+      case LPS22DF_FILTER_ALWAYS_ON:
+        val->filter = LPS22DF_FILTER_ALWAYS_ON;
         break;
       default:
-        val->filter = LPS22DF_AUTO;
+        val->filter = LPS22DF_FILTER_AUTO;
         break;
     }
 
-    switch (i3c_if_ctrl_add.i3c_bus_avb_sel)
+    switch (i3c_if_ctrl.i3c_bus_avb_sel)
     {
       case LPS22DF_IBI_50us:
         val->i3c_ibi_time = LPS22DF_IBI_50us;
@@ -314,7 +314,7 @@ int32_t lps22df_init_set(const stmdev_ctx_t *ctx, lps22df_init_t val)
             break;
           }
 
-          /* boot procedue ended correctly */
+          /* boot procedure ended correctly */
           if (int_src.boot_on == 0U)
           {
             break;
@@ -349,7 +349,7 @@ int32_t lps22df_init_set(const stmdev_ctx_t *ctx, lps22df_init_t val)
             break;
           }
 
-          /* sw-reset procedue ended correctly */
+          /* sw-reset procedure ended correctly */
           if (status.sw_reset == 0U)
           {
             break;
@@ -381,6 +381,7 @@ int32_t lps22df_init_set(const stmdev_ctx_t *ctx, lps22df_init_t val)
         break;
     }
   }
+
   return ret;
 }
 
@@ -446,8 +447,9 @@ int32_t lps22df_pin_conf_set(const stmdev_ctx_t *ctx, lps22df_pin_conf_t *val)
   if (ret == 0)
   {
     if_ctrl.int_pd_dis = ~val->int_pull_down;
-    if_ctrl.sda_pu_en = val->sda_pull_up;
     if_ctrl.sdo_pu_en = val->sdo_pull_up;
+    if_ctrl.sda_pu_en = val->sda_pull_up;
+    if_ctrl.cs_pu_dis = ~val->cs_pull_up;
     ret = lps22df_write_reg(ctx, LPS22DF_IF_CTRL, (uint8_t *)&if_ctrl, 1);
   }
   if (ret == 0)
@@ -483,8 +485,9 @@ int32_t lps22df_pin_conf_get(const stmdev_ctx_t *ctx, lps22df_pin_conf_t *val)
     ret = lps22df_read_reg(ctx, LPS22DF_CTRL_REG3, (uint8_t *)&ctrl_reg3, 1);
   }
 
-  val->int_pull_down = ~if_ctrl.int_pd_dis;
   val->sda_pull_up  = if_ctrl.sda_pu_en;
+  val->cs_pull_up = ~if_ctrl.cs_pu_dis;
+  val->int_pull_down = ~if_ctrl.int_pd_dis;
   val->sdo_pull_up  = if_ctrl.sdo_pu_en;
   val->int_push_pull  = ~ctrl_reg3.pp_od;
 
@@ -684,11 +687,11 @@ int32_t lps22df_mode_get(const stmdev_ctx_t *ctx, lps22df_md_t *val)
 int32_t lps22df_trigger_sw(const stmdev_ctx_t *ctx, lps22df_md_t *md)
 {
   lps22df_ctrl_reg2_t ctrl_reg2;
-  int32_t ret;
+  int32_t ret = 0;
 
-  ret = lps22df_read_reg(ctx, LPS22DF_CTRL_REG2, (uint8_t *)&ctrl_reg2, 1);
   if (md->odr == LPS22DF_ONE_SHOT)
   {
+    ret = lps22df_read_reg(ctx, LPS22DF_CTRL_REG2, (uint8_t *)&ctrl_reg2, 1);
     ctrl_reg2.oneshot = PROPERTY_ENABLE;
     if (ret == 0)
     {
@@ -699,10 +702,10 @@ int32_t lps22df_trigger_sw(const stmdev_ctx_t *ctx, lps22df_md_t *md)
 }
 
 /**
-  * @brief  Software trigger for One-Shot.[get]
+  * @brief  Sensor data.[get]
   *
   * @param  ctx   communication interface handler.(ptr)
-  * @param  data  data retrived from the sensor.(ptr)
+  * @param  data  data retrieved from the sensor.(ptr)
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
@@ -904,7 +907,7 @@ int32_t lps22df_fifo_level_get(const stmdev_ctx_t *ctx, uint8_t *val)
   *
   * @param  ctx   communication interface handler.(ptr)
   * @param  samp  number of samples stored in FIFO.(ptr)
-  * @param  data  data retrived from FIFO.(ptr)
+  * @param  data  data retrieved from FIFO.(ptr)
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
@@ -971,11 +974,8 @@ int32_t lps22df_interrupt_mode_set(const stmdev_ctx_t *ctx,
 
     ret = lps22df_write_reg(ctx, LPS22DF_CTRL_REG3, reg, 2);
   }
-  if (ret == 0)
-  {
-    ret = lps22df_read_reg(ctx, LPS22DF_INTERRUPT_CFG,
-                           (uint8_t *)&interrupt_cfg, 1);
-  }
+  ret += lps22df_read_reg(ctx, LPS22DF_INTERRUPT_CFG,
+                          (uint8_t *)&interrupt_cfg, 1);
   if (ret == 0)
   {
     interrupt_cfg.lir = val->int_latched ;
@@ -1003,11 +1003,8 @@ int32_t lps22df_interrupt_mode_get(const stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lps22df_read_reg(ctx, LPS22DF_CTRL_REG3, reg, 2);
-  if (ret == 0)
-  {
-    ret = lps22df_read_reg(ctx, LPS22DF_INTERRUPT_CFG,
-                           (uint8_t *)&interrupt_cfg, 1);
-  }
+  ret += lps22df_read_reg(ctx, LPS22DF_INTERRUPT_CFG,
+                          (uint8_t *)&interrupt_cfg, 1);
 
   bytecpy((uint8_t *)&ctrl_reg3, &reg[0]);
   bytecpy((uint8_t *)&ctrl_reg4, &reg[1]);
@@ -1130,6 +1127,7 @@ int32_t lps22df_int_on_threshold_mode_set(const stmdev_ctx_t *ctx,
       ret = lps22df_write_reg(ctx, LPS22DF_CTRL_REG4, (uint8_t *)&ctrl_reg4, 1);
     }
   }
+
   return ret;
 }
 
@@ -1283,7 +1281,6 @@ int32_t lps22df_opc_get(const stmdev_ctx_t *ctx, int16_t *val)
 
   return ret;
 }
-
 
 /**
   * @}

--- a/sensor/stmemsc/lps22df_STdC/driver/lps22df_reg.h
+++ b/sensor/stmemsc/lps22df_STdC/driver/lps22df_reg.h
@@ -358,16 +358,16 @@ typedef struct
 #define LPS22DF_REF_P_L                 0x16U
 typedef struct
 {
-  uint8_t refl             : 8;
+  uint8_t refp             : 8;
 } lps22df_ref_p_l_t;
 
 #define LPS22DF_REF_P_H                 0x17U
 typedef struct
 {
-  uint8_t refl             : 8;
+  uint8_t refp             : 8;
 } lps22df_ref_p_h_t;
 
-#define LPS22DF_I3C_IF_CTRL_ADD         0x19U
+#define LPS22DF_I3C_IF_CTRL             0x19U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -381,7 +381,7 @@ typedef struct
   uint8_t not_used_02      : 3;
   uint8_t i3c_bus_avb_sel  : 2;
 #endif /* DRV_BYTE_ORDER */
-} lps22df_i3c_if_ctrl_add_t;
+} lps22df_i3c_if_ctrl_t;
 
 #define LPS22DF_RPDS_L                  0x1AU
 #define LPS22DF_RPDS_H                  0x1BU
@@ -481,7 +481,7 @@ typedef union
   lps22df_fifo_wtm_t         fifo_wtm;
   lps22df_ref_p_l_t          ref_p_l;
   lps22df_ref_p_h_t          ref_p_h;
-  lps22df_i3c_if_ctrl_add_t  i3c_if_ctrl_add;
+  lps22df_i3c_if_ctrl_t      i3c_if_ctrl;
   lps22df_int_source_t       int_source;
   lps22df_fifo_status1_t     fifo_status1;
   lps22df_fifo_status2_t     fifo_status2;
@@ -527,8 +527,8 @@ typedef enum
 
 typedef enum
 {
-  LPS22DF_AUTO      = 0x00, /* bus mode select by HW (SPI 3W disable) */
-  LPS22DF_ALWAYS_ON = 0x01, /* Only SPI: SDO / SDI separated pins */
+  LPS22DF_FILTER_AUTO      = 0x00, /* Disable anti-spike filters */
+  LPS22DF_FILTER_ALWAYS_ON = 0x01, /* Enable anti-spike filters */
 } lps22df_filter_t;
 
 typedef enum
@@ -573,9 +573,9 @@ typedef struct
 {
   uint8_t int_push_pull : 1; /* 1 = push-pull / 0 = open-drain */
   uint8_t int_pull_down : 1; /* 1 = pull-down enabled */
-  uint8_t sda_pull_up : 1; /* 1 = pull-up enabled */
   uint8_t sdo_pull_up : 1; /* 1 = pull-up enabled */
-  uint8_t cs_pull_up : 1; /* 1 = pull-up enabled */
+  uint8_t sda_pull_up : 1; /* 1 = pull-up enabled */
+  uint8_t cs_pull_up  : 1; /* 1 = pull-up enabled */
 } lps22df_pin_conf_t;
 int32_t lps22df_pin_conf_set(const stmdev_ctx_t *ctx, lps22df_pin_conf_t *val);
 int32_t lps22df_pin_conf_get(const stmdev_ctx_t *ctx, lps22df_pin_conf_t *val);
@@ -667,7 +667,7 @@ typedef enum
 typedef struct
 {
   lps22df_operation_t operation;
-  uint8_t watermark; /* (0 disable) max 128.*/
+  uint8_t watermark : 7; /* (0 disable) max 128.*/
 } lps22df_fifo_md_t;
 int32_t lps22df_fifo_mode_set(const stmdev_ctx_t *ctx, lps22df_fifo_md_t *val);
 int32_t lps22df_fifo_mode_get(const stmdev_ctx_t *ctx, lps22df_fifo_md_t *val);

--- a/sensor/stmemsc/lps28dfw_STdC/driver/lps28dfw_reg.h
+++ b/sensor/stmemsc/lps28dfw_STdC/driver/lps28dfw_reg.h
@@ -7,7 +7,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2021 STMicroelectronics.
+  * <h2><center>&copy; Copyright (c) 2024 STMicroelectronics.
   * All rights reserved.</center></h2>
   *
   * This software component is licensed by ST under BSD 3-Clause license,
@@ -168,7 +168,7 @@ typedef struct
   *
   */
 
-/** I2C Device Address 8 bit format **/
+/** I2C Device Address 8 bit format  if SA0=0 -> 0xB9 if SA0=1 -> 0xBB **/
 #define LPS28DFW_I2C_ADD_L               0xB9U
 #define LPS28DFW_I2C_ADD_H               0xBBU
 
@@ -227,7 +227,7 @@ typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used_01      : 2;
-  uint8_t int_pd_dis      : 1;
+  uint8_t int_pd_dis       : 1;
   uint8_t not_used_02      : 1;
   uint8_t sda_pu_en        : 1;
   uint8_t not_used_03      : 2;
@@ -237,7 +237,7 @@ typedef struct
   uint8_t not_used_03      : 2;
   uint8_t sda_pu_en        : 1;
   uint8_t not_used_02      : 1;
-  uint8_t int_pd_dis      : 1;
+  uint8_t int_pd_dis       : 1;
   uint8_t not_used_01      : 2;
 #endif /* DRV_BYTE_ORDER */
 } lps28dfw_if_ctrl_t;
@@ -363,7 +363,7 @@ typedef struct
   uint8_t refp             : 8;
 } lps28dfw_ref_p_h_t;
 
-#define LPS28DFW_I3C_IF_CTRL_ADD         0x19U
+#define LPS28DFW_I3C_IF_CTRL             0x19U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -377,7 +377,7 @@ typedef struct
   uint8_t not_used_02      : 3;
   uint8_t I3C_Bus_Avb_Sel  : 2;
 #endif /* DRV_BYTE_ORDER */
-} lps28dfw_i3c_if_ctrl_add_t;
+} lps28dfw_i3c_if_ctrl_t;
 
 #define LPS28DFW_RPDS_L                  0x1AU
 #define LPS28DFW_RPDS_H                  0x1BU
@@ -446,6 +446,7 @@ typedef struct
 #define LPS28DFW_PRESS_OUT_H             0x2AU
 #define LPS28DFW_TEMP_OUT_L              0x2BU
 #define LPS28DFW_TEMP_OUT_H              0x2CU
+
 #define LPS28DFW_FIFO_DATA_OUT_PRESS_XL  0x78U
 #define LPS28DFW_FIFO_DATA_OUT_PRESS_L   0x79U
 #define LPS28DFW_FIFO_DATA_OUT_PRESS_H   0x7AU
@@ -477,7 +478,7 @@ typedef union
   lps28dfw_fifo_wtm_t         fifo_wtm;
   lps28dfw_ref_p_l_t          ref_p_l;
   lps28dfw_ref_p_h_t          ref_p_h;
-  lps28dfw_i3c_if_ctrl_add_t  i3c_if_ctrl_add;
+  lps28dfw_i3c_if_ctrl_t      i3c_if_ctrl;
   lps28dfw_int_source_t       int_source;
   lps28dfw_fifo_status1_t     fifo_status1;
   lps28dfw_fifo_status2_t     fifo_status2;
@@ -505,7 +506,7 @@ int32_t lps28dfw_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
                            uint8_t *data, uint16_t len);
 
 extern float_t lps28dfw_from_fs1260_to_hPa(int32_t lsb);
-extern float_t lps28dfw_from_fs4000_to_hPa(int32_t lsb);
+extern float_t lps28dfw_from_fs4060_to_hPa(int32_t lsb);
 
 extern float_t lps28dfw_from_lsb_to_celsius(int16_t lsb);
 
@@ -523,8 +524,8 @@ typedef enum
 
 typedef enum
 {
-  LPS28DFW_AUTO      = 0x00, /* bus mode select by HW (SPI 3W disable) */
-  LPS28DFW_ALWAYS_ON = 0x01, /* Only SPI: SDO / SDI separated pins */
+  LPS28DFW_AUTO      = 0x00, /* anti-spike filters managed by protocol */
+  LPS28DFW_ALWAYS_ON = 0x01, /* anti-spike filters always on */
 } lps28dfw_filter_t;
 
 typedef enum
@@ -591,7 +592,7 @@ int32_t lps28dfw_all_sources_get(const stmdev_ctx_t *ctx,
 typedef enum
 {
   LPS28DFW_1260hPa = 0x00,
-  LPS28DFW_4000hPa = 0x01,
+  LPS28DFW_4060hPa = 0x01,
 } lps28dfw_fs_t;
 
 typedef enum
@@ -670,7 +671,7 @@ typedef enum
 typedef struct
 {
   lps28dfw_operation_t operation;
-  uint8_t watermark; /* (0 disable) max 128.*/
+  uint8_t watermark : 7; /* (0 disable) max 128.*/
 } lps28dfw_fifo_md_t;
 int32_t lps28dfw_fifo_mode_set(const stmdev_ctx_t *ctx, lps28dfw_fifo_md_t *val);
 int32_t lps28dfw_fifo_mode_get(const stmdev_ctx_t *ctx, lps28dfw_fifo_md_t *val);
@@ -711,7 +712,7 @@ int32_t lps28dfw_pin_int_route_get(const stmdev_ctx_t *ctx,
 typedef struct
 {
   uint16_t threshold;   /* Threshold in hPa * 16 (@1260hPa)
-                         * Threshold in hPa * 8  (@4000hPa)
+                         * Threshold in hPa * 8  (@4060hPa)
                          */
   uint8_t over_th  : 1; /* Pressure data over threshold event */
   uint8_t under_th : 1; /* Pressure data under threshold event */

--- a/sensor/stmemsc/lsm6dso32_STdC/driver/lsm6dso32_reg.c
+++ b/sensor/stmemsc/lsm6dso32_STdC/driver/lsm6dso32_reg.c
@@ -5954,48 +5954,53 @@ int32_t lsm6dso32_batch_counter_threshold_get(const stmdev_ctx_t *ctx,
 }
 
 /**
-  * @brief  Number of unread sensor data(TAG + 6 bytes) stored in FIFO.[get]
+  * @brief  Number of unread sensor data (TAG + 6 bytes) stored in FIFO.[get]
   *
-  * @param  ctx      read / write interface definitions
-  * @param  val      change the values of diff_fifo in reg FIFO_STATUS1
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Read the value of diff_fifo in reg FIFO_STATUS1 and FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dso32_fifo_data_level_get(const stmdev_ctx_t *ctx,
-                                      uint16_t *val)
+                                     uint16_t *val)
 {
-  lsm6dso32_fifo_status1_t fifo_status1;
-  lsm6dso32_fifo_status2_t fifo_status2;
+  uint8_t reg[2];
+  lsm6dso32_fifo_status1_t *fifo_status1 = (lsm6dso32_fifo_status1_t *)&reg[0];
+  lsm6dso32_fifo_status2_t *fifo_status2 = (lsm6dso32_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dso32_read_reg(ctx, LSM6DSO32_FIFO_STATUS1,
-                           (uint8_t *)&fifo_status1, 1);
-
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dso32_read_reg(ctx, LSM6DSO32_FIFO_STATUS1, (uint8_t *)reg, 2);
   if (ret == 0)
   {
-    ret = lsm6dso32_read_reg(ctx, LSM6DSO32_FIFO_STATUS2,
-                             (uint8_t *)&fifo_status2, 1);
-    *val = ((uint16_t)fifo_status2.diff_fifo << 8) +
-           (uint16_t)fifo_status1.diff_fifo;
+    *val = fifo_status2->diff_fifo;
+    *val = (*val * 256U) + fifo_status1->diff_fifo;
   }
 
   return ret;
 }
 
 /**
-  * @brief  FIFO status.[get]
+  * @brief  Smart FIFO status.[get]
   *
-  * @param  ctx      read / write interface definitions
-  * @param  val      registers FIFO_STATUS2
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Read registers FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dso32_fifo_status_get(const stmdev_ctx_t *ctx,
-                                  lsm6dso32_fifo_status2_t *val)
+                                 lsm6dso32_fifo_status2_t *val)
 {
+  uint8_t reg[2];
+  lsm6dso32_fifo_status2_t *fifo_status2 = (lsm6dso32_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dso32_read_reg(ctx, LSM6DSO32_FIFO_STATUS2, (uint8_t *) val, 1);
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dso32_read_reg(ctx, LSM6DSO32_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = *fifo_status2;
+  }
 
   return ret;
 }
@@ -6003,18 +6008,23 @@ int32_t lsm6dso32_fifo_status_get(const stmdev_ctx_t *ctx,
 /**
   * @brief  Smart FIFO full status.[get]
   *
-  * @param  ctx      read / write interface definitions
-  * @param  val      change the values of fifo_full_ia in reg FIFO_STATUS2
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Read the values of fifo_full_ia in reg FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dso32_fifo_full_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm6dso32_fifo_status2_t reg;
+  uint8_t reg[2];
+  lsm6dso32_fifo_status2_t *fifo_status2 = (lsm6dso32_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dso32_read_reg(ctx, LSM6DSO32_FIFO_STATUS2, (uint8_t *)&reg, 1);
-  *val = reg.fifo_full_ia;
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dso32_read_reg(ctx, LSM6DSO32_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_full_ia;
+  }
 
   return ret;
 }
@@ -6022,19 +6032,24 @@ int32_t lsm6dso32_fifo_full_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 /**
   * @brief  FIFO overrun status.[get]
   *
-  * @param  ctx      read / write interface definitions
-  * @param  val      change the values of  fifo_over_run_latched in
-  *                  reg FIFO_STATUS2
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Read the values of  fifo_over_run_latched in
+  *                reg FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dso32_fifo_ovr_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm6dso32_fifo_status2_t reg;
+  uint8_t reg[2];
+  lsm6dso32_fifo_status2_t *fifo_status2 = (lsm6dso32_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dso32_read_reg(ctx, LSM6DSO32_FIFO_STATUS2, (uint8_t *)&reg, 1);
-  *val = reg.fifo_ovr_ia;
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dso32_read_reg(ctx, LSM6DSO32_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_ovr_ia;
+  }
 
   return ret;
 }
@@ -6042,18 +6057,23 @@ int32_t lsm6dso32_fifo_ovr_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 /**
   * @brief  FIFO watermark status.[get]
   *
-  * @param  ctx      read / write interface definitions
-  * @param  val      change the values of fifo_wtm_ia in reg FIFO_STATUS2
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Read the values of fifo_wtm_ia in reg FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dso32_fifo_wtm_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm6dso32_fifo_status2_t reg;
+  uint8_t reg[2];
+  lsm6dso32_fifo_status2_t *fifo_status2 = (lsm6dso32_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dso32_read_reg(ctx, LSM6DSO32_FIFO_STATUS2, (uint8_t *)&reg, 1);
-  *val = reg.fifo_wtm_ia;
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dso32_read_reg(ctx, LSM6DSO32_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_wtm_ia;
+  }
 
   return ret;
 }

--- a/sensor/stmemsc/lsm6dso32x_STdC/driver/lsm6dso32x_reg.c
+++ b/sensor/stmemsc/lsm6dso32x_STdC/driver/lsm6dso32x_reg.c
@@ -6080,49 +6080,53 @@ int32_t lsm6dso32x_batch_counter_threshold_get(const stmdev_ctx_t *ctx,
 }
 
 /**
-  * @brief  Number of unread sensor data(TAG + 6 bytes) stored in FIFO.[get]
+  * @brief  Number of unread sensor data (TAG + 6 bytes) stored in FIFO.[get]
   *
-  * @param  ctx      read / write interface definitions
-  * @param  val      change the values of diff_fifo in reg FIFO_STATUS1
-  * @retval          interface status (MANDATORY: return 0 -> no Error).
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Read the value of diff_fifo in reg FIFO_STATUS1 and FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dso32x_fifo_data_level_get(const stmdev_ctx_t *ctx,
-                                       uint16_t *val)
+                                     uint16_t *val)
 {
-  lsm6dso32x_fifo_status1_t fifo_status1;
-  lsm6dso32x_fifo_status2_t fifo_status2;
+  uint8_t reg[2];
+  lsm6dso32x_fifo_status1_t *fifo_status1 = (lsm6dso32x_fifo_status1_t *)&reg[0];
+  lsm6dso32x_fifo_status2_t *fifo_status2 = (lsm6dso32x_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dso32x_read_reg(ctx, LSM6DSO32X_FIFO_STATUS1,
-                            (uint8_t *)&fifo_status1, 1);
-
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dso32x_read_reg(ctx, LSM6DSO32X_FIFO_STATUS1, (uint8_t *)reg, 2);
   if (ret == 0)
   {
-    ret = lsm6dso32x_read_reg(ctx, LSM6DSO32X_FIFO_STATUS2,
-                              (uint8_t *)&fifo_status2, 1);
-    *val = ((uint16_t)fifo_status2.diff_fifo << 8) +
-           (uint16_t)fifo_status1.diff_fifo;
+    *val = fifo_status2->diff_fifo;
+    *val = (*val * 256U) + fifo_status1->diff_fifo;
   }
 
   return ret;
 }
 
 /**
-  * @brief  FIFO status.[get]
+  * @brief  Smart FIFO status.[get]
   *
-  * @param  ctx      read / write interface definitions
-  * @param  val      registers FIFO_STATUS2
-  * @retval          interface status (MANDATORY: return 0 -> no Error).
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Read registers FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dso32x_fifo_status_get(const stmdev_ctx_t *ctx,
-                                   lsm6dso32x_fifo_status2_t *val)
+                                 lsm6dso32x_fifo_status2_t *val)
 {
+  uint8_t reg[2];
+  lsm6dso32x_fifo_status2_t *fifo_status2 = (lsm6dso32x_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dso32x_read_reg(ctx, LSM6DSO32X_FIFO_STATUS2,
-                            (uint8_t *) val, 1);
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dso32x_read_reg(ctx, LSM6DSO32X_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = *fifo_status2;
+  }
 
   return ret;
 }
@@ -6130,19 +6134,23 @@ int32_t lsm6dso32x_fifo_status_get(const stmdev_ctx_t *ctx,
 /**
   * @brief  Smart FIFO full status.[get]
   *
-  * @param  ctx      read / write interface definitions
-  * @param  val      change the values of fifo_full_ia in reg FIFO_STATUS2
-  * @retval          interface status (MANDATORY: return 0 -> no Error).
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Read the values of fifo_full_ia in reg FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dso32x_fifo_full_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm6dso32x_fifo_status2_t reg;
+  uint8_t reg[2];
+  lsm6dso32x_fifo_status2_t *fifo_status2 = (lsm6dso32x_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dso32x_read_reg(ctx, LSM6DSO32X_FIFO_STATUS2,
-                            (uint8_t *)&reg, 1);
-  *val = reg.fifo_full_ia;
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dso32x_read_reg(ctx, LSM6DSO32X_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_full_ia;
+  }
 
   return ret;
 }
@@ -6150,20 +6158,24 @@ int32_t lsm6dso32x_fifo_full_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 /**
   * @brief  FIFO overrun status.[get]
   *
-  * @param  ctx      read / write interface definitions
-  * @param  val      change the values of  fifo_over_run_latched in
-  *                  reg FIFO_STATUS2
-  * @retval          interface status (MANDATORY: return 0 -> no Error).
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Read the values of  fifo_over_run_latched in
+  *                reg FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dso32x_fifo_ovr_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm6dso32x_fifo_status2_t reg;
+  uint8_t reg[2];
+  lsm6dso32x_fifo_status2_t *fifo_status2 = (lsm6dso32x_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dso32x_read_reg(ctx, LSM6DSO32X_FIFO_STATUS2,
-                            (uint8_t *)&reg, 1);
-  *val = reg.fifo_ovr_ia;
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dso32x_read_reg(ctx, LSM6DSO32X_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_ovr_ia;
+  }
 
   return ret;
 }
@@ -6171,19 +6183,23 @@ int32_t lsm6dso32x_fifo_ovr_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 /**
   * @brief  FIFO watermark status.[get]
   *
-  * @param  ctx      read / write interface definitions
-  * @param  val      change the values of fifo_wtm_ia in reg FIFO_STATUS2
-  * @retval          interface status (MANDATORY: return 0 -> no Error).
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Read the values of fifo_wtm_ia in reg FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dso32x_fifo_wtm_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm6dso32x_fifo_status2_t reg;
+  uint8_t reg[2];
+  lsm6dso32x_fifo_status2_t *fifo_status2 = (lsm6dso32x_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dso32x_read_reg(ctx, LSM6DSO32X_FIFO_STATUS2,
-                            (uint8_t *)&reg, 1);
-  *val = reg.fifo_wtm_ia;
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dso32x_read_reg(ctx, LSM6DSO32X_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_wtm_ia;
+  }
 
   return ret;
 }

--- a/sensor/stmemsc/lsm6dso_STdC/driver/lsm6dso_reg.c
+++ b/sensor/stmemsc/lsm6dso_STdC/driver/lsm6dso_reg.c
@@ -6714,47 +6714,53 @@ int32_t lsm6dso_batch_counter_threshold_get(const stmdev_ctx_t *ctx,
 }
 
 /**
-  * @brief  Number of unread sensor data(TAG + 6 bytes) stored in FIFO.[get]
+  * @brief  Number of unread sensor data (TAG + 6 bytes) stored in FIFO.[get]
   *
-  * @param  ctx      read / write interface definitions
-  * @param  val      Get the values of diff_fifo in reg FIFO_STATUS1
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Read the value of diff_fifo in reg FIFO_STATUS1 and FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dso_fifo_data_level_get(const stmdev_ctx_t *ctx, uint16_t *val)
+int32_t lsm6dso_fifo_data_level_get(const stmdev_ctx_t *ctx,
+                                     uint16_t *val)
 {
-  lsm6dso_fifo_status1_t fifo_status1;
-  lsm6dso_fifo_status2_t fifo_status2;
+  uint8_t reg[2];
+  lsm6dso_fifo_status1_t *fifo_status1 = (lsm6dso_fifo_status1_t *)&reg[0];
+  lsm6dso_fifo_status2_t *fifo_status2 = (lsm6dso_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_STATUS1,
-                         (uint8_t *)&fifo_status1, 1);
-
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_STATUS1, (uint8_t *)reg, 2);
   if (ret == 0)
   {
-    ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_STATUS2,
-                           (uint8_t *)&fifo_status2, 1);
-    *val = ((uint16_t)fifo_status2.diff_fifo << 8) +
-           (uint16_t)fifo_status1.diff_fifo;
+    *val = fifo_status2->diff_fifo;
+    *val = (*val * 256U) + fifo_status1->diff_fifo;
   }
 
   return ret;
 }
 
 /**
-  * @brief  FIFO status.[get]
+  * @brief  Smart FIFO status.[get]
   *
-  * @param  ctx      read / write interface definitions
-  * @param  val      registers FIFO_STATUS2
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Read registers FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dso_fifo_status_get(const stmdev_ctx_t *ctx,
-                                lsm6dso_fifo_status2_t *val)
+                                 lsm6dso_fifo_status2_t *val)
 {
+  uint8_t reg[2];
+  lsm6dso_fifo_status2_t *fifo_status2 = (lsm6dso_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_STATUS2, (uint8_t *) val, 1);
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = *fifo_status2;
+  }
 
   return ret;
 }
@@ -6762,18 +6768,23 @@ int32_t lsm6dso_fifo_status_get(const stmdev_ctx_t *ctx,
 /**
   * @brief  Smart FIFO full status.[get]
   *
-  * @param  ctx      read / write interface definitions
-  * @param  val      Get the values of fifo_full_ia in reg FIFO_STATUS2
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Read the values of fifo_full_ia in reg FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dso_fifo_full_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm6dso_fifo_status2_t reg;
+  uint8_t reg[2];
+  lsm6dso_fifo_status2_t *fifo_status2 = (lsm6dso_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_STATUS2, (uint8_t *)&reg, 1);
-  *val = reg.fifo_full_ia;
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_full_ia;
+  }
 
   return ret;
 }
@@ -6781,19 +6792,24 @@ int32_t lsm6dso_fifo_full_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 /**
   * @brief  FIFO overrun status.[get]
   *
-  * @param  ctx      read / write interface definitions
-  * @param  val      Get the values of  fifo_over_run_latched in
-  *                  reg FIFO_STATUS2
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Read the values of  fifo_over_run_latched in
+  *                reg FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dso_fifo_ovr_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm6dso_fifo_status2_t reg;
+  uint8_t reg[2];
+  lsm6dso_fifo_status2_t *fifo_status2 = (lsm6dso_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_STATUS2, (uint8_t *)&reg, 1);
-  *val = reg.fifo_ovr_ia;
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_ovr_ia;
+  }
 
   return ret;
 }
@@ -6801,18 +6817,23 @@ int32_t lsm6dso_fifo_ovr_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 /**
   * @brief  FIFO watermark status.[get]
   *
-  * @param  ctx      read / write interface definitions
-  * @param  val      Get the values of fifo_wtm_ia in reg FIFO_STATUS2
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Read the values of fifo_wtm_ia in reg FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dso_fifo_wtm_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm6dso_fifo_status2_t reg;
+  uint8_t reg[2];
+  lsm6dso_fifo_status2_t *fifo_status2 = (lsm6dso_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_STATUS2, (uint8_t *)&reg, 1);
-  *val = reg.fifo_wtm_ia;
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_wtm_ia;
+  }
 
   return ret;
 }

--- a/sensor/stmemsc/lsm6dsox_STdC/driver/lsm6dsox_reg.c
+++ b/sensor/stmemsc/lsm6dsox_STdC/driver/lsm6dsox_reg.c
@@ -7380,47 +7380,53 @@ int32_t lsm6dsox_batch_counter_threshold_get(const stmdev_ctx_t *ctx,
 }
 
 /**
-  * @brief  Number of unread sensor data(TAG + 6 bytes) stored in FIFO.[get]
+  * @brief  Number of unread sensor data (TAG + 6 bytes) stored in FIFO.[get]
   *
-  * @param  ctx      read / write interface definitions
-  * @param  val      change the values of diff_fifo in reg FIFO_STATUS1
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Read the value of diff_fifo in reg FIFO_STATUS1 and FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsox_fifo_data_level_get(const stmdev_ctx_t *ctx, uint16_t *val)
+int32_t lsm6dsox_fifo_data_level_get(const stmdev_ctx_t *ctx,
+                                     uint16_t *val)
 {
-  lsm6dsox_fifo_status1_t fifo_status1;
-  lsm6dsox_fifo_status2_t fifo_status2;
+  uint8_t reg[2];
+  lsm6dsox_fifo_status1_t *fifo_status1 = (lsm6dsox_fifo_status1_t *)&reg[0];
+  lsm6dsox_fifo_status2_t *fifo_status2 = (lsm6dsox_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_STATUS1,
-                          (uint8_t *)&fifo_status1, 1);
-
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_STATUS1, (uint8_t *)reg, 2);
   if (ret == 0)
   {
-    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_STATUS2,
-                            (uint8_t *)&fifo_status2, 1);
-    *val = ((uint16_t)fifo_status2.diff_fifo << 8) +
-           (uint16_t)fifo_status1.diff_fifo;
+    *val = fifo_status2->diff_fifo;
+    *val = (*val * 256U) + fifo_status1->diff_fifo;
   }
 
   return ret;
 }
 
 /**
-  * @brief  FIFO status.[get]
+  * @brief  Smart FIFO status.[get]
   *
-  * @param  ctx      read / write interface definitions
-  * @param  val      registers FIFO_STATUS2
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Read registers FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dsox_fifo_status_get(const stmdev_ctx_t *ctx,
                                  lsm6dsox_fifo_status2_t *val)
 {
+  uint8_t reg[2];
+  lsm6dsox_fifo_status2_t *fifo_status2 = (lsm6dsox_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_STATUS2, (uint8_t *) val, 1);
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = *fifo_status2;
+  }
 
   return ret;
 }
@@ -7428,18 +7434,23 @@ int32_t lsm6dsox_fifo_status_get(const stmdev_ctx_t *ctx,
 /**
   * @brief  Smart FIFO full status.[get]
   *
-  * @param  ctx      read / write interface definitions
-  * @param  val      change the values of fifo_full_ia in reg FIFO_STATUS2
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Read the values of fifo_full_ia in reg FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dsox_fifo_full_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm6dsox_fifo_status2_t reg;
+  uint8_t reg[2];
+  lsm6dsox_fifo_status2_t *fifo_status2 = (lsm6dsox_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_STATUS2, (uint8_t *)&reg, 1);
-  *val = reg.fifo_full_ia;
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_full_ia;
+  }
 
   return ret;
 }
@@ -7447,19 +7458,24 @@ int32_t lsm6dsox_fifo_full_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 /**
   * @brief  FIFO overrun status.[get]
   *
-  * @param  ctx      read / write interface definitions
-  * @param  val      change the values of  fifo_over_run_latched in
-  *                  reg FIFO_STATUS2
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Read the values of  fifo_over_run_latched in
+  *                reg FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dsox_fifo_ovr_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm6dsox_fifo_status2_t reg;
+  uint8_t reg[2];
+  lsm6dsox_fifo_status2_t *fifo_status2 = (lsm6dsox_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_STATUS2, (uint8_t *)&reg, 1);
-  *val = reg.fifo_ovr_ia;
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_ovr_ia;
+  }
 
   return ret;
 }
@@ -7467,18 +7483,23 @@ int32_t lsm6dsox_fifo_ovr_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 /**
   * @brief  FIFO watermark status.[get]
   *
-  * @param  ctx      read / write interface definitions
-  * @param  val      change the values of fifo_wtm_ia in reg FIFO_STATUS2
-  * @retval             interface status (MANDATORY: return 0 -> no Error)
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Read the values of fifo_wtm_ia in reg FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dsox_fifo_wtm_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm6dsox_fifo_status2_t reg;
+  uint8_t reg[2];
+  lsm6dsox_fifo_status2_t *fifo_status2 = (lsm6dsox_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_STATUS2, (uint8_t *)&reg, 1);
-  *val = reg.fifo_wtm_ia;
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_wtm_ia;
+  }
 
   return ret;
 }

--- a/sensor/stmemsc/lsm6dsr_STdC/driver/lsm6dsr_reg.c
+++ b/sensor/stmemsc/lsm6dsr_STdC/driver/lsm6dsr_reg.c
@@ -155,9 +155,9 @@ float_t lsm6dsr_from_lsb_to_celsius(int16_t lsb)
   return (((float_t)lsb / 256.0f) + 25.0f);
 }
 
-float_t lsm6dsr_from_lsb_to_nsec(int32_t lsb)
+uint64_t lsm6dsr_from_lsb_to_nsec(uint32_t lsb)
 {
-  return ((float_t)lsb * 25000.0f);
+  return ((uint64_t)lsb * 25000ULL);
 }
 
 /**
@@ -186,8 +186,8 @@ int32_t lsm6dsr_xl_full_scale_set(const stmdev_ctx_t *ctx,
 {
   lsm6dsr_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
-
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_XL, (uint8_t *)&ctrl1_xl, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_XL,
+                         (uint8_t *)&ctrl1_xl, 1);
 
   if (ret == 0)
   {
@@ -212,8 +212,8 @@ int32_t lsm6dsr_xl_full_scale_get(const stmdev_ctx_t *ctx,
 {
   lsm6dsr_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
-
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_XL, (uint8_t *)&ctrl1_xl, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_XL,
+                         (uint8_t *)&ctrl1_xl, 1);
 
   switch (ctrl1_xl.fs_xl)
   {
@@ -378,7 +378,8 @@ int32_t lsm6dsr_xl_data_rate_set(const stmdev_ctx_t *ctx,
 
   if (ret == 0)
   {
-    ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_XL, (uint8_t *)&ctrl1_xl, 1);
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_XL,
+                           (uint8_t *)&ctrl1_xl, 1);
   }
 
   if (ret == 0)
@@ -404,8 +405,8 @@ int32_t lsm6dsr_xl_data_rate_get(const stmdev_ctx_t *ctx,
 {
   lsm6dsr_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
-
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_XL, (uint8_t *)&ctrl1_xl, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_XL,
+                         (uint8_t *)&ctrl1_xl, 1);
 
   switch (ctrl1_xl.odr_xl)
   {
@@ -478,13 +479,14 @@ int32_t lsm6dsr_gy_full_scale_set(const stmdev_ctx_t *ctx,
 {
   lsm6dsr_ctrl2_g_t ctrl2_g;
   int32_t ret;
-
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL2_G, (uint8_t *)&ctrl2_g, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL2_G,
+                         (uint8_t *)&ctrl2_g, 1);
 
   if (ret == 0)
   {
     ctrl2_g.fs_g = (uint8_t)val;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL2_G, (uint8_t *)&ctrl2_g, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL2_G,
+                            (uint8_t *)&ctrl2_g, 1);
   }
 
   return ret;
@@ -503,8 +505,8 @@ int32_t lsm6dsr_gy_full_scale_get(const stmdev_ctx_t *ctx,
 {
   lsm6dsr_ctrl2_g_t ctrl2_g;
   int32_t ret;
-
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL2_G, (uint8_t *)&ctrl2_g, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL2_G,
+                         (uint8_t *)&ctrl2_g, 1);
 
   switch (ctrl2_g.fs_g)
   {
@@ -677,13 +679,15 @@ int32_t lsm6dsr_gy_data_rate_set(const stmdev_ctx_t *ctx,
 
   if (ret == 0)
   {
-    ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL2_G, (uint8_t *)&ctrl2_g, 1);
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL2_G,
+                           (uint8_t *)&ctrl2_g, 1);
   }
 
   if (ret == 0)
   {
     ctrl2_g.odr_g = (uint8_t)odr_gy;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL2_G, (uint8_t *)&ctrl2_g, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL2_G,
+                            (uint8_t *)&ctrl2_g, 1);
   }
 
   return ret;
@@ -702,8 +706,8 @@ int32_t lsm6dsr_gy_data_rate_get(const stmdev_ctx_t *ctx,
 {
   lsm6dsr_ctrl2_g_t ctrl2_g;
   int32_t ret;
-
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL2_G, (uint8_t *)&ctrl2_g, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL2_G,
+                         (uint8_t *)&ctrl2_g, 1);
 
   switch (ctrl2_g.odr_g)
   {
@@ -767,17 +771,19 @@ int32_t lsm6dsr_gy_data_rate_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_block_data_update_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsr_block_data_update_set(const stmdev_ctx_t *ctx,
+                                      uint8_t val)
 {
   lsm6dsr_ctrl3_c_t ctrl3_c;
   int32_t ret;
-
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C,
+                         (uint8_t *)&ctrl3_c, 1);
 
   if (ret == 0)
   {
     ctrl3_c.bdu = (uint8_t)val;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL3_C,
+                            (uint8_t *)&ctrl3_c, 1);
   }
 
   return ret;
@@ -791,12 +797,13 @@ int32_t lsm6dsr_block_data_update_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_block_data_update_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsr_block_data_update_get(const stmdev_ctx_t *ctx,
+                                      uint8_t *val)
 {
   lsm6dsr_ctrl3_c_t ctrl3_c;
   int32_t ret;
-
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C,
+                         (uint8_t *)&ctrl3_c, 1);
   *val = ctrl3_c.bdu;
 
   return ret;
@@ -816,13 +823,14 @@ int32_t lsm6dsr_xl_offset_weight_set(const stmdev_ctx_t *ctx,
 {
   lsm6dsr_ctrl6_c_t ctrl6_c;
   int32_t ret;
-
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL6_C,
+                         (uint8_t *)&ctrl6_c, 1);
 
   if (ret == 0)
   {
     ctrl6_c.usr_off_w = (uint8_t)val;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL6_C,
+                            (uint8_t *)&ctrl6_c, 1);
   }
 
   return ret;
@@ -842,8 +850,8 @@ int32_t lsm6dsr_xl_offset_weight_get(const stmdev_ctx_t *ctx,
 {
   lsm6dsr_ctrl6_c_t ctrl6_c;
   int32_t ret;
-
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL6_C,
+                         (uint8_t *)&ctrl6_c, 1);
 
   switch (ctrl6_c.usr_off_w)
   {
@@ -876,13 +884,14 @@ int32_t lsm6dsr_xl_power_mode_set(const stmdev_ctx_t *ctx,
 {
   lsm6dsr_ctrl6_c_t ctrl6_c;
   int32_t ret;
-
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL6_C,
+                         (uint8_t *)&ctrl6_c, 1);
 
   if (ret == 0)
   {
     ctrl6_c.xl_hm_mode = (uint8_t)val & 0x01U;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL6_C,
+                            (uint8_t *)&ctrl6_c, 1);
   }
 
   return ret;
@@ -901,8 +910,8 @@ int32_t lsm6dsr_xl_power_mode_get(const stmdev_ctx_t *ctx,
 {
   lsm6dsr_ctrl6_c_t ctrl6_c;
   int32_t ret;
-
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL6_C,
+                         (uint8_t *)&ctrl6_c, 1);
 
   switch (ctrl6_c.xl_hm_mode)
   {
@@ -935,13 +944,14 @@ int32_t lsm6dsr_gy_power_mode_set(const stmdev_ctx_t *ctx,
 {
   lsm6dsr_ctrl7_g_t ctrl7_g;
   int32_t ret;
-
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL7_G,
+                         (uint8_t *)&ctrl7_g, 1);
 
   if (ret == 0)
   {
     ctrl7_g.g_hm_mode = (uint8_t)val;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL7_G,
+                            (uint8_t *)&ctrl7_g, 1);
   }
 
   return ret;
@@ -960,8 +970,8 @@ int32_t lsm6dsr_gy_power_mode_get(const stmdev_ctx_t *ctx,
 {
   lsm6dsr_ctrl7_g_t ctrl7_g;
   int32_t ret;
-
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL7_G,
+                         (uint8_t *)&ctrl7_g, 1);
 
   switch (ctrl7_g.g_hm_mode)
   {
@@ -1136,7 +1146,7 @@ int32_t lsm6dsr_temp_flag_data_ready_get(const stmdev_ctx_t *ctx,
 }
 
 /**
-  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  * @brief  Accelerometer X-axis user offset correction expressed in two's
   *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
   *         The value must be in the range [-127 127].[set]
   *
@@ -1145,7 +1155,8 @@ int32_t lsm6dsr_temp_flag_data_ready_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_xl_usr_offset_x_set(const stmdev_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsr_xl_usr_offset_x_set(const stmdev_ctx_t *ctx,
+                                    uint8_t *buff)
 {
   int32_t ret;
 
@@ -1155,7 +1166,7 @@ int32_t lsm6dsr_xl_usr_offset_x_set(const stmdev_ctx_t *ctx, uint8_t *buff)
 }
 
 /**
-  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  * @brief  Accelerometer X-axis user offset correction expressed in two's
   *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
   *         The value must be in the range [-127 127].[get]
   *
@@ -1164,7 +1175,8 @@ int32_t lsm6dsr_xl_usr_offset_x_set(const stmdev_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_xl_usr_offset_x_get(const stmdev_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsr_xl_usr_offset_x_get(const stmdev_ctx_t *ctx,
+                                    uint8_t *buff)
 {
   int32_t ret;
 
@@ -1174,7 +1186,7 @@ int32_t lsm6dsr_xl_usr_offset_x_get(const stmdev_ctx_t *ctx, uint8_t *buff)
 }
 
 /**
-  * @brief  Accelerometer Y-axis user offset correction expressed in two’s
+  * @brief  Accelerometer Y-axis user offset correction expressed in two's
   *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
   *         The value must be in the range [-127 127].[set]
   *
@@ -1183,7 +1195,8 @@ int32_t lsm6dsr_xl_usr_offset_x_get(const stmdev_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_xl_usr_offset_y_set(const stmdev_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsr_xl_usr_offset_y_set(const stmdev_ctx_t *ctx,
+                                    uint8_t *buff)
 {
   int32_t ret;
 
@@ -1193,7 +1206,7 @@ int32_t lsm6dsr_xl_usr_offset_y_set(const stmdev_ctx_t *ctx, uint8_t *buff)
 }
 
 /**
-  * @brief  Accelerometer Y-axis user offset correction expressed in two’s
+  * @brief  Accelerometer Y-axis user offset correction expressed in two's
   *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
   *         The value must be in the range [-127 127].[get]
   *
@@ -1202,7 +1215,8 @@ int32_t lsm6dsr_xl_usr_offset_y_set(const stmdev_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_xl_usr_offset_y_get(const stmdev_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsr_xl_usr_offset_y_get(const stmdev_ctx_t *ctx,
+                                    uint8_t *buff)
 {
   int32_t ret;
 
@@ -1212,7 +1226,7 @@ int32_t lsm6dsr_xl_usr_offset_y_get(const stmdev_ctx_t *ctx, uint8_t *buff)
 }
 
 /**
-  * @brief  Accelerometer Z-axis user offset correction expressed in two’s
+  * @brief  Accelerometer Z-axis user offset correction expressed in two's
   *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
   *         The value must be in the range [-127 127].[set]
   *
@@ -1221,7 +1235,8 @@ int32_t lsm6dsr_xl_usr_offset_y_get(const stmdev_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_xl_usr_offset_z_set(const stmdev_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsr_xl_usr_offset_z_set(const stmdev_ctx_t *ctx,
+                                    uint8_t *buff)
 {
   int32_t ret;
 
@@ -1231,7 +1246,7 @@ int32_t lsm6dsr_xl_usr_offset_z_set(const stmdev_ctx_t *ctx, uint8_t *buff)
 }
 
 /**
-  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  * @brief  Accelerometer X-axis user offset correction expressed in two's
   *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
   *         The value must be in the range [-127 127].[get]
   *
@@ -1240,7 +1255,8 @@ int32_t lsm6dsr_xl_usr_offset_z_set(const stmdev_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_xl_usr_offset_z_get(const stmdev_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsr_xl_usr_offset_z_get(const stmdev_ctx_t *ctx,
+                                    uint8_t *buff)
 {
   int32_t ret;
 
@@ -1262,12 +1278,14 @@ int32_t lsm6dsr_xl_usr_offset_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsr_ctrl7_g_t ctrl7_g;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL7_G,
+                         (uint8_t *)&ctrl7_g, 1);
 
   if (ret == 0)
   {
     ctrl7_g.usr_off_on_out = (uint8_t)val;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL7_G,
+                            (uint8_t *)&ctrl7_g, 1);
   }
 
   return ret;
@@ -1286,7 +1304,8 @@ int32_t lsm6dsr_xl_usr_offset_get(const stmdev_ctx_t *ctx, uint8_t *val)
   lsm6dsr_ctrl7_g_t ctrl7_g;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL7_G,
+                         (uint8_t *)&ctrl7_g, 1);
   *val = ctrl7_g.usr_off_on_out;
 
   return ret;
@@ -1331,7 +1350,8 @@ int32_t lsm6dsr_timestamp_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsr_ctrl10_c_t ctrl10_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL10_C, (uint8_t *)&ctrl10_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL10_C,
+                         (uint8_t *)&ctrl10_c, 1);
 
   if (ret == 0)
   {
@@ -1356,7 +1376,8 @@ int32_t lsm6dsr_timestamp_get(const stmdev_ctx_t *ctx, uint8_t *val)
   lsm6dsr_ctrl10_c_t ctrl10_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL10_C, (uint8_t *)&ctrl10_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL10_C,
+                         (uint8_t *)&ctrl10_c, 1);
   *val = ctrl10_c.timestamp_en;
 
   return ret;
@@ -1365,7 +1386,7 @@ int32_t lsm6dsr_timestamp_get(const stmdev_ctx_t *ctx, uint8_t *val)
 /**
   * @brief  Timestamp first data output register (r).
   *         The value is expressed as a 32-bit word and the bit resolution
-  *         is 25 μs.[get]
+  *         is 25 us.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
   * @param  buff   Buffer that stores data read
@@ -1412,12 +1433,14 @@ int32_t lsm6dsr_rounding_mode_set(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl5_c_t ctrl5_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL5_C, (uint8_t *)&ctrl5_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL5_C,
+                         (uint8_t *)&ctrl5_c, 1);
 
   if (ret == 0)
   {
     ctrl5_c.rounding = (uint8_t)val;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL5_C, (uint8_t *)&ctrl5_c, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL5_C,
+                            (uint8_t *)&ctrl5_c, 1);
   }
 
   return ret;
@@ -1437,7 +1460,8 @@ int32_t lsm6dsr_rounding_mode_get(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl5_c_t ctrl5_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL5_C, (uint8_t *)&ctrl5_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL5_C,
+                         (uint8_t *)&ctrl5_c, 1);
 
   switch (ctrl5_c.rounding)
   {
@@ -1467,7 +1491,7 @@ int32_t lsm6dsr_rounding_mode_get(const stmdev_ctx_t *ctx,
 
 /**
   * @brief  Temperature data output register (r).
-  *         L and H registers together express a 16-bit word in two’s
+  *         L and H registers together express a 16-bit word in two's
   *         complement.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
@@ -1475,28 +1499,30 @@ int32_t lsm6dsr_rounding_mode_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_temperature_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
+int32_t lsm6dsr_temperature_raw_get(const stmdev_ctx_t *ctx,
+                                    int16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
 
   ret = lsm6dsr_read_reg(ctx, LSM6DSR_OUT_TEMP_L, buff, 2);
-  val[0] = (int16_t)buff[1];
-  val[0] = (val[0] * 256) + (int16_t)buff[0];
+  *val = (int16_t)buff[1];
+  *val = (*val * 256) + (int16_t)buff[0];
 
   return ret;
 }
 
 /**
   * @brief  Angular rate sensor. The value is expressed as a 16-bit
-  *         word in two’s complement.[get]
+  *         word in two's complement.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
   * @param  buff   Buffer that stores data read
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_angular_rate_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
+int32_t lsm6dsr_angular_rate_raw_get(const stmdev_ctx_t *ctx,
+                                     int16_t *val)
 {
   uint8_t buff[6];
   int32_t ret;
@@ -1514,14 +1540,15 @@ int32_t lsm6dsr_angular_rate_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
 
 /**
   * @brief  Linear acceleration output register. The value is expressed as a
-  *         16-bit word in two’s complement.[get]
+  *         16-bit word in two's complement.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
   * @param  buff   Buffer that stores data read
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
+int32_t lsm6dsr_acceleration_raw_get(const stmdev_ctx_t *ctx,
+                                     int16_t *val)
 {
   uint8_t buff[6];
   int32_t ret;
@@ -1562,7 +1589,8 @@ int32_t lsm6dsr_fifo_out_raw_get(const stmdev_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_number_of_steps_get(const stmdev_ctx_t *ctx, uint16_t *val)
+int32_t lsm6dsr_number_of_steps_get(const stmdev_ctx_t *ctx,
+                                    uint16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -1572,12 +1600,12 @@ int32_t lsm6dsr_number_of_steps_get(const stmdev_ctx_t *ctx, uint16_t *val)
   if (ret == 0)
   {
     ret = lsm6dsr_read_reg(ctx, LSM6DSR_STEP_COUNTER_L, buff, 2);
+    *val = buff[1];
+    *val = (*val * 256U) +  buff[0];
   }
 
   if (ret == 0)
   {
-    *val = buff[1];
-    *val = (*val * 256U) +  buff[0];
     ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
   }
 
@@ -1770,23 +1798,26 @@ int32_t lsm6dsr_ln_pg_write_byte(const stmdev_ctx_t *ctx, uint16_t add,
 
   if (ret == 0)
   {
-    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_RW,
+                           (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
   {
     page_rw.page_rw = 0x02U; /* page_write enable */
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_RW,
+                            (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
   {
-    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_SEL, (uint8_t *)&page_sel, 1);
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_SEL,
+                           (uint8_t *)&page_sel, 1);
   }
 
   if (ret == 0)
   {
-    page_sel.page_sel = (uint8_t)((add >> 8) & 0x0FU);
+    page_sel.page_sel = (uint8_t)((add / 256U) & 0x0FU);
     page_sel.not_used_01 = 1;
     ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_SEL,
                             (uint8_t *)&page_sel, 1);
@@ -1794,7 +1825,7 @@ int32_t lsm6dsr_ln_pg_write_byte(const stmdev_ctx_t *ctx, uint16_t add,
 
   if (ret == 0)
   {
-    page_address.page_addr = (uint8_t)(add & 0xFFU);
+    page_address.page_addr = (uint8_t)(add - (page_sel.page_sel * 256U));
     ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_ADDRESS,
                             (uint8_t *)&page_address, 1);
   }
@@ -1806,13 +1837,15 @@ int32_t lsm6dsr_ln_pg_write_byte(const stmdev_ctx_t *ctx, uint16_t add,
 
   if (ret == 0)
   {
-    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_RW,
+                           (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
   {
     page_rw.page_rw = 0x00; /* page_write disable */
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_RW,
+                            (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
@@ -1839,28 +1872,32 @@ int32_t lsm6dsr_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t add,
   lsm6dsr_page_rw_t page_rw;
   lsm6dsr_page_sel_t page_sel;
   lsm6dsr_page_address_t page_address;
+  uint8_t msb;
+  uint8_t lsb;
   int32_t ret;
-
-  uint8_t msb, lsb;
   uint8_t i ;
-  msb = (uint8_t)((add >> 8) & 0x0FU);
-  lsb = (uint8_t)(add & 0xFFU);
+
+  msb = (uint8_t)((add / 256U) & 0x0FU);
+  lsb = (uint8_t)(add - (msb * 256U));
   ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
   {
-    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_RW,
+                           (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
   {
     page_rw.page_rw = 0x02U; /* page_write enable*/
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_RW,
+                            (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
   {
-    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_SEL, (uint8_t *)&page_sel, 1);
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_SEL,
+                           (uint8_t *)&page_sel, 1);
   }
 
   if (ret == 0)
@@ -1917,13 +1954,15 @@ int32_t lsm6dsr_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t add,
 
   if (ret == 0)
   {
-    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_RW,
+                           (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
   {
     page_rw.page_rw = 0x00U; /* page_write disable */
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_RW,
+                            (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
@@ -1955,23 +1994,26 @@ int32_t lsm6dsr_ln_pg_read_byte(const stmdev_ctx_t *ctx, uint16_t add,
 
   if (ret == 0)
   {
-    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_RW,
+                           (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
   {
     page_rw.page_rw = 0x01U; /* page_read enable*/
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_RW,
+                            (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
   {
-    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_SEL, (uint8_t *)&page_sel, 1);
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_SEL,
+                           (uint8_t *)&page_sel, 1);
   }
 
   if (ret == 0)
   {
-    page_sel.page_sel = (uint8_t)((add >> 8) & 0x0FU);
+    page_sel.page_sel = (uint8_t)((add / 256U) & 0x0FU);
     page_sel.not_used_01 = 1;
     ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_SEL,
                             (uint8_t *)&page_sel, 1);
@@ -1979,7 +2021,7 @@ int32_t lsm6dsr_ln_pg_read_byte(const stmdev_ctx_t *ctx, uint16_t add,
 
   if (ret == 0)
   {
-    page_address.page_addr = (uint8_t)(add & 0x00FFU);
+    page_address.page_addr = (uint8_t)(add - (page_sel.page_sel * 256U));
     ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_ADDRESS,
                             (uint8_t *)&page_address, 1);
   }
@@ -1991,13 +2033,15 @@ int32_t lsm6dsr_ln_pg_read_byte(const stmdev_ctx_t *ctx, uint16_t add,
 
   if (ret == 0)
   {
-    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_RW,
+                           (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
   {
     page_rw.page_rw = 0x00U; /* page_read disable */
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_RW,
+                            (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
@@ -2102,12 +2146,14 @@ int32_t lsm6dsr_reset_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsr_ctrl3_c_t ctrl3_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C,
+                         (uint8_t *)&ctrl3_c, 1);
 
   if (ret == 0)
   {
     ctrl3_c.sw_reset = (uint8_t)val;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL3_C,
+                            (uint8_t *)&ctrl3_c, 1);
   }
 
   return ret;
@@ -2126,7 +2172,8 @@ int32_t lsm6dsr_reset_get(const stmdev_ctx_t *ctx, uint8_t *val)
   lsm6dsr_ctrl3_c_t ctrl3_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C,
+                         (uint8_t *)&ctrl3_c, 1);
   *val = ctrl3_c.sw_reset;
 
   return ret;
@@ -2146,12 +2193,14 @@ int32_t lsm6dsr_auto_increment_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsr_ctrl3_c_t ctrl3_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C,
+                         (uint8_t *)&ctrl3_c, 1);
 
   if (ret == 0)
   {
     ctrl3_c.if_inc = (uint8_t)val;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL3_C,
+                            (uint8_t *)&ctrl3_c, 1);
   }
 
   return ret;
@@ -2171,7 +2220,8 @@ int32_t lsm6dsr_auto_increment_get(const stmdev_ctx_t *ctx, uint8_t *val)
   lsm6dsr_ctrl3_c_t ctrl3_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C,
+                         (uint8_t *)&ctrl3_c, 1);
   *val = ctrl3_c.if_inc;
 
   return ret;
@@ -2190,12 +2240,14 @@ int32_t lsm6dsr_boot_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsr_ctrl3_c_t ctrl3_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C,
+                         (uint8_t *)&ctrl3_c, 1);
 
   if (ret == 0)
   {
     ctrl3_c.boot = (uint8_t)val;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL3_C,
+                            (uint8_t *)&ctrl3_c, 1);
   }
 
   return ret;
@@ -2214,7 +2266,8 @@ int32_t lsm6dsr_boot_get(const stmdev_ctx_t *ctx, uint8_t *val)
   lsm6dsr_ctrl3_c_t ctrl3_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C,
+                         (uint8_t *)&ctrl3_c, 1);
   *val = ctrl3_c.boot;
 
   return ret;
@@ -2236,12 +2289,14 @@ int32_t lsm6dsr_xl_self_test_set(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl5_c_t ctrl5_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL5_C, (uint8_t *)&ctrl5_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL5_C,
+                         (uint8_t *)&ctrl5_c, 1);
 
   if (ret == 0)
   {
     ctrl5_c.st_xl = (uint8_t)val;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL5_C, (uint8_t *)&ctrl5_c, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL5_C,
+                            (uint8_t *)&ctrl5_c, 1);
   }
 
   return ret;
@@ -2261,7 +2316,8 @@ int32_t lsm6dsr_xl_self_test_get(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl5_c_t ctrl5_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL5_C, (uint8_t *)&ctrl5_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL5_C,
+                         (uint8_t *)&ctrl5_c, 1);
 
   switch (ctrl5_c.st_xl)
   {
@@ -2299,12 +2355,14 @@ int32_t lsm6dsr_gy_self_test_set(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl5_c_t ctrl5_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL5_C, (uint8_t *)&ctrl5_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL5_C,
+                         (uint8_t *)&ctrl5_c, 1);
 
   if (ret == 0)
   {
     ctrl5_c.st_g = (uint8_t)val;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL5_C, (uint8_t *)&ctrl5_c, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL5_C,
+                            (uint8_t *)&ctrl5_c, 1);
   }
 
   return ret;
@@ -2324,7 +2382,8 @@ int32_t lsm6dsr_gy_self_test_get(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl5_c_t ctrl5_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL5_C, (uint8_t *)&ctrl5_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL5_C,
+                         (uint8_t *)&ctrl5_c, 1);
 
   switch (ctrl5_c.st_g)
   {
@@ -2374,7 +2433,8 @@ int32_t lsm6dsr_xl_filter_lp2_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsr_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_XL, (uint8_t *)&ctrl1_xl, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_XL,
+                         (uint8_t *)&ctrl1_xl, 1);
 
   if (ret == 0)
   {
@@ -2399,7 +2459,8 @@ int32_t lsm6dsr_xl_filter_lp2_get(const stmdev_ctx_t *ctx, uint8_t *val)
   lsm6dsr_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_XL, (uint8_t *)&ctrl1_xl, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_XL,
+                         (uint8_t *)&ctrl1_xl, 1);
   *val = ctrl1_xl.lpf2_xl_en;
 
   return ret;
@@ -2419,12 +2480,14 @@ int32_t lsm6dsr_gy_filter_lp1_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsr_ctrl4_c_t ctrl4_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C,
+                         (uint8_t *)&ctrl4_c, 1);
 
   if (ret == 0)
   {
     ctrl4_c.lpf1_sel_g = (uint8_t)val;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL4_C,
+                            (uint8_t *)&ctrl4_c, 1);
   }
 
   return ret;
@@ -2444,7 +2507,8 @@ int32_t lsm6dsr_gy_filter_lp1_get(const stmdev_ctx_t *ctx, uint8_t *val)
   lsm6dsr_ctrl4_c_t ctrl4_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C,
+                         (uint8_t *)&ctrl4_c, 1);
   *val = ctrl4_c.lpf1_sel_g;
 
   return ret;
@@ -2465,12 +2529,14 @@ int32_t lsm6dsr_filter_settling_mask_set(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl4_c_t ctrl4_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C,
+                         (uint8_t *)&ctrl4_c, 1);
 
   if (ret == 0)
   {
     ctrl4_c.drdy_mask = (uint8_t)val;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL4_C,
+                            (uint8_t *)&ctrl4_c, 1);
   }
 
   return ret;
@@ -2491,7 +2557,8 @@ int32_t lsm6dsr_filter_settling_mask_get(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl4_c_t ctrl4_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C,
+                         (uint8_t *)&ctrl4_c, 1);
   *val = ctrl4_c.drdy_mask;
 
   return ret;
@@ -2511,12 +2578,14 @@ int32_t lsm6dsr_gy_lp1_bandwidth_set(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl6_c_t ctrl6_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL6_C,
+                         (uint8_t *)&ctrl6_c, 1);
 
   if (ret == 0)
   {
     ctrl6_c.ftype = (uint8_t)val;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL6_C,
+                            (uint8_t *)&ctrl6_c, 1);
   }
 
   return ret;
@@ -2536,7 +2605,8 @@ int32_t lsm6dsr_gy_lp1_bandwidth_get(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl6_c_t ctrl6_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL6_C,
+                         (uint8_t *)&ctrl6_c, 1);
 
   switch (ctrl6_c.ftype)
   {
@@ -2593,7 +2663,8 @@ int32_t lsm6dsr_xl_lp2_on_6d_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsr_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL8_XL, (uint8_t *)&ctrl8_xl, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL8_XL,
+                         (uint8_t *)&ctrl8_xl, 1);
 
   if (ret == 0)
   {
@@ -2618,7 +2689,8 @@ int32_t lsm6dsr_xl_lp2_on_6d_get(const stmdev_ctx_t *ctx, uint8_t *val)
   lsm6dsr_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL8_XL, (uint8_t *)&ctrl8_xl, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL8_XL,
+                         (uint8_t *)&ctrl8_xl, 1);
   *val = ctrl8_xl.low_pass_on_6d;
 
   return ret;
@@ -2639,7 +2711,8 @@ int32_t lsm6dsr_xl_hp_path_on_out_set(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL8_XL, (uint8_t *)&ctrl8_xl, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL8_XL,
+                         (uint8_t *)&ctrl8_xl, 1);
 
   if (ret == 0)
   {
@@ -2668,7 +2741,8 @@ int32_t lsm6dsr_xl_hp_path_on_out_get(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL8_XL, (uint8_t *)&ctrl8_xl, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL8_XL,
+                         (uint8_t *)&ctrl8_xl, 1);
 
   switch (((ctrl8_xl.hp_ref_mode_xl << 5) + (ctrl8_xl.hp_slope_xl_en <<
                                              4) +
@@ -2784,12 +2858,14 @@ int32_t lsm6dsr_xl_hp_path_on_out_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_xl_fast_settling_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsr_xl_fast_settling_set(const stmdev_ctx_t *ctx,
+                                     uint8_t val)
 {
   lsm6dsr_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL8_XL, (uint8_t *)&ctrl8_xl, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL8_XL,
+                         (uint8_t *)&ctrl8_xl, 1);
 
   if (ret == 0)
   {
@@ -2811,12 +2887,14 @@ int32_t lsm6dsr_xl_fast_settling_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_xl_fast_settling_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsr_xl_fast_settling_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val)
 {
   lsm6dsr_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL8_XL, (uint8_t *)&ctrl8_xl, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL8_XL,
+                         (uint8_t *)&ctrl8_xl, 1);
   *val = ctrl8_xl.fastsettl_mode_xl;
 
   return ret;
@@ -2837,7 +2915,8 @@ int32_t lsm6dsr_xl_hp_path_internal_set(const stmdev_ctx_t *ctx,
   lsm6dsr_tap_cfg0_t tap_cfg0;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0,
+                         (uint8_t *)&tap_cfg0, 1);
 
   if (ret == 0)
   {
@@ -2864,7 +2943,8 @@ int32_t lsm6dsr_xl_hp_path_internal_get(const stmdev_ctx_t *ctx,
   lsm6dsr_tap_cfg0_t tap_cfg0;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0,
+                         (uint8_t *)&tap_cfg0, 1);
 
   switch (tap_cfg0.slope_fds)
   {
@@ -2899,13 +2979,15 @@ int32_t lsm6dsr_gy_hp_path_internal_set(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl7_g_t ctrl7_g;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL7_G,
+                         (uint8_t *)&ctrl7_g, 1);
 
   if (ret == 0)
   {
     ctrl7_g.hp_en_g = (((uint8_t)val & 0x80U) >> 7);
     ctrl7_g.hpm_g = (uint8_t)val & 0x03U;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL7_G,
+                            (uint8_t *)&ctrl7_g, 1);
   }
 
   return ret;
@@ -2926,7 +3008,8 @@ int32_t lsm6dsr_gy_hp_path_internal_get(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl7_g_t ctrl7_g;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL7_G,
+                         (uint8_t *)&ctrl7_g, 1);
 
   switch ((ctrl7_g.hp_en_g << 7) + ctrl7_g.hpm_g)
   {
@@ -2986,7 +3069,8 @@ int32_t lsm6dsr_aux_sdo_ocs_mode_set(const stmdev_ctx_t *ctx,
   lsm6dsr_pin_ctrl_t pin_ctrl;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_PIN_CTRL,
+                         (uint8_t *)&pin_ctrl, 1);
 
   if (ret == 0)
   {
@@ -3013,7 +3097,8 @@ int32_t lsm6dsr_aux_sdo_ocs_mode_get(const stmdev_ctx_t *ctx,
   lsm6dsr_pin_ctrl_t pin_ctrl;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_PIN_CTRL,
+                         (uint8_t *)&pin_ctrl, 1);
 
   switch (pin_ctrl.ois_pu_dis)
   {
@@ -3047,13 +3132,15 @@ int32_t lsm6dsr_aux_pw_on_ctrl_set(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl7_g_t ctrl7_g;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL7_G,
+                         (uint8_t *)&ctrl7_g, 1);
 
   if (ret == 0)
   {
     ctrl7_g.ois_on_en = (uint8_t)val & 0x01U;
     ctrl7_g.ois_on = (uint8_t)val & 0x01U;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL7_G,
+                            (uint8_t *)&ctrl7_g, 1);
   }
 
   return ret;
@@ -3073,7 +3160,8 @@ int32_t lsm6dsr_aux_pw_on_ctrl_get(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl7_g_t ctrl7_g;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL7_G,
+                         (uint8_t *)&ctrl7_g, 1);
 
   switch (ctrl7_g.ois_on)
   {
@@ -3106,7 +3194,8 @@ int32_t lsm6dsr_aux_status_reg_get(const stmdev_ctx_t *ctx,
 {
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_STATUS_SPIAUX, (uint8_t *)val, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_STATUS_SPIAUX,
+                         (uint8_t *)val, 1);
 
   return ret;
 }
@@ -3189,12 +3278,14 @@ int32_t lsm6dsr_aux_xl_self_test_set(const stmdev_ctx_t *ctx,
   lsm6dsr_int_ois_t int_ois;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_OIS, (uint8_t *)&int_ois, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_OIS,
+                         (uint8_t *)&int_ois, 1);
 
   if (ret == 0)
   {
     int_ois.st_xl_ois = (uint8_t)val;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_INT_OIS, (uint8_t *)&int_ois, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_INT_OIS,
+                            (uint8_t *)&int_ois, 1);
   }
 
   return ret;
@@ -3215,7 +3306,8 @@ int32_t lsm6dsr_aux_xl_self_test_get(const stmdev_ctx_t *ctx,
   lsm6dsr_int_ois_t int_ois;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_OIS, (uint8_t *)&int_ois, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_OIS,
+                         (uint8_t *)&int_ois, 1);
 
   switch (int_ois.st_xl_ois)
   {
@@ -3253,12 +3345,14 @@ int32_t lsm6dsr_aux_den_polarity_set(const stmdev_ctx_t *ctx,
   lsm6dsr_int_ois_t int_ois;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_OIS, (uint8_t *)&int_ois, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_OIS,
+                         (uint8_t *)&int_ois, 1);
 
   if (ret == 0)
   {
     int_ois.den_lh_ois = (uint8_t)val;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_INT_OIS, (uint8_t *)&int_ois, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_INT_OIS,
+                            (uint8_t *)&int_ois, 1);
   }
 
   return ret;
@@ -3278,7 +3372,8 @@ int32_t lsm6dsr_aux_den_polarity_get(const stmdev_ctx_t *ctx,
   lsm6dsr_int_ois_t int_ois;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_OIS, (uint8_t *)&int_ois, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_OIS,
+                         (uint8_t *)&int_ois, 1);
 
   switch (int_ois.den_lh_ois)
   {
@@ -3313,12 +3408,14 @@ int32_t lsm6dsr_aux_den_mode_set(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_OIS, (uint8_t *)&int_ois, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_OIS,
+                         (uint8_t *)&int_ois, 1);
 
   if (ret == 0)
   {
     int_ois.lvl2_ois = (uint8_t)val & 0x01U;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_INT_OIS, (uint8_t *)&int_ois, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_INT_OIS,
+                            (uint8_t *)&int_ois, 1);
   }
 
   if (ret == 0)
@@ -3352,7 +3449,8 @@ int32_t lsm6dsr_aux_den_mode_get(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_OIS, (uint8_t *)&int_ois, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_OIS,
+                         (uint8_t *)&int_ois, 1);
 
   if (ret == 0)
   {
@@ -3391,17 +3489,20 @@ int32_t lsm6dsr_aux_den_mode_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_aux_drdy_on_int2_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsr_aux_drdy_on_int2_set(const stmdev_ctx_t *ctx,
+                                     uint8_t val)
 {
   lsm6dsr_int_ois_t int_ois;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_OIS, (uint8_t *)&int_ois, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_OIS,
+                         (uint8_t *)&int_ois, 1);
 
   if (ret == 0)
   {
     int_ois.int2_drdy_ois = (uint8_t)val;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_INT_OIS, (uint8_t *)&int_ois, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_INT_OIS,
+                            (uint8_t *)&int_ois, 1);
   }
 
   return ret;
@@ -3416,12 +3517,14 @@ int32_t lsm6dsr_aux_drdy_on_int2_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_aux_drdy_on_int2_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsr_aux_drdy_on_int2_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val)
 {
   lsm6dsr_int_ois_t int_ois;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_OIS, (uint8_t *)&int_ois, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_OIS,
+                         (uint8_t *)&int_ois, 1);
   *val = int_ois.int2_drdy_ois;
 
   return ret;
@@ -3446,7 +3549,8 @@ int32_t lsm6dsr_aux_mode_set(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_OIS, (uint8_t *)&ctrl1_ois, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_OIS,
+                         (uint8_t *)&ctrl1_ois, 1);
 
   if (ret == 0)
   {
@@ -3479,7 +3583,8 @@ int32_t lsm6dsr_aux_mode_get(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_OIS, (uint8_t *)&ctrl1_ois, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_OIS,
+                         (uint8_t *)&ctrl1_ois, 1);
 
   switch (((ctrl1_ois.mode4_en << 1) + ctrl1_ois.ois_en_spi2))
   {
@@ -3517,7 +3622,8 @@ int32_t lsm6dsr_aux_gy_full_scale_set(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_OIS, (uint8_t *)&ctrl1_ois, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_OIS,
+                         (uint8_t *)&ctrl1_ois, 1);
 
   if (ret == 0)
   {
@@ -3591,7 +3697,8 @@ int32_t lsm6dsr_aux_spi_mode_set(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_OIS, (uint8_t *)&ctrl1_ois, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_OIS,
+                         (uint8_t *)&ctrl1_ois, 1);
 
   if (ret == 0)
   {
@@ -3617,7 +3724,8 @@ int32_t lsm6dsr_aux_spi_mode_get(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_OIS, (uint8_t *)&ctrl1_ois, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_OIS,
+                         (uint8_t *)&ctrl1_ois, 1);
 
   switch (ctrl1_ois.sim_ois)
   {
@@ -3651,7 +3759,8 @@ int32_t lsm6dsr_aux_gy_lp1_bandwidth_set(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl2_ois_t ctrl2_ois;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL2_OIS, (uint8_t *)&ctrl2_ois, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL2_OIS,
+                         (uint8_t *)&ctrl2_ois, 1);
 
   if (ret == 0)
   {
@@ -3677,7 +3786,8 @@ int32_t lsm6dsr_aux_gy_lp1_bandwidth_get(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl2_ois_t ctrl2_ois;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL2_OIS, (uint8_t *)&ctrl2_ois, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL2_OIS,
+                         (uint8_t *)&ctrl2_ois, 1);
 
   switch (ctrl2_ois.ftype_ois)
   {
@@ -3719,7 +3829,8 @@ int32_t lsm6dsr_aux_gy_hp_bandwidth_set(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl2_ois_t ctrl2_ois;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL2_OIS, (uint8_t *)&ctrl2_ois, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL2_OIS,
+                         (uint8_t *)&ctrl2_ois, 1);
 
   if (ret == 0)
   {
@@ -3746,7 +3857,8 @@ int32_t lsm6dsr_aux_gy_hp_bandwidth_get(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl2_ois_t ctrl2_ois;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL2_OIS, (uint8_t *)&ctrl2_ois, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL2_OIS,
+                         (uint8_t *)&ctrl2_ois, 1);
 
   switch ((ctrl2_ois.hp_en_ois << 4) + ctrl2_ois.hpm_ois)
   {
@@ -3794,7 +3906,8 @@ int32_t lsm6dsr_aux_gy_clamp_set(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl3_ois_t ctrl3_ois;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_OIS, (uint8_t *)&ctrl3_ois, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_OIS,
+                         (uint8_t *)&ctrl3_ois, 1);
 
   if (ret == 0)
   {
@@ -3822,7 +3935,8 @@ int32_t lsm6dsr_aux_gy_clamp_get(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl3_ois_t ctrl3_ois;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_OIS, (uint8_t *)&ctrl3_ois, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_OIS,
+                         (uint8_t *)&ctrl3_ois, 1);
 
   switch (ctrl3_ois.st_ois_clampdis)
   {
@@ -3856,7 +3970,8 @@ int32_t lsm6dsr_aux_gy_self_test_set(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl3_ois_t ctrl3_ois;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_OIS, (uint8_t *)&ctrl3_ois, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_OIS,
+                         (uint8_t *)&ctrl3_ois, 1);
 
   if (ret == 0)
   {
@@ -3882,7 +3997,8 @@ int32_t lsm6dsr_aux_gy_self_test_get(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl3_ois_t ctrl3_ois;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_OIS, (uint8_t *)&ctrl3_ois, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_OIS,
+                         (uint8_t *)&ctrl3_ois, 1);
 
   switch (ctrl3_ois.st_ois)
   {
@@ -3920,7 +4036,8 @@ int32_t lsm6dsr_aux_xl_bandwidth_set(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl3_ois_t ctrl3_ois;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_OIS, (uint8_t *)&ctrl3_ois, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_OIS,
+                         (uint8_t *)&ctrl3_ois, 1);
 
   if (ret == 0)
   {
@@ -3946,7 +4063,8 @@ int32_t lsm6dsr_aux_xl_bandwidth_get(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl3_ois_t ctrl3_ois;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_OIS, (uint8_t *)&ctrl3_ois, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_OIS,
+                         (uint8_t *)&ctrl3_ois, 1);
 
   switch (ctrl3_ois.filter_xl_conf_ois)
   {
@@ -4004,7 +4122,8 @@ int32_t lsm6dsr_aux_xl_full_scale_set(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl3_ois_t ctrl3_ois;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_OIS, (uint8_t *)&ctrl3_ois, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_OIS,
+                         (uint8_t *)&ctrl3_ois, 1);
 
   if (ret == 0)
   {
@@ -4030,7 +4149,8 @@ int32_t lsm6dsr_aux_xl_full_scale_get(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl3_ois_t ctrl3_ois;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_OIS, (uint8_t *)&ctrl3_ois, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_OIS,
+                         (uint8_t *)&ctrl3_ois, 1);
 
   switch (ctrl3_ois.fs_xl_ois)
   {
@@ -4085,12 +4205,14 @@ int32_t lsm6dsr_sdo_sa0_mode_set(const stmdev_ctx_t *ctx,
   lsm6dsr_pin_ctrl_t pin_ctrl;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_PIN_CTRL,
+                         (uint8_t *)&pin_ctrl, 1);
 
   if (ret == 0)
   {
     pin_ctrl.sdo_pu_en = (uint8_t)val;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PIN_CTRL,
+                            (uint8_t *)&pin_ctrl, 1);
   }
 
   return ret;
@@ -4110,7 +4232,8 @@ int32_t lsm6dsr_sdo_sa0_mode_get(const stmdev_ctx_t *ctx,
   lsm6dsr_pin_ctrl_t pin_ctrl;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_PIN_CTRL,
+                         (uint8_t *)&pin_ctrl, 1);
 
   switch (pin_ctrl.sdo_pu_en)
   {
@@ -4200,17 +4323,20 @@ int32_t lsm6dsr_int1_mode_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_spi_mode_set(const stmdev_ctx_t *ctx, lsm6dsr_sim_t val)
+int32_t lsm6dsr_spi_mode_set(const stmdev_ctx_t *ctx,
+                             lsm6dsr_sim_t val)
 {
   lsm6dsr_ctrl3_c_t ctrl3_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C,
+                         (uint8_t *)&ctrl3_c, 1);
 
   if (ret == 0)
   {
     ctrl3_c.sim = (uint8_t)val;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL3_C,
+                            (uint8_t *)&ctrl3_c, 1);
   }
 
   return ret;
@@ -4224,12 +4350,14 @@ int32_t lsm6dsr_spi_mode_set(const stmdev_ctx_t *ctx, lsm6dsr_sim_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_spi_mode_get(const stmdev_ctx_t *ctx, lsm6dsr_sim_t *val)
+int32_t lsm6dsr_spi_mode_get(const stmdev_ctx_t *ctx,
+                             lsm6dsr_sim_t *val)
 {
   lsm6dsr_ctrl3_c_t ctrl3_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C,
+                         (uint8_t *)&ctrl3_c, 1);
 
   switch (ctrl3_c.sim)
   {
@@ -4263,12 +4391,14 @@ int32_t lsm6dsr_i2c_interface_set(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl4_c_t ctrl4_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C,
+                         (uint8_t *)&ctrl4_c, 1);
 
   if (ret == 0)
   {
     ctrl4_c.i2c_disable = (uint8_t)val;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL4_C,
+                            (uint8_t *)&ctrl4_c, 1);
   }
 
   return ret;
@@ -4288,7 +4418,8 @@ int32_t lsm6dsr_i2c_interface_get(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl4_c_t ctrl4_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C,
+                         (uint8_t *)&ctrl4_c, 1);
 
   switch (ctrl4_c.i2c_disable)
   {
@@ -4479,7 +4610,6 @@ int32_t lsm6dsr_pin_int1_route_set(const stmdev_ctx_t *ctx,
     {
       val->md1_cfg.int1_emb_func = PROPERTY_ENABLE;
     }
-
     else
     {
       val->md1_cfg.int1_emb_func = PROPERTY_DISABLE;
@@ -4497,7 +4627,8 @@ int32_t lsm6dsr_pin_int1_route_set(const stmdev_ctx_t *ctx,
 
   if (ret == 0)
   {
-    ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG2,
+                           (uint8_t *)&tap_cfg2, 1);
 
     if ((val->int1_ctrl.den_drdy_flag |
          val->int1_ctrl.int1_boot |
@@ -4507,6 +4638,7 @@ int32_t lsm6dsr_pin_int1_route_set(const stmdev_ctx_t *ctx,
          val->int1_ctrl.int1_fifo_full |
          val->int1_ctrl.int1_fifo_ovr |
          val->int1_ctrl.int1_fifo_th |
+         val->md1_cfg.int1_shub |
          val->md1_cfg.int1_6d |
          val->md1_cfg.int1_double_tap |
          val->md1_cfg.int1_ff |
@@ -4651,7 +4783,6 @@ int32_t lsm6dsr_pin_int2_route_set(const stmdev_ctx_t *ctx,
     {
       val->md2_cfg.int2_emb_func = PROPERTY_ENABLE;
     }
-
     else
     {
       val->md2_cfg.int2_emb_func = PROPERTY_DISABLE;
@@ -4766,17 +4897,20 @@ int32_t lsm6dsr_pin_int2_route_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_pin_mode_set(const stmdev_ctx_t *ctx, lsm6dsr_pp_od_t val)
+int32_t lsm6dsr_pin_mode_set(const stmdev_ctx_t *ctx,
+                             lsm6dsr_pp_od_t val)
 {
   lsm6dsr_ctrl3_c_t ctrl3_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C,
+                         (uint8_t *)&ctrl3_c, 1);
 
   if (ret == 0)
   {
     ctrl3_c.pp_od = (uint8_t)val;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL3_C,
+                            (uint8_t *)&ctrl3_c, 1);
   }
 
   return ret;
@@ -4790,12 +4924,14 @@ int32_t lsm6dsr_pin_mode_set(const stmdev_ctx_t *ctx, lsm6dsr_pp_od_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_pin_mode_get(const stmdev_ctx_t *ctx, lsm6dsr_pp_od_t *val)
+int32_t lsm6dsr_pin_mode_get(const stmdev_ctx_t *ctx,
+                             lsm6dsr_pp_od_t *val)
 {
   lsm6dsr_ctrl3_c_t ctrl3_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C,
+                         (uint8_t *)&ctrl3_c, 1);
 
   switch (ctrl3_c.pp_od)
   {
@@ -4829,12 +4965,14 @@ int32_t lsm6dsr_pin_polarity_set(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl3_c_t ctrl3_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C,
+                         (uint8_t *)&ctrl3_c, 1);
 
   if (ret == 0)
   {
     ctrl3_c.h_lactive = (uint8_t)val;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL3_C,
+                            (uint8_t *)&ctrl3_c, 1);
   }
 
   return ret;
@@ -4854,7 +4992,8 @@ int32_t lsm6dsr_pin_polarity_get(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl3_c_t ctrl3_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C,
+                         (uint8_t *)&ctrl3_c, 1);
 
   switch (ctrl3_c.h_lactive)
   {
@@ -4887,12 +5026,14 @@ int32_t lsm6dsr_all_on_int1_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsr_ctrl4_c_t ctrl4_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C,
+                         (uint8_t *)&ctrl4_c, 1);
 
   if (ret == 0)
   {
     ctrl4_c.int2_on_int1 = (uint8_t)val;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL4_C,
+                            (uint8_t *)&ctrl4_c, 1);
   }
 
   return ret;
@@ -4911,7 +5052,8 @@ int32_t lsm6dsr_all_on_int1_get(const stmdev_ctx_t *ctx, uint8_t *val)
   lsm6dsr_ctrl4_c_t ctrl4_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C,
+                         (uint8_t *)&ctrl4_c, 1);
   *val = ctrl4_c.int2_on_int1;
 
   return ret;
@@ -4932,7 +5074,8 @@ int32_t lsm6dsr_int_notification_set(const stmdev_ctx_t *ctx,
   lsm6dsr_page_rw_t page_rw;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0,
+                         (uint8_t *)&tap_cfg0, 1);
 
   if (ret == 0)
   {
@@ -4949,13 +5092,15 @@ int32_t lsm6dsr_int_notification_set(const stmdev_ctx_t *ctx,
 
   if (ret == 0)
   {
-    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_RW,
+                           (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
   {
     page_rw.emb_func_lir = ((uint8_t)val & 0x02U) >> 1;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_RW,
+                            (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
@@ -4982,7 +5127,8 @@ int32_t lsm6dsr_int_notification_get(const stmdev_ctx_t *ctx,
   int32_t ret;
 
   *val = LSM6DSR_ALL_INT_PULSED;
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0,
+                         (uint8_t *)&tap_cfg0, 1);
 
   if (ret == 0)
   {
@@ -4991,7 +5137,8 @@ int32_t lsm6dsr_int_notification_get(const stmdev_ctx_t *ctx,
 
   if (ret == 0)
   {
-    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_RW,
+                           (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
@@ -5272,12 +5419,14 @@ int32_t lsm6dsr_gy_sleep_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsr_ctrl4_c_t ctrl4_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C,
+                         (uint8_t *)&ctrl4_c, 1);
 
   if (ret == 0)
   {
     ctrl4_c.sleep_g = (uint8_t)val;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL4_C,
+                            (uint8_t *)&ctrl4_c, 1);
   }
 
   return ret;
@@ -5296,7 +5445,8 @@ int32_t lsm6dsr_gy_sleep_mode_get(const stmdev_ctx_t *ctx, uint8_t *val)
   lsm6dsr_ctrl4_c_t ctrl4_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C,
+                         (uint8_t *)&ctrl4_c, 1);
   *val = ctrl4_c.sleep_g;
 
   return ret;
@@ -5318,7 +5468,8 @@ int32_t lsm6dsr_act_pin_notification_set(const stmdev_ctx_t *ctx,
   lsm6dsr_tap_cfg0_t tap_cfg0;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0,
+                         (uint8_t *)&tap_cfg0, 1);
 
   if (ret == 0)
   {
@@ -5346,7 +5497,8 @@ int32_t lsm6dsr_act_pin_notification_get(const stmdev_ctx_t *ctx,
   lsm6dsr_tap_cfg0_t tap_cfg0;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0,
+                         (uint8_t *)&tap_cfg0, 1);
 
   switch (tap_cfg0. sleep_status_on_int)
   {
@@ -5380,12 +5532,14 @@ int32_t lsm6dsr_act_mode_set(const stmdev_ctx_t *ctx,
   lsm6dsr_tap_cfg2_t tap_cfg2;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG2,
+                         (uint8_t *)&tap_cfg2, 1);
 
   if (ret == 0)
   {
     tap_cfg2.inact_en = (uint8_t)val;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_TAP_CFG2,
+                            (uint8_t *)&tap_cfg2, 1);
   }
 
   return ret;
@@ -5405,7 +5559,8 @@ int32_t lsm6dsr_act_mode_get(const stmdev_ctx_t *ctx,
   lsm6dsr_tap_cfg2_t tap_cfg2;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG2,
+                         (uint8_t *)&tap_cfg2, 1);
 
   switch (tap_cfg2.inact_en)
   {
@@ -5500,12 +5655,14 @@ int32_t lsm6dsr_act_sleep_dur_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_tap_detection_on_z_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsr_tap_detection_on_z_set(const stmdev_ctx_t *ctx,
+                                       uint8_t val)
 {
   lsm6dsr_tap_cfg0_t tap_cfg0;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0,
+                         (uint8_t *)&tap_cfg0, 1);
 
   if (ret == 0)
   {
@@ -5531,7 +5688,8 @@ int32_t lsm6dsr_tap_detection_on_z_get(const stmdev_ctx_t *ctx,
   lsm6dsr_tap_cfg0_t tap_cfg0;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0,
+                         (uint8_t *)&tap_cfg0, 1);
   *val = tap_cfg0.tap_z_en;
 
   return ret;
@@ -5545,12 +5703,14 @@ int32_t lsm6dsr_tap_detection_on_z_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_tap_detection_on_y_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsr_tap_detection_on_y_set(const stmdev_ctx_t *ctx,
+                                       uint8_t val)
 {
   lsm6dsr_tap_cfg0_t tap_cfg0;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0,
+                         (uint8_t *)&tap_cfg0, 1);
 
   if (ret == 0)
   {
@@ -5576,7 +5736,8 @@ int32_t lsm6dsr_tap_detection_on_y_get(const stmdev_ctx_t *ctx,
   lsm6dsr_tap_cfg0_t tap_cfg0;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0,
+                         (uint8_t *)&tap_cfg0, 1);
   *val = tap_cfg0.tap_y_en;
 
   return ret;
@@ -5590,12 +5751,14 @@ int32_t lsm6dsr_tap_detection_on_y_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_tap_detection_on_x_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsr_tap_detection_on_x_set(const stmdev_ctx_t *ctx,
+                                       uint8_t val)
 {
   lsm6dsr_tap_cfg0_t tap_cfg0;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0,
+                         (uint8_t *)&tap_cfg0, 1);
 
   if (ret == 0)
   {
@@ -5621,7 +5784,8 @@ int32_t lsm6dsr_tap_detection_on_x_get(const stmdev_ctx_t *ctx,
   lsm6dsr_tap_cfg0_t tap_cfg0;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0,
+                         (uint8_t *)&tap_cfg0, 1);
   *val = tap_cfg0.tap_x_en;
 
   return ret;
@@ -5640,7 +5804,8 @@ int32_t lsm6dsr_tap_threshold_x_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsr_tap_cfg1_t tap_cfg1;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG1,
+                         (uint8_t *)&tap_cfg1, 1);
 
   if (ret == 0)
   {
@@ -5660,12 +5825,14 @@ int32_t lsm6dsr_tap_threshold_x_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_tap_threshold_x_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsr_tap_threshold_x_get(const stmdev_ctx_t *ctx,
+                                    uint8_t *val)
 {
   lsm6dsr_tap_cfg1_t tap_cfg1;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG1,
+                         (uint8_t *)&tap_cfg1, 1);
   *val = tap_cfg1.tap_ths_x;
 
   return ret;
@@ -5685,12 +5852,14 @@ int32_t lsm6dsr_tap_axis_priority_set(const stmdev_ctx_t *ctx,
   lsm6dsr_tap_cfg1_t tap_cfg1;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG1,
+                         (uint8_t *)&tap_cfg1, 1);
 
   if (ret == 0)
   {
     tap_cfg1.tap_priority = (uint8_t)val;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_TAP_CFG1,
+                            (uint8_t *)&tap_cfg1, 1);
   }
 
   return ret;
@@ -5710,7 +5879,8 @@ int32_t lsm6dsr_tap_axis_priority_get(const stmdev_ctx_t *ctx,
   lsm6dsr_tap_cfg1_t tap_cfg1;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG1,
+                         (uint8_t *)&tap_cfg1, 1);
 
   switch (tap_cfg1.tap_priority)
   {
@@ -5759,7 +5929,8 @@ int32_t lsm6dsr_tap_threshold_y_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsr_tap_cfg2_t tap_cfg2;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG2,
+                         (uint8_t *)&tap_cfg2, 1);
 
   if (ret == 0)
   {
@@ -5779,12 +5950,14 @@ int32_t lsm6dsr_tap_threshold_y_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_tap_threshold_y_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsr_tap_threshold_y_get(const stmdev_ctx_t *ctx,
+                                    uint8_t *val)
 {
   lsm6dsr_tap_cfg2_t tap_cfg2;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG2,
+                         (uint8_t *)&tap_cfg2, 1);
   *val = tap_cfg2.tap_ths_y;
 
   return ret;
@@ -5824,7 +5997,8 @@ int32_t lsm6dsr_tap_threshold_z_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_tap_threshold_z_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsr_tap_threshold_z_get(const stmdev_ctx_t *ctx,
+                                    uint8_t *val)
 {
   lsm6dsr_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -5853,7 +6027,8 @@ int32_t lsm6dsr_tap_shock_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsr_int_dur2_t int_dur2;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_DUR2, (uint8_t *)&int_dur2, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_DUR2,
+                         (uint8_t *)&int_dur2, 1);
 
   if (ret == 0)
   {
@@ -5882,7 +6057,8 @@ int32_t lsm6dsr_tap_shock_get(const stmdev_ctx_t *ctx, uint8_t *val)
   lsm6dsr_int_dur2_t int_dur2;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_DUR2, (uint8_t *)&int_dur2, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_DUR2,
+                         (uint8_t *)&int_dur2, 1);
   *val = int_dur2.shock;
 
   return ret;
@@ -5905,7 +6081,8 @@ int32_t lsm6dsr_tap_quiet_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsr_int_dur2_t int_dur2;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_DUR2, (uint8_t *)&int_dur2, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_DUR2,
+                         (uint8_t *)&int_dur2, 1);
 
   if (ret == 0)
   {
@@ -5934,7 +6111,8 @@ int32_t lsm6dsr_tap_quiet_get(const stmdev_ctx_t *ctx, uint8_t *val)
   lsm6dsr_int_dur2_t int_dur2;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_DUR2, (uint8_t *)&int_dur2, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_DUR2,
+                         (uint8_t *)&int_dur2, 1);
   *val = int_dur2.quiet;
 
   return ret;
@@ -5959,7 +6137,8 @@ int32_t lsm6dsr_tap_dur_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsr_int_dur2_t int_dur2;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_DUR2, (uint8_t *)&int_dur2, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_DUR2,
+                         (uint8_t *)&int_dur2, 1);
 
   if (ret == 0)
   {
@@ -5988,7 +6167,8 @@ int32_t lsm6dsr_tap_dur_get(const stmdev_ctx_t *ctx, uint8_t *val)
   lsm6dsr_int_dur2_t int_dur2;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_DUR2, (uint8_t *)&int_dur2, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_DUR2,
+                         (uint8_t *)&int_dur2, 1);
   *val = int_dur2.dur;
 
   return ret;
@@ -6212,7 +6392,8 @@ int32_t lsm6dsr_ff_threshold_set(const stmdev_ctx_t *ctx,
   lsm6dsr_free_fall_t free_fall;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FREE_FALL, (uint8_t *)&free_fall, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FREE_FALL,
+                         (uint8_t *)&free_fall, 1);
 
   if (ret == 0)
   {
@@ -6238,7 +6419,8 @@ int32_t lsm6dsr_ff_threshold_get(const stmdev_ctx_t *ctx,
   lsm6dsr_free_fall_t free_fall;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FREE_FALL, (uint8_t *)&free_fall, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FREE_FALL,
+                         (uint8_t *)&free_fall, 1);
 
   switch (free_fall.ff_ths)
   {
@@ -6377,21 +6559,16 @@ int32_t lsm6dsr_fifo_watermark_set(const stmdev_ctx_t *ctx, uint16_t val)
   lsm6dsr_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_CTRL2,
-                         (uint8_t *)&fifo_ctrl2, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
+  ret += lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
 
   if (ret == 0)
   {
-    fifo_ctrl1.wtm = (uint8_t)(0x00FFU & val);
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_FIFO_CTRL1,
-                            (uint8_t *)&fifo_ctrl1, 1);
-  }
+    fifo_ctrl1.wtm = (uint8_t)(val  & 0xFFU);
+    fifo_ctrl2.wtm = (uint8_t)(val / 256U) & 0x01U;
 
-  if (ret == 0)
-  {
-    fifo_ctrl2.wtm = (uint8_t)((0x0100U & val) >> 8);
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_FIFO_CTRL2,
-                            (uint8_t *)&fifo_ctrl2, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
+    ret += lsm6dsr_write_reg(ctx, LSM6DSR_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
   }
 
   return ret;
@@ -6405,24 +6582,18 @@ int32_t lsm6dsr_fifo_watermark_set(const stmdev_ctx_t *ctx, uint16_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_fifo_watermark_get(const stmdev_ctx_t *ctx, uint16_t *val)
+int32_t lsm6dsr_fifo_watermark_get(const stmdev_ctx_t *ctx,
+                                   uint16_t *val)
 {
   lsm6dsr_fifo_ctrl1_t fifo_ctrl1;
   lsm6dsr_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_CTRL2,
-                         (uint8_t *)&fifo_ctrl2, 1);
-
-  if (ret == 0)
-  {
-    ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_CTRL1,
-                           (uint8_t *)&fifo_ctrl1, 1);
-  }
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
+  ret += lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
 
   *val = fifo_ctrl2.wtm;
-  *val = *val << 8;
-  *val += fifo_ctrl1.wtm;
+  *val = (*val * 256U) +  fifo_ctrl1.wtm;;
 
   return ret;
 }
@@ -6705,7 +6876,8 @@ int32_t lsm6dsr_compression_algo_real_time_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_fifo_stop_on_wtm_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsr_fifo_stop_on_wtm_set(const stmdev_ctx_t *ctx,
+                                     uint8_t val)
 {
   lsm6dsr_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
@@ -6732,7 +6904,8 @@ int32_t lsm6dsr_fifo_stop_on_wtm_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_fifo_stop_on_wtm_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsr_fifo_stop_on_wtm_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val)
 {
   lsm6dsr_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
@@ -7245,14 +7418,15 @@ int32_t lsm6dsr_fifo_cnt_event_batch_get(const stmdev_ctx_t *ctx,
 
 /**
   * @brief  Resets the internal counter of batching events for a single sensor.
-  *         This bit is automatically reset to zero if it was set to ‘1’.[set]
+  *         This bit is automatically reset to zero if it was set to '1'.[set]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
   * @param  val    Change the values of rst_counter_bdr in reg COUNTER_BDR_REG1
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_rst_batch_counter_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsr_rst_batch_counter_set(const stmdev_ctx_t *ctx,
+                                      uint8_t val)
 {
   lsm6dsr_counter_bdr_reg1_t counter_bdr_reg1;
   int32_t ret;
@@ -7272,14 +7446,15 @@ int32_t lsm6dsr_rst_batch_counter_set(const stmdev_ctx_t *ctx, uint8_t val)
 
 /**
   * @brief  Resets the internal counter of batching events for a single sensor.
-  *         This bit is automatically reset to zero if it was set to ‘1’.[get]
+  *         This bit is automatically reset to zero if it was set to '1'.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
   * @param  val    Change the values of rst_counter_bdr in reg COUNTER_BDR_REG1
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_rst_batch_counter_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsr_rst_batch_counter_get(const stmdev_ctx_t *ctx,
+                                      uint8_t *val)
 {
   lsm6dsr_counter_bdr_reg1_t counter_bdr_reg1;
   int32_t ret;
@@ -7312,14 +7487,15 @@ int32_t lsm6dsr_batch_counter_threshold_set(const stmdev_ctx_t *ctx,
 
   if (ret == 0)
   {
-    counter_bdr_reg1.cnt_bdr_th = (uint8_t)((0x0700U & val) >> 8);
+    counter_bdr_reg1.cnt_bdr_th = (uint8_t)((val / 256U) & 0x07U);
     ret = lsm6dsr_write_reg(ctx, LSM6DSR_COUNTER_BDR_REG1,
                             (uint8_t *)&counter_bdr_reg1, 1);
   }
 
   if (ret == 0)
   {
-    counter_bdr_reg2.cnt_bdr_th = (uint8_t)(0x00FFU & val);
+    counter_bdr_reg2.cnt_bdr_th = (uint8_t)(val -
+                                            (counter_bdr_reg1.cnt_bdr_th * 256U));
     ret = lsm6dsr_write_reg(ctx, LSM6DSR_COUNTER_BDR_REG2,
                             (uint8_t *)&counter_bdr_reg2, 1);
   }
@@ -7353,8 +7529,7 @@ int32_t lsm6dsr_batch_counter_threshold_get(const stmdev_ctx_t *ctx,
   }
 
   *val = counter_bdr_reg1.cnt_bdr_th;
-  *val = *val << 8;
-  *val += counter_bdr_reg2.cnt_bdr_th;
+  *val = (*val * 256U) +  counter_bdr_reg2.cnt_bdr_th;
 
   return ret;
 }
@@ -7363,26 +7538,24 @@ int32_t lsm6dsr_batch_counter_threshold_get(const stmdev_ctx_t *ctx,
   * @brief  Number of unread sensor data (TAG + 6 bytes) stored in FIFO.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of diff_fifo in reg FIFO_STATUS1
+  * @param  val    Read the value of diff_fifo in reg FIFO_STATUS1 and FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_fifo_data_level_get(const stmdev_ctx_t *ctx, uint16_t *val)
+int32_t lsm6dsr_fifo_data_level_get(const stmdev_ctx_t *ctx,
+                                    uint16_t *val)
 {
-  lsm6dsr_fifo_status1_t fifo_status1;
-  lsm6dsr_fifo_status2_t fifo_status2;
+  uint8_t reg[2];
+  lsm6dsr_fifo_status1_t *fifo_status1 = (lsm6dsr_fifo_status1_t *)&reg[0];
+  lsm6dsr_fifo_status2_t *fifo_status2 = (lsm6dsr_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_STATUS1,
-                         (uint8_t *)&fifo_status1, 1);
-
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_STATUS1, (uint8_t *)reg, 2);
   if (ret == 0)
   {
-    ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_STATUS2,
-                           (uint8_t *)&fifo_status2, 1);
-    *val = fifo_status2.diff_fifo;
-    *val = *val << 8;
-    *val += fifo_status1.diff_fifo;
+    *val = fifo_status2->diff_fifo;
+    *val = (*val * 256U) + fifo_status1->diff_fifo;
   }
 
   return ret;
@@ -7392,16 +7565,23 @@ int32_t lsm6dsr_fifo_data_level_get(const stmdev_ctx_t *ctx, uint16_t *val)
   * @brief  Smart FIFO status.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Registers FIFO_STATUS2
+  * @param  val    Read registers FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dsr_fifo_status_get(const stmdev_ctx_t *ctx,
                                 lsm6dsr_fifo_status2_t *val)
 {
+  uint8_t reg[2];
+  lsm6dsr_fifo_status2_t *fifo_status2 = (lsm6dsr_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_STATUS2, (uint8_t *)val, 1);
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = *fifo_status2;
+  }
 
   return ret;
 }
@@ -7410,18 +7590,22 @@ int32_t lsm6dsr_fifo_status_get(const stmdev_ctx_t *ctx,
   * @brief  Smart FIFO full status.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of fifo_full_ia in reg FIFO_STATUS2
+  * @param  val    Read the values of fifo_full_ia in reg FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dsr_fifo_full_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm6dsr_fifo_status2_t fifo_status2;
+  uint8_t reg[2];
+  lsm6dsr_fifo_status2_t *fifo_status2 = (lsm6dsr_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_STATUS2,
-                         (uint8_t *)&fifo_status2, 1);
-  *val = fifo_status2.fifo_full_ia;
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_full_ia;
+  }
 
   return ret;
 }
@@ -7430,19 +7614,23 @@ int32_t lsm6dsr_fifo_full_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @brief  FIFO overrun status.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of  fifo_over_run_latched in
+  * @param  val    Read the values of  fifo_over_run_latched in
   *                reg FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dsr_fifo_ovr_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm6dsr_fifo_status2_t fifo_status2;
+  uint8_t reg[2];
+  lsm6dsr_fifo_status2_t *fifo_status2 = (lsm6dsr_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_STATUS2,
-                         (uint8_t *)&fifo_status2, 1);
-  *val = fifo_status2. fifo_ovr_ia;
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_ovr_ia;
+  }
 
   return ret;
 }
@@ -7451,18 +7639,22 @@ int32_t lsm6dsr_fifo_ovr_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @brief  FIFO watermark status.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of fifo_wtm_ia in reg FIFO_STATUS2
+  * @param  val    Read the values of fifo_wtm_ia in reg FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dsr_fifo_wtm_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm6dsr_fifo_status2_t fifo_status2;
+  uint8_t reg[2];
+  lsm6dsr_fifo_status2_t *fifo_status2 = (lsm6dsr_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_STATUS2,
-                         (uint8_t *)&fifo_status2, 1);
-  *val = fifo_status2.fifo_wtm_ia;
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_wtm_ia;
+  }
 
   return ret;
 }
@@ -7628,7 +7820,8 @@ int32_t lsm6dsr_fifo_pedo_batch_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_fifo_pedo_batch_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsr_fifo_pedo_batch_get(const stmdev_ctx_t *ctx,
+                                    uint8_t *val)
 {
   lsm6dsr_emb_func_fifo_cfg_t emb_func_fifo_cfg;
   int32_t ret;
@@ -7658,7 +7851,8 @@ int32_t lsm6dsr_fifo_pedo_batch_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_sh_batch_slave_0_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsr_sh_batch_slave_0_set(const stmdev_ctx_t *ctx,
+                                     uint8_t val)
 {
   lsm6dsr_slv0_config_t slv0_config;
   int32_t ret;
@@ -7695,7 +7889,8 @@ int32_t lsm6dsr_sh_batch_slave_0_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_sh_batch_slave_0_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsr_sh_batch_slave_0_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val)
 {
   lsm6dsr_slv0_config_t slv0_config;
   int32_t ret;
@@ -7726,7 +7921,8 @@ int32_t lsm6dsr_sh_batch_slave_0_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_sh_batch_slave_1_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsr_sh_batch_slave_1_set(const stmdev_ctx_t *ctx,
+                                     uint8_t val)
 {
   lsm6dsr_slv1_config_t slv1_config;
   int32_t ret;
@@ -7763,7 +7959,8 @@ int32_t lsm6dsr_sh_batch_slave_1_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_sh_batch_slave_1_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsr_sh_batch_slave_1_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val)
 {
   lsm6dsr_slv1_config_t slv1_config;
   int32_t ret;
@@ -7794,7 +7991,8 @@ int32_t lsm6dsr_sh_batch_slave_1_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_sh_batch_slave_2_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsr_sh_batch_slave_2_set(const stmdev_ctx_t *ctx,
+                                     uint8_t val)
 {
   lsm6dsr_slv2_config_t slv2_config;
   int32_t ret;
@@ -7831,7 +8029,8 @@ int32_t lsm6dsr_sh_batch_slave_2_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_sh_batch_slave_2_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsr_sh_batch_slave_2_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val)
 {
   lsm6dsr_slv2_config_t slv2_config;
   int32_t ret;
@@ -7862,7 +8061,8 @@ int32_t lsm6dsr_sh_batch_slave_2_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_sh_batch_slave_3_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsr_sh_batch_slave_3_set(const stmdev_ctx_t *ctx,
+                                     uint8_t val)
 {
   lsm6dsr_slv3_config_t slv3_config;
   int32_t ret;
@@ -7899,7 +8099,8 @@ int32_t lsm6dsr_sh_batch_slave_3_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_sh_batch_slave_3_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsr_sh_batch_slave_3_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val)
 {
   lsm6dsr_slv3_config_t slv3_config;
   int32_t ret;
@@ -7948,12 +8149,14 @@ int32_t lsm6dsr_den_mode_set(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl6_c_t ctrl6_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL6_C,
+                         (uint8_t *)&ctrl6_c, 1);
 
   if (ret == 0)
   {
     ctrl6_c.den_mode = (uint8_t)val;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL6_C,
+                            (uint8_t *)&ctrl6_c, 1);
   }
 
   return ret;
@@ -7973,7 +8176,8 @@ int32_t lsm6dsr_den_mode_get(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl6_c_t ctrl6_c;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL6_C,
+                         (uint8_t *)&ctrl6_c, 1);
 
   switch (ctrl6_c.den_mode)
   {
@@ -8019,7 +8223,8 @@ int32_t lsm6dsr_den_polarity_set(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL,
+                         (uint8_t *)&ctrl9_xl, 1);
 
   if (ret == 0)
   {
@@ -8045,7 +8250,8 @@ int32_t lsm6dsr_den_polarity_get(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL,
+                         (uint8_t *)&ctrl9_xl, 1);
 
   switch (ctrl9_xl.den_lh)
   {
@@ -8079,7 +8285,8 @@ int32_t lsm6dsr_den_enable_set(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL,
+                         (uint8_t *)&ctrl9_xl, 1);
 
   if (ret == 0)
   {
@@ -8105,7 +8312,8 @@ int32_t lsm6dsr_den_enable_get(const stmdev_ctx_t *ctx,
   lsm6dsr_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL,
+                         (uint8_t *)&ctrl9_xl, 1);
 
   switch (ctrl9_xl.den_xl_g)
   {
@@ -8142,7 +8350,8 @@ int32_t lsm6dsr_den_mark_axis_x_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsr_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL,
+                         (uint8_t *)&ctrl9_xl, 1);
 
   if (ret == 0)
   {
@@ -8162,12 +8371,14 @@ int32_t lsm6dsr_den_mark_axis_x_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_den_mark_axis_x_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsr_den_mark_axis_x_get(const stmdev_ctx_t *ctx,
+                                    uint8_t *val)
 {
   lsm6dsr_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL,
+                         (uint8_t *)&ctrl9_xl, 1);
   *val = ctrl9_xl.den_z;
 
   return ret;
@@ -8186,7 +8397,8 @@ int32_t lsm6dsr_den_mark_axis_y_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsr_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL,
+                         (uint8_t *)&ctrl9_xl, 1);
 
   if (ret == 0)
   {
@@ -8206,12 +8418,14 @@ int32_t lsm6dsr_den_mark_axis_y_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_den_mark_axis_y_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsr_den_mark_axis_y_get(const stmdev_ctx_t *ctx,
+                                    uint8_t *val)
 {
   lsm6dsr_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL,
+                         (uint8_t *)&ctrl9_xl, 1);
   *val = ctrl9_xl.den_y;
 
   return ret;
@@ -8230,12 +8444,14 @@ int32_t lsm6dsr_den_mark_axis_z_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsr_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL,
+                         (uint8_t *)&ctrl9_xl, 1);
 
   if (ret == 0)
   {
     ctrl9_xl.den_x = (uint8_t)val;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL9_XL,
+                            (uint8_t *)&ctrl9_xl, 1);
   }
 
   return ret;
@@ -8249,12 +8465,14 @@ int32_t lsm6dsr_den_mark_axis_z_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_den_mark_axis_z_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsr_den_mark_axis_z_get(const stmdev_ctx_t *ctx,
+                                    uint8_t *val)
 {
   lsm6dsr_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL,
+                         (uint8_t *)&ctrl9_xl, 1);
   *val = ctrl9_xl.den_x;
 
   return ret;
@@ -8456,7 +8674,8 @@ int32_t lsm6dsr_pedo_mode_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_pedo_step_detect_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsr_pedo_step_detect_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val)
 {
   lsm6dsr_emb_func_status_t emb_func_status;
   int32_t ret;
@@ -8510,7 +8729,8 @@ int32_t lsm6dsr_pedo_debounce_steps_get(const stmdev_ctx_t *ctx,
 {
   int32_t ret;
 
-  ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_PEDO_DEB_STEPS_CONF, buff);
+  ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_PEDO_DEB_STEPS_CONF,
+                                buff);
 
   return ret;
 }
@@ -8523,7 +8743,8 @@ int32_t lsm6dsr_pedo_debounce_steps_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_pedo_steps_period_set(const stmdev_ctx_t *ctx, uint16_t val)
+int32_t lsm6dsr_pedo_steps_period_set(const stmdev_ctx_t *ctx,
+                                      uint16_t val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -8970,7 +9191,8 @@ int32_t lsm6dsr_tilt_flag_data_ready_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_mag_sensitivity_set(const stmdev_ctx_t *ctx, uint16_t val)
+int32_t lsm6dsr_mag_sensitivity_set(const stmdev_ctx_t *ctx,
+                                    uint16_t val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -8997,7 +9219,8 @@ int32_t lsm6dsr_mag_sensitivity_set(const stmdev_ctx_t *ctx, uint16_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_mag_sensitivity_get(const stmdev_ctx_t *ctx, uint16_t *val)
+int32_t lsm6dsr_mag_sensitivity_get(const stmdev_ctx_t *ctx,
+                                    uint16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -9010,7 +9233,7 @@ int32_t lsm6dsr_mag_sensitivity_get(const stmdev_ctx_t *ctx, uint16_t *val)
     ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SENSITIVITY_H,
                                   &buff[1]);
     *val = buff[1];
-    *val = (*val * 256U) +  buff[0];
+    *val = (*val * 256U) + buff[0];
   }
 
   return ret;
@@ -9028,8 +9251,8 @@ int32_t lsm6dsr_mag_offset_set(const stmdev_ctx_t *ctx, int16_t *val)
 {
   uint8_t buff[6];
   int32_t ret;
-
   uint8_t i;
+
   buff[1] = (uint8_t)((uint16_t)val[0] / 256U);
   buff[0] = (uint8_t)((uint16_t)val[0] - (buff[1] * 256U));
   buff[3] = (uint8_t)((uint16_t)val[1] / 256U);
@@ -9084,8 +9307,8 @@ int32_t lsm6dsr_mag_offset_get(const stmdev_ctx_t *ctx, int16_t *val)
 {
   uint8_t buff[6];
   int32_t ret;
-
   uint8_t i;
+
   i = 0x00U;
   ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_OFFX_L, &buff[i]);
 
@@ -9117,6 +9340,7 @@ int32_t lsm6dsr_mag_offset_get(const stmdev_ctx_t *ctx, int16_t *val)
   {
     i++;
     ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_OFFZ_H, &buff[i]);
+
     val[0] = (int16_t)buff[1];
     val[0] = (val[0] * 256) + (int16_t)buff[0];
     val[1] = (int16_t)buff[3];
@@ -9141,91 +9365,103 @@ int32_t lsm6dsr_mag_offset_get(const stmdev_ctx_t *ctx, int16_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_mag_soft_iron_set(const stmdev_ctx_t *ctx,  int16_t *val)
+int32_t lsm6dsr_mag_soft_iron_set(const stmdev_ctx_t *ctx, uint16_t *val)
 {
   uint8_t buff[12];
   int32_t ret;
-
-  buff[1] = (uint8_t)((uint16_t)val[0] / 256U);
-  buff[0] = (uint8_t)((uint16_t)val[0] - (buff[1] * 256U));
-  buff[3] = (uint8_t)((uint16_t)val[1] / 256U);
-  buff[2] = (uint8_t)((uint16_t)val[1] - (buff[3] * 256U));
-  buff[5] = (uint8_t)((uint16_t)val[2] / 256U);
-  buff[4] = (uint8_t)((uint16_t)val[2] - (buff[5] * 256U));
-  buff[7] = (uint8_t)((uint16_t)val[3] / 256U);
-  buff[6] = (uint8_t)((uint16_t)val[3] - (buff[7] * 256U));
-  buff[9] = (uint8_t)((uint16_t)val[4] / 256U);
-  buff[8] = (uint8_t)((uint16_t)val[4] - (buff[9] * 256U));
-  buff[11] = (uint8_t)((uint16_t)val[5] / 256U);
-  buff[10] = (uint8_t)((uint16_t)val[5] - (buff[11] * 256U));
   uint8_t i;
+
+  buff[1] = (uint8_t)(val[0] / 256U);
+  buff[0] = (uint8_t)(val[0] - (buff[1] * 256U));
+  buff[3] = (uint8_t)(val[1] / 256U);
+  buff[2] = (uint8_t)(val[1] - (buff[3] * 256U));
+  buff[5] = (uint8_t)(val[2] / 256U);
+  buff[4] = (uint8_t)(val[2] - (buff[5] * 256U));
+  buff[7] = (uint8_t)(val[3] / 256U);
+  buff[6] = (uint8_t)(val[3] - (buff[1] * 256U));
+  buff[9] = (uint8_t)(val[4] / 256U);
+  buff[8] = (uint8_t)(val[4] - (buff[3] * 256U));
+  buff[11] = (uint8_t)(val[5] / 256U);
+  buff[10] = (uint8_t)(val[5] - (buff[5] * 256U));
   i = 0x00U;
-  ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_XX_L, &buff[i]);
+  ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_XX_L,
+                                 &buff[i]);
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_XX_H, &buff[i]);
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_XX_H,
+                                   &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_XY_L, &buff[i]);
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_XY_L,
+                                   &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_XY_H, &buff[i]);
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_XY_H,
+                                   &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_XZ_L, &buff[i]);
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_XZ_L,
+                                   &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_XZ_H, &buff[i]);
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_XZ_H,
+                                   &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_YY_L, &buff[i]);
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_YY_L,
+                                   &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_YY_H, &buff[i]);
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_YY_H,
+                                   &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_YZ_L, &buff[i]);
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_YZ_L,
+                                   &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_YZ_H, &buff[i]);
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_YZ_H,
+                                   &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_ZZ_L, &buff[i]);
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_ZZ_L,
+                                   &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_ZZ_H, &buff[i]);
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_ZZ_H,
+                                   &buff[i]);
   }
 
   return ret;
@@ -9244,93 +9480,105 @@ int32_t lsm6dsr_mag_soft_iron_set(const stmdev_ctx_t *ctx,  int16_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_mag_soft_iron_get(const stmdev_ctx_t *ctx,  int16_t *val)
+int32_t lsm6dsr_mag_soft_iron_get(const stmdev_ctx_t *ctx, uint16_t *val)
 {
   uint8_t buff[12];
   int32_t ret;
-
   uint8_t i;
+
   i = 0x00U;
-  ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_XX_L, &buff[i]);
+  ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_XX_L,
+                                &buff[i]);
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_XX_H, &buff[i]);
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_XX_H,
+                                  &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_XY_L, &buff[i]);
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_XY_L,
+                                  &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_XY_H, &buff[i]);
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_XY_H,
+                                  &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_XZ_L, &buff[i]);
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_XZ_L,
+                                  &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_XZ_H, &buff[i]);
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_XZ_H,
+                                  &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_YY_L, &buff[i]);
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_YY_L,
+                                  &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_YY_H, &buff[i]);
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_YY_H,
+                                  &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_YZ_L, &buff[i]);
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_YZ_L,
+                                  &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_YZ_H, &buff[i]);
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_YZ_H,
+                                  &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_ZZ_L, &buff[i]);
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_ZZ_L,
+                                  &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_ZZ_H, &buff[i]);
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_ZZ_H,
+                                  &buff[i]);
   }
 
-  val[0] = (int16_t)buff[1];
-  val[0] = (val[0] * 256) + (int16_t)buff[0];
-  val[1] = (int16_t)buff[3];
-  val[1] = (val[1] * 256) + (int16_t)buff[2];
-  val[2] = (int16_t)buff[5];
-  val[2] = (val[2] * 256) + (int16_t)buff[4];
-  val[3] = (int16_t)buff[7];
-  val[3] = (val[3] * 256) + (int16_t)buff[6];
-  val[4] = (int16_t)buff[9];
-  val[4] = (val[4] * 256) + (int16_t)buff[8];
-  val[5] = (int16_t)buff[11];
-  val[5] = (val[5] * 256) + (int16_t)buff[10];
+  val[0] = buff[1];
+  val[0] = (val[0] * 256U) +  buff[0];
+  val[1] = buff[3];
+  val[1] = (val[1] * 256U) +  buff[2];
+  val[2] = buff[5];
+  val[2] = (val[2] * 256U) +  buff[4];
+  val[3] = buff[7];
+  val[3] = (val[3] * 256U) +  buff[6];
+  val[4] = buff[9];
+  val[4] = (val[4] * 256U) +  buff[8];
+  val[5] = buff[11];
+  val[6] = (val[5] * 256U) +  buff[10];
 
   return ret;
 }
@@ -9668,8 +9916,8 @@ int32_t lsm6dsr_emb_fsm_en_set(const stmdev_ctx_t *ctx, uint8_t val)
 int32_t lsm6dsr_emb_fsm_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   int32_t ret;
-
   lsm6dsr_emb_func_en_b_t emb_func_en_b;
+
   ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -9824,7 +10072,8 @@ int32_t lsm6dsr_long_cnt_set(const stmdev_ctx_t *ctx, uint16_t val)
 
   if (ret == 0)
   {
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_FSM_LONG_COUNTER_L, buff, 2);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_FSM_LONG_COUNTER_L, buff,
+                            2);
   }
 
   if (ret == 0)
@@ -9853,14 +10102,15 @@ int32_t lsm6dsr_long_cnt_get(const stmdev_ctx_t *ctx, uint16_t *val)
 
   if (ret == 0)
   {
-    ret = lsm6dsr_read_reg(ctx, LSM6DSR_FSM_LONG_COUNTER_L, buff, 2);
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_FSM_LONG_COUNTER_L, buff,
+                           2);
+    *val = buff[1];
+    *val = (*val * 256U) +  buff[0];
   }
 
   if (ret == 0)
   {
     ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
-    *val = buff[1];
-    *val = (*val * 256U) +  buff[0];
   }
 
   return ret;
@@ -9961,7 +10211,8 @@ int32_t lsm6dsr_long_clr_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_fsm_out_get(const stmdev_ctx_t *ctx, lsm6dsr_fsm_out_t *val)
+int32_t lsm6dsr_fsm_out_get(const stmdev_ctx_t *ctx,
+                            lsm6dsr_fsm_out_t *val)
 {
   int32_t ret;
 
@@ -10218,7 +10469,8 @@ int32_t lsm6dsr_fsm_number_of_programs_set(const stmdev_ctx_t *ctx,
 
   if (ret == 0)
   {
-    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_FSM_PROGRAMS + 0x01U,
+    ret = lsm6dsr_ln_pg_write_byte(ctx,
+                                   LSM6DSR_FSM_PROGRAMS + 0x01U,
                                    buff);
   }
 
@@ -10252,7 +10504,8 @@ int32_t lsm6dsr_fsm_number_of_programs_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_fsm_start_address_set(const stmdev_ctx_t *ctx, uint16_t val)
+int32_t lsm6dsr_fsm_start_address_set(const stmdev_ctx_t *ctx,
+                                      uint16_t val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -10286,11 +10539,13 @@ int32_t lsm6dsr_fsm_start_address_get(const stmdev_ctx_t *ctx,
   uint8_t buff[2];
   int32_t ret;
 
-  ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_FSM_START_ADD_L, &buff[0]);
+  ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_FSM_START_ADD_L,
+                                &buff[0]);
 
   if (ret == 0)
   {
-    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_FSM_START_ADD_H, &buff[1]);
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_FSM_START_ADD_H,
+                                  &buff[1]);
     *val = buff[1];
     *val = (*val * 256U) +  buff[0];
   }
@@ -10320,7 +10575,8 @@ int32_t lsm6dsr_fsm_start_address_get(const stmdev_ctx_t *ctx,
   *
   */
 int32_t lsm6dsr_sh_read_data_raw_get(const stmdev_ctx_t *ctx,
-                                     lsm6dsr_emb_sh_read_t *val)
+                                     lsm6dsr_emb_sh_read_t *val,
+                                     uint8_t len)
 {
   int32_t ret;
 
@@ -10328,7 +10584,8 @@ int32_t lsm6dsr_sh_read_data_raw_get(const stmdev_ctx_t *ctx,
 
   if (ret == 0)
   {
-    ret = lsm6dsr_read_reg(ctx, LSM6DSR_SENSOR_HUB_1, (uint8_t *)val, 18);
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_SENSOR_HUB_1,
+                           (uint8_t *)val, len);
   }
 
   if (ret == 0)
@@ -10621,7 +10878,8 @@ int32_t lsm6dsr_sh_pass_through_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsr_sh_pass_through_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsr_sh_pass_through_get(const stmdev_ctx_t *ctx,
+                                    uint8_t *val)
 {
   lsm6dsr_master_config_t master_config;
   int32_t ret;
@@ -11097,7 +11355,8 @@ int32_t lsm6dsr_sh_slv1_cfg_read(const stmdev_ctx_t *ctx,
   {
     slv1_add.slave1_add = (uint8_t)(val->slv_add >> 1);
     slv1_add.r_1 = 1;
-    ret = lsm6dsr_write_reg(ctx, LSM6DSR_SLV1_ADD, (uint8_t *)&slv1_add, 1);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_SLV1_ADD,
+                            (uint8_t *)&slv1_add, 1);
   }
 
   if (ret == 0)
@@ -11254,7 +11513,8 @@ int32_t lsm6dsr_sh_status_get(const stmdev_ctx_t *ctx,
 
   if (ret == 0)
   {
-    ret = lsm6dsr_read_reg(ctx, LSM6DSR_STATUS_MASTER, (uint8_t *)val, 1);
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_STATUS_MASTER,
+                           (uint8_t *)val, 1);
   }
 
   if (ret == 0)

--- a/sensor/stmemsc/lsm6dsr_STdC/driver/lsm6dsr_reg.h
+++ b/sensor/stmemsc/lsm6dsr_STdC/driver/lsm6dsr_reg.h
@@ -1,7 +1,7 @@
 /**
   ******************************************************************************
   * @file    lsm6dsr_reg.h
-  * @author  Sensors Software Solution Team
+  * @author  Sensor Solutions Software Team
   * @brief   This file contains all the functions prototypes for the
   *          lsm6dsr_reg.c driver.
   ******************************************************************************
@@ -50,7 +50,7 @@ extern "C" {
 /** if _BYTE_ORDER is not defined, choose the endianness of your architecture
   * by uncommenting the define which fits your platform endianness
   */
-//#define DRV_BYTE_ORDER    DRV_BIG_ENDIAN
+/* #define DRV_BYTE_ORDER    DRV_BIG_ENDIAN */
 #define DRV_BYTE_ORDER    DRV_LITTLE_ENDIAN
 
 #else /* defined __BYTE_ORDER__ */
@@ -695,6 +695,7 @@ typedef struct
 #define LSM6DSR_OUTY_H_A                     0x2BU
 #define LSM6DSR_OUTZ_L_A                     0x2CU
 #define LSM6DSR_OUTZ_H_A                     0x2DU
+
 #define LSM6DSR_EMB_FUNC_STATUS_MAINPAGE     0x35U
 typedef struct
 {
@@ -1459,7 +1460,7 @@ typedef struct
   uint8_t fsm15_en                 : 1;
   uint8_t fsm16_en                 : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t fsm16_en                  : 1;
+  uint8_t fsm16_en                 : 1;
   uint8_t fsm15_en                 : 1;
   uint8_t fsm14_en                 : 1;
   uint8_t fsm13_en                 : 1;
@@ -1940,6 +1941,10 @@ typedef struct
 #endif /* DRV_BYTE_ORDER */
 } lsm6dsr_emb_func_init_b_t;
 
+/** @defgroup bitfields page 0 and 1
+  * @{
+  *
+  */
 #define LSM6DSR_MAG_SENSITIVITY_L            0xBAU
 #define LSM6DSR_MAG_SENSITIVITY_H            0xBBU
 #define LSM6DSR_MAG_OFFX_L                   0xC0U
@@ -2014,6 +2019,17 @@ typedef struct
 #define LSM6DSR_PEDO_DEB_STEPS_CONF          0x184U
 #define LSM6DSR_PEDO_SC_DELTAT_L             0x1D0U
 #define LSM6DSR_PEDO_SC_DELTAT_H             0x1D1U
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup bitfields page sensor_hub
+  * @{
+  *
+  */
+
 #define LSM6DSR_SENSOR_HUB_1                 0x02U
 typedef struct
 {
@@ -2627,6 +2643,11 @@ typedef struct
 } lsm6dsr_status_master_t;
 
 /**
+  * @}
+  *
+  */
+
+/**
   * @defgroup LSM6DSR_Register_Union
   * @brief    This union group all the registers having a bit-field
   *           description.
@@ -2765,8 +2786,8 @@ typedef union
   lsm6dsr_slv3_config_t                   slv3_config;
   lsm6dsr_datawrite_slv0_t                datawrite_slv0;
   lsm6dsr_status_master_t                 status_master;
-  bitwise_t                               bitwise;
-  uint8_t                                 byte;
+  bitwise_t                                 bitwise;
+  uint8_t                                   byte;
 } lsm6dsr_reg_t;
 
 /**
@@ -2786,7 +2807,6 @@ typedef union
  * The __weak directive allows the final application to overwrite
  * them with a custom implementation.
  */
-
 int32_t lsm6dsr_read_reg(const stmdev_ctx_t *ctx, uint8_t reg,
                          uint8_t *data,
                          uint16_t len);
@@ -2808,7 +2828,7 @@ float_t lsm6dsr_from_fs4000dps_to_mdps(int16_t lsb);
 
 float_t lsm6dsr_from_lsb_to_celsius(int16_t lsb);
 
-float_t lsm6dsr_from_lsb_to_nsec(int32_t lsb);
+uint64_t lsm6dsr_from_lsb_to_nsec(uint32_t lsb);
 
 typedef enum
 {
@@ -2875,7 +2895,8 @@ int32_t lsm6dsr_gy_data_rate_set(const stmdev_ctx_t *ctx,
 int32_t lsm6dsr_gy_data_rate_get(const stmdev_ctx_t *ctx,
                                  lsm6dsr_odr_g_t *val);
 
-int32_t lsm6dsr_block_data_update_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_block_data_update_set(const stmdev_ctx_t *ctx,
+                                      uint8_t val);
 int32_t lsm6dsr_block_data_update_get(const stmdev_ctx_t *ctx,
                                       uint8_t *val);
 
@@ -2911,14 +2932,14 @@ int32_t lsm6dsr_gy_power_mode_get(const stmdev_ctx_t *ctx,
 
 typedef struct
 {
-  lsm6dsr_all_int_src_t       all_int_src;
-  lsm6dsr_wake_up_src_t       wake_up_src;
-  lsm6dsr_tap_src_t           tap_src;
-  lsm6dsr_d6d_src_t           d6d_src;
-  lsm6dsr_status_reg_t        status_reg;
-  lsm6dsr_emb_func_status_t   emb_func_status;
-  lsm6dsr_fsm_status_a_t      fsm_status_a;
-  lsm6dsr_fsm_status_b_t      fsm_status_b;
+  lsm6dsr_all_int_src_t           all_int_src;
+  lsm6dsr_wake_up_src_t           wake_up_src;
+  lsm6dsr_tap_src_t               tap_src;
+  lsm6dsr_d6d_src_t               d6d_src;
+  lsm6dsr_status_reg_t            status_reg;
+  lsm6dsr_emb_func_status_t       emb_func_status;
+  lsm6dsr_fsm_status_a_t          fsm_status_a;
+  lsm6dsr_fsm_status_b_t          fsm_status_b;
 } lsm6dsr_all_sources_t;
 int32_t lsm6dsr_all_sources_get(const stmdev_ctx_t *ctx,
                                 lsm6dsr_all_sources_t *val);
@@ -2935,14 +2956,20 @@ int32_t lsm6dsr_gy_flag_data_ready_get(const stmdev_ctx_t *ctx,
 int32_t lsm6dsr_temp_flag_data_ready_get(const stmdev_ctx_t *ctx,
                                          uint8_t *val);
 
-int32_t lsm6dsr_xl_usr_offset_x_set(const stmdev_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsr_xl_usr_offset_x_get(const stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsr_xl_usr_offset_x_set(const stmdev_ctx_t *ctx,
+                                    uint8_t *val);
+int32_t lsm6dsr_xl_usr_offset_x_get(const stmdev_ctx_t *ctx,
+                                    uint8_t *val);
 
-int32_t lsm6dsr_xl_usr_offset_y_set(const stmdev_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsr_xl_usr_offset_y_get(const stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsr_xl_usr_offset_y_set(const stmdev_ctx_t *ctx,
+                                    uint8_t *val);
+int32_t lsm6dsr_xl_usr_offset_y_get(const stmdev_ctx_t *ctx,
+                                    uint8_t *val);
 
-int32_t lsm6dsr_xl_usr_offset_z_set(const stmdev_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsr_xl_usr_offset_z_get(const stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsr_xl_usr_offset_z_set(const stmdev_ctx_t *ctx,
+                                    uint8_t *val);
+int32_t lsm6dsr_xl_usr_offset_z_get(const stmdev_ctx_t *ctx,
+                                    uint8_t *val);
 
 int32_t lsm6dsr_xl_usr_offset_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsr_xl_usr_offset_get(const stmdev_ctx_t *ctx, uint8_t *val);
@@ -2972,7 +2999,7 @@ int32_t lsm6dsr_angular_rate_raw_get(const stmdev_ctx_t *ctx, int16_t *val);
 
 int32_t lsm6dsr_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *val);
 
-int32_t lsm6dsr_fifo_out_raw_get(const stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsr_fifo_out_raw_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 int32_t lsm6dsr_odr_cal_reg_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsr_odr_cal_reg_get(const stmdev_ctx_t *ctx, uint8_t *val);
@@ -3011,7 +3038,7 @@ int32_t lsm6dsr_data_ready_mode_set(const stmdev_ctx_t *ctx,
 int32_t lsm6dsr_data_ready_mode_get(const stmdev_ctx_t *ctx,
                                     lsm6dsr_dataready_pulsed_t *val);
 
-int32_t lsm6dsr_device_id_get(const stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsr_device_id_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 int32_t lsm6dsr_reset_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsr_reset_get(const stmdev_ctx_t *ctx, uint8_t *val);
@@ -3050,10 +3077,8 @@ int32_t lsm6dsr_xl_filter_lp2_get(const stmdev_ctx_t *ctx, uint8_t *val);
 int32_t lsm6dsr_gy_filter_lp1_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsr_gy_filter_lp1_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsr_filter_settling_mask_set(const stmdev_ctx_t *ctx,
-                                         uint8_t val);
-int32_t lsm6dsr_filter_settling_mask_get(const stmdev_ctx_t *ctx,
-                                         uint8_t *val);
+int32_t lsm6dsr_filter_settling_mask_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_filter_settling_mask_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum
 {
@@ -3331,8 +3356,10 @@ typedef enum
   LSM6DSR_SPI_4_WIRE = 0,
   LSM6DSR_SPI_3_WIRE = 1,
 } lsm6dsr_sim_t;
-int32_t lsm6dsr_spi_mode_set(const stmdev_ctx_t *ctx, lsm6dsr_sim_t val);
-int32_t lsm6dsr_spi_mode_get(const stmdev_ctx_t *ctx, lsm6dsr_sim_t *val);
+int32_t lsm6dsr_spi_mode_set(const stmdev_ctx_t *ctx,
+                             lsm6dsr_sim_t val);
+int32_t lsm6dsr_spi_mode_get(const stmdev_ctx_t *ctx,
+                             lsm6dsr_sim_t *val);
 
 typedef enum
 {
@@ -3388,8 +3415,10 @@ typedef enum
   LSM6DSR_PUSH_PULL   = 0,
   LSM6DSR_OPEN_DRAIN  = 1,
 } lsm6dsr_pp_od_t;
-int32_t lsm6dsr_pin_mode_set(const stmdev_ctx_t *ctx, lsm6dsr_pp_od_t val);
-int32_t lsm6dsr_pin_mode_get(const stmdev_ctx_t *ctx, lsm6dsr_pp_od_t *val);
+int32_t lsm6dsr_pin_mode_set(const stmdev_ctx_t *ctx,
+                             lsm6dsr_pp_od_t val);
+int32_t lsm6dsr_pin_mode_get(const stmdev_ctx_t *ctx,
+                             lsm6dsr_pp_od_t *val);
 
 typedef enum
 {
@@ -3427,7 +3456,8 @@ int32_t lsm6dsr_wkup_ths_weight_get(const stmdev_ctx_t *ctx,
                                     lsm6dsr_wake_ths_w_t *val);
 
 int32_t lsm6dsr_wkup_threshold_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsr_wkup_threshold_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsr_wkup_threshold_get(const stmdev_ctx_t *ctx,
+                                   uint8_t *val);
 
 int32_t lsm6dsr_xl_usr_offset_on_wkup_set(const stmdev_ctx_t *ctx,
                                           uint8_t val);
@@ -3480,8 +3510,10 @@ int32_t lsm6dsr_tap_detection_on_x_set(const stmdev_ctx_t *ctx,
 int32_t lsm6dsr_tap_detection_on_x_get(const stmdev_ctx_t *ctx,
                                        uint8_t *val);
 
-int32_t lsm6dsr_tap_threshold_x_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsr_tap_threshold_x_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsr_tap_threshold_x_set(const stmdev_ctx_t *ctx,
+                                    uint8_t val);
+int32_t lsm6dsr_tap_threshold_x_get(const stmdev_ctx_t *ctx,
+                                    uint8_t *val);
 
 typedef enum
 {
@@ -3497,11 +3529,15 @@ int32_t lsm6dsr_tap_axis_priority_set(const stmdev_ctx_t *ctx,
 int32_t lsm6dsr_tap_axis_priority_get(const stmdev_ctx_t *ctx,
                                       lsm6dsr_tap_priority_t *val);
 
-int32_t lsm6dsr_tap_threshold_y_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsr_tap_threshold_y_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsr_tap_threshold_y_set(const stmdev_ctx_t *ctx,
+                                    uint8_t val);
+int32_t lsm6dsr_tap_threshold_y_get(const stmdev_ctx_t *ctx,
+                                    uint8_t *val);
 
-int32_t lsm6dsr_tap_threshold_z_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsr_tap_threshold_z_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsr_tap_threshold_z_set(const stmdev_ctx_t *ctx,
+                                    uint8_t val);
+int32_t lsm6dsr_tap_threshold_z_get(const stmdev_ctx_t *ctx,
+                                    uint8_t *val);
 
 int32_t lsm6dsr_tap_shock_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsr_tap_shock_get(const stmdev_ctx_t *ctx, uint8_t *val);
@@ -3556,8 +3592,10 @@ int32_t lsm6dsr_ff_threshold_get(const stmdev_ctx_t *ctx,
 int32_t lsm6dsr_ff_dur_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsr_ff_dur_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsr_fifo_watermark_set(const stmdev_ctx_t *ctx, uint16_t val);
-int32_t lsm6dsr_fifo_watermark_get(const stmdev_ctx_t *ctx, uint16_t *val);
+int32_t lsm6dsr_fifo_watermark_set(const stmdev_ctx_t *ctx,
+                                   uint16_t val);
+int32_t lsm6dsr_fifo_watermark_get(const stmdev_ctx_t *ctx,
+                                   uint16_t *val);
 
 int32_t lsm6dsr_compression_algo_init_set(const stmdev_ctx_t *ctx,
                                           uint8_t val);
@@ -3587,12 +3625,14 @@ int32_t lsm6dsr_compression_algo_real_time_set(const stmdev_ctx_t *ctx,
 int32_t lsm6dsr_compression_algo_real_time_get(const stmdev_ctx_t *ctx,
                                                uint8_t *val);
 
-int32_t lsm6dsr_fifo_stop_on_wtm_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsr_fifo_stop_on_wtm_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsr_fifo_stop_on_wtm_set(const stmdev_ctx_t *ctx,
+                                     uint8_t val);
+int32_t lsm6dsr_fifo_stop_on_wtm_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val);
 
 typedef enum
 {
-  LSM6DSR_XL_NOT_BATCHED      =  0,
+  LSM6DSR_XL_NOT_BATCHED       =  0,
   LSM6DSR_XL_BATCHED_AT_12Hz5   =  1,
   LSM6DSR_XL_BATCHED_AT_26Hz    =  2,
   LSM6DSR_XL_BATCHED_AT_52Hz    =  3,
@@ -3678,7 +3718,8 @@ int32_t lsm6dsr_fifo_cnt_event_batch_set(const stmdev_ctx_t *ctx,
 int32_t lsm6dsr_fifo_cnt_event_batch_get(const stmdev_ctx_t *ctx,
                                          lsm6dsr_trig_counter_bdr_t *val);
 
-int32_t lsm6dsr_rst_batch_counter_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_rst_batch_counter_set(const stmdev_ctx_t *ctx,
+                                      uint8_t val);
 int32_t lsm6dsr_rst_batch_counter_get(const stmdev_ctx_t *ctx,
                                       uint8_t *val);
 
@@ -3687,12 +3728,14 @@ int32_t lsm6dsr_batch_counter_threshold_set(const stmdev_ctx_t *ctx,
 int32_t lsm6dsr_batch_counter_threshold_get(const stmdev_ctx_t *ctx,
                                             uint16_t *val);
 
-int32_t lsm6dsr_fifo_data_level_get(const stmdev_ctx_t *ctx, uint16_t *val);
+int32_t lsm6dsr_fifo_data_level_get(const stmdev_ctx_t *ctx,
+                                    uint16_t *val);
 
 int32_t lsm6dsr_fifo_status_get(const stmdev_ctx_t *ctx,
                                 lsm6dsr_fifo_status2_t *val);
 
-int32_t lsm6dsr_fifo_full_flag_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsr_fifo_full_flag_get(const stmdev_ctx_t *ctx,
+                                   uint8_t *val);
 
 int32_t lsm6dsr_fifo_ovr_flag_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
@@ -3721,25 +3764,35 @@ typedef enum
   LSM6DSR_GAME_ROTATION_TAG,
   LSM6DSR_GEOMAG_ROTATION_TAG,
   LSM6DSR_ROTATION_TAG,
-  LSM6DSR_SENSORHUB_NACK_TAG  = 0x19,
+  LSM6DSR_SENSORHUB_NACK_TAG = 0x19,
 } lsm6dsr_fifo_tag_t;
 int32_t lsm6dsr_fifo_sensor_tag_get(const stmdev_ctx_t *ctx,
                                     lsm6dsr_fifo_tag_t *val);
 
-int32_t lsm6dsr_fifo_pedo_batch_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsr_fifo_pedo_batch_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsr_fifo_pedo_batch_set(const stmdev_ctx_t *ctx,
+                                    uint8_t val);
+int32_t lsm6dsr_fifo_pedo_batch_get(const stmdev_ctx_t *ctx,
+                                    uint8_t *val);
 
-int32_t lsm6dsr_sh_batch_slave_0_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsr_sh_batch_slave_0_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsr_sh_batch_slave_0_set(const stmdev_ctx_t *ctx,
+                                     uint8_t val);
+int32_t lsm6dsr_sh_batch_slave_0_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val);
 
-int32_t lsm6dsr_sh_batch_slave_1_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsr_sh_batch_slave_1_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsr_sh_batch_slave_1_set(const stmdev_ctx_t *ctx,
+                                     uint8_t val);
+int32_t lsm6dsr_sh_batch_slave_1_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val);
 
-int32_t lsm6dsr_sh_batch_slave_2_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsr_sh_batch_slave_2_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsr_sh_batch_slave_2_set(const stmdev_ctx_t *ctx,
+                                     uint8_t val);
+int32_t lsm6dsr_sh_batch_slave_2_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val);
 
-int32_t lsm6dsr_sh_batch_slave_3_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsr_sh_batch_slave_3_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsr_sh_batch_slave_3_set(const stmdev_ctx_t *ctx,
+                                     uint8_t val);
+int32_t lsm6dsr_sh_batch_slave_3_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val);
 
 typedef enum
 {
@@ -3775,14 +3828,20 @@ int32_t lsm6dsr_den_enable_set(const stmdev_ctx_t *ctx,
 int32_t lsm6dsr_den_enable_get(const stmdev_ctx_t *ctx,
                                lsm6dsr_den_xl_g_t *val);
 
-int32_t lsm6dsr_den_mark_axis_x_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsr_den_mark_axis_x_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsr_den_mark_axis_x_set(const stmdev_ctx_t *ctx,
+                                    uint8_t val);
+int32_t lsm6dsr_den_mark_axis_x_get(const stmdev_ctx_t *ctx,
+                                    uint8_t *val);
 
-int32_t lsm6dsr_den_mark_axis_y_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsr_den_mark_axis_y_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsr_den_mark_axis_y_set(const stmdev_ctx_t *ctx,
+                                    uint8_t val);
+int32_t lsm6dsr_den_mark_axis_y_get(const stmdev_ctx_t *ctx,
+                                    uint8_t *val);
 
-int32_t lsm6dsr_den_mark_axis_z_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsr_den_mark_axis_z_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsr_den_mark_axis_z_set(const stmdev_ctx_t *ctx,
+                                    uint8_t val);
+int32_t lsm6dsr_den_mark_axis_z_get(const stmdev_ctx_t *ctx,
+                                    uint8_t *val);
 
 int32_t lsm6dsr_pedo_sens_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsr_pedo_sens_get(const stmdev_ctx_t *ctx, uint8_t *val);
@@ -3798,12 +3857,13 @@ int32_t lsm6dsr_pedo_mode_set(const stmdev_ctx_t *ctx,
 int32_t lsm6dsr_pedo_mode_get(const stmdev_ctx_t *ctx,
                               lsm6dsr_pedo_mode_t *val);
 
-int32_t lsm6dsr_pedo_step_detect_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsr_pedo_step_detect_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val);
 
 int32_t lsm6dsr_pedo_debounce_steps_set(const stmdev_ctx_t *ctx,
-                                        uint8_t *buff);
+                                        uint8_t *val);
 int32_t lsm6dsr_pedo_debounce_steps_get(const stmdev_ctx_t *ctx,
-                                        uint8_t *buff);
+                                        uint8_t *val);
 
 int32_t lsm6dsr_pedo_steps_period_set(const stmdev_ctx_t *ctx,
                                       uint16_t val);
@@ -3842,14 +3902,18 @@ int32_t lsm6dsr_tilt_sens_get(const stmdev_ctx_t *ctx, uint8_t *val);
 int32_t lsm6dsr_tilt_flag_data_ready_get(const stmdev_ctx_t *ctx,
                                          uint8_t *val);
 
-int32_t lsm6dsr_mag_sensitivity_set(const stmdev_ctx_t *ctx, uint16_t val);
-int32_t lsm6dsr_mag_sensitivity_get(const stmdev_ctx_t *ctx, uint16_t *val);
+int32_t lsm6dsr_mag_sensitivity_set(const stmdev_ctx_t *ctx,
+                                    uint16_t val);
+int32_t lsm6dsr_mag_sensitivity_get(const stmdev_ctx_t *ctx,
+                                    uint16_t *val);
 
 int32_t lsm6dsr_mag_offset_set(const stmdev_ctx_t *ctx, int16_t *val);
 int32_t lsm6dsr_mag_offset_get(const stmdev_ctx_t *ctx, int16_t *val);
 
-int32_t lsm6dsr_mag_soft_iron_set(const stmdev_ctx_t *ctx, int16_t *val);
-int32_t lsm6dsr_mag_soft_iron_get(const stmdev_ctx_t *ctx, int16_t *val);
+int32_t lsm6dsr_mag_soft_iron_set(const stmdev_ctx_t *ctx,
+                                  uint16_t *val);
+int32_t lsm6dsr_mag_soft_iron_get(const stmdev_ctx_t *ctx,
+                                  uint16_t *val);
 
 typedef enum
 {
@@ -3966,9 +4030,9 @@ int32_t lsm6dsr_long_cnt_int_value_get(const stmdev_ctx_t *ctx,
                                        uint16_t *val);
 
 int32_t lsm6dsr_fsm_number_of_programs_set(const stmdev_ctx_t *ctx,
-                                           uint8_t *buff);
+                                           uint8_t *val);
 int32_t lsm6dsr_fsm_number_of_programs_get(const stmdev_ctx_t *ctx,
-                                           uint8_t *buff);
+                                           uint8_t *val);
 
 int32_t lsm6dsr_fsm_start_address_set(const stmdev_ctx_t *ctx,
                                       uint16_t val);
@@ -3997,7 +4061,8 @@ typedef struct
   lsm6dsr_sensor_hub_18_t  sh_byte_18;
 } lsm6dsr_emb_sh_read_t;
 int32_t lsm6dsr_sh_read_data_raw_get(const stmdev_ctx_t *ctx,
-                                     lsm6dsr_emb_sh_read_t *val);
+                                     lsm6dsr_emb_sh_read_t *val,
+                                     uint8_t len);
 
 typedef enum
 {
@@ -4024,8 +4089,10 @@ int32_t lsm6dsr_sh_pin_mode_set(const stmdev_ctx_t *ctx,
 int32_t lsm6dsr_sh_pin_mode_get(const stmdev_ctx_t *ctx,
                                 lsm6dsr_shub_pu_en_t *val);
 
-int32_t lsm6dsr_sh_pass_through_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsr_sh_pass_through_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsr_sh_pass_through_set(const stmdev_ctx_t *ctx,
+                                    uint8_t val);
+int32_t lsm6dsr_sh_pass_through_get(const stmdev_ctx_t *ctx,
+                                    uint8_t *val);
 
 typedef enum
 {

--- a/sensor/stmemsc/lsm6dsrx_STdC/driver/lsm6dsrx_reg.c
+++ b/sensor/stmemsc/lsm6dsrx_STdC/driver/lsm6dsrx_reg.c
@@ -155,9 +155,9 @@ float_t lsm6dsrx_from_lsb_to_celsius(int16_t lsb)
   return (((float_t)lsb / 256.0f) + 25.0f);
 }
 
-float_t lsm6dsrx_from_lsb_to_nsec(int32_t lsb)
+uint64_t lsm6dsrx_from_lsb_to_nsec(uint32_t lsb)
 {
-  return ((float_t)lsb * 25000.0f);
+  return ((uint64_t)lsb * 25000ULL);
 }
 
 /**
@@ -186,8 +186,8 @@ int32_t lsm6dsrx_xl_full_scale_set(const stmdev_ctx_t *ctx,
 {
   lsm6dsrx_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
-
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL1_XL, (uint8_t *)&ctrl1_xl, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL1_XL,
+                          (uint8_t *)&ctrl1_xl, 1);
 
   if (ret == 0)
   {
@@ -212,8 +212,8 @@ int32_t lsm6dsrx_xl_full_scale_get(const stmdev_ctx_t *ctx,
 {
   lsm6dsrx_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
-
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL1_XL, (uint8_t *)&ctrl1_xl, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL1_XL,
+                          (uint8_t *)&ctrl1_xl, 1);
 
   switch (ctrl1_xl.fs_xl)
   {
@@ -255,9 +255,9 @@ int32_t lsm6dsrx_xl_data_rate_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_odr_xl_t odr_xl =  val;
   lsm6dsrx_emb_fsm_enable_t fsm_enable;
   lsm6dsrx_fsm_odr_t fsm_odr;
-  lsm6dsrx_ctrl1_xl_t ctrl1_xl;
-  lsm6dsrx_mlc_odr_t mlc_odr;
   uint8_t mlc_enable;
+  lsm6dsrx_mlc_odr_t mlc_odr;
+  lsm6dsrx_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
 
   /* Check the Finite State Machine data rate constraints */
@@ -485,7 +485,8 @@ int32_t lsm6dsrx_xl_data_rate_set(const stmdev_ctx_t *ctx,
 
   if (ret == 0)
   {
-    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL1_XL, (uint8_t *)&ctrl1_xl, 1);
+    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL1_XL,
+                            (uint8_t *)&ctrl1_xl, 1);
   }
 
   if (ret == 0)
@@ -511,8 +512,8 @@ int32_t lsm6dsrx_xl_data_rate_get(const stmdev_ctx_t *ctx,
 {
   lsm6dsrx_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
-
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL1_XL, (uint8_t *)&ctrl1_xl, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL1_XL,
+                          (uint8_t *)&ctrl1_xl, 1);
 
   switch (ctrl1_xl.odr_xl)
   {
@@ -585,13 +586,14 @@ int32_t lsm6dsrx_gy_full_scale_set(const stmdev_ctx_t *ctx,
 {
   lsm6dsrx_ctrl2_g_t ctrl2_g;
   int32_t ret;
-
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL2_G, (uint8_t *)&ctrl2_g, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL2_G,
+                          (uint8_t *)&ctrl2_g, 1);
 
   if (ret == 0)
   {
     ctrl2_g.fs_g = (uint8_t)val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL2_G, (uint8_t *)&ctrl2_g, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL2_G,
+                             (uint8_t *)&ctrl2_g, 1);
   }
 
   return ret;
@@ -610,8 +612,8 @@ int32_t lsm6dsrx_gy_full_scale_get(const stmdev_ctx_t *ctx,
 {
   lsm6dsrx_ctrl2_g_t ctrl2_g;
   int32_t ret;
-
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL2_G, (uint8_t *)&ctrl2_g, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL2_G,
+                          (uint8_t *)&ctrl2_g, 1);
 
   switch (ctrl2_g.fs_g)
   {
@@ -661,9 +663,9 @@ int32_t lsm6dsrx_gy_data_rate_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_odr_g_t odr_gy =  val;
   lsm6dsrx_emb_fsm_enable_t fsm_enable;
   lsm6dsrx_fsm_odr_t fsm_odr;
-  lsm6dsrx_ctrl2_g_t ctrl2_g;
-  lsm6dsrx_mlc_odr_t mlc_odr;
   uint8_t mlc_enable;
+  lsm6dsrx_mlc_odr_t mlc_odr;
+  lsm6dsrx_ctrl2_g_t ctrl2_g;
   int32_t ret;
 
   /* Check the Finite State Machine data rate constraints */
@@ -891,13 +893,15 @@ int32_t lsm6dsrx_gy_data_rate_set(const stmdev_ctx_t *ctx,
 
   if (ret == 0)
   {
-    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL2_G, (uint8_t *)&ctrl2_g, 1);
+    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL2_G,
+                            (uint8_t *)&ctrl2_g, 1);
   }
 
   if (ret == 0)
   {
     ctrl2_g.odr_g = (uint8_t)odr_gy;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL2_G, (uint8_t *)&ctrl2_g, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL2_G,
+                             (uint8_t *)&ctrl2_g, 1);
   }
 
   return ret;
@@ -916,8 +920,8 @@ int32_t lsm6dsrx_gy_data_rate_get(const stmdev_ctx_t *ctx,
 {
   lsm6dsrx_ctrl2_g_t ctrl2_g;
   int32_t ret;
-
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL2_G, (uint8_t *)&ctrl2_g, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL2_G,
+                          (uint8_t *)&ctrl2_g, 1);
 
   switch (ctrl2_g.odr_g)
   {
@@ -981,17 +985,19 @@ int32_t lsm6dsrx_gy_data_rate_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_block_data_update_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsrx_block_data_update_set(const stmdev_ctx_t *ctx,
+                                       uint8_t val)
 {
   lsm6dsrx_ctrl3_c_t ctrl3_c;
   int32_t ret;
-
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL3_C,
+                          (uint8_t *)&ctrl3_c, 1);
 
   if (ret == 0)
   {
     ctrl3_c.bdu = (uint8_t)val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL3_C,
+                             (uint8_t *)&ctrl3_c, 1);
   }
 
   return ret;
@@ -1010,8 +1016,8 @@ int32_t lsm6dsrx_block_data_update_get(const stmdev_ctx_t *ctx,
 {
   lsm6dsrx_ctrl3_c_t ctrl3_c;
   int32_t ret;
-
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL3_C,
+                          (uint8_t *)&ctrl3_c, 1);
   *val = ctrl3_c.bdu;
 
   return ret;
@@ -1031,13 +1037,14 @@ int32_t lsm6dsrx_xl_offset_weight_set(const stmdev_ctx_t *ctx,
 {
   lsm6dsrx_ctrl6_c_t ctrl6_c;
   int32_t ret;
-
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL6_C,
+                          (uint8_t *)&ctrl6_c, 1);
 
   if (ret == 0)
   {
     ctrl6_c.usr_off_w = (uint8_t)val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL6_C,
+                             (uint8_t *)&ctrl6_c, 1);
   }
 
   return ret;
@@ -1057,8 +1064,8 @@ int32_t lsm6dsrx_xl_offset_weight_get(const stmdev_ctx_t *ctx,
 {
   lsm6dsrx_ctrl6_c_t ctrl6_c;
   int32_t ret;
-
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL6_C,
+                          (uint8_t *)&ctrl6_c, 1);
 
   switch (ctrl6_c.usr_off_w)
   {
@@ -1091,13 +1098,14 @@ int32_t lsm6dsrx_xl_power_mode_set(const stmdev_ctx_t *ctx,
 {
   lsm6dsrx_ctrl6_c_t ctrl6_c;
   int32_t ret;
-
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL6_C,
+                          (uint8_t *)&ctrl6_c, 1);
 
   if (ret == 0)
   {
     ctrl6_c.xl_hm_mode = (uint8_t)val & 0x01U;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL6_C,
+                             (uint8_t *)&ctrl6_c, 1);
   }
 
   return ret;
@@ -1116,8 +1124,8 @@ int32_t lsm6dsrx_xl_power_mode_get(const stmdev_ctx_t *ctx,
 {
   lsm6dsrx_ctrl6_c_t ctrl6_c;
   int32_t ret;
-
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL6_C,
+                          (uint8_t *)&ctrl6_c, 1);
 
   switch (ctrl6_c.xl_hm_mode)
   {
@@ -1150,13 +1158,14 @@ int32_t lsm6dsrx_gy_power_mode_set(const stmdev_ctx_t *ctx,
 {
   lsm6dsrx_ctrl7_g_t ctrl7_g;
   int32_t ret;
-
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL7_G,
+                          (uint8_t *)&ctrl7_g, 1);
 
   if (ret == 0)
   {
     ctrl7_g.g_hm_mode = (uint8_t)val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL7_G,
+                             (uint8_t *)&ctrl7_g, 1);
   }
 
   return ret;
@@ -1175,8 +1184,8 @@ int32_t lsm6dsrx_gy_power_mode_get(const stmdev_ctx_t *ctx,
 {
   lsm6dsrx_ctrl7_g_t ctrl7_g;
   int32_t ret;
-
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL7_G,
+                          (uint8_t *)&ctrl7_g, 1);
 
   switch (ctrl7_g.g_hm_mode)
   {
@@ -1259,12 +1268,6 @@ int32_t lsm6dsrx_all_sources_get(const stmdev_ctx_t *ctx,
   {
     ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_FSM_STATUS_B,
                             (uint8_t *)&val->fsm_status_b, 1);
-  }
-
-  if (ret == 0)
-  {
-    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_MLC_STATUS,
-                            (uint8_t *)&val->mlc_status, 1);
   }
 
   if (ret == 0)
@@ -1357,7 +1360,7 @@ int32_t lsm6dsrx_temp_flag_data_ready_get(const stmdev_ctx_t *ctx,
 }
 
 /**
-  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  * @brief  Accelerometer X-axis user offset correction expressed in two's
   *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
   *         The value must be in the range [-127 127].[set]
   *
@@ -1366,7 +1369,8 @@ int32_t lsm6dsrx_temp_flag_data_ready_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_xl_usr_offset_x_set(const stmdev_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsrx_xl_usr_offset_x_set(const stmdev_ctx_t *ctx,
+                                     uint8_t *buff)
 {
   int32_t ret;
 
@@ -1376,7 +1380,7 @@ int32_t lsm6dsrx_xl_usr_offset_x_set(const stmdev_ctx_t *ctx, uint8_t *buff)
 }
 
 /**
-  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  * @brief  Accelerometer X-axis user offset correction expressed in two's
   *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
   *         The value must be in the range [-127 127].[get]
   *
@@ -1385,7 +1389,8 @@ int32_t lsm6dsrx_xl_usr_offset_x_set(const stmdev_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_xl_usr_offset_x_get(const stmdev_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsrx_xl_usr_offset_x_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *buff)
 {
   int32_t ret;
 
@@ -1395,7 +1400,7 @@ int32_t lsm6dsrx_xl_usr_offset_x_get(const stmdev_ctx_t *ctx, uint8_t *buff)
 }
 
 /**
-  * @brief  Accelerometer Y-axis user offset correction expressed in two’s
+  * @brief  Accelerometer Y-axis user offset correction expressed in two's
   *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
   *         The value must be in the range [-127 127].[set]
   *
@@ -1404,7 +1409,8 @@ int32_t lsm6dsrx_xl_usr_offset_x_get(const stmdev_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_xl_usr_offset_y_set(const stmdev_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsrx_xl_usr_offset_y_set(const stmdev_ctx_t *ctx,
+                                     uint8_t *buff)
 {
   int32_t ret;
 
@@ -1414,7 +1420,7 @@ int32_t lsm6dsrx_xl_usr_offset_y_set(const stmdev_ctx_t *ctx, uint8_t *buff)
 }
 
 /**
-  * @brief  Accelerometer Y-axis user offset correction expressed in two’s
+  * @brief  Accelerometer Y-axis user offset correction expressed in two's
   *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
   *         The value must be in the range [-127 127].[get]
   *
@@ -1423,7 +1429,8 @@ int32_t lsm6dsrx_xl_usr_offset_y_set(const stmdev_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_xl_usr_offset_y_get(const stmdev_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsrx_xl_usr_offset_y_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *buff)
 {
   int32_t ret;
 
@@ -1433,7 +1440,7 @@ int32_t lsm6dsrx_xl_usr_offset_y_get(const stmdev_ctx_t *ctx, uint8_t *buff)
 }
 
 /**
-  * @brief  Accelerometer Z-axis user offset correction expressed in two’s
+  * @brief  Accelerometer Z-axis user offset correction expressed in two's
   *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
   *         The value must be in the range [-127 127].[set]
   *
@@ -1442,7 +1449,8 @@ int32_t lsm6dsrx_xl_usr_offset_y_get(const stmdev_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_xl_usr_offset_z_set(const stmdev_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsrx_xl_usr_offset_z_set(const stmdev_ctx_t *ctx,
+                                     uint8_t *buff)
 {
   int32_t ret;
 
@@ -1452,7 +1460,7 @@ int32_t lsm6dsrx_xl_usr_offset_z_set(const stmdev_ctx_t *ctx, uint8_t *buff)
 }
 
 /**
-  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  * @brief  Accelerometer X-axis user offset correction expressed in two's
   *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
   *         The value must be in the range [-127 127].[get]
   *
@@ -1461,7 +1469,8 @@ int32_t lsm6dsrx_xl_usr_offset_z_set(const stmdev_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_xl_usr_offset_z_get(const stmdev_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsrx_xl_usr_offset_z_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *buff)
 {
   int32_t ret;
 
@@ -1483,12 +1492,14 @@ int32_t lsm6dsrx_xl_usr_offset_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsrx_ctrl7_g_t ctrl7_g;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL7_G,
+                          (uint8_t *)&ctrl7_g, 1);
 
   if (ret == 0)
   {
     ctrl7_g.usr_off_on_out = (uint8_t)val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL7_G,
+                             (uint8_t *)&ctrl7_g, 1);
   }
 
   return ret;
@@ -1507,7 +1518,8 @@ int32_t lsm6dsrx_xl_usr_offset_get(const stmdev_ctx_t *ctx, uint8_t *val)
   lsm6dsrx_ctrl7_g_t ctrl7_g;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL7_G,
+                          (uint8_t *)&ctrl7_g, 1);
   *val = ctrl7_g.usr_off_on_out;
 
   return ret;
@@ -1552,7 +1564,8 @@ int32_t lsm6dsrx_timestamp_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsrx_ctrl10_c_t ctrl10_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL10_C, (uint8_t *)&ctrl10_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL10_C,
+                          (uint8_t *)&ctrl10_c, 1);
 
   if (ret == 0)
   {
@@ -1577,7 +1590,8 @@ int32_t lsm6dsrx_timestamp_get(const stmdev_ctx_t *ctx, uint8_t *val)
   lsm6dsrx_ctrl10_c_t ctrl10_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL10_C, (uint8_t *)&ctrl10_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL10_C,
+                          (uint8_t *)&ctrl10_c, 1);
   *val = ctrl10_c.timestamp_en;
 
   return ret;
@@ -1586,7 +1600,7 @@ int32_t lsm6dsrx_timestamp_get(const stmdev_ctx_t *ctx, uint8_t *val)
 /**
   * @brief  Timestamp first data output register (r).
   *         The value is expressed as a 32-bit word and the bit resolution
-  *         is 25 μs.[get]
+  *         is 25 us.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
   * @param  buff   Buffer that stores data read
@@ -1633,12 +1647,14 @@ int32_t lsm6dsrx_rounding_mode_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl5_c_t ctrl5_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL5_C, (uint8_t *)&ctrl5_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL5_C,
+                          (uint8_t *)&ctrl5_c, 1);
 
   if (ret == 0)
   {
     ctrl5_c.rounding = (uint8_t)val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL5_C, (uint8_t *)&ctrl5_c, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL5_C,
+                             (uint8_t *)&ctrl5_c, 1);
   }
 
   return ret;
@@ -1658,7 +1674,8 @@ int32_t lsm6dsrx_rounding_mode_get(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl5_c_t ctrl5_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL5_C, (uint8_t *)&ctrl5_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL5_C,
+                          (uint8_t *)&ctrl5_c, 1);
 
   switch (ctrl5_c.rounding)
   {
@@ -1688,7 +1705,7 @@ int32_t lsm6dsrx_rounding_mode_get(const stmdev_ctx_t *ctx,
 
 /**
   * @brief  Temperature data output register (r).
-  *         L and H registers together express a 16-bit word in two’s
+  *         L and H registers together express a 16-bit word in two's
   *         complement.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
@@ -1696,7 +1713,8 @@ int32_t lsm6dsrx_rounding_mode_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_temperature_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
+int32_t lsm6dsrx_temperature_raw_get(const stmdev_ctx_t *ctx,
+                                     int16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -1710,14 +1728,15 @@ int32_t lsm6dsrx_temperature_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
 
 /**
   * @brief  Angular rate sensor. The value is expressed as a 16-bit
-  *         word in two’s complement.[get]
+  *         word in two's complement.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
   * @param  buff   Buffer that stores data read
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_angular_rate_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
+int32_t lsm6dsrx_angular_rate_raw_get(const stmdev_ctx_t *ctx,
+                                      int16_t *val)
 {
   uint8_t buff[6];
   int32_t ret;
@@ -1735,14 +1754,15 @@ int32_t lsm6dsrx_angular_rate_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
 
 /**
   * @brief  Linear acceleration output register. The value is expressed as a
-  *         16-bit word in two’s complement.[get]
+  *         16-bit word in two's complement.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
   * @param  buff   Buffer that stores data read
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
+int32_t lsm6dsrx_acceleration_raw_get(const stmdev_ctx_t *ctx,
+                                      int16_t *val)
 {
   uint8_t buff[6];
   int32_t ret;
@@ -1766,11 +1786,11 @@ int32_t lsm6dsrx_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_fifo_out_raw_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsrx_fifo_out_raw_get(const stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_FIFO_DATA_OUT_X_L, val, 6);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_FIFO_DATA_OUT_X_L, buff, 6);
 
   return ret;
 }
@@ -1783,7 +1803,8 @@ int32_t lsm6dsrx_fifo_out_raw_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_number_of_steps_get(const stmdev_ctx_t *ctx, uint16_t *val)
+int32_t lsm6dsrx_number_of_steps_get(const stmdev_ctx_t *ctx,
+                                     uint16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -1991,18 +2012,21 @@ int32_t lsm6dsrx_ln_pg_write_byte(const stmdev_ctx_t *ctx, uint16_t add,
 
   if (ret == 0)
   {
-    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PAGE_RW,
+                            (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
   {
     page_rw.page_rw = 0x02U; /* page_write enable */
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_PAGE_RW,
+                             (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
   {
-    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PAGE_SEL, (uint8_t *)&page_sel, 1);
+    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PAGE_SEL,
+                            (uint8_t *)&page_sel, 1);
   }
 
   if (ret == 0)
@@ -2027,13 +2051,15 @@ int32_t lsm6dsrx_ln_pg_write_byte(const stmdev_ctx_t *ctx, uint16_t add,
 
   if (ret == 0)
   {
-    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PAGE_RW,
+                            (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
   {
     page_rw.page_rw = 0x00; /* page_write disable */
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_PAGE_RW,
+                             (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
@@ -2060,28 +2086,32 @@ int32_t lsm6dsrx_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t add,
   lsm6dsrx_page_rw_t page_rw;
   lsm6dsrx_page_sel_t page_sel;
   lsm6dsrx_page_address_t page_address;
+  uint8_t msb;
+  uint8_t lsb;
   int32_t ret;
-
-  uint8_t msb, lsb;
   uint8_t i ;
-  msb = (uint8_t)(add / 256U);
+
+  msb = (uint8_t)((add / 256U) & 0x0FU);
   lsb = (uint8_t)(add - (msb * 256U));
   ret = lsm6dsrx_mem_bank_set(ctx, LSM6DSRX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
   {
-    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PAGE_RW,
+                            (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
   {
     page_rw.page_rw = 0x02U; /* page_write enable*/
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_PAGE_RW,
+                             (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
   {
-    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PAGE_SEL, (uint8_t *)&page_sel, 1);
+    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PAGE_SEL,
+                            (uint8_t *)&page_sel, 1);
   }
 
   if (ret == 0)
@@ -2138,13 +2168,15 @@ int32_t lsm6dsrx_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t add,
 
   if (ret == 0)
   {
-    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PAGE_RW,
+                            (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
   {
     page_rw.page_rw = 0x00U; /* page_write disable */
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_PAGE_RW,
+                             (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
@@ -2176,18 +2208,21 @@ int32_t lsm6dsrx_ln_pg_read_byte(const stmdev_ctx_t *ctx, uint16_t add,
 
   if (ret == 0)
   {
-    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PAGE_RW,
+                            (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
   {
     page_rw.page_rw = 0x01U; /* page_read enable*/
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_PAGE_RW,
+                             (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
   {
-    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PAGE_SEL, (uint8_t *)&page_sel, 1);
+    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PAGE_SEL,
+                            (uint8_t *)&page_sel, 1);
   }
 
   if (ret == 0)
@@ -2212,13 +2247,15 @@ int32_t lsm6dsrx_ln_pg_read_byte(const stmdev_ctx_t *ctx, uint16_t add,
 
   if (ret == 0)
   {
-    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PAGE_RW,
+                            (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
   {
     page_rw.page_rw = 0x00U; /* page_read disable */
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_PAGE_RW,
+                             (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
@@ -2323,12 +2360,14 @@ int32_t lsm6dsrx_reset_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsrx_ctrl3_c_t ctrl3_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL3_C,
+                          (uint8_t *)&ctrl3_c, 1);
 
   if (ret == 0)
   {
     ctrl3_c.sw_reset = (uint8_t)val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL3_C,
+                             (uint8_t *)&ctrl3_c, 1);
   }
 
   return ret;
@@ -2347,7 +2386,8 @@ int32_t lsm6dsrx_reset_get(const stmdev_ctx_t *ctx, uint8_t *val)
   lsm6dsrx_ctrl3_c_t ctrl3_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL3_C,
+                          (uint8_t *)&ctrl3_c, 1);
   *val = ctrl3_c.sw_reset;
 
   return ret;
@@ -2367,12 +2407,14 @@ int32_t lsm6dsrx_auto_increment_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsrx_ctrl3_c_t ctrl3_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL3_C,
+                          (uint8_t *)&ctrl3_c, 1);
 
   if (ret == 0)
   {
     ctrl3_c.if_inc = (uint8_t)val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL3_C,
+                             (uint8_t *)&ctrl3_c, 1);
   }
 
   return ret;
@@ -2392,7 +2434,8 @@ int32_t lsm6dsrx_auto_increment_get(const stmdev_ctx_t *ctx, uint8_t *val)
   lsm6dsrx_ctrl3_c_t ctrl3_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL3_C,
+                          (uint8_t *)&ctrl3_c, 1);
   *val = ctrl3_c.if_inc;
 
   return ret;
@@ -2411,12 +2454,14 @@ int32_t lsm6dsrx_boot_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsrx_ctrl3_c_t ctrl3_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL3_C,
+                          (uint8_t *)&ctrl3_c, 1);
 
   if (ret == 0)
   {
     ctrl3_c.boot = (uint8_t)val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL3_C,
+                             (uint8_t *)&ctrl3_c, 1);
   }
 
   return ret;
@@ -2435,7 +2480,8 @@ int32_t lsm6dsrx_boot_get(const stmdev_ctx_t *ctx, uint8_t *val)
   lsm6dsrx_ctrl3_c_t ctrl3_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL3_C,
+                          (uint8_t *)&ctrl3_c, 1);
   *val = ctrl3_c.boot;
 
   return ret;
@@ -2457,12 +2503,14 @@ int32_t lsm6dsrx_xl_self_test_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl5_c_t ctrl5_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL5_C, (uint8_t *)&ctrl5_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL5_C,
+                          (uint8_t *)&ctrl5_c, 1);
 
   if (ret == 0)
   {
     ctrl5_c.st_xl = (uint8_t)val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL5_C, (uint8_t *)&ctrl5_c, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL5_C,
+                             (uint8_t *)&ctrl5_c, 1);
   }
 
   return ret;
@@ -2482,7 +2530,8 @@ int32_t lsm6dsrx_xl_self_test_get(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl5_c_t ctrl5_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL5_C, (uint8_t *)&ctrl5_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL5_C,
+                          (uint8_t *)&ctrl5_c, 1);
 
   switch (ctrl5_c.st_xl)
   {
@@ -2520,12 +2569,14 @@ int32_t lsm6dsrx_gy_self_test_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl5_c_t ctrl5_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL5_C, (uint8_t *)&ctrl5_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL5_C,
+                          (uint8_t *)&ctrl5_c, 1);
 
   if (ret == 0)
   {
     ctrl5_c.st_g = (uint8_t)val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL5_C, (uint8_t *)&ctrl5_c, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL5_C,
+                             (uint8_t *)&ctrl5_c, 1);
   }
 
   return ret;
@@ -2545,7 +2596,8 @@ int32_t lsm6dsrx_gy_self_test_get(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl5_c_t ctrl5_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL5_C, (uint8_t *)&ctrl5_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL5_C,
+                          (uint8_t *)&ctrl5_c, 1);
 
   switch (ctrl5_c.st_g)
   {
@@ -2595,7 +2647,8 @@ int32_t lsm6dsrx_xl_filter_lp2_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsrx_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL1_XL, (uint8_t *)&ctrl1_xl, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL1_XL,
+                          (uint8_t *)&ctrl1_xl, 1);
 
   if (ret == 0)
   {
@@ -2620,7 +2673,8 @@ int32_t lsm6dsrx_xl_filter_lp2_get(const stmdev_ctx_t *ctx, uint8_t *val)
   lsm6dsrx_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL1_XL, (uint8_t *)&ctrl1_xl, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL1_XL,
+                          (uint8_t *)&ctrl1_xl, 1);
   *val = ctrl1_xl.lpf2_xl_en;
 
   return ret;
@@ -2640,12 +2694,14 @@ int32_t lsm6dsrx_gy_filter_lp1_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsrx_ctrl4_c_t ctrl4_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL4_C,
+                          (uint8_t *)&ctrl4_c, 1);
 
   if (ret == 0)
   {
     ctrl4_c.lpf1_sel_g = (uint8_t)val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL4_C,
+                             (uint8_t *)&ctrl4_c, 1);
   }
 
   return ret;
@@ -2665,7 +2721,8 @@ int32_t lsm6dsrx_gy_filter_lp1_get(const stmdev_ctx_t *ctx, uint8_t *val)
   lsm6dsrx_ctrl4_c_t ctrl4_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL4_C,
+                          (uint8_t *)&ctrl4_c, 1);
   *val = ctrl4_c.lpf1_sel_g;
 
   return ret;
@@ -2686,12 +2743,14 @@ int32_t lsm6dsrx_filter_settling_mask_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl4_c_t ctrl4_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL4_C,
+                          (uint8_t *)&ctrl4_c, 1);
 
   if (ret == 0)
   {
     ctrl4_c.drdy_mask = (uint8_t)val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL4_C,
+                             (uint8_t *)&ctrl4_c, 1);
   }
 
   return ret;
@@ -2712,7 +2771,8 @@ int32_t lsm6dsrx_filter_settling_mask_get(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl4_c_t ctrl4_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL4_C,
+                          (uint8_t *)&ctrl4_c, 1);
   *val = ctrl4_c.drdy_mask;
 
   return ret;
@@ -2732,12 +2792,14 @@ int32_t lsm6dsrx_gy_lp1_bandwidth_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl6_c_t ctrl6_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL6_C,
+                          (uint8_t *)&ctrl6_c, 1);
 
   if (ret == 0)
   {
     ctrl6_c.ftype = (uint8_t)val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL6_C,
+                             (uint8_t *)&ctrl6_c, 1);
   }
 
   return ret;
@@ -2757,7 +2819,8 @@ int32_t lsm6dsrx_gy_lp1_bandwidth_get(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl6_c_t ctrl6_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL6_C,
+                          (uint8_t *)&ctrl6_c, 1);
 
   switch (ctrl6_c.ftype)
   {
@@ -2814,7 +2877,8 @@ int32_t lsm6dsrx_xl_lp2_on_6d_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsrx_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL8_XL, (uint8_t *)&ctrl8_xl, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL8_XL,
+                          (uint8_t *)&ctrl8_xl, 1);
 
   if (ret == 0)
   {
@@ -2839,7 +2903,8 @@ int32_t lsm6dsrx_xl_lp2_on_6d_get(const stmdev_ctx_t *ctx, uint8_t *val)
   lsm6dsrx_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL8_XL, (uint8_t *)&ctrl8_xl, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL8_XL,
+                          (uint8_t *)&ctrl8_xl, 1);
   *val = ctrl8_xl.low_pass_on_6d;
 
   return ret;
@@ -2860,7 +2925,8 @@ int32_t lsm6dsrx_xl_hp_path_on_out_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL8_XL, (uint8_t *)&ctrl8_xl, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL8_XL,
+                          (uint8_t *)&ctrl8_xl, 1);
 
   if (ret == 0)
   {
@@ -2889,7 +2955,8 @@ int32_t lsm6dsrx_xl_hp_path_on_out_get(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL8_XL, (uint8_t *)&ctrl8_xl, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL8_XL,
+                          (uint8_t *)&ctrl8_xl, 1);
 
   switch (((ctrl8_xl.hp_ref_mode_xl << 5) + (ctrl8_xl.hp_slope_xl_en <<
                                              4) +
@@ -3005,12 +3072,14 @@ int32_t lsm6dsrx_xl_hp_path_on_out_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_xl_fast_settling_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsrx_xl_fast_settling_set(const stmdev_ctx_t *ctx,
+                                      uint8_t val)
 {
   lsm6dsrx_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL8_XL, (uint8_t *)&ctrl8_xl, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL8_XL,
+                          (uint8_t *)&ctrl8_xl, 1);
 
   if (ret == 0)
   {
@@ -3032,12 +3101,14 @@ int32_t lsm6dsrx_xl_fast_settling_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_xl_fast_settling_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsrx_xl_fast_settling_get(const stmdev_ctx_t *ctx,
+                                      uint8_t *val)
 {
   lsm6dsrx_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL8_XL, (uint8_t *)&ctrl8_xl, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL8_XL,
+                          (uint8_t *)&ctrl8_xl, 1);
   *val = ctrl8_xl.fastsettl_mode_xl;
 
   return ret;
@@ -3058,7 +3129,8 @@ int32_t lsm6dsrx_xl_hp_path_internal_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_tap_cfg0_t tap_cfg0;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG0,
+                          (uint8_t *)&tap_cfg0, 1);
 
   if (ret == 0)
   {
@@ -3085,7 +3157,8 @@ int32_t lsm6dsrx_xl_hp_path_internal_get(const stmdev_ctx_t *ctx,
   lsm6dsrx_tap_cfg0_t tap_cfg0;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG0,
+                          (uint8_t *)&tap_cfg0, 1);
 
   switch (tap_cfg0.slope_fds)
   {
@@ -3120,13 +3193,15 @@ int32_t lsm6dsrx_gy_hp_path_internal_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl7_g_t ctrl7_g;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL7_G,
+                          (uint8_t *)&ctrl7_g, 1);
 
   if (ret == 0)
   {
     ctrl7_g.hp_en_g = (((uint8_t)val & 0x80U) >> 7);
     ctrl7_g.hpm_g = (uint8_t)val & 0x03U;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL7_G,
+                             (uint8_t *)&ctrl7_g, 1);
   }
 
   return ret;
@@ -3147,7 +3222,8 @@ int32_t lsm6dsrx_gy_hp_path_internal_get(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl7_g_t ctrl7_g;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL7_G,
+                          (uint8_t *)&ctrl7_g, 1);
 
   switch ((ctrl7_g.hp_en_g << 7) + ctrl7_g.hpm_g)
   {
@@ -3207,7 +3283,8 @@ int32_t lsm6dsrx_aux_sdo_ocs_mode_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_pin_ctrl_t pin_ctrl;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PIN_CTRL,
+                          (uint8_t *)&pin_ctrl, 1);
 
   if (ret == 0)
   {
@@ -3234,7 +3311,8 @@ int32_t lsm6dsrx_aux_sdo_ocs_mode_get(const stmdev_ctx_t *ctx,
   lsm6dsrx_pin_ctrl_t pin_ctrl;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PIN_CTRL,
+                          (uint8_t *)&pin_ctrl, 1);
 
   switch (pin_ctrl.ois_pu_dis)
   {
@@ -3268,13 +3346,15 @@ int32_t lsm6dsrx_aux_pw_on_ctrl_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl7_g_t ctrl7_g;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL7_G,
+                          (uint8_t *)&ctrl7_g, 1);
 
   if (ret == 0)
   {
     ctrl7_g.ois_on_en = (uint8_t)val & 0x01U;
     ctrl7_g.ois_on = (uint8_t)val & 0x01U;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL7_G,
+                             (uint8_t *)&ctrl7_g, 1);
   }
 
   return ret;
@@ -3294,7 +3374,8 @@ int32_t lsm6dsrx_aux_pw_on_ctrl_get(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl7_g_t ctrl7_g;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL7_G, (uint8_t *)&ctrl7_g, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL7_G,
+                          (uint8_t *)&ctrl7_g, 1);
 
   switch (ctrl7_g.ois_on)
   {
@@ -3327,7 +3408,8 @@ int32_t lsm6dsrx_aux_status_reg_get(const stmdev_ctx_t *ctx,
 {
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_STATUS_SPIAUX, (uint8_t *)val, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_STATUS_SPIAUX,
+                          (uint8_t *)val, 1);
 
   return ret;
 }
@@ -3410,12 +3492,14 @@ int32_t lsm6dsrx_aux_xl_self_test_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_int_ois_t int_ois;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_INT_OIS, (uint8_t *)&int_ois, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_INT_OIS,
+                          (uint8_t *)&int_ois, 1);
 
   if (ret == 0)
   {
     int_ois.st_xl_ois = (uint8_t)val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_INT_OIS, (uint8_t *)&int_ois, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_INT_OIS,
+                             (uint8_t *)&int_ois, 1);
   }
 
   return ret;
@@ -3436,7 +3520,8 @@ int32_t lsm6dsrx_aux_xl_self_test_get(const stmdev_ctx_t *ctx,
   lsm6dsrx_int_ois_t int_ois;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_INT_OIS, (uint8_t *)&int_ois, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_INT_OIS,
+                          (uint8_t *)&int_ois, 1);
 
   switch (int_ois.st_xl_ois)
   {
@@ -3474,12 +3559,14 @@ int32_t lsm6dsrx_aux_den_polarity_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_int_ois_t int_ois;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_INT_OIS, (uint8_t *)&int_ois, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_INT_OIS,
+                          (uint8_t *)&int_ois, 1);
 
   if (ret == 0)
   {
     int_ois.den_lh_ois = (uint8_t)val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_INT_OIS, (uint8_t *)&int_ois, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_INT_OIS,
+                             (uint8_t *)&int_ois, 1);
   }
 
   return ret;
@@ -3499,7 +3586,8 @@ int32_t lsm6dsrx_aux_den_polarity_get(const stmdev_ctx_t *ctx,
   lsm6dsrx_int_ois_t int_ois;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_INT_OIS, (uint8_t *)&int_ois, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_INT_OIS,
+                          (uint8_t *)&int_ois, 1);
 
   switch (int_ois.den_lh_ois)
   {
@@ -3534,12 +3622,14 @@ int32_t lsm6dsrx_aux_den_mode_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_INT_OIS, (uint8_t *)&int_ois, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_INT_OIS,
+                          (uint8_t *)&int_ois, 1);
 
   if (ret == 0)
   {
     int_ois.lvl2_ois = (uint8_t)val & 0x01U;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_INT_OIS, (uint8_t *)&int_ois, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_INT_OIS,
+                             (uint8_t *)&int_ois, 1);
   }
 
   if (ret == 0)
@@ -3573,7 +3663,8 @@ int32_t lsm6dsrx_aux_den_mode_get(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_INT_OIS, (uint8_t *)&int_ois, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_INT_OIS,
+                          (uint8_t *)&int_ois, 1);
 
   if (ret == 0)
   {
@@ -3612,17 +3703,20 @@ int32_t lsm6dsrx_aux_den_mode_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_aux_drdy_on_int2_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsrx_aux_drdy_on_int2_set(const stmdev_ctx_t *ctx,
+                                      uint8_t val)
 {
   lsm6dsrx_int_ois_t int_ois;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_INT_OIS, (uint8_t *)&int_ois, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_INT_OIS,
+                          (uint8_t *)&int_ois, 1);
 
   if (ret == 0)
   {
     int_ois.int2_drdy_ois = (uint8_t)val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_INT_OIS, (uint8_t *)&int_ois, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_INT_OIS,
+                             (uint8_t *)&int_ois, 1);
   }
 
   return ret;
@@ -3637,12 +3731,14 @@ int32_t lsm6dsrx_aux_drdy_on_int2_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_aux_drdy_on_int2_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsrx_aux_drdy_on_int2_get(const stmdev_ctx_t *ctx,
+                                      uint8_t *val)
 {
   lsm6dsrx_int_ois_t int_ois;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_INT_OIS, (uint8_t *)&int_ois, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_INT_OIS,
+                          (uint8_t *)&int_ois, 1);
   *val = int_ois.int2_drdy_ois;
 
   return ret;
@@ -4323,12 +4419,14 @@ int32_t lsm6dsrx_sdo_sa0_mode_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_pin_ctrl_t pin_ctrl;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PIN_CTRL,
+                          (uint8_t *)&pin_ctrl, 1);
 
   if (ret == 0)
   {
     pin_ctrl.sdo_pu_en = (uint8_t)val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_PIN_CTRL,
+                             (uint8_t *)&pin_ctrl, 1);
   }
 
   return ret;
@@ -4348,7 +4446,8 @@ int32_t lsm6dsrx_sdo_sa0_mode_get(const stmdev_ctx_t *ctx,
   lsm6dsrx_pin_ctrl_t pin_ctrl;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PIN_CTRL,
+                          (uint8_t *)&pin_ctrl, 1);
 
   switch (pin_ctrl.sdo_pu_en)
   {
@@ -4438,17 +4537,20 @@ int32_t lsm6dsrx_int1_mode_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_spi_mode_set(const stmdev_ctx_t *ctx, lsm6dsrx_sim_t val)
+int32_t lsm6dsrx_spi_mode_set(const stmdev_ctx_t *ctx,
+                              lsm6dsrx_sim_t val)
 {
   lsm6dsrx_ctrl3_c_t ctrl3_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL3_C,
+                          (uint8_t *)&ctrl3_c, 1);
 
   if (ret == 0)
   {
     ctrl3_c.sim = (uint8_t)val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL3_C,
+                             (uint8_t *)&ctrl3_c, 1);
   }
 
   return ret;
@@ -4462,12 +4564,14 @@ int32_t lsm6dsrx_spi_mode_set(const stmdev_ctx_t *ctx, lsm6dsrx_sim_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_spi_mode_get(const stmdev_ctx_t *ctx, lsm6dsrx_sim_t *val)
+int32_t lsm6dsrx_spi_mode_get(const stmdev_ctx_t *ctx,
+                              lsm6dsrx_sim_t *val)
 {
   lsm6dsrx_ctrl3_c_t ctrl3_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL3_C,
+                          (uint8_t *)&ctrl3_c, 1);
 
   switch (ctrl3_c.sim)
   {
@@ -4501,12 +4605,14 @@ int32_t lsm6dsrx_i2c_interface_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl4_c_t ctrl4_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL4_C,
+                          (uint8_t *)&ctrl4_c, 1);
 
   if (ret == 0)
   {
     ctrl4_c.i2c_disable = (uint8_t)val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL4_C,
+                             (uint8_t *)&ctrl4_c, 1);
   }
 
   return ret;
@@ -4526,7 +4632,8 @@ int32_t lsm6dsrx_i2c_interface_get(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl4_c_t ctrl4_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL4_C,
+                          (uint8_t *)&ctrl4_c, 1);
 
   switch (ctrl4_c.i2c_disable)
   {
@@ -4653,18 +4760,17 @@ int32_t lsm6dsrx_i3c_disable_get(const stmdev_ctx_t *ctx,
   */
 
 /**
-  * @brief  Select the signal that need to route on int1 pad.[set]
+  * @brief   Select the signal that need to route on int1 pad[set]
   *
-  * @param  ctx      read / write interface definitions
-  * @param  val      struct of registers: INT1_CTRL,
-  *                  MD1_CFG, EMB_FUNC_INT1, FSM_INT1_A,
-  *                  FSM_INT1_B
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers: INT1_CTRL,MD1_CFG,
+  *                EMB_FUNC_INT1, FSM_INT1_A, FSM_INT1_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dsrx_pin_int1_route_set(const stmdev_ctx_t *ctx,
                                     lsm6dsrx_pin_int1_route_t *val)
 {
-  lsm6dsrx_pin_int2_route_t pin_int2_route;
   lsm6dsrx_tap_cfg2_t tap_cfg2;
   int32_t ret;
 
@@ -4701,38 +4807,37 @@ int32_t lsm6dsrx_pin_int1_route_set(const stmdev_ctx_t *ctx,
 
   if (ret == 0)
   {
-    if ((val->emb_func_int1.int1_fsm_lc
-         | val->emb_func_int1.int1_sig_mot
-         | val->emb_func_int1.int1_step_detector
-         | val->emb_func_int1.int1_tilt
-         | val->fsm_int1_a.int1_fsm1
-         | val->fsm_int1_a.int1_fsm2
-         | val->fsm_int1_a.int1_fsm3
-         | val->fsm_int1_a.int1_fsm4
-         | val->fsm_int1_a.int1_fsm5
-         | val->fsm_int1_a.int1_fsm6
-         | val->fsm_int1_a.int1_fsm7
-         | val->fsm_int1_a.int1_fsm8
-         | val->fsm_int1_b.int1_fsm9
-         | val->fsm_int1_b.int1_fsm10
-         | val->fsm_int1_b.int1_fsm11
-         | val->fsm_int1_b.int1_fsm12
-         | val->fsm_int1_b.int1_fsm13
-         | val->fsm_int1_b.int1_fsm14
-         | val->fsm_int1_b.int1_fsm15
-         | val->fsm_int1_b.int1_fsm16
-         | val->mlc_int1.int1_mlc1
-         | val->mlc_int1.int1_mlc2
-         | val->mlc_int1.int1_mlc3
-         | val->mlc_int1.int1_mlc4
-         | val->mlc_int1.int1_mlc5
-         | val->mlc_int1.int1_mlc6
-         | val->mlc_int1.int1_mlc7
-         | val->mlc_int1.int1_mlc8) != PROPERTY_DISABLE)
+    if ((val->emb_func_int1.int1_fsm_lc |
+         val->emb_func_int1.int1_sig_mot |
+         val->emb_func_int1.int1_step_detector |
+         val->emb_func_int1.int1_tilt |
+         val->fsm_int1_a.int1_fsm1 |
+         val->fsm_int1_a.int1_fsm2 |
+         val->fsm_int1_a.int1_fsm3 |
+         val->fsm_int1_a.int1_fsm4 |
+         val->fsm_int1_a.int1_fsm5 |
+         val->fsm_int1_a.int1_fsm6 |
+         val->fsm_int1_a.int1_fsm7 |
+         val->fsm_int1_a.int1_fsm8 |
+         val->fsm_int1_b.int1_fsm9 |
+         val->fsm_int1_b.int1_fsm10 |
+         val->fsm_int1_b.int1_fsm11 |
+         val->fsm_int1_b.int1_fsm12 |
+         val->fsm_int1_b.int1_fsm13 |
+         val->fsm_int1_b.int1_fsm14 |
+         val->fsm_int1_b.int1_fsm15 |
+         val->fsm_int1_b.int1_fsm16 |
+         val->mlc_int1.int1_mlc1 |
+         val->mlc_int1.int1_mlc2 |
+         val->mlc_int1.int1_mlc3 |
+         val->mlc_int1.int1_mlc4 |
+         val->mlc_int1.int1_mlc5 |
+         val->mlc_int1.int1_mlc6 |
+         val->mlc_int1.int1_mlc7 |
+         val->mlc_int1.int1_mlc8) != PROPERTY_DISABLE)
     {
       val->md1_cfg.int1_emb_func = PROPERTY_ENABLE;
     }
-
     else
     {
       val->md1_cfg.int1_emb_func = PROPERTY_DISABLE;
@@ -4750,44 +4855,24 @@ int32_t lsm6dsrx_pin_int1_route_set(const stmdev_ctx_t *ctx,
 
   if (ret == 0)
   {
-    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG2, (uint8_t *) &tap_cfg2, 1);
-  }
+    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG2,
+                            (uint8_t *)&tap_cfg2, 1);
 
-  if (ret == 0)
-  {
-    ret = lsm6dsrx_pin_int2_route_get(ctx, &pin_int2_route);
-  }
-
-  if (ret == 0)
-  {
-    if ((pin_int2_route.int2_ctrl.int2_cnt_bdr
-         | pin_int2_route.int2_ctrl.int2_drdy_g
-         | pin_int2_route.int2_ctrl.int2_drdy_temp
-         | pin_int2_route.int2_ctrl.int2_drdy_xl
-         | pin_int2_route.int2_ctrl.int2_fifo_full
-         | pin_int2_route.int2_ctrl.int2_fifo_ovr
-         | pin_int2_route.int2_ctrl.int2_fifo_th
-         | pin_int2_route.md2_cfg.int2_6d
-         | pin_int2_route.md2_cfg.int2_double_tap
-         | pin_int2_route.md2_cfg.int2_ff
-         | pin_int2_route.md2_cfg.int2_wu
-         | pin_int2_route.md2_cfg.int2_single_tap
-         | pin_int2_route.md2_cfg.int2_sleep_change
-         | val->int1_ctrl.den_drdy_flag
-         | val->int1_ctrl.int1_boot
-         | val->int1_ctrl.int1_cnt_bdr
-         | val->int1_ctrl.int1_drdy_g
-         | val->int1_ctrl.int1_drdy_xl
-         | val->int1_ctrl.int1_fifo_full
-         | val->int1_ctrl.int1_fifo_ovr
-         | val->int1_ctrl.int1_fifo_th
-         | val->md1_cfg.int1_shub
-         | val->md1_cfg.int1_6d
-         | val->md1_cfg.int1_double_tap
-         | val->md1_cfg.int1_ff
-         | val->md1_cfg.int1_wu
-         | val->md1_cfg.int1_single_tap
-         | val->md1_cfg.int1_sleep_change) != PROPERTY_DISABLE)
+    if ((val->int1_ctrl.den_drdy_flag |
+         val->int1_ctrl.int1_boot |
+         val->int1_ctrl.int1_cnt_bdr |
+         val->int1_ctrl.int1_drdy_g |
+         val->int1_ctrl.int1_drdy_xl |
+         val->int1_ctrl.int1_fifo_full |
+         val->int1_ctrl.int1_fifo_ovr |
+         val->int1_ctrl.int1_fifo_th |
+         val->md1_cfg.int1_shub |
+         val->md1_cfg.int1_6d |
+         val->md1_cfg.int1_double_tap |
+         val->md1_cfg.int1_ff |
+         val->md1_cfg.int1_wu |
+         val->md1_cfg.int1_single_tap |
+         val->md1_cfg.int1_sleep_change) != PROPERTY_DISABLE)
     {
       tap_cfg2.interrupts_enable = PROPERTY_ENABLE;
     }
@@ -4796,9 +4881,12 @@ int32_t lsm6dsrx_pin_int1_route_set(const stmdev_ctx_t *ctx,
     {
       tap_cfg2.interrupts_enable = PROPERTY_DISABLE;
     }
+  }
 
+  if (ret == 0)
+  {
     ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_TAP_CFG2,
-                             (uint8_t *) &tap_cfg2, 1);
+                             (uint8_t *)&tap_cfg2, 1);
   }
 
   return ret;
@@ -4807,9 +4895,10 @@ int32_t lsm6dsrx_pin_int1_route_set(const stmdev_ctx_t *ctx,
 /**
   * @brief  Select the signal that need to route on int1 pad.[get]
   *
-  * @param  ctx      read / write interface definitions
-  * @param  val      struct of registers: INT1_CTRL, MD1_CFG,
-  *                  EMB_FUNC_INT1, FSM_INT1_A, FSM_INT1_B
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers: INT1_CTRL, MD1_CFG,
+  *                EMB_FUNC_INT1, FSM_INT1_A, FSM_INT1_B.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dsrx_pin_int1_route_get(const stmdev_ctx_t *ctx,
@@ -4864,17 +4953,17 @@ int32_t lsm6dsrx_pin_int1_route_get(const stmdev_ctx_t *ctx,
 }
 
 /**
-  * @brief  Select the signal that need to route on int2 pad.[set]
+  * @brief  Select the signal that need to route on int2 pad[set]
   *
-  * @param  ctx      read / write interface definitions
-  * @param  val      union of registers INT2_CTRL,  MD2_CFG,
-  *                  EMB_FUNC_INT2, FSM_INT2_A, FSM_INT2_B
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers INT2_CTRL,  MD2_CFG,
+  *                EMB_FUNC_INT2, FSM_INT2_A, FSM_INT2_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dsrx_pin_int2_route_set(const stmdev_ctx_t *ctx,
                                     lsm6dsrx_pin_int2_route_t *val)
 {
-  lsm6dsrx_pin_int1_route_t pin_int1_route;
   lsm6dsrx_tap_cfg2_t tap_cfg2;
   int32_t ret;
 
@@ -4911,38 +5000,37 @@ int32_t lsm6dsrx_pin_int2_route_set(const stmdev_ctx_t *ctx,
 
   if (ret == 0)
   {
-    if ((val->emb_func_int2.int2_fsm_lc
-         | val->emb_func_int2.int2_sig_mot
-         | val->emb_func_int2.int2_step_detector
-         | val->emb_func_int2.int2_tilt
-         | val->fsm_int2_a.int2_fsm1
-         | val->fsm_int2_a.int2_fsm2
-         | val->fsm_int2_a.int2_fsm3
-         | val->fsm_int2_a.int2_fsm4
-         | val->fsm_int2_a.int2_fsm5
-         | val->fsm_int2_a.int2_fsm6
-         | val->fsm_int2_a.int2_fsm7
-         | val->fsm_int2_a.int2_fsm8
-         | val->fsm_int2_b.int2_fsm9
-         | val->fsm_int2_b.int2_fsm10
-         | val->fsm_int2_b.int2_fsm11
-         | val->fsm_int2_b.int2_fsm12
-         | val->fsm_int2_b.int2_fsm13
-         | val->fsm_int2_b.int2_fsm14
-         | val->fsm_int2_b.int2_fsm15
-         | val->fsm_int2_b.int2_fsm16
-         | val->mlc_int2.int2_mlc1
-         | val->mlc_int2.int2_mlc2
-         | val->mlc_int2.int2_mlc3
-         | val->mlc_int2.int2_mlc4
-         | val->mlc_int2.int2_mlc5
-         | val->mlc_int2.int2_mlc6
-         | val->mlc_int2.int2_mlc7
-         | val->mlc_int2.int2_mlc8) != PROPERTY_DISABLE)
+    if ((val->emb_func_int2.int2_step_detector |
+         val->emb_func_int2.int2_tilt |
+         val->emb_func_int2.int2_sig_mot |
+         val->emb_func_int2.int2_fsm_lc |
+         val->fsm_int2_a.int2_fsm1 |
+         val->fsm_int2_a.int2_fsm2 |
+         val->fsm_int2_a.int2_fsm3 |
+         val->fsm_int2_a.int2_fsm4 |
+         val->fsm_int2_a.int2_fsm5 |
+         val->fsm_int2_a.int2_fsm6 |
+         val->fsm_int2_a.int2_fsm7 |
+         val->fsm_int2_a.int2_fsm8 |
+         val->fsm_int2_b.int2_fsm9 |
+         val->fsm_int2_b.int2_fsm10 |
+         val->fsm_int2_b.int2_fsm11 |
+         val->fsm_int2_b.int2_fsm12 |
+         val->fsm_int2_b.int2_fsm13 |
+         val->fsm_int2_b.int2_fsm14 |
+         val->fsm_int2_b.int2_fsm15 |
+         val->fsm_int2_b.int2_fsm16 |
+         val->mlc_int2.int2_mlc1 |
+         val->mlc_int2.int2_mlc2 |
+         val->mlc_int2.int2_mlc3 |
+         val->mlc_int2.int2_mlc4 |
+         val->mlc_int2.int2_mlc5 |
+         val->mlc_int2.int2_mlc6 |
+         val->mlc_int2.int2_mlc7 |
+         val->mlc_int2.int2_mlc8) != PROPERTY_DISABLE)
     {
       val->md2_cfg.int2_emb_func = PROPERTY_ENABLE;
     }
-
     else
     {
       val->md2_cfg.int2_emb_func = PROPERTY_DISABLE;
@@ -4960,43 +5048,25 @@ int32_t lsm6dsrx_pin_int2_route_set(const stmdev_ctx_t *ctx,
 
   if (ret == 0)
   {
-    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG2, (uint8_t *) &tap_cfg2, 1);
+    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG2,
+                            (uint8_t *)&tap_cfg2, 1);
   }
 
   if (ret == 0)
   {
-    ret = lsm6dsrx_pin_int1_route_get(ctx, &pin_int1_route);
-  }
-
-  if (ret == 0)
-  {
-    if ((val->int2_ctrl.int2_cnt_bdr
-         | val->int2_ctrl.int2_drdy_g
-         | val->int2_ctrl.int2_drdy_temp
-         | val->int2_ctrl.int2_drdy_xl
-         | val->int2_ctrl.int2_fifo_full
-         | val->int2_ctrl.int2_fifo_ovr
-         | val->int2_ctrl.int2_fifo_th
-         | val->md2_cfg.int2_6d
-         | val->md2_cfg.int2_double_tap
-         | val->md2_cfg.int2_ff
-         | val->md2_cfg.int2_wu
-         | val->md2_cfg.int2_single_tap
-         | val->md2_cfg.int2_sleep_change
-         | pin_int1_route.int1_ctrl.den_drdy_flag
-         | pin_int1_route.int1_ctrl.int1_boot
-         | pin_int1_route.int1_ctrl.int1_cnt_bdr
-         | pin_int1_route.int1_ctrl.int1_drdy_g
-         | pin_int1_route.int1_ctrl.int1_drdy_xl
-         | pin_int1_route.int1_ctrl.int1_fifo_full
-         | pin_int1_route.int1_ctrl.int1_fifo_ovr
-         | pin_int1_route.int1_ctrl.int1_fifo_th
-         | pin_int1_route.md1_cfg.int1_6d
-         | pin_int1_route.md1_cfg.int1_double_tap
-         | pin_int1_route.md1_cfg.int1_ff
-         | pin_int1_route.md1_cfg.int1_wu
-         | pin_int1_route.md1_cfg.int1_single_tap
-         | pin_int1_route.md1_cfg.int1_sleep_change) != PROPERTY_DISABLE)
+    if ((val->int2_ctrl.int2_drdy_xl |
+         val->int2_ctrl.int2_drdy_g |
+         val->int2_ctrl.int2_drdy_temp |
+         val->int2_ctrl.int2_fifo_th |
+         val->int2_ctrl.int2_fifo_ovr |
+         val->int2_ctrl.int2_fifo_full |
+         val->int2_ctrl.int2_cnt_bdr |
+         val->md2_cfg.int2_6d |
+         val->md2_cfg.int2_double_tap |
+         val->md2_cfg.int2_ff |
+         val->md2_cfg.int2_wu |
+         val->md2_cfg.int2_single_tap |
+         val->md2_cfg.int2_sleep_change) != PROPERTY_DISABLE)
     {
       tap_cfg2.interrupts_enable = PROPERTY_ENABLE;
     }
@@ -5007,7 +5077,7 @@ int32_t lsm6dsrx_pin_int2_route_set(const stmdev_ctx_t *ctx,
     }
 
     ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_TAP_CFG2,
-                             (uint8_t *) &tap_cfg2, 1);
+                             (uint8_t *)&tap_cfg2, 1);
   }
 
   return ret;
@@ -5016,9 +5086,10 @@ int32_t lsm6dsrx_pin_int2_route_set(const stmdev_ctx_t *ctx,
 /**
   * @brief  Select the signal that need to route on int2 pad.[get]
   *
-  * @param  ctx      read / write interface definitions
-  * @param  val      union of registers INT2_CTRL,  MD2_CFG,
-  *                  EMB_FUNC_INT2, FSM_INT2_A, FSM_INT2_B
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers INT2_CTRL,  MD2_CFG,
+  *                EMB_FUNC_INT2, FSM_INT2_A, FSM_INT2_B.[get]
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dsrx_pin_int2_route_get(const stmdev_ctx_t *ctx,
@@ -5080,17 +5151,20 @@ int32_t lsm6dsrx_pin_int2_route_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_pin_mode_set(const stmdev_ctx_t *ctx, lsm6dsrx_pp_od_t val)
+int32_t lsm6dsrx_pin_mode_set(const stmdev_ctx_t *ctx,
+                              lsm6dsrx_pp_od_t val)
 {
   lsm6dsrx_ctrl3_c_t ctrl3_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL3_C,
+                          (uint8_t *)&ctrl3_c, 1);
 
   if (ret == 0)
   {
     ctrl3_c.pp_od = (uint8_t)val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL3_C,
+                             (uint8_t *)&ctrl3_c, 1);
   }
 
   return ret;
@@ -5110,7 +5184,8 @@ int32_t lsm6dsrx_pin_mode_get(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl3_c_t ctrl3_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL3_C,
+                          (uint8_t *)&ctrl3_c, 1);
 
   switch (ctrl3_c.pp_od)
   {
@@ -5144,12 +5219,14 @@ int32_t lsm6dsrx_pin_polarity_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl3_c_t ctrl3_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL3_C,
+                          (uint8_t *)&ctrl3_c, 1);
 
   if (ret == 0)
   {
     ctrl3_c.h_lactive = (uint8_t)val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL3_C,
+                             (uint8_t *)&ctrl3_c, 1);
   }
 
   return ret;
@@ -5169,7 +5246,8 @@ int32_t lsm6dsrx_pin_polarity_get(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl3_c_t ctrl3_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL3_C,
+                          (uint8_t *)&ctrl3_c, 1);
 
   switch (ctrl3_c.h_lactive)
   {
@@ -5202,12 +5280,14 @@ int32_t lsm6dsrx_all_on_int1_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsrx_ctrl4_c_t ctrl4_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL4_C,
+                          (uint8_t *)&ctrl4_c, 1);
 
   if (ret == 0)
   {
     ctrl4_c.int2_on_int1 = (uint8_t)val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL4_C,
+                             (uint8_t *)&ctrl4_c, 1);
   }
 
   return ret;
@@ -5226,7 +5306,8 @@ int32_t lsm6dsrx_all_on_int1_get(const stmdev_ctx_t *ctx, uint8_t *val)
   lsm6dsrx_ctrl4_c_t ctrl4_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL4_C,
+                          (uint8_t *)&ctrl4_c, 1);
   *val = ctrl4_c.int2_on_int1;
 
   return ret;
@@ -5247,7 +5328,8 @@ int32_t lsm6dsrx_int_notification_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_page_rw_t page_rw;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG0,
+                          (uint8_t *)&tap_cfg0, 1);
 
   if (ret == 0)
   {
@@ -5264,13 +5346,15 @@ int32_t lsm6dsrx_int_notification_set(const stmdev_ctx_t *ctx,
 
   if (ret == 0)
   {
-    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PAGE_RW,
+                            (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
   {
     page_rw.emb_func_lir = ((uint8_t)val & 0x02U) >> 1;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_PAGE_RW,
+                             (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
@@ -5297,7 +5381,8 @@ int32_t lsm6dsrx_int_notification_get(const stmdev_ctx_t *ctx,
   int32_t ret;
 
   *val = LSM6DSRX_ALL_INT_PULSED;
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG0,
+                          (uint8_t *)&tap_cfg0, 1);
 
   if (ret == 0)
   {
@@ -5306,7 +5391,8 @@ int32_t lsm6dsrx_int_notification_get(const stmdev_ctx_t *ctx,
 
   if (ret == 0)
   {
-    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_PAGE_RW,
+                            (uint8_t *)&page_rw, 1);
   }
 
   if (ret == 0)
@@ -5587,12 +5673,14 @@ int32_t lsm6dsrx_gy_sleep_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsrx_ctrl4_c_t ctrl4_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL4_C,
+                          (uint8_t *)&ctrl4_c, 1);
 
   if (ret == 0)
   {
     ctrl4_c.sleep_g = (uint8_t)val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL4_C,
+                             (uint8_t *)&ctrl4_c, 1);
   }
 
   return ret;
@@ -5611,7 +5699,8 @@ int32_t lsm6dsrx_gy_sleep_mode_get(const stmdev_ctx_t *ctx, uint8_t *val)
   lsm6dsrx_ctrl4_c_t ctrl4_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL4_C, (uint8_t *)&ctrl4_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL4_C,
+                          (uint8_t *)&ctrl4_c, 1);
   *val = ctrl4_c.sleep_g;
 
   return ret;
@@ -5633,7 +5722,8 @@ int32_t lsm6dsrx_act_pin_notification_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_tap_cfg0_t tap_cfg0;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG0,
+                          (uint8_t *)&tap_cfg0, 1);
 
   if (ret == 0)
   {
@@ -5661,7 +5751,8 @@ int32_t lsm6dsrx_act_pin_notification_get(const stmdev_ctx_t *ctx,
   lsm6dsrx_tap_cfg0_t tap_cfg0;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG0,
+                          (uint8_t *)&tap_cfg0, 1);
 
   switch (tap_cfg0. sleep_status_on_int)
   {
@@ -5695,12 +5786,14 @@ int32_t lsm6dsrx_act_mode_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_tap_cfg2_t tap_cfg2;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG2,
+                          (uint8_t *)&tap_cfg2, 1);
 
   if (ret == 0)
   {
     tap_cfg2.inact_en = (uint8_t)val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_TAP_CFG2,
+                             (uint8_t *)&tap_cfg2, 1);
   }
 
   return ret;
@@ -5720,7 +5813,8 @@ int32_t lsm6dsrx_act_mode_get(const stmdev_ctx_t *ctx,
   lsm6dsrx_tap_cfg2_t tap_cfg2;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG2,
+                          (uint8_t *)&tap_cfg2, 1);
 
   switch (tap_cfg2.inact_en)
   {
@@ -5821,7 +5915,8 @@ int32_t lsm6dsrx_tap_detection_on_z_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_tap_cfg0_t tap_cfg0;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG0,
+                          (uint8_t *)&tap_cfg0, 1);
 
   if (ret == 0)
   {
@@ -5847,7 +5942,8 @@ int32_t lsm6dsrx_tap_detection_on_z_get(const stmdev_ctx_t *ctx,
   lsm6dsrx_tap_cfg0_t tap_cfg0;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG0,
+                          (uint8_t *)&tap_cfg0, 1);
   *val = tap_cfg0.tap_z_en;
 
   return ret;
@@ -5867,7 +5963,8 @@ int32_t lsm6dsrx_tap_detection_on_y_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_tap_cfg0_t tap_cfg0;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG0,
+                          (uint8_t *)&tap_cfg0, 1);
 
   if (ret == 0)
   {
@@ -5893,7 +5990,8 @@ int32_t lsm6dsrx_tap_detection_on_y_get(const stmdev_ctx_t *ctx,
   lsm6dsrx_tap_cfg0_t tap_cfg0;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG0,
+                          (uint8_t *)&tap_cfg0, 1);
   *val = tap_cfg0.tap_y_en;
 
   return ret;
@@ -5913,7 +6011,8 @@ int32_t lsm6dsrx_tap_detection_on_x_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_tap_cfg0_t tap_cfg0;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG0,
+                          (uint8_t *)&tap_cfg0, 1);
 
   if (ret == 0)
   {
@@ -5939,7 +6038,8 @@ int32_t lsm6dsrx_tap_detection_on_x_get(const stmdev_ctx_t *ctx,
   lsm6dsrx_tap_cfg0_t tap_cfg0;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG0,
+                          (uint8_t *)&tap_cfg0, 1);
   *val = tap_cfg0.tap_x_en;
 
   return ret;
@@ -5958,7 +6058,8 @@ int32_t lsm6dsrx_tap_threshold_x_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsrx_tap_cfg1_t tap_cfg1;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG1,
+                          (uint8_t *)&tap_cfg1, 1);
 
   if (ret == 0)
   {
@@ -5978,12 +6079,14 @@ int32_t lsm6dsrx_tap_threshold_x_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_tap_threshold_x_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsrx_tap_threshold_x_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val)
 {
   lsm6dsrx_tap_cfg1_t tap_cfg1;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG1,
+                          (uint8_t *)&tap_cfg1, 1);
   *val = tap_cfg1.tap_ths_x;
 
   return ret;
@@ -6003,12 +6106,14 @@ int32_t lsm6dsrx_tap_axis_priority_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_tap_cfg1_t tap_cfg1;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG1,
+                          (uint8_t *)&tap_cfg1, 1);
 
   if (ret == 0)
   {
     tap_cfg1.tap_priority = (uint8_t)val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_TAP_CFG1,
+                             (uint8_t *)&tap_cfg1, 1);
   }
 
   return ret;
@@ -6028,7 +6133,8 @@ int32_t lsm6dsrx_tap_axis_priority_get(const stmdev_ctx_t *ctx,
   lsm6dsrx_tap_cfg1_t tap_cfg1;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG1,
+                          (uint8_t *)&tap_cfg1, 1);
 
   switch (tap_cfg1.tap_priority)
   {
@@ -6077,7 +6183,8 @@ int32_t lsm6dsrx_tap_threshold_y_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsrx_tap_cfg2_t tap_cfg2;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG2,
+                          (uint8_t *)&tap_cfg2, 1);
 
   if (ret == 0)
   {
@@ -6097,12 +6204,14 @@ int32_t lsm6dsrx_tap_threshold_y_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_tap_threshold_y_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsrx_tap_threshold_y_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val)
 {
   lsm6dsrx_tap_cfg2_t tap_cfg2;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_TAP_CFG2,
+                          (uint8_t *)&tap_cfg2, 1);
   *val = tap_cfg2.tap_ths_y;
 
   return ret;
@@ -6142,7 +6251,8 @@ int32_t lsm6dsrx_tap_threshold_z_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_tap_threshold_z_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsrx_tap_threshold_z_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val)
 {
   lsm6dsrx_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -6171,7 +6281,8 @@ int32_t lsm6dsrx_tap_shock_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsrx_int_dur2_t int_dur2;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_INT_DUR2, (uint8_t *)&int_dur2, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_INT_DUR2,
+                          (uint8_t *)&int_dur2, 1);
 
   if (ret == 0)
   {
@@ -6200,7 +6311,8 @@ int32_t lsm6dsrx_tap_shock_get(const stmdev_ctx_t *ctx, uint8_t *val)
   lsm6dsrx_int_dur2_t int_dur2;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_INT_DUR2, (uint8_t *)&int_dur2, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_INT_DUR2,
+                          (uint8_t *)&int_dur2, 1);
   *val = int_dur2.shock;
 
   return ret;
@@ -6223,7 +6335,8 @@ int32_t lsm6dsrx_tap_quiet_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsrx_int_dur2_t int_dur2;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_INT_DUR2, (uint8_t *)&int_dur2, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_INT_DUR2,
+                          (uint8_t *)&int_dur2, 1);
 
   if (ret == 0)
   {
@@ -6252,7 +6365,8 @@ int32_t lsm6dsrx_tap_quiet_get(const stmdev_ctx_t *ctx, uint8_t *val)
   lsm6dsrx_int_dur2_t int_dur2;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_INT_DUR2, (uint8_t *)&int_dur2, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_INT_DUR2,
+                          (uint8_t *)&int_dur2, 1);
   *val = int_dur2.quiet;
 
   return ret;
@@ -6277,7 +6391,8 @@ int32_t lsm6dsrx_tap_dur_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsrx_int_dur2_t int_dur2;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_INT_DUR2, (uint8_t *)&int_dur2, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_INT_DUR2,
+                          (uint8_t *)&int_dur2, 1);
 
   if (ret == 0)
   {
@@ -6306,7 +6421,8 @@ int32_t lsm6dsrx_tap_dur_get(const stmdev_ctx_t *ctx, uint8_t *val)
   lsm6dsrx_int_dur2_t int_dur2;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_INT_DUR2, (uint8_t *)&int_dur2, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_INT_DUR2,
+                          (uint8_t *)&int_dur2, 1);
   *val = int_dur2.dur;
 
   return ret;
@@ -6697,21 +6813,16 @@ int32_t lsm6dsrx_fifo_watermark_set(const stmdev_ctx_t *ctx, uint16_t val)
   lsm6dsrx_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_FIFO_CTRL2,
-                          (uint8_t *)&fifo_ctrl2, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
+  ret += lsm6dsrx_read_reg(ctx, LSM6DSRX_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
 
   if (ret == 0)
   {
-    fifo_ctrl2.wtm = (uint8_t)((val / 256U) & 0x01U);
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_FIFO_CTRL2,
-                             (uint8_t *)&fifo_ctrl2, 1);
-  }
+    fifo_ctrl1.wtm = (uint8_t)(val  & 0xFFU);
+    fifo_ctrl2.wtm = (uint8_t)(val / 256U) & 0x01U;
 
-  if (ret == 0)
-  {
-    fifo_ctrl1.wtm = (uint8_t)(val - (fifo_ctrl2.wtm * 256U));
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_FIFO_CTRL1,
-                             (uint8_t *)&fifo_ctrl1, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
+    ret += lsm6dsrx_write_reg(ctx, LSM6DSRX_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
   }
 
   return ret;
@@ -6725,23 +6836,18 @@ int32_t lsm6dsrx_fifo_watermark_set(const stmdev_ctx_t *ctx, uint16_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_fifo_watermark_get(const stmdev_ctx_t *ctx, uint16_t *val)
+int32_t lsm6dsrx_fifo_watermark_get(const stmdev_ctx_t *ctx,
+                                    uint16_t *val)
 {
   lsm6dsrx_fifo_ctrl1_t fifo_ctrl1;
   lsm6dsrx_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_FIFO_CTRL2,
-                          (uint8_t *)&fifo_ctrl2, 1);
-
-  if (ret == 0)
-  {
-    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_FIFO_CTRL1,
-                            (uint8_t *)&fifo_ctrl1, 1);
-  }
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
+  ret += lsm6dsrx_read_reg(ctx, LSM6DSRX_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
 
   *val = fifo_ctrl2.wtm;
-  *val = (*val * 256U) +  fifo_ctrl1.wtm;
+  *val = (*val * 256U) +  fifo_ctrl1.wtm;;
 
   return ret;
 }
@@ -7024,7 +7130,8 @@ int32_t lsm6dsrx_compression_algo_real_time_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_fifo_stop_on_wtm_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsrx_fifo_stop_on_wtm_set(const stmdev_ctx_t *ctx,
+                                      uint8_t val)
 {
   lsm6dsrx_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
@@ -7051,7 +7158,8 @@ int32_t lsm6dsrx_fifo_stop_on_wtm_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_fifo_stop_on_wtm_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsrx_fifo_stop_on_wtm_get(const stmdev_ctx_t *ctx,
+                                      uint8_t *val)
 {
   lsm6dsrx_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
@@ -7564,14 +7672,15 @@ int32_t lsm6dsrx_fifo_cnt_event_batch_get(const stmdev_ctx_t *ctx,
 
 /**
   * @brief  Resets the internal counter of batching events for a single sensor.
-  *         This bit is automatically reset to zero if it was set to ‘1’.[set]
+  *         This bit is automatically reset to zero if it was set to '1'.[set]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
   * @param  val    Change the values of rst_counter_bdr in reg COUNTER_BDR_REG1
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_rst_batch_counter_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsrx_rst_batch_counter_set(const stmdev_ctx_t *ctx,
+                                       uint8_t val)
 {
   lsm6dsrx_counter_bdr_reg1_t counter_bdr_reg1;
   int32_t ret;
@@ -7591,7 +7700,7 @@ int32_t lsm6dsrx_rst_batch_counter_set(const stmdev_ctx_t *ctx, uint8_t val)
 
 /**
   * @brief  Resets the internal counter of batching events for a single sensor.
-  *         This bit is automatically reset to zero if it was set to ‘1’.[get]
+  *         This bit is automatically reset to zero if it was set to '1'.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
   * @param  val    Change the values of rst_counter_bdr in reg COUNTER_BDR_REG1
@@ -7683,25 +7792,24 @@ int32_t lsm6dsrx_batch_counter_threshold_get(const stmdev_ctx_t *ctx,
   * @brief  Number of unread sensor data (TAG + 6 bytes) stored in FIFO.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of diff_fifo in reg FIFO_STATUS1
+  * @param  val    Read the value of diff_fifo in reg FIFO_STATUS1 and FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_fifo_data_level_get(const stmdev_ctx_t *ctx, uint16_t *val)
+int32_t lsm6dsrx_fifo_data_level_get(const stmdev_ctx_t *ctx,
+                                     uint16_t *val)
 {
-  lsm6dsrx_fifo_status1_t fifo_status1;
-  lsm6dsrx_fifo_status2_t fifo_status2;
+  uint8_t reg[2];
+  lsm6dsrx_fifo_status1_t *fifo_status1 = (lsm6dsrx_fifo_status1_t *)&reg[0];
+  lsm6dsrx_fifo_status2_t *fifo_status2 = (lsm6dsrx_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_FIFO_STATUS1,
-                          (uint8_t *)&fifo_status1, 1);
-
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_FIFO_STATUS1, (uint8_t *)reg, 2);
   if (ret == 0)
   {
-    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_FIFO_STATUS2,
-                            (uint8_t *)&fifo_status2, 1);
-    *val = fifo_status2.diff_fifo;
-    *val = (*val * 256U) + fifo_status1.diff_fifo;
+    *val = fifo_status2->diff_fifo;
+    *val = (*val * 256U) + fifo_status1->diff_fifo;
   }
 
   return ret;
@@ -7711,16 +7819,23 @@ int32_t lsm6dsrx_fifo_data_level_get(const stmdev_ctx_t *ctx, uint16_t *val)
   * @brief  Smart FIFO status.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Registers FIFO_STATUS2
+  * @param  val    Read registers FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dsrx_fifo_status_get(const stmdev_ctx_t *ctx,
                                  lsm6dsrx_fifo_status2_t *val)
 {
+  uint8_t reg[2];
+  lsm6dsrx_fifo_status2_t *fifo_status2 = (lsm6dsrx_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_FIFO_STATUS2, (uint8_t *)val, 1);
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = *fifo_status2;
+  }
 
   return ret;
 }
@@ -7729,18 +7844,22 @@ int32_t lsm6dsrx_fifo_status_get(const stmdev_ctx_t *ctx,
   * @brief  Smart FIFO full status.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of fifo_full_ia in reg FIFO_STATUS2
+  * @param  val    Read the values of fifo_full_ia in reg FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dsrx_fifo_full_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm6dsrx_fifo_status2_t fifo_status2;
+  uint8_t reg[2];
+  lsm6dsrx_fifo_status2_t *fifo_status2 = (lsm6dsrx_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_FIFO_STATUS2,
-                          (uint8_t *)&fifo_status2, 1);
-  *val = fifo_status2.fifo_full_ia;
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_full_ia;
+  }
 
   return ret;
 }
@@ -7749,19 +7868,23 @@ int32_t lsm6dsrx_fifo_full_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @brief  FIFO overrun status.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of  fifo_over_run_latched in
+  * @param  val    Read the values of  fifo_over_run_latched in
   *                reg FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dsrx_fifo_ovr_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm6dsrx_fifo_status2_t fifo_status2;
+  uint8_t reg[2];
+  lsm6dsrx_fifo_status2_t *fifo_status2 = (lsm6dsrx_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_FIFO_STATUS2,
-                          (uint8_t *)&fifo_status2, 1);
-  *val = fifo_status2. fifo_ovr_ia;
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_ovr_ia;
+  }
 
   return ret;
 }
@@ -7770,18 +7893,22 @@ int32_t lsm6dsrx_fifo_ovr_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @brief  FIFO watermark status.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of fifo_wtm_ia in reg FIFO_STATUS2
+  * @param  val    Read the values of fifo_wtm_ia in reg FIFO_STATUS2
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
 int32_t lsm6dsrx_fifo_wtm_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm6dsrx_fifo_status2_t fifo_status2;
+  uint8_t reg[2];
+  lsm6dsrx_fifo_status2_t *fifo_status2 = (lsm6dsrx_fifo_status2_t *)&reg[1];
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_FIFO_STATUS2,
-                          (uint8_t *)&fifo_status2, 1);
-  *val = fifo_status2.fifo_wtm_ia;
+  /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_FIFO_STATUS1, (uint8_t *)reg, 2);
+  if (ret == 0)
+  {
+    *val = fifo_status2->fifo_wtm_ia;
+  }
 
   return ret;
 }
@@ -7947,7 +8074,8 @@ int32_t lsm6dsrx_fifo_pedo_batch_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_fifo_pedo_batch_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsrx_fifo_pedo_batch_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val)
 {
   lsm6dsrx_emb_func_fifo_cfg_t emb_func_fifo_cfg;
   int32_t ret;
@@ -7977,7 +8105,8 @@ int32_t lsm6dsrx_fifo_pedo_batch_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_sh_batch_slave_0_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsrx_sh_batch_slave_0_set(const stmdev_ctx_t *ctx,
+                                      uint8_t val)
 {
   lsm6dsrx_slv0_config_t slv0_config;
   int32_t ret;
@@ -8014,7 +8143,8 @@ int32_t lsm6dsrx_sh_batch_slave_0_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_sh_batch_slave_0_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsrx_sh_batch_slave_0_get(const stmdev_ctx_t *ctx,
+                                      uint8_t *val)
 {
   lsm6dsrx_slv0_config_t slv0_config;
   int32_t ret;
@@ -8045,7 +8175,8 @@ int32_t lsm6dsrx_sh_batch_slave_0_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_sh_batch_slave_1_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsrx_sh_batch_slave_1_set(const stmdev_ctx_t *ctx,
+                                      uint8_t val)
 {
   lsm6dsrx_slv1_config_t slv1_config;
   int32_t ret;
@@ -8082,7 +8213,8 @@ int32_t lsm6dsrx_sh_batch_slave_1_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_sh_batch_slave_1_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsrx_sh_batch_slave_1_get(const stmdev_ctx_t *ctx,
+                                      uint8_t *val)
 {
   lsm6dsrx_slv1_config_t slv1_config;
   int32_t ret;
@@ -8113,7 +8245,8 @@ int32_t lsm6dsrx_sh_batch_slave_1_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_sh_batch_slave_2_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsrx_sh_batch_slave_2_set(const stmdev_ctx_t *ctx,
+                                      uint8_t val)
 {
   lsm6dsrx_slv2_config_t slv2_config;
   int32_t ret;
@@ -8150,7 +8283,8 @@ int32_t lsm6dsrx_sh_batch_slave_2_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_sh_batch_slave_2_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsrx_sh_batch_slave_2_get(const stmdev_ctx_t *ctx,
+                                      uint8_t *val)
 {
   lsm6dsrx_slv2_config_t slv2_config;
   int32_t ret;
@@ -8181,7 +8315,8 @@ int32_t lsm6dsrx_sh_batch_slave_2_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_sh_batch_slave_3_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsrx_sh_batch_slave_3_set(const stmdev_ctx_t *ctx,
+                                      uint8_t val)
 {
   lsm6dsrx_slv3_config_t slv3_config;
   int32_t ret;
@@ -8218,7 +8353,8 @@ int32_t lsm6dsrx_sh_batch_slave_3_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_sh_batch_slave_3_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsrx_sh_batch_slave_3_get(const stmdev_ctx_t *ctx,
+                                      uint8_t *val)
 {
   lsm6dsrx_slv3_config_t slv3_config;
   int32_t ret;
@@ -8267,12 +8403,14 @@ int32_t lsm6dsrx_den_mode_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl6_c_t ctrl6_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL6_C,
+                          (uint8_t *)&ctrl6_c, 1);
 
   if (ret == 0)
   {
     ctrl6_c.den_mode = (uint8_t)val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL6_C,
+                             (uint8_t *)&ctrl6_c, 1);
   }
 
   return ret;
@@ -8292,7 +8430,8 @@ int32_t lsm6dsrx_den_mode_get(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl6_c_t ctrl6_c;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL6_C, (uint8_t *)&ctrl6_c, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL6_C,
+                          (uint8_t *)&ctrl6_c, 1);
 
   switch (ctrl6_c.den_mode)
   {
@@ -8338,7 +8477,8 @@ int32_t lsm6dsrx_den_polarity_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL9_XL,
+                          (uint8_t *)&ctrl9_xl, 1);
 
   if (ret == 0)
   {
@@ -8364,7 +8504,8 @@ int32_t lsm6dsrx_den_polarity_get(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL9_XL,
+                          (uint8_t *)&ctrl9_xl, 1);
 
   switch (ctrl9_xl.den_lh)
   {
@@ -8398,7 +8539,8 @@ int32_t lsm6dsrx_den_enable_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL9_XL,
+                          (uint8_t *)&ctrl9_xl, 1);
 
   if (ret == 0)
   {
@@ -8424,7 +8566,8 @@ int32_t lsm6dsrx_den_enable_get(const stmdev_ctx_t *ctx,
   lsm6dsrx_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL9_XL,
+                          (uint8_t *)&ctrl9_xl, 1);
 
   switch (ctrl9_xl.den_xl_g)
   {
@@ -8461,7 +8604,8 @@ int32_t lsm6dsrx_den_mark_axis_x_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsrx_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL9_XL,
+                          (uint8_t *)&ctrl9_xl, 1);
 
   if (ret == 0)
   {
@@ -8481,12 +8625,14 @@ int32_t lsm6dsrx_den_mark_axis_x_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_den_mark_axis_x_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsrx_den_mark_axis_x_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val)
 {
   lsm6dsrx_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL9_XL,
+                          (uint8_t *)&ctrl9_xl, 1);
   *val = ctrl9_xl.den_z;
 
   return ret;
@@ -8505,7 +8651,8 @@ int32_t lsm6dsrx_den_mark_axis_y_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsrx_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL9_XL,
+                          (uint8_t *)&ctrl9_xl, 1);
 
   if (ret == 0)
   {
@@ -8525,12 +8672,14 @@ int32_t lsm6dsrx_den_mark_axis_y_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_den_mark_axis_y_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsrx_den_mark_axis_y_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val)
 {
   lsm6dsrx_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL9_XL,
+                          (uint8_t *)&ctrl9_xl, 1);
   *val = ctrl9_xl.den_y;
 
   return ret;
@@ -8549,12 +8698,14 @@ int32_t lsm6dsrx_den_mark_axis_z_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsrx_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL9_XL,
+                          (uint8_t *)&ctrl9_xl, 1);
 
   if (ret == 0)
   {
     ctrl9_xl.den_x = (uint8_t)val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_CTRL9_XL,
+                             (uint8_t *)&ctrl9_xl, 1);
   }
 
   return ret;
@@ -8568,12 +8719,14 @@ int32_t lsm6dsrx_den_mark_axis_z_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_den_mark_axis_z_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsrx_den_mark_axis_z_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val)
 {
   lsm6dsrx_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL9_XL, (uint8_t *)&ctrl9_xl, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_CTRL9_XL,
+                          (uint8_t *)&ctrl9_xl, 1);
   *val = ctrl9_xl.den_x;
 
   return ret;
@@ -8665,7 +8818,8 @@ int32_t lsm6dsrx_pedo_sens_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_pedo_step_detect_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsrx_pedo_step_detect_get(const stmdev_ctx_t *ctx,
+                                      uint8_t *val)
 {
   lsm6dsrx_emb_func_status_t emb_func_status;
   int32_t ret;
@@ -9086,7 +9240,8 @@ int32_t lsm6dsrx_tilt_flag_data_ready_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_mag_sensitivity_set(const stmdev_ctx_t *ctx, uint16_t val)
+int32_t lsm6dsrx_mag_sensitivity_set(const stmdev_ctx_t *ctx,
+                                     uint16_t val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -9113,7 +9268,8 @@ int32_t lsm6dsrx_mag_sensitivity_set(const stmdev_ctx_t *ctx, uint16_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_mag_sensitivity_get(const stmdev_ctx_t *ctx, uint16_t *val)
+int32_t lsm6dsrx_mag_sensitivity_get(const stmdev_ctx_t *ctx,
+                                     uint16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -9126,7 +9282,7 @@ int32_t lsm6dsrx_mag_sensitivity_get(const stmdev_ctx_t *ctx, uint16_t *val)
     ret = lsm6dsrx_ln_pg_read_byte(ctx, LSM6DSRX_MAG_SENSITIVITY_H,
                                    &buff[1]);
     *val = buff[1];
-    *val = (*val * 256U) +  buff[0];
+    *val = (*val * 256U) + buff[0];
   }
 
   return ret;
@@ -9144,8 +9300,8 @@ int32_t lsm6dsrx_mag_offset_set(const stmdev_ctx_t *ctx, int16_t *val)
 {
   uint8_t buff[6];
   int32_t ret;
-
   uint8_t i;
+
   buff[1] = (uint8_t)((uint16_t)val[0] / 256U);
   buff[0] = (uint8_t)((uint16_t)val[0] - (buff[1] * 256U));
   buff[3] = (uint8_t)((uint16_t)val[1] / 256U);
@@ -9200,8 +9356,8 @@ int32_t lsm6dsrx_mag_offset_get(const stmdev_ctx_t *ctx, int16_t *val)
 {
   uint8_t buff[6];
   int32_t ret;
-
   uint8_t i;
+
   i = 0x00U;
   ret = lsm6dsrx_ln_pg_read_byte(ctx, LSM6DSRX_MAG_OFFX_L, &buff[i]);
 
@@ -9233,14 +9389,14 @@ int32_t lsm6dsrx_mag_offset_get(const stmdev_ctx_t *ctx, int16_t *val)
   {
     i++;
     ret = lsm6dsrx_ln_pg_read_byte(ctx, LSM6DSRX_MAG_OFFZ_H, &buff[i]);
-  }
 
-  val[0] = (int16_t)buff[1];
-  val[0] = (val[0] * 256) + (int16_t)buff[0];
-  val[1] = (int16_t)buff[3];
-  val[1] = (val[1] * 256) + (int16_t)buff[2];
-  val[2] = (int16_t)buff[5];
-  val[2] = (val[2] * 256) + (int16_t)buff[4];
+    val[0] = (int16_t)buff[1];
+    val[0] = (val[0] * 256) + (int16_t)buff[0];
+    val[1] = (int16_t)buff[3];
+    val[1] = (val[1] * 256) + (int16_t)buff[2];
+    val[2] = (int16_t)buff[5];
+    val[2] = (val[2] * 256) + (int16_t)buff[4];
+  }
 
   return ret;
 }
@@ -9262,8 +9418,8 @@ int32_t lsm6dsrx_mag_soft_iron_set(const stmdev_ctx_t *ctx, uint16_t *val)
 {
   uint8_t buff[12];
   int32_t ret;
-
   uint8_t i;
+
   buff[1] = (uint8_t)(val[0] / 256U);
   buff[0] = (uint8_t)(val[0] - (buff[1] * 256U));
   buff[3] = (uint8_t)(val[1] / 256U);
@@ -9277,72 +9433,84 @@ int32_t lsm6dsrx_mag_soft_iron_set(const stmdev_ctx_t *ctx, uint16_t *val)
   buff[11] = (uint8_t)(val[5] / 256U);
   buff[10] = (uint8_t)(val[5] - (buff[5] * 256U));
   i = 0x00U;
-  ret = lsm6dsrx_ln_pg_write_byte(ctx, LSM6DSRX_MAG_SI_XX_L, &buff[i]);
+  ret = lsm6dsrx_ln_pg_write_byte(ctx, LSM6DSRX_MAG_SI_XX_L,
+                                  &buff[i]);
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsrx_ln_pg_write_byte(ctx, LSM6DSRX_MAG_SI_XX_H, &buff[i]);
+    ret = lsm6dsrx_ln_pg_write_byte(ctx, LSM6DSRX_MAG_SI_XX_H,
+                                    &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsrx_ln_pg_write_byte(ctx, LSM6DSRX_MAG_SI_XY_L, &buff[i]);
+    ret = lsm6dsrx_ln_pg_write_byte(ctx, LSM6DSRX_MAG_SI_XY_L,
+                                    &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsrx_ln_pg_write_byte(ctx, LSM6DSRX_MAG_SI_XY_H, &buff[i]);
+    ret = lsm6dsrx_ln_pg_write_byte(ctx, LSM6DSRX_MAG_SI_XY_H,
+                                    &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsrx_ln_pg_write_byte(ctx, LSM6DSRX_MAG_SI_XZ_L, &buff[i]);
+    ret = lsm6dsrx_ln_pg_write_byte(ctx, LSM6DSRX_MAG_SI_XZ_L,
+                                    &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsrx_ln_pg_write_byte(ctx, LSM6DSRX_MAG_SI_XZ_H, &buff[i]);
+    ret = lsm6dsrx_ln_pg_write_byte(ctx, LSM6DSRX_MAG_SI_XZ_H,
+                                    &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsrx_ln_pg_write_byte(ctx, LSM6DSRX_MAG_SI_YY_L, &buff[i]);
+    ret = lsm6dsrx_ln_pg_write_byte(ctx, LSM6DSRX_MAG_SI_YY_L,
+                                    &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsrx_ln_pg_write_byte(ctx, LSM6DSRX_MAG_SI_YY_H, &buff[i]);
+    ret = lsm6dsrx_ln_pg_write_byte(ctx, LSM6DSRX_MAG_SI_YY_H,
+                                    &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsrx_ln_pg_write_byte(ctx, LSM6DSRX_MAG_SI_YZ_L, &buff[i]);
+    ret = lsm6dsrx_ln_pg_write_byte(ctx, LSM6DSRX_MAG_SI_YZ_L,
+                                    &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsrx_ln_pg_write_byte(ctx, LSM6DSRX_MAG_SI_YZ_H, &buff[i]);
+    ret = lsm6dsrx_ln_pg_write_byte(ctx, LSM6DSRX_MAG_SI_YZ_H,
+                                    &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsrx_ln_pg_write_byte(ctx, LSM6DSRX_MAG_SI_ZZ_L, &buff[i]);
+    ret = lsm6dsrx_ln_pg_write_byte(ctx, LSM6DSRX_MAG_SI_ZZ_L,
+                                    &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsrx_ln_pg_write_byte(ctx, LSM6DSRX_MAG_SI_ZZ_H, &buff[i]);
+    ret = lsm6dsrx_ln_pg_write_byte(ctx, LSM6DSRX_MAG_SI_ZZ_H,
+                                    &buff[i]);
   }
 
   return ret;
@@ -9365,75 +9533,87 @@ int32_t lsm6dsrx_mag_soft_iron_get(const stmdev_ctx_t *ctx, uint16_t *val)
 {
   uint8_t buff[12];
   int32_t ret;
-
   uint8_t i;
+
   i = 0x00U;
-  ret = lsm6dsrx_ln_pg_read_byte(ctx, LSM6DSRX_MAG_SI_XX_L, &buff[i]);
+  ret = lsm6dsrx_ln_pg_read_byte(ctx, LSM6DSRX_MAG_SI_XX_L,
+                                 &buff[i]);
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsrx_ln_pg_read_byte(ctx, LSM6DSRX_MAG_SI_XX_H, &buff[i]);
+    ret = lsm6dsrx_ln_pg_read_byte(ctx, LSM6DSRX_MAG_SI_XX_H,
+                                   &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsrx_ln_pg_read_byte(ctx, LSM6DSRX_MAG_SI_XY_L, &buff[i]);
+    ret = lsm6dsrx_ln_pg_read_byte(ctx, LSM6DSRX_MAG_SI_XY_L,
+                                   &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsrx_ln_pg_read_byte(ctx, LSM6DSRX_MAG_SI_XY_H, &buff[i]);
+    ret = lsm6dsrx_ln_pg_read_byte(ctx, LSM6DSRX_MAG_SI_XY_H,
+                                   &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsrx_ln_pg_read_byte(ctx, LSM6DSRX_MAG_SI_XZ_L, &buff[i]);
+    ret = lsm6dsrx_ln_pg_read_byte(ctx, LSM6DSRX_MAG_SI_XZ_L,
+                                   &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsrx_ln_pg_read_byte(ctx, LSM6DSRX_MAG_SI_XZ_H, &buff[i]);
+    ret = lsm6dsrx_ln_pg_read_byte(ctx, LSM6DSRX_MAG_SI_XZ_H,
+                                   &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsrx_ln_pg_read_byte(ctx, LSM6DSRX_MAG_SI_YY_L, &buff[i]);
+    ret = lsm6dsrx_ln_pg_read_byte(ctx, LSM6DSRX_MAG_SI_YY_L,
+                                   &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsrx_ln_pg_read_byte(ctx, LSM6DSRX_MAG_SI_YY_H, &buff[i]);
+    ret = lsm6dsrx_ln_pg_read_byte(ctx, LSM6DSRX_MAG_SI_YY_H,
+                                   &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsrx_ln_pg_read_byte(ctx, LSM6DSRX_MAG_SI_YZ_L, &buff[i]);
+    ret = lsm6dsrx_ln_pg_read_byte(ctx, LSM6DSRX_MAG_SI_YZ_L,
+                                   &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsrx_ln_pg_read_byte(ctx, LSM6DSRX_MAG_SI_YZ_H, &buff[i]);
+    ret = lsm6dsrx_ln_pg_read_byte(ctx, LSM6DSRX_MAG_SI_YZ_H,
+                                   &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsrx_ln_pg_read_byte(ctx, LSM6DSRX_MAG_SI_ZZ_L, &buff[i]);
+    ret = lsm6dsrx_ln_pg_read_byte(ctx, LSM6DSRX_MAG_SI_ZZ_L,
+                                   &buff[i]);
   }
 
   if (ret == 0)
   {
     i++;
-    ret = lsm6dsrx_ln_pg_read_byte(ctx, LSM6DSRX_MAG_SI_ZZ_H, &buff[i]);
+    ret = lsm6dsrx_ln_pg_read_byte(ctx, LSM6DSRX_MAG_SI_ZZ_H,
+                                   &buff[i]);
   }
 
   val[0] = buff[1];
@@ -9785,8 +9965,8 @@ int32_t lsm6dsrx_emb_fsm_en_set(const stmdev_ctx_t *ctx, uint8_t val)
 int32_t lsm6dsrx_emb_fsm_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   int32_t ret;
-
   lsm6dsrx_emb_func_en_b_t emb_func_en_b;
+
   ret = lsm6dsrx_mem_bank_set(ctx, LSM6DSRX_EMBEDDED_FUNC_BANK);
 
   if (ret == 0)
@@ -9941,7 +10121,8 @@ int32_t lsm6dsrx_long_cnt_set(const stmdev_ctx_t *ctx, uint16_t val)
 
   if (ret == 0)
   {
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_FSM_LONG_COUNTER_L, buff, 2);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_FSM_LONG_COUNTER_L, buff,
+                             2);
   }
 
   if (ret == 0)
@@ -9970,7 +10151,8 @@ int32_t lsm6dsrx_long_cnt_get(const stmdev_ctx_t *ctx, uint16_t *val)
 
   if (ret == 0)
   {
-    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_FSM_LONG_COUNTER_L, buff, 2);
+    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_FSM_LONG_COUNTER_L, buff,
+                            2);
     *val = buff[1];
     *val = (*val * 256U) +  buff[0];
   }
@@ -10336,7 +10518,8 @@ int32_t lsm6dsrx_fsm_number_of_programs_set(const stmdev_ctx_t *ctx,
 
   if (ret == 0)
   {
-    ret = lsm6dsrx_ln_pg_write_byte(ctx, LSM6DSRX_FSM_PROGRAMS + 0x01U,
+    ret = lsm6dsrx_ln_pg_write_byte(ctx,
+                                    LSM6DSRX_FSM_PROGRAMS + 0x01U,
                                     buff);
   }
 
@@ -10450,13 +10633,15 @@ int32_t lsm6dsrx_mlc_set(const stmdev_ctx_t *ctx, uint8_t val)
 
   if (ret == 0)
   {
-    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_EMB_FUNC_EN_B, (uint8_t *)&reg, 1);
+    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_EMB_FUNC_EN_B,
+                            (uint8_t *)&reg, 1);
   }
 
   if (ret == 0)
   {
     reg.mlc_en = val;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_EMB_FUNC_EN_B, (uint8_t *)&reg, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_EMB_FUNC_EN_B,
+                             (uint8_t *)&reg, 1);
   }
 
   if ((val != PROPERTY_DISABLE) && (ret == 0))
@@ -10497,7 +10682,8 @@ int32_t lsm6dsrx_mlc_get(const stmdev_ctx_t *ctx, uint8_t *val)
 
   if (ret == 0)
   {
-    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_EMB_FUNC_EN_B, (uint8_t *)&reg, 1);
+    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_EMB_FUNC_EN_B,
+                            (uint8_t *)&reg, 1);
   }
 
   if (ret == 0)
@@ -10717,7 +10903,8 @@ int32_t lsm6dsrx_mlc_mag_sensitivity_get(const stmdev_ctx_t *ctx,
   *
   */
 int32_t lsm6dsrx_sh_read_data_raw_get(const stmdev_ctx_t *ctx,
-                                      lsm6dsrx_emb_sh_read_t *val)
+                                      lsm6dsrx_emb_sh_read_t *val,
+                                      uint8_t len)
 {
   int32_t ret;
 
@@ -10725,8 +10912,8 @@ int32_t lsm6dsrx_sh_read_data_raw_get(const stmdev_ctx_t *ctx,
 
   if (ret == 0)
   {
-    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_SENSOR_HUB_1, (uint8_t *)val,
-                            18);
+    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_SENSOR_HUB_1,
+                            (uint8_t *)val, len);
   }
 
   if (ret == 0)
@@ -11019,7 +11206,8 @@ int32_t lsm6dsrx_sh_pass_through_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsrx_sh_pass_through_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsrx_sh_pass_through_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val)
 {
   lsm6dsrx_master_config_t master_config;
   int32_t ret;
@@ -11495,7 +11683,8 @@ int32_t lsm6dsrx_sh_slv1_cfg_read(const stmdev_ctx_t *ctx,
   {
     slv1_add.slave1_add = (uint8_t)(val->slv_add >> 1);
     slv1_add.r_1 = 1;
-    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_SLV1_ADD, (uint8_t *)&slv1_add, 1);
+    ret = lsm6dsrx_write_reg(ctx, LSM6DSRX_SLV1_ADD,
+                             (uint8_t *)&slv1_add, 1);
   }
 
   if (ret == 0)
@@ -11652,7 +11841,8 @@ int32_t lsm6dsrx_sh_status_get(const stmdev_ctx_t *ctx,
 
   if (ret == 0)
   {
-    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_STATUS_MASTER, (uint8_t *)val, 1);
+    ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_STATUS_MASTER,
+                            (uint8_t *)val, 1);
   }
 
   if (ret == 0)
@@ -11690,8 +11880,7 @@ int32_t lsm6dsrx_s4s_tph_res_set(const stmdev_ctx_t *ctx,
   lsm6dsrx_s4s_tph_l_t s4s_tph_l;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_S4S_TPH_L,
-                          (uint8_t *)&s4s_tph_l, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_S4S_TPH_L, (uint8_t *)&s4s_tph_l, 1);
 
   if (ret == 0)
   {
@@ -11717,8 +11906,7 @@ int32_t lsm6dsrx_s4s_tph_res_get(const stmdev_ctx_t *ctx,
   lsm6dsrx_s4s_tph_l_t s4s_tph_l;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_S4S_TPH_L,
-                          (uint8_t *)&s4s_tph_l, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_S4S_TPH_L, (uint8_t *)&s4s_tph_l, 1);
 
   switch (s4s_tph_l.tph_h_sel)
   {
@@ -11753,8 +11941,7 @@ int32_t lsm6dsrx_s4s_tph_val_set(const stmdev_ctx_t *ctx, uint16_t val)
   lsm6dsrx_s4s_tph_h_t s4s_tph_h;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_S4S_TPH_L,
-                          (uint8_t *)&s4s_tph_l, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_S4S_TPH_L, (uint8_t *)&s4s_tph_l, 1);
 
   if (ret == 0)
   {
@@ -11793,8 +11980,7 @@ int32_t lsm6dsrx_s4s_tph_val_get(const stmdev_ctx_t *ctx, uint16_t *val)
   lsm6dsrx_s4s_tph_h_t s4s_tph_h;
   int32_t ret;
 
-  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_S4S_TPH_L,
-                          (uint8_t *)&s4s_tph_l, 1);
+  ret = lsm6dsrx_read_reg(ctx, LSM6DSRX_S4S_TPH_L, (uint8_t *)&s4s_tph_l, 1);
 
   if (ret == 0)
   {

--- a/sensor/stmemsc/lsm6dsrx_STdC/driver/lsm6dsrx_reg.h
+++ b/sensor/stmemsc/lsm6dsrx_STdC/driver/lsm6dsrx_reg.h
@@ -50,7 +50,7 @@ extern "C" {
 /** if _BYTE_ORDER is not defined, choose the endianness of your architecture
   * by uncommenting the define which fits your platform endianness
   */
-//#define DRV_BYTE_ORDER    DRV_BIG_ENDIAN
+/* #define DRV_BYTE_ORDER    DRV_BIG_ENDIAN */
 #define DRV_BYTE_ORDER    DRV_LITTLE_ENDIAN
 
 #else /* defined __BYTE_ORDER__ */
@@ -695,6 +695,7 @@ typedef struct
 #define LSM6DSRX_OUTY_H_A                     0x2BU
 #define LSM6DSRX_OUTZ_L_A                     0x2CU
 #define LSM6DSRX_OUTZ_H_A                     0x2DU
+
 #define LSM6DSRX_EMB_FUNC_STATUS_MAINPAGE     0x35U
 typedef struct
 {
@@ -2027,9 +2028,11 @@ typedef struct
   uint8_t fsm_init                 : 1;
   uint8_t not_used_01              : 2;
   uint8_t fifo_compr_init          : 1;
-  uint8_t not_used_02              : 4;
+  uint8_t mlc_init                 : 1;
+  uint8_t not_used_02              : 3;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t not_used_02              : 4;
+  uint8_t not_used_02              : 3;
+  uint8_t mlc_init                 : 1;
   uint8_t fifo_compr_init          : 1;
   uint8_t not_used_01              : 2;
   uint8_t fsm_init                 : 1;
@@ -2044,6 +2047,11 @@ typedef struct
 #define LSM6DSRX_MLC5_SRC                     0x75U
 #define LSM6DSRX_MLC6_SRC                     0x76U
 #define LSM6DSRX_MLC7_SRC                     0x77U
+
+/** @defgroup bitfields page 0 and 1
+  * @{
+  *
+  */
 #define LSM6DSRX_MAG_SENSITIVITY_L            0xBAU
 #define LSM6DSRX_MAG_SENSITIVITY_H            0xBBU
 #define LSM6DSRX_MAG_OFFX_L                   0xC0U
@@ -2114,9 +2122,18 @@ typedef struct
 #define LSM6DSRX_PEDO_DEB_STEPS_CONF          0x184U
 #define LSM6DSRX_PEDO_SC_DELTAT_L             0x1D0U
 #define LSM6DSRX_PEDO_SC_DELTAT_H             0x1D1U
-
 #define LSM6DSRX_MLC_MAG_SENSITIVITY_L        0x1E8U
 #define LSM6DSRX_MLC_MAG_SENSITIVITY_H        0x1E9U
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup bitfields page sensor_hub
+  * @{
+  *
+  */
 
 #define LSM6DSRX_SENSOR_HUB_1                 0x02U
 typedef struct
@@ -2731,6 +2748,11 @@ typedef struct
 } lsm6dsrx_status_master_t;
 
 /**
+  * @}
+  *
+  */
+
+/**
   * @defgroup LSM6DSRX_Register_Union
   * @brief    This union group all the registers having a bit-field
   *           description.
@@ -2811,9 +2833,8 @@ typedef union
   lsm6dsrx_fsm_status_a_t                  fsm_status_a;
   lsm6dsrx_fsm_status_b_t                  fsm_status_b;
   lsm6dsrx_mlc_status_mainpage_t           mlc_status_mainpage;
-  lsm6dsrx_emb_func_odr_cfg_c_t            emb_func_odr_cfg_c;
   lsm6dsrx_page_rw_t                       page_rw;
-  lsm6dsrx_emb_func_fifo_cfg_t              emb_func_fifo_cfg;
+  lsm6dsrx_emb_func_fifo_cfg_t             emb_func_fifo_cfg;
   lsm6dsrx_fsm_enable_a_t                  fsm_enable_a;
   lsm6dsrx_fsm_enable_b_t                  fsm_enable_b;
   lsm6dsrx_fsm_long_counter_clear_t        fsm_long_counter_clear;
@@ -2834,6 +2855,7 @@ typedef union
   lsm6dsrx_fsm_outs15_t                    fsm_outs15;
   lsm6dsrx_fsm_outs16_t                    fsm_outs16;
   lsm6dsrx_emb_func_odr_cfg_b_t            emb_func_odr_cfg_b;
+  lsm6dsrx_emb_func_odr_cfg_c_t            emb_func_odr_cfg_c_t;
   lsm6dsrx_emb_func_src_t                  emb_func_src;
   lsm6dsrx_emb_func_init_a_t               emb_func_init_a;
   lsm6dsrx_emb_func_init_b_t               emb_func_init_b;
@@ -2873,8 +2895,8 @@ typedef union
   lsm6dsrx_slv3_config_t                   slv3_config;
   lsm6dsrx_datawrite_slv0_t                datawrite_slv0;
   lsm6dsrx_status_master_t                 status_master;
-  bitwise_t                               bitwise;
-  uint8_t                                 byte;
+  bitwise_t                                 bitwise;
+  uint8_t                                   byte;
 } lsm6dsrx_reg_t;
 
 /**
@@ -2894,7 +2916,6 @@ typedef union
  * The __weak directive allows the final application to overwrite
  * them with a custom implementation.
  */
-
 int32_t lsm6dsrx_read_reg(const stmdev_ctx_t *ctx, uint8_t reg,
                           uint8_t *data,
                           uint16_t len);
@@ -2916,7 +2937,7 @@ float_t lsm6dsrx_from_fs4000dps_to_mdps(int16_t lsb);
 
 float_t lsm6dsrx_from_lsb_to_celsius(int16_t lsb);
 
-float_t lsm6dsrx_from_lsb_to_nsec(int32_t lsb);
+uint64_t lsm6dsrx_from_lsb_to_nsec(uint32_t lsb);
 
 typedef enum
 {
@@ -3046,19 +3067,19 @@ int32_t lsm6dsrx_temp_flag_data_ready_get(const stmdev_ctx_t *ctx,
                                           uint8_t *val);
 
 int32_t lsm6dsrx_xl_usr_offset_x_set(const stmdev_ctx_t *ctx,
-                                     uint8_t *buff);
+                                     uint8_t *val);
 int32_t lsm6dsrx_xl_usr_offset_x_get(const stmdev_ctx_t *ctx,
-                                     uint8_t *buff);
+                                     uint8_t *val);
 
 int32_t lsm6dsrx_xl_usr_offset_y_set(const stmdev_ctx_t *ctx,
-                                     uint8_t *buff);
+                                     uint8_t *val);
 int32_t lsm6dsrx_xl_usr_offset_y_get(const stmdev_ctx_t *ctx,
-                                     uint8_t *buff);
+                                     uint8_t *val);
 
 int32_t lsm6dsrx_xl_usr_offset_z_set(const stmdev_ctx_t *ctx,
-                                     uint8_t *buff);
+                                     uint8_t *val);
 int32_t lsm6dsrx_xl_usr_offset_z_get(const stmdev_ctx_t *ctx,
-                                     uint8_t *buff);
+                                     uint8_t *val);
 
 int32_t lsm6dsrx_xl_usr_offset_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsrx_xl_usr_offset_get(const stmdev_ctx_t *ctx, uint8_t *val);
@@ -3084,19 +3105,18 @@ int32_t lsm6dsrx_rounding_mode_get(const stmdev_ctx_t *ctx,
 
 int32_t lsm6dsrx_temperature_raw_get(const stmdev_ctx_t *ctx, int16_t *val);
 
-int32_t lsm6dsrx_angular_rate_raw_get(const stmdev_ctx_t *ctx,
-                                      int16_t *val);
+int32_t lsm6dsrx_angular_rate_raw_get(const stmdev_ctx_t *ctx, int16_t *val);
 
-int32_t lsm6dsrx_acceleration_raw_get(const stmdev_ctx_t *ctx,
-                                      int16_t *val);
+int32_t lsm6dsrx_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *val);
 
 int32_t lsm6dsrx_fifo_out_raw_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsrx_mlc_out_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 int32_t lsm6dsrx_odr_cal_reg_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsrx_odr_cal_reg_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsrx_number_of_steps_get(const stmdev_ctx_t *ctx,
-                                     uint16_t *val);
+int32_t lsm6dsrx_number_of_steps_get(const stmdev_ctx_t *ctx, uint16_t *val);
 
 int32_t lsm6dsrx_steps_reset(const stmdev_ctx_t *ctx);
 
@@ -3130,7 +3150,7 @@ int32_t lsm6dsrx_data_ready_mode_set(const stmdev_ctx_t *ctx,
 int32_t lsm6dsrx_data_ready_mode_get(const stmdev_ctx_t *ctx,
                                      lsm6dsrx_dataready_pulsed_t *val);
 
-int32_t lsm6dsrx_device_id_get(const stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsrx_device_id_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 int32_t lsm6dsrx_reset_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsrx_reset_get(const stmdev_ctx_t *ctx, uint8_t *val);
@@ -3169,10 +3189,8 @@ int32_t lsm6dsrx_xl_filter_lp2_get(const stmdev_ctx_t *ctx, uint8_t *val);
 int32_t lsm6dsrx_gy_filter_lp1_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsrx_gy_filter_lp1_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsrx_filter_settling_mask_set(const stmdev_ctx_t *ctx,
-                                          uint8_t val);
-int32_t lsm6dsrx_filter_settling_mask_get(const stmdev_ctx_t *ctx,
-                                          uint8_t *val);
+int32_t lsm6dsrx_filter_settling_mask_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsrx_filter_settling_mask_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum
 {
@@ -3225,8 +3243,7 @@ int32_t lsm6dsrx_xl_hp_path_on_out_get(const stmdev_ctx_t *ctx,
                                        lsm6dsrx_hp_slope_xl_en_t *val);
 
 int32_t lsm6dsrx_xl_fast_settling_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsrx_xl_fast_settling_get(const stmdev_ctx_t *ctx,
-                                      uint8_t *val);
+int32_t lsm6dsrx_xl_fast_settling_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum
 {
@@ -3316,8 +3333,7 @@ int32_t lsm6dsrx_aux_den_mode_get(const stmdev_ctx_t *ctx,
                                   lsm6dsrx_lvl2_ois_t *val);
 
 int32_t lsm6dsrx_aux_drdy_on_int2_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsrx_aux_drdy_on_int2_get(const stmdev_ctx_t *ctx,
-                                      uint8_t *val);
+int32_t lsm6dsrx_aux_drdy_on_int2_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum
 {
@@ -3452,8 +3468,10 @@ typedef enum
   LSM6DSRX_SPI_4_WIRE = 0,
   LSM6DSRX_SPI_3_WIRE = 1,
 } lsm6dsrx_sim_t;
-int32_t lsm6dsrx_spi_mode_set(const stmdev_ctx_t *ctx, lsm6dsrx_sim_t val);
-int32_t lsm6dsrx_spi_mode_get(const stmdev_ctx_t *ctx, lsm6dsrx_sim_t *val);
+int32_t lsm6dsrx_spi_mode_set(const stmdev_ctx_t *ctx,
+                              lsm6dsrx_sim_t val);
+int32_t lsm6dsrx_spi_mode_get(const stmdev_ctx_t *ctx,
+                              lsm6dsrx_sim_t *val);
 
 typedef enum
 {
@@ -3552,7 +3570,8 @@ int32_t lsm6dsrx_wkup_ths_weight_get(const stmdev_ctx_t *ctx,
                                      lsm6dsrx_wake_ths_w_t *val);
 
 int32_t lsm6dsrx_wkup_threshold_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsrx_wkup_threshold_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsrx_wkup_threshold_get(const stmdev_ctx_t *ctx,
+                                    uint8_t *val);
 
 int32_t lsm6dsrx_xl_usr_offset_on_wkup_set(const stmdev_ctx_t *ctx,
                                            uint8_t val);
@@ -3605,8 +3624,10 @@ int32_t lsm6dsrx_tap_detection_on_x_set(const stmdev_ctx_t *ctx,
 int32_t lsm6dsrx_tap_detection_on_x_get(const stmdev_ctx_t *ctx,
                                         uint8_t *val);
 
-int32_t lsm6dsrx_tap_threshold_x_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsrx_tap_threshold_x_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsrx_tap_threshold_x_set(const stmdev_ctx_t *ctx,
+                                     uint8_t val);
+int32_t lsm6dsrx_tap_threshold_x_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val);
 
 typedef enum
 {
@@ -3622,11 +3643,15 @@ int32_t lsm6dsrx_tap_axis_priority_set(const stmdev_ctx_t *ctx,
 int32_t lsm6dsrx_tap_axis_priority_get(const stmdev_ctx_t *ctx,
                                        lsm6dsrx_tap_priority_t *val);
 
-int32_t lsm6dsrx_tap_threshold_y_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsrx_tap_threshold_y_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsrx_tap_threshold_y_set(const stmdev_ctx_t *ctx,
+                                     uint8_t val);
+int32_t lsm6dsrx_tap_threshold_y_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val);
 
-int32_t lsm6dsrx_tap_threshold_z_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsrx_tap_threshold_z_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsrx_tap_threshold_z_set(const stmdev_ctx_t *ctx,
+                                     uint8_t val);
+int32_t lsm6dsrx_tap_threshold_z_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val);
 
 int32_t lsm6dsrx_tap_shock_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsrx_tap_shock_get(const stmdev_ctx_t *ctx, uint8_t *val);
@@ -3681,8 +3706,10 @@ int32_t lsm6dsrx_ff_threshold_get(const stmdev_ctx_t *ctx,
 int32_t lsm6dsrx_ff_dur_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsrx_ff_dur_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsrx_fifo_watermark_set(const stmdev_ctx_t *ctx, uint16_t val);
-int32_t lsm6dsrx_fifo_watermark_get(const stmdev_ctx_t *ctx, uint16_t *val);
+int32_t lsm6dsrx_fifo_watermark_set(const stmdev_ctx_t *ctx,
+                                    uint16_t val);
+int32_t lsm6dsrx_fifo_watermark_get(const stmdev_ctx_t *ctx,
+                                    uint16_t *val);
 
 int32_t lsm6dsrx_compression_algo_init_set(const stmdev_ctx_t *ctx,
                                            uint8_t val);
@@ -3712,7 +3739,8 @@ int32_t lsm6dsrx_compression_algo_real_time_set(const stmdev_ctx_t *ctx,
 int32_t lsm6dsrx_compression_algo_real_time_get(const stmdev_ctx_t *ctx,
                                                 uint8_t *val);
 
-int32_t lsm6dsrx_fifo_stop_on_wtm_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsrx_fifo_stop_on_wtm_set(const stmdev_ctx_t *ctx,
+                                      uint8_t val);
 int32_t lsm6dsrx_fifo_stop_on_wtm_get(const stmdev_ctx_t *ctx,
                                       uint8_t *val);
 
@@ -3820,7 +3848,8 @@ int32_t lsm6dsrx_fifo_data_level_get(const stmdev_ctx_t *ctx,
 int32_t lsm6dsrx_fifo_status_get(const stmdev_ctx_t *ctx,
                                  lsm6dsrx_fifo_status2_t *val);
 
-int32_t lsm6dsrx_fifo_full_flag_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsrx_fifo_full_flag_get(const stmdev_ctx_t *ctx,
+                                    uint8_t *val);
 
 int32_t lsm6dsrx_fifo_ovr_flag_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
@@ -3849,27 +3878,33 @@ typedef enum
   LSM6DSRX_GAME_ROTATION_TAG,
   LSM6DSRX_GEOMAG_ROTATION_TAG,
   LSM6DSRX_ROTATION_TAG,
-  LSM6DSRX_SENSORHUB_NACK_TAG  = 0x19,
+  LSM6DSRX_SENSORHUB_NACK_TAG = 0x19,
 } lsm6dsrx_fifo_tag_t;
 int32_t lsm6dsrx_fifo_sensor_tag_get(const stmdev_ctx_t *ctx,
                                      lsm6dsrx_fifo_tag_t *val);
 
-int32_t lsm6dsrx_fifo_pedo_batch_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsrx_fifo_pedo_batch_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsrx_fifo_pedo_batch_set(const stmdev_ctx_t *ctx,
+                                     uint8_t val);
+int32_t lsm6dsrx_fifo_pedo_batch_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val);
 
-int32_t lsm6dsrx_sh_batch_slave_0_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsrx_sh_batch_slave_0_set(const stmdev_ctx_t *ctx,
+                                      uint8_t val);
 int32_t lsm6dsrx_sh_batch_slave_0_get(const stmdev_ctx_t *ctx,
                                       uint8_t *val);
 
-int32_t lsm6dsrx_sh_batch_slave_1_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsrx_sh_batch_slave_1_set(const stmdev_ctx_t *ctx,
+                                      uint8_t val);
 int32_t lsm6dsrx_sh_batch_slave_1_get(const stmdev_ctx_t *ctx,
                                       uint8_t *val);
 
-int32_t lsm6dsrx_sh_batch_slave_2_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsrx_sh_batch_slave_2_set(const stmdev_ctx_t *ctx,
+                                      uint8_t val);
 int32_t lsm6dsrx_sh_batch_slave_2_get(const stmdev_ctx_t *ctx,
                                       uint8_t *val);
 
-int32_t lsm6dsrx_sh_batch_slave_3_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsrx_sh_batch_slave_3_set(const stmdev_ctx_t *ctx,
+                                      uint8_t val);
 int32_t lsm6dsrx_sh_batch_slave_3_get(const stmdev_ctx_t *ctx,
                                       uint8_t *val);
 
@@ -3907,14 +3942,20 @@ int32_t lsm6dsrx_den_enable_set(const stmdev_ctx_t *ctx,
 int32_t lsm6dsrx_den_enable_get(const stmdev_ctx_t *ctx,
                                 lsm6dsrx_den_xl_g_t *val);
 
-int32_t lsm6dsrx_den_mark_axis_x_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsrx_den_mark_axis_x_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsrx_den_mark_axis_x_set(const stmdev_ctx_t *ctx,
+                                     uint8_t val);
+int32_t lsm6dsrx_den_mark_axis_x_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val);
 
-int32_t lsm6dsrx_den_mark_axis_y_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsrx_den_mark_axis_y_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsrx_den_mark_axis_y_set(const stmdev_ctx_t *ctx,
+                                     uint8_t val);
+int32_t lsm6dsrx_den_mark_axis_y_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val);
 
-int32_t lsm6dsrx_den_mark_axis_z_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsrx_den_mark_axis_z_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsrx_den_mark_axis_z_set(const stmdev_ctx_t *ctx,
+                                     uint8_t val);
+int32_t lsm6dsrx_den_mark_axis_z_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val);
 
 int32_t lsm6dsrx_pedo_sens_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsrx_pedo_sens_get(const stmdev_ctx_t *ctx, uint8_t *val);
@@ -3923,9 +3964,9 @@ int32_t lsm6dsrx_pedo_step_detect_get(const stmdev_ctx_t *ctx,
                                       uint8_t *val);
 
 int32_t lsm6dsrx_pedo_debounce_steps_set(const stmdev_ctx_t *ctx,
-                                         uint8_t *buff);
+                                         uint8_t *val);
 int32_t lsm6dsrx_pedo_debounce_steps_get(const stmdev_ctx_t *ctx,
-                                         uint8_t *buff);
+                                         uint8_t *val);
 
 int32_t lsm6dsrx_pedo_steps_period_set(const stmdev_ctx_t *ctx,
                                        uint16_t val);
@@ -3954,15 +3995,18 @@ int32_t lsm6dsrx_tilt_sens_get(const stmdev_ctx_t *ctx, uint8_t *val);
 int32_t lsm6dsrx_tilt_flag_data_ready_get(const stmdev_ctx_t *ctx,
                                           uint8_t *val);
 
-int32_t lsm6dsrx_mag_sensitivity_set(const stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsrx_mag_sensitivity_set(const stmdev_ctx_t *ctx,
+                                     uint16_t val);
 int32_t lsm6dsrx_mag_sensitivity_get(const stmdev_ctx_t *ctx,
                                      uint16_t *val);
 
 int32_t lsm6dsrx_mag_offset_set(const stmdev_ctx_t *ctx, int16_t *val);
 int32_t lsm6dsrx_mag_offset_get(const stmdev_ctx_t *ctx, int16_t *val);
 
-int32_t lsm6dsrx_mag_soft_iron_set(const stmdev_ctx_t *ctx, uint16_t *val);
-int32_t lsm6dsrx_mag_soft_iron_get(const stmdev_ctx_t *ctx, uint16_t *val);
+int32_t lsm6dsrx_mag_soft_iron_set(const stmdev_ctx_t *ctx,
+                                   uint16_t *val);
+int32_t lsm6dsrx_mag_soft_iron_get(const stmdev_ctx_t *ctx,
+                                   uint16_t *val);
 
 typedef enum
 {
@@ -4079,9 +4123,9 @@ int32_t lsm6dsrx_long_cnt_int_value_get(const stmdev_ctx_t *ctx,
                                         uint16_t *val);
 
 int32_t lsm6dsrx_fsm_number_of_programs_set(const stmdev_ctx_t *ctx,
-                                            uint8_t *buff);
+                                            uint8_t *val);
 int32_t lsm6dsrx_fsm_number_of_programs_get(const stmdev_ctx_t *ctx,
-                                            uint8_t *buff);
+                                            uint8_t *val);
 
 int32_t lsm6dsrx_fsm_start_address_set(const stmdev_ctx_t *ctx,
                                        uint16_t val);
@@ -4107,11 +4151,8 @@ int32_t lsm6dsrx_mlc_data_rate_get(const stmdev_ctx_t *ctx,
                                    lsm6dsrx_mlc_odr_t *val);
 
 int32_t lsm6dsrx_mlc_out_get(const stmdev_ctx_t *ctx, uint8_t *buff);
-
-int32_t lsm6dsrx_mlc_mag_sensitivity_set(const stmdev_ctx_t *ctx,
-                                         uint16_t val);
-int32_t lsm6dsrx_mlc_mag_sensitivity_get(const stmdev_ctx_t *ctx,
-                                         uint16_t *val);
+int32_t lsm6dsrx_mlc_mag_sensitivity_set(const stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsrx_mlc_mag_sensitivity_get(const stmdev_ctx_t *ctx, uint16_t *val);
 
 typedef struct
 {
@@ -4135,7 +4176,8 @@ typedef struct
   lsm6dsrx_sensor_hub_18_t  sh_byte_18;
 } lsm6dsrx_emb_sh_read_t;
 int32_t lsm6dsrx_sh_read_data_raw_get(const stmdev_ctx_t *ctx,
-                                      lsm6dsrx_emb_sh_read_t *val);
+                                      lsm6dsrx_emb_sh_read_t *val,
+                                      uint8_t len);
 
 typedef enum
 {
@@ -4162,8 +4204,10 @@ int32_t lsm6dsrx_sh_pin_mode_set(const stmdev_ctx_t *ctx,
 int32_t lsm6dsrx_sh_pin_mode_get(const stmdev_ctx_t *ctx,
                                  lsm6dsrx_shub_pu_en_t *val);
 
-int32_t lsm6dsrx_sh_pass_through_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsrx_sh_pass_through_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsrx_sh_pass_through_set(const stmdev_ctx_t *ctx,
+                                     uint8_t val);
+int32_t lsm6dsrx_sh_pass_through_get(const stmdev_ctx_t *ctx,
+                                     uint8_t *val);
 
 typedef enum
 {

--- a/sensor/stmemsc/lsm6dsv16bx_STdC/driver/lsm6dsv16bx_reg.c
+++ b/sensor/stmemsc/lsm6dsv16bx_STdC/driver/lsm6dsv16bx_reg.c
@@ -7507,7 +7507,7 @@ int32_t lsm6dsv16bx_mlc_out_get(const stmdev_ctx_t *ctx, lsm6dsv16bx_mlc_out_t *
   ret = lsm6dsv16bx_mem_bank_set(ctx, LSM6DSV16BX_EMBED_FUNC_MEM_BANK);
   if (ret == 0)
   {
-    ret = lsm6dsv16bx_read_reg(ctx, LSM6DSV16BX_MLC1_SRC, (uint8_t *)&val, 4);
+    ret = lsm6dsv16bx_read_reg(ctx, LSM6DSV16BX_MLC1_SRC, (uint8_t *)val, 4);
   }
 
   ret += lsm6dsv16bx_mem_bank_set(ctx, LSM6DSV16BX_MAIN_MEM_BANK);

--- a/sensor/stmemsc/lsm6dsv16x_STdC/driver/lsm6dsv16x_reg.c
+++ b/sensor/stmemsc/lsm6dsv16x_STdC/driver/lsm6dsv16x_reg.c
@@ -189,6 +189,60 @@ float_t lsm6dsv16x_from_lsb_to_mv(int16_t lsb)
   return ((float_t)lsb) / 78.0f;
 }
 
+/*
+ * Original conversion routines taken from: https://github.com/numpy/numpy
+ *
+ * Converts from half-precision (16-bit) float number to single precision (32-bit).
+ *
+ * uint32_t  static uint32_t ToFloatBits(uint16_t h);
+ * Released under BSD-3-Clause License
+ */
+static uint32_t ToFloatBits(uint16_t h)
+{
+  uint16_t h_exp = (h & 0x7c00u);
+  uint32_t f_sgn = ((uint32_t)h & 0x8000u) << 16;
+  switch (h_exp)
+  {
+    case 0x0000u:   // 0 or subnormal
+    {
+      uint16_t h_sig = (h & 0x03ffu);
+      // Signed zero
+      if (h_sig == 0)
+      {
+        return f_sgn;
+      }
+      // Subnormal
+      h_sig <<= 1;
+      while ((h_sig & 0x0400u) == 0)
+      {
+        h_sig <<= 1;
+        h_exp++;
+      }
+      uint32_t f_exp = ((uint32_t)(127 - 15 - h_exp)) << 23;
+      uint32_t f_sig = ((uint32_t)(h_sig & 0x03ffu)) << 13;
+      return f_sgn + f_exp + f_sig;
+    }
+    case 0x7c00u: // inf or NaN
+      // All-ones exponent and a copy of the significand
+      return f_sgn + 0x7f800000u + (((uint32_t)(h & 0x03ffu)) << 13);
+    default: // normalized
+      // Just need to adjust the exponent and shift
+      return f_sgn + (((uint32_t)(h & 0x7fffu) + 0x1c000u) << 13);
+  }
+}
+
+/**
+  * @brief  Convert from 16-bit to 32-bit float number
+  *
+  * @param  val      Batching in FIFO buffer of SFLP values.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+uint32_t lsm6dsv16x_from_f16_to_f32(uint16_t val)
+{
+  return ToFloatBits(val);
+}
+
 /**
   * @}
   *
@@ -1998,7 +2052,7 @@ int32_t lsm6dsv16x_pin_int1_route_get(const stmdev_ctx_t *ctx,
   * @brief   Select the signal that need to route on int2 pad[set]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    the signals to route on int1 pin.
+  * @param  val    the signals to route on int2 pin.
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
@@ -2007,6 +2061,7 @@ int32_t lsm6dsv16x_pin_int2_route_set(const stmdev_ctx_t *ctx,
 {
   lsm6dsv16x_int2_ctrl_t          int2_ctrl;
   lsm6dsv16x_ctrl4_t              ctrl4;
+  lsm6dsv16x_ctrl7_t              ctrl7;
   lsm6dsv16x_md2_cfg_t            md2_cfg;
   int32_t ret;
 
@@ -2039,6 +2094,14 @@ int32_t lsm6dsv16x_pin_int2_route_set(const stmdev_ctx_t *ctx,
     return ret;
   }
 
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL7, (uint8_t *)&ctrl7, 1);
+  ctrl7.int2_drdy_ah_qvar         = val->drdy_ah_qvar;
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL7, (uint8_t *)&ctrl7, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MD2_CFG, (uint8_t *)&md2_cfg, 1);
   if (ret != 0)
   {
@@ -2063,7 +2126,7 @@ int32_t lsm6dsv16x_pin_int2_route_set(const stmdev_ctx_t *ctx,
   * @brief  Select the signal that need to route on int2 pad.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    the signals that are routed on int1 pin.(ptr)
+  * @param  val    the signals that are routed on int2 pin.(ptr)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
@@ -2072,6 +2135,7 @@ int32_t lsm6dsv16x_pin_int2_route_get(const stmdev_ctx_t *ctx,
 {
   lsm6dsv16x_int2_ctrl_t          int2_ctrl;
   lsm6dsv16x_ctrl4_t              ctrl4;
+  lsm6dsv16x_ctrl7_t              ctrl7;
   lsm6dsv16x_md2_cfg_t            md2_cfg;
   int32_t ret;
 
@@ -2098,6 +2162,14 @@ int32_t lsm6dsv16x_pin_int2_route_get(const stmdev_ctx_t *ctx,
 
   val->drdy_temp      = ctrl4.int2_drdy_temp;
 
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL7, (uint8_t *)&ctrl7, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->drdy_ah_qvar = ctrl7.int2_drdy_ah_qvar;
+
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MD2_CFG, (uint8_t *)&md2_cfg, 1);
   if (ret != 0)
   {
@@ -2112,6 +2184,270 @@ int32_t lsm6dsv16x_pin_int2_route_get(const stmdev_ctx_t *ctx,
   val->wakeup         = md2_cfg.int2_wu;
   val->freefall       = md2_cfg.int2_ff;
   val->sleep_change   = md2_cfg.int2_sleep_change;
+
+  return ret;
+}
+
+/**
+  * @brief  routes embedded func interrupt signals on INT 1 pin.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      routes embedded func interrupt signals on INT 1 pin.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv16x_emb_pin_int1_route_set(const stmdev_ctx_t *ctx,
+                                          const lsm6dsv16x_emb_pin_int_route_t *val)
+{
+  lsm6dsv16x_emb_func_int1_t emb_func_int1;
+  lsm6dsv16x_md1_cfg_t md1_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_INT1, (uint8_t *)&emb_func_int1, 1);
+  }
+
+  if (ret == 0)
+  {
+    emb_func_int1.int1_tilt = val->tilt;
+    emb_func_int1.int1_sig_mot = val->sig_mot;
+    emb_func_int1.int1_step_detector = val->step_det;
+    emb_func_int1.int1_fsm_lc = val->fsm_lc;
+
+    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_INT1, (uint8_t *)&emb_func_int1, 1);
+  }
+  ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
+
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  if (ret == 0)
+  {
+    md1_cfg.int1_emb_func = 1;
+    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  routes embedded func interrupt signals on INT 1 pin.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      routes embedded func interrupt signals on INT 1 pin.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv16x_emb_pin_int1_route_get(const stmdev_ctx_t *ctx,
+                                          lsm6dsv16x_emb_pin_int_route_t *val)
+{
+  lsm6dsv16x_emb_func_int1_t emb_func_int1;
+  int32_t ret;
+
+  ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_INT1, (uint8_t *)&emb_func_int1, 1);
+  }
+
+  if (ret == 0)
+  {
+    val->tilt = emb_func_int1.int1_tilt;
+    val->sig_mot = emb_func_int1.int1_sig_mot;
+    val->step_det = emb_func_int1.int1_step_detector;
+    val->fsm_lc = emb_func_int1.int1_fsm_lc;
+  }
+  ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  routes embedded func interrupt signals on INT 2 pin.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      routes embedded func interrupt signals on INT 2 pin.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv16x_emb_pin_int2_route_set(const stmdev_ctx_t *ctx,
+                                          const lsm6dsv16x_emb_pin_int_route_t *val)
+{
+  lsm6dsv16x_emb_func_int2_t emb_func_int2;
+  lsm6dsv16x_md2_cfg_t md2_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_INT2, (uint8_t *)&emb_func_int2, 1);
+  }
+
+  if (ret == 0)
+  {
+    emb_func_int2.int2_tilt = val->tilt;
+    emb_func_int2.int2_sig_mot = val->sig_mot;
+    emb_func_int2.int2_step_detector = val->step_det;
+    emb_func_int2.int2_fsm_lc = val->fsm_lc;
+
+    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_INT2, (uint8_t *)&emb_func_int2, 1);
+  }
+  ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
+
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  if (ret == 0)
+  {
+    md2_cfg.int2_emb_func = 1;
+    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  routes embedded func interrupt signals on INT 2 pin.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      routes embedded func interrupt signals on INT 2 pin.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv16x_emb_pin_int2_route_get(const stmdev_ctx_t *ctx,
+                                          lsm6dsv16x_emb_pin_int_route_t *val)
+{
+  lsm6dsv16x_emb_func_int2_t emb_func_int2;
+  int32_t ret;
+
+  ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_INT2, (uint8_t *)&emb_func_int2, 1);
+  }
+
+  if (ret == 0)
+  {
+    val->tilt = emb_func_int2.int2_tilt;
+    val->sig_mot = emb_func_int2.int2_sig_mot;
+    val->step_det = emb_func_int2.int2_step_detector;
+    val->fsm_lc = emb_func_int2.int2_fsm_lc;
+  }
+  ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Embedded Interrupt configuration mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      INT_PULSED, INT_LATCHED
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv16x_embedded_int_cfg_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv16x_embedded_int_config_t val)
+{
+  lsm6dsv16x_page_rw_t page_rw;
+  int32_t ret;
+
+  ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_RW, (uint8_t *)&page_rw, 1);
+
+    switch (val)
+    {
+      case LSM6DSV16X_INT_LATCH_DISABLE:
+        page_rw.emb_func_lir = 0;
+        break;
+
+      case LSM6DSV16X_INT_LATCH_ENABLE:
+      default:
+        page_rw.emb_func_lir = 1;
+        break;
+    }
+
+    ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_RW, (uint8_t *)&page_rw, 1);
+  }
+
+  ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt configuration mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      INT_DISABLED, INT_PULSED, INT_LATCHED
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv16x_embedded_int_cfg_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv16x_embedded_int_config_t *val)
+{
+  lsm6dsv16x_page_rw_t page_rw;
+  int32_t ret;
+
+  ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_RW, (uint8_t *)&page_rw, 1);
+
+    if (page_rw.emb_func_lir == 0U)
+    {
+      *val = LSM6DSV16X_INT_LATCH_DISABLE;
+    }
+    else
+    {
+      *val = LSM6DSV16X_INT_LATCH_ENABLE;
+    }
+  }
+
+  ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Get the status of embedded functions.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lsm6dsv16x_embedded_status_t ptr
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv16x_embedded_status_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv16x_embedded_status_t *val)
+{
+  lsm6dsv16x_emb_func_status_mainpage_t emb_func_status;
+  lsm6dsv16x_emb_func_src_t emb_func_src;
+  int32_t ret;
+
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_STATUS_MAINPAGE, (uint8_t *)&emb_func_status, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->step_detector = emb_func_status.is_step_det;
+  val->tilt = emb_func_status.is_tilt;
+  val->sig_mot = emb_func_status.is_sigmot;
+  val->fsm_lc = emb_func_status.is_fsm_lc;
+
+  /* embedded func */
+  ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
+  ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->step_count_inc = emb_func_src.stepcounter_bit_set;
+  val->step_count_overflow = emb_func_src.step_overflow;
+  val->step_on_delta_time = emb_func_src.step_count_delta_ia;
+  val->step_detector = emb_func_src.step_detected;
 
   return ret;
 }
@@ -3238,13 +3574,8 @@ int32_t lsm6dsv16x_fifo_watermark_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsv16x_fifo_ctrl1_t fifo_ctrl1;
   int32_t ret;
 
-  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
-
-  if (ret == 0)
-  {
-    fifo_ctrl1.wtm = val;
-    ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
-  }
+  fifo_ctrl1.wtm = val;
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
 
   return ret;
 }

--- a/sensor/stmemsc/lsm6dsv16x_STdC/driver/lsm6dsv16x_reg.h
+++ b/sensor/stmemsc/lsm6dsv16x_STdC/driver/lsm6dsv16x_reg.h
@@ -3898,6 +3898,8 @@ float_t lsm6dsv16x_from_lsb_to_nsec(uint32_t lsb);
 
 float_t lsm6dsv16x_from_lsb_to_mv(int16_t lsb);
 
+uint32_t lsm6dsv16x_from_f16_to_f32(uint16_t val);
+
 int32_t lsm6dsv16x_xl_offset_on_out_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv16x_xl_offset_on_out_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
@@ -4179,6 +4181,7 @@ typedef struct
   uint8_t drdy_g               : 1;
   uint8_t drdy_g_eis           : 1;
   uint8_t drdy_temp            : 1;
+  uint8_t drdy_ah_qvar         : 1;
   uint8_t fifo_th              : 1;
   uint8_t fifo_ovr             : 1;
   uint8_t fifo_full            : 1;
@@ -4202,6 +4205,45 @@ int32_t lsm6dsv16x_pin_int2_route_set(const stmdev_ctx_t *ctx,
                                       lsm6dsv16x_pin_int_route_t *val);
 int32_t lsm6dsv16x_pin_int2_route_get(const stmdev_ctx_t *ctx,
                                       lsm6dsv16x_pin_int_route_t *val);
+
+typedef struct
+{
+  uint8_t step_det                     : 1; /* route step detection event on INT pad */
+  uint8_t tilt                         : 1; /* route tilt event on INT pad */
+  uint8_t sig_mot                      : 1; /* route significant motion event on INT pad */
+  uint8_t fsm_lc                       : 1; /* route FSM long counter event on INT pad */
+} lsm6dsv16x_emb_pin_int_route_t;
+int32_t lsm6dsv16x_emb_pin_int1_route_set(const stmdev_ctx_t *ctx,
+                                          const lsm6dsv16x_emb_pin_int_route_t *val);
+int32_t lsm6dsv16x_emb_pin_int1_route_get(const stmdev_ctx_t *ctx,
+                                          lsm6dsv16x_emb_pin_int_route_t *val);
+int32_t lsm6dsv16x_emb_pin_int2_route_set(const stmdev_ctx_t *ctx,
+                                          const lsm6dsv16x_emb_pin_int_route_t *val);
+int32_t lsm6dsv16x_emb_pin_int2_route_get(const stmdev_ctx_t *ctx,
+                                          lsm6dsv16x_emb_pin_int_route_t *val);
+
+typedef enum
+{
+  LSM6DSV16X_INT_LATCH_DISABLE         = 0x0,
+  LSM6DSV16X_INT_LATCH_ENABLE          = 0x1,
+} lsm6dsv16x_embedded_int_config_t;
+int32_t lsm6dsv16x_embedded_int_cfg_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv16x_embedded_int_config_t val);
+int32_t lsm6dsv16x_embedded_int_cfg_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv16x_embedded_int_config_t *val);
+
+typedef struct
+{
+  uint8_t tilt                 : 1;
+  uint8_t sig_mot              : 1;
+  uint8_t fsm_lc               : 1;
+  uint8_t step_detector        : 1;
+  uint8_t step_count_inc       : 1;
+  uint8_t step_count_overflow  : 1;
+  uint8_t step_on_delta_time   : 1;
+} lsm6dsv16x_embedded_status_t;
+int32_t lsm6dsv16x_embedded_status_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv16x_embedded_status_t *val);
 
 typedef struct
 {
@@ -4439,40 +4481,68 @@ typedef struct
 int32_t lsm6dsv16x_fifo_status_get(const stmdev_ctx_t *ctx,
                                    lsm6dsv16x_fifo_status_t *val);
 
+/* Accel data format in FIFO */
 typedef struct
 {
-  enum
-  {
-    LSM6DSV16X_FIFO_EMPTY                    = 0x0,
-    LSM6DSV16X_GY_NC_TAG                     = 0x1,
-    LSM6DSV16X_XL_NC_TAG                     = 0x2,
-    LSM6DSV16X_TEMPERATURE_TAG               = 0x3,
-    LSM6DSV16X_TIMESTAMP_TAG                 = 0x4,
-    LSM6DSV16X_CFG_CHANGE_TAG                = 0x5,
-    LSM6DSV16X_XL_NC_T_2_TAG                 = 0x6,
-    LSM6DSV16X_XL_NC_T_1_TAG                 = 0x7,
-    LSM6DSV16X_XL_2XC_TAG                    = 0x8,
-    LSM6DSV16X_XL_3XC_TAG                    = 0x9,
-    LSM6DSV16X_GY_NC_T_2_TAG                 = 0xA,
-    LSM6DSV16X_GY_NC_T_1_TAG                 = 0xB,
-    LSM6DSV16X_GY_2XC_TAG                    = 0xC,
-    LSM6DSV16X_GY_3XC_TAG                    = 0xD,
-    LSM6DSV16X_SENSORHUB_SLAVE0_TAG          = 0xE,
-    LSM6DSV16X_SENSORHUB_SLAVE1_TAG          = 0xF,
-    LSM6DSV16X_SENSORHUB_SLAVE2_TAG          = 0x10,
-    LSM6DSV16X_SENSORHUB_SLAVE3_TAG          = 0x11,
-    LSM6DSV16X_STEP_COUNTER_TAG              = 0x12,
-    LSM6DSV16X_SFLP_GAME_ROTATION_VECTOR_TAG = 0x13,
-    LSM6DSV16X_SFLP_GYROSCOPE_BIAS_TAG       = 0x16,
-    LSM6DSV16X_SFLP_GRAVITY_VECTOR_TAG       = 0x17,
-    LSM6DSV16X_SENSORHUB_NACK_TAG            = 0x19,
-    LSM6DSV16X_MLC_RESULT_TAG                = 0x1A,
-    LSM6DSV16X_MLC_FILTER                    = 0x1B,
-    LSM6DSV16X_MLC_FEATURE                   = 0x1C,
-    LSM6DSV16X_XL_DUAL_CORE                  = 0x1D,
-    LSM6DSV16X_GY_ENHANCED_EIS               = 0x1E,
-  } tag;
-  uint8_t cnt;
+  int16_t axis[3];
+} lsm6dsv16x_fifo_xl;
+
+/* Temperature data format in FIFO */
+typedef struct
+{
+  uint16_t temperature;
+} lsm6dsv16x_fifo_temperature;
+
+/* Timestamp  format in FIFO */
+typedef struct
+{
+  uint32_t timestamp;
+} lsm6dsv16x_fifo_timestamp;
+
+/* Step counter data format in FIFO */
+typedef struct
+{
+  uint16_t steps;
+  uint32_t timestamp;
+} lsm6dsv16x_fifo_step_counter;
+
+typedef enum
+{
+  LSM6DSV16X_FIFO_EMPTY                    = 0x0,
+  LSM6DSV16X_GY_NC_TAG                     = 0x1,
+  LSM6DSV16X_XL_NC_TAG                     = 0x2,
+  LSM6DSV16X_TEMPERATURE_TAG               = 0x3,
+  LSM6DSV16X_TIMESTAMP_TAG                 = 0x4,
+  LSM6DSV16X_CFG_CHANGE_TAG                = 0x5,
+  LSM6DSV16X_XL_NC_T_2_TAG                 = 0x6,
+  LSM6DSV16X_XL_NC_T_1_TAG                 = 0x7,
+  LSM6DSV16X_XL_2XC_TAG                    = 0x8,
+  LSM6DSV16X_XL_3XC_TAG                    = 0x9,
+  LSM6DSV16X_GY_NC_T_2_TAG                 = 0xA,
+  LSM6DSV16X_GY_NC_T_1_TAG                 = 0xB,
+  LSM6DSV16X_GY_2XC_TAG                    = 0xC,
+  LSM6DSV16X_GY_3XC_TAG                    = 0xD,
+  LSM6DSV16X_SENSORHUB_SLAVE0_TAG          = 0xE,
+  LSM6DSV16X_SENSORHUB_SLAVE1_TAG          = 0xF,
+  LSM6DSV16X_SENSORHUB_SLAVE2_TAG          = 0x10,
+  LSM6DSV16X_SENSORHUB_SLAVE3_TAG          = 0x11,
+  LSM6DSV16X_STEP_COUNTER_TAG              = 0x12,
+  LSM6DSV16X_SFLP_GAME_ROTATION_VECTOR_TAG = 0x13,
+  LSM6DSV16X_SFLP_GYROSCOPE_BIAS_TAG       = 0x16,
+  LSM6DSV16X_SFLP_GRAVITY_VECTOR_TAG       = 0x17,
+  LSM6DSV16X_SENSORHUB_NACK_TAG            = 0x19,
+  LSM6DSV16X_MLC_RESULT_TAG                = 0x1A,
+  LSM6DSV16X_MLC_FILTER                    = 0x1B,
+  LSM6DSV16X_MLC_FEATURE                   = 0x1C,
+  LSM6DSV16X_XL_DUAL_CORE                  = 0x1D,
+  LSM6DSV16X_GY_ENHANCED_EIS               = 0x1E,
+} lsm6dsv16x_fifo_tag;
+
+typedef struct
+{
+  uint8_t tag  : 5;
+  uint8_t cnt  : 2;
+  uint8_t rsvd : 1;
   uint8_t data[6];
 } lsm6dsv16x_fifo_out_raw_t;
 int32_t lsm6dsv16x_fifo_out_raw_get(const stmdev_ctx_t *ctx,

--- a/sensor/stmemsc/lsm6dsv32x_STdC/driver/lsm6dsv32x_reg.c
+++ b/sensor/stmemsc/lsm6dsv32x_STdC/driver/lsm6dsv32x_reg.c
@@ -189,6 +189,60 @@ float_t lsm6dsv32x_from_lsb_to_mv(int16_t lsb)
   return ((float_t)lsb) / 78.0f;
 }
 
+/*
+ * Original conversion routines taken from: https://github.com/numpy/numpy
+ *
+ * Converts from half-precision (16-bit) float number to single precision (32-bit).
+ *
+ * uint32_t  static uint32_t ToFloatBits(uint16_t h);
+ * Released under BSD-3-Clause License
+ */
+static uint32_t ToFloatBits(uint16_t h)
+{
+  uint16_t h_exp = (h & 0x7c00u);
+  uint32_t f_sgn = ((uint32_t)h & 0x8000u) << 16;
+  switch (h_exp)
+  {
+    case 0x0000u:   // 0 or subnormal
+    {
+      uint16_t h_sig = (h & 0x03ffu);
+      // Signed zero
+      if (h_sig == 0)
+      {
+        return f_sgn;
+      }
+      // Subnormal
+      h_sig <<= 1;
+      while ((h_sig & 0x0400u) == 0)
+      {
+        h_sig <<= 1;
+        h_exp++;
+      }
+      uint32_t f_exp = ((uint32_t)(127 - 15 - h_exp)) << 23;
+      uint32_t f_sig = ((uint32_t)(h_sig & 0x03ffu)) << 13;
+      return f_sgn + f_exp + f_sig;
+    }
+    case 0x7c00u: // inf or NaN
+      // All-ones exponent and a copy of the significand
+      return f_sgn + 0x7f800000u + (((uint32_t)(h & 0x03ffu)) << 13);
+    default: // normalized
+      // Just need to adjust the exponent and shift
+      return f_sgn + (((uint32_t)(h & 0x7fffu) + 0x1c000u) << 13);
+  }
+}
+
+/**
+  * @brief  Convert from 16-bit to 32-bit float number
+  *
+  * @param  val      Batching in FIFO buffer of SFLP values.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+uint32_t lsm6dsv32x_from_f16_to_f32(uint16_t val)
+{
+  return ToFloatBits(val);
+}
+
 /**
   * @}
   *
@@ -1999,7 +2053,7 @@ int32_t lsm6dsv32x_pin_int1_route_get(const stmdev_ctx_t *ctx,
   * @brief   Select the signal that need to route on int2 pad[set]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    the signals to route on int1 pin.
+  * @param  val    the signals to route on int2 pin.
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
@@ -2008,6 +2062,7 @@ int32_t lsm6dsv32x_pin_int2_route_set(const stmdev_ctx_t *ctx,
 {
   lsm6dsv32x_int2_ctrl_t          int2_ctrl;
   lsm6dsv32x_ctrl4_t              ctrl4;
+  lsm6dsv32x_ctrl7_t              ctrl7;
   lsm6dsv32x_md2_cfg_t            md2_cfg;
   int32_t ret;
 
@@ -2040,6 +2095,14 @@ int32_t lsm6dsv32x_pin_int2_route_set(const stmdev_ctx_t *ctx,
     return ret;
   }
 
+  ret = lsm6dsv32x_read_reg(ctx, LSM6DSV32X_CTRL7, (uint8_t *)&ctrl7, 1);
+  ctrl7.int2_drdy_ah_qvar         = val->drdy_ah_qvar;
+  ret += lsm6dsv32x_write_reg(ctx, LSM6DSV32X_CTRL7, (uint8_t *)&ctrl7, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
   ret = lsm6dsv32x_read_reg(ctx, LSM6DSV32X_MD2_CFG, (uint8_t *)&md2_cfg, 1);
   if (ret != 0)
   {
@@ -2064,7 +2127,7 @@ int32_t lsm6dsv32x_pin_int2_route_set(const stmdev_ctx_t *ctx,
   * @brief  Select the signal that need to route on int2 pad.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    the signals that are routed on int1 pin.(ptr)
+  * @param  val    the signals that are routed on int2 pin.(ptr)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
@@ -2073,6 +2136,7 @@ int32_t lsm6dsv32x_pin_int2_route_get(const stmdev_ctx_t *ctx,
 {
   lsm6dsv32x_int2_ctrl_t          int2_ctrl;
   lsm6dsv32x_ctrl4_t              ctrl4;
+  lsm6dsv32x_ctrl7_t              ctrl7;
   lsm6dsv32x_md2_cfg_t            md2_cfg;
   int32_t ret;
 
@@ -2099,6 +2163,14 @@ int32_t lsm6dsv32x_pin_int2_route_get(const stmdev_ctx_t *ctx,
 
   val->drdy_temp      = ctrl4.int2_drdy_temp;
 
+  ret = lsm6dsv32x_read_reg(ctx, LSM6DSV32X_CTRL7, (uint8_t *)&ctrl7, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->drdy_ah_qvar = ctrl7.int2_drdy_ah_qvar;
+
   ret = lsm6dsv32x_read_reg(ctx, LSM6DSV32X_MD2_CFG, (uint8_t *)&md2_cfg, 1);
   if (ret != 0)
   {
@@ -2113,6 +2185,270 @@ int32_t lsm6dsv32x_pin_int2_route_get(const stmdev_ctx_t *ctx,
   val->wakeup         = md2_cfg.int2_wu;
   val->freefall       = md2_cfg.int2_ff;
   val->sleep_change   = md2_cfg.int2_sleep_change;
+
+  return ret;
+}
+
+/**
+  * @brief  routes embedded func interrupt signals on INT 1 pin.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      routes embedded func interrupt signals on INT 1 pin.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv32x_emb_pin_int1_route_set(const stmdev_ctx_t *ctx,
+                                          const lsm6dsv32x_emb_pin_int_route_t *val)
+{
+  lsm6dsv32x_emb_func_int1_t emb_func_int1;
+  lsm6dsv32x_md1_cfg_t md1_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv32x_mem_bank_set(ctx, LSM6DSV32X_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = lsm6dsv32x_read_reg(ctx, LSM6DSV32X_EMB_FUNC_INT1, (uint8_t *)&emb_func_int1, 1);
+  }
+
+  if (ret == 0)
+  {
+    emb_func_int1.int1_tilt = val->tilt;
+    emb_func_int1.int1_sig_mot = val->sig_mot;
+    emb_func_int1.int1_step_detector = val->step_det;
+    emb_func_int1.int1_fsm_lc = val->fsm_lc;
+
+    ret = lsm6dsv32x_write_reg(ctx, LSM6DSV32X_EMB_FUNC_INT1, (uint8_t *)&emb_func_int1, 1);
+  }
+  ret += lsm6dsv32x_mem_bank_set(ctx, LSM6DSV32X_MAIN_MEM_BANK);
+
+  ret += lsm6dsv32x_read_reg(ctx, LSM6DSV32X_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  if (ret == 0)
+  {
+    md1_cfg.int1_emb_func = 1;
+    ret = lsm6dsv32x_write_reg(ctx, LSM6DSV32X_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  routes embedded func interrupt signals on INT 1 pin.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      routes embedded func interrupt signals on INT 1 pin.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv32x_emb_pin_int1_route_get(const stmdev_ctx_t *ctx,
+                                          lsm6dsv32x_emb_pin_int_route_t *val)
+{
+  lsm6dsv32x_emb_func_int1_t emb_func_int1;
+  int32_t ret;
+
+  ret = lsm6dsv32x_mem_bank_set(ctx, LSM6DSV32X_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = lsm6dsv32x_read_reg(ctx, LSM6DSV32X_EMB_FUNC_INT1, (uint8_t *)&emb_func_int1, 1);
+  }
+
+  if (ret == 0)
+  {
+    val->tilt = emb_func_int1.int1_tilt;
+    val->sig_mot = emb_func_int1.int1_sig_mot;
+    val->step_det = emb_func_int1.int1_step_detector;
+    val->fsm_lc = emb_func_int1.int1_fsm_lc;
+  }
+  ret = lsm6dsv32x_mem_bank_set(ctx, LSM6DSV32X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  routes embedded func interrupt signals on INT 2 pin.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      routes embedded func interrupt signals on INT 2 pin.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv32x_emb_pin_int2_route_set(const stmdev_ctx_t *ctx,
+                                          const lsm6dsv32x_emb_pin_int_route_t *val)
+{
+  lsm6dsv32x_emb_func_int2_t emb_func_int2;
+  lsm6dsv32x_md2_cfg_t md2_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv32x_mem_bank_set(ctx, LSM6DSV32X_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = lsm6dsv32x_read_reg(ctx, LSM6DSV32X_EMB_FUNC_INT2, (uint8_t *)&emb_func_int2, 1);
+  }
+
+  if (ret == 0)
+  {
+    emb_func_int2.int2_tilt = val->tilt;
+    emb_func_int2.int2_sig_mot = val->sig_mot;
+    emb_func_int2.int2_step_detector = val->step_det;
+    emb_func_int2.int2_fsm_lc = val->fsm_lc;
+
+    ret = lsm6dsv32x_write_reg(ctx, LSM6DSV32X_EMB_FUNC_INT2, (uint8_t *)&emb_func_int2, 1);
+  }
+  ret += lsm6dsv32x_mem_bank_set(ctx, LSM6DSV32X_MAIN_MEM_BANK);
+
+  ret += lsm6dsv32x_read_reg(ctx, LSM6DSV32X_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  if (ret == 0)
+  {
+    md2_cfg.int2_emb_func = 1;
+    ret = lsm6dsv32x_write_reg(ctx, LSM6DSV32X_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  routes embedded func interrupt signals on INT 2 pin.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      routes embedded func interrupt signals on INT 2 pin.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv32x_emb_pin_int2_route_get(const stmdev_ctx_t *ctx,
+                                          lsm6dsv32x_emb_pin_int_route_t *val)
+{
+  lsm6dsv32x_emb_func_int2_t emb_func_int2;
+  int32_t ret;
+
+  ret = lsm6dsv32x_mem_bank_set(ctx, LSM6DSV32X_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = lsm6dsv32x_read_reg(ctx, LSM6DSV32X_EMB_FUNC_INT2, (uint8_t *)&emb_func_int2, 1);
+  }
+
+  if (ret == 0)
+  {
+    val->tilt = emb_func_int2.int2_tilt;
+    val->sig_mot = emb_func_int2.int2_sig_mot;
+    val->step_det = emb_func_int2.int2_step_detector;
+    val->fsm_lc = emb_func_int2.int2_fsm_lc;
+  }
+  ret = lsm6dsv32x_mem_bank_set(ctx, LSM6DSV32X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Embedded Interrupt configuration mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      INT_PULSED, INT_LATCHED
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv32x_embedded_int_cfg_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv32x_embedded_int_config_t val)
+{
+  lsm6dsv32x_page_rw_t page_rw;
+  int32_t ret;
+
+  ret = lsm6dsv32x_mem_bank_set(ctx, LSM6DSV32X_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = lsm6dsv32x_read_reg(ctx, LSM6DSV32X_PAGE_RW, (uint8_t *)&page_rw, 1);
+
+    switch (val)
+    {
+      case LSM6DSV32X_INT_LATCH_DISABLE:
+        page_rw.emb_func_lir = 0;
+        break;
+
+      case LSM6DSV32X_INT_LATCH_ENABLE:
+      default:
+        page_rw.emb_func_lir = 1;
+        break;
+    }
+
+    ret += lsm6dsv32x_write_reg(ctx, LSM6DSV32X_PAGE_RW, (uint8_t *)&page_rw, 1);
+  }
+
+  ret += lsm6dsv32x_mem_bank_set(ctx, LSM6DSV32X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt configuration mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      INT_DISABLED, INT_PULSED, INT_LATCHED
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv32x_embedded_int_cfg_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv32x_embedded_int_config_t *val)
+{
+  lsm6dsv32x_page_rw_t page_rw;
+  int32_t ret;
+
+  ret = lsm6dsv32x_mem_bank_set(ctx, LSM6DSV32X_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = lsm6dsv32x_read_reg(ctx, LSM6DSV32X_PAGE_RW, (uint8_t *)&page_rw, 1);
+
+    if (page_rw.emb_func_lir == 0U)
+    {
+      *val = LSM6DSV32X_INT_LATCH_DISABLE;
+    }
+    else
+    {
+      *val = LSM6DSV32X_INT_LATCH_ENABLE;
+    }
+  }
+
+  ret += lsm6dsv32x_mem_bank_set(ctx, LSM6DSV32X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Get the status of embedded functions.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lsm6dsv32x_embedded_status_t ptr
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv32x_embedded_status_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv32x_embedded_status_t *val)
+{
+  lsm6dsv32x_emb_func_status_mainpage_t emb_func_status;
+  lsm6dsv32x_emb_func_src_t emb_func_src;
+  int32_t ret;
+
+  ret = lsm6dsv32x_read_reg(ctx, LSM6DSV32X_EMB_FUNC_STATUS_MAINPAGE, (uint8_t *)&emb_func_status, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->step_detector = emb_func_status.is_step_det;
+  val->tilt = emb_func_status.is_tilt;
+  val->sig_mot = emb_func_status.is_sigmot;
+  val->fsm_lc = emb_func_status.is_fsm_lc;
+
+  /* embedded func */
+  ret = lsm6dsv32x_mem_bank_set(ctx, LSM6DSV32X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv32x_read_reg(ctx, LSM6DSV32X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
+  ret += lsm6dsv32x_mem_bank_set(ctx, LSM6DSV32X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->step_count_inc = emb_func_src.stepcounter_bit_set;
+  val->step_count_overflow = emb_func_src.step_overflow;
+  val->step_on_delta_time = emb_func_src.step_count_delta_ia;
+  val->step_detector = emb_func_src.step_detected;
 
   return ret;
 }
@@ -3239,13 +3575,8 @@ int32_t lsm6dsv32x_fifo_watermark_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsv32x_fifo_ctrl1_t fifo_ctrl1;
   int32_t ret;
 
-  ret = lsm6dsv32x_read_reg(ctx, LSM6DSV32X_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
-
-  if (ret == 0)
-  {
-    fifo_ctrl1.wtm = val;
-    ret = lsm6dsv32x_write_reg(ctx, LSM6DSV32X_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
-  }
+  fifo_ctrl1.wtm = val;
+  ret = lsm6dsv32x_write_reg(ctx, LSM6DSV32X_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
 
   return ret;
 }

--- a/sensor/stmemsc/lsm6dsv32x_STdC/driver/lsm6dsv32x_reg.h
+++ b/sensor/stmemsc/lsm6dsv32x_STdC/driver/lsm6dsv32x_reg.h
@@ -3898,6 +3898,8 @@ float_t lsm6dsv32x_from_lsb_to_nsec(uint32_t lsb);
 
 float_t lsm6dsv32x_from_lsb_to_mv(int16_t lsb);
 
+uint32_t lsm6dsv32x_from_f16_to_f32(uint16_t val);
+
 int32_t lsm6dsv32x_xl_offset_on_out_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv32x_xl_offset_on_out_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
@@ -4179,6 +4181,7 @@ typedef struct
   uint8_t drdy_g               : 1;
   uint8_t drdy_g_eis           : 1;
   uint8_t drdy_temp            : 1;
+  uint8_t drdy_ah_qvar         : 1;
   uint8_t fifo_th              : 1;
   uint8_t fifo_ovr             : 1;
   uint8_t fifo_full            : 1;
@@ -4202,6 +4205,45 @@ int32_t lsm6dsv32x_pin_int2_route_set(const stmdev_ctx_t *ctx,
                                       lsm6dsv32x_pin_int_route_t *val);
 int32_t lsm6dsv32x_pin_int2_route_get(const stmdev_ctx_t *ctx,
                                       lsm6dsv32x_pin_int_route_t *val);
+
+typedef struct
+{
+  uint8_t step_det                     : 1; /* route step detection event on INT pad */
+  uint8_t tilt                         : 1; /* route tilt event on INT pad */
+  uint8_t sig_mot                      : 1; /* route significant motion event on INT pad */
+  uint8_t fsm_lc                       : 1; /* route FSM long counter event on INT pad */
+} lsm6dsv32x_emb_pin_int_route_t;
+int32_t lsm6dsv32x_emb_pin_int1_route_set(const stmdev_ctx_t *ctx,
+                                          const lsm6dsv32x_emb_pin_int_route_t *val);
+int32_t lsm6dsv32x_emb_pin_int1_route_get(const stmdev_ctx_t *ctx,
+                                          lsm6dsv32x_emb_pin_int_route_t *val);
+int32_t lsm6dsv32x_emb_pin_int2_route_set(const stmdev_ctx_t *ctx,
+                                          const lsm6dsv32x_emb_pin_int_route_t *val);
+int32_t lsm6dsv32x_emb_pin_int2_route_get(const stmdev_ctx_t *ctx,
+                                          lsm6dsv32x_emb_pin_int_route_t *val);
+
+typedef enum
+{
+  LSM6DSV32X_INT_LATCH_DISABLE         = 0x0,
+  LSM6DSV32X_INT_LATCH_ENABLE          = 0x1,
+} lsm6dsv32x_embedded_int_config_t;
+int32_t lsm6dsv32x_embedded_int_cfg_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv32x_embedded_int_config_t val);
+int32_t lsm6dsv32x_embedded_int_cfg_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv32x_embedded_int_config_t *val);
+
+typedef struct
+{
+  uint8_t tilt                 : 1;
+  uint8_t sig_mot              : 1;
+  uint8_t fsm_lc               : 1;
+  uint8_t step_detector        : 1;
+  uint8_t step_count_inc       : 1;
+  uint8_t step_count_overflow  : 1;
+  uint8_t step_on_delta_time   : 1;
+} lsm6dsv32x_embedded_status_t;
+int32_t lsm6dsv32x_embedded_status_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv32x_embedded_status_t *val);
 
 typedef struct
 {
@@ -4439,40 +4481,68 @@ typedef struct
 int32_t lsm6dsv32x_fifo_status_get(const stmdev_ctx_t *ctx,
                                    lsm6dsv32x_fifo_status_t *val);
 
+/* Accel data format in FIFO */
 typedef struct
 {
-  enum
-  {
-    LSM6DSV32X_FIFO_EMPTY                    = 0x0,
-    LSM6DSV32X_GY_NC_TAG                     = 0x1,
-    LSM6DSV32X_XL_NC_TAG                     = 0x2,
-    LSM6DSV32X_TEMPERATURE_TAG               = 0x3,
-    LSM6DSV32X_TIMESTAMP_TAG                 = 0x4,
-    LSM6DSV32X_CFG_CHANGE_TAG                = 0x5,
-    LSM6DSV32X_XL_NC_T_2_TAG                 = 0x6,
-    LSM6DSV32X_XL_NC_T_1_TAG                 = 0x7,
-    LSM6DSV32X_XL_2XC_TAG                    = 0x8,
-    LSM6DSV32X_XL_3XC_TAG                    = 0x9,
-    LSM6DSV32X_GY_NC_T_2_TAG                 = 0xA,
-    LSM6DSV32X_GY_NC_T_1_TAG                 = 0xB,
-    LSM6DSV32X_GY_2XC_TAG                    = 0xC,
-    LSM6DSV32X_GY_3XC_TAG                    = 0xD,
-    LSM6DSV32X_SENSORHUB_SLAVE0_TAG          = 0xE,
-    LSM6DSV32X_SENSORHUB_SLAVE1_TAG          = 0xF,
-    LSM6DSV32X_SENSORHUB_SLAVE2_TAG          = 0x10,
-    LSM6DSV32X_SENSORHUB_SLAVE3_TAG          = 0x11,
-    LSM6DSV32X_STEP_COUNTER_TAG              = 0x12,
-    LSM6DSV32X_SFLP_GAME_ROTATION_VECTOR_TAG = 0x13,
-    LSM6DSV32X_SFLP_GYROSCOPE_BIAS_TAG       = 0x16,
-    LSM6DSV32X_SFLP_GRAVITY_VECTOR_TAG       = 0x17,
-    LSM6DSV32X_SENSORHUB_NACK_TAG            = 0x19,
-    LSM6DSV32X_MLC_RESULT_TAG                = 0x1A,
-    LSM6DSV32X_MLC_FILTER                    = 0x1B,
-    LSM6DSV32X_MLC_FEATURE                   = 0x1C,
-    LSM6DSV32X_XL_DUAL_CORE                  = 0x1D,
-    LSM6DSV32X_GY_ENHANCED_EIS               = 0x1E,
-  } tag;
-  uint8_t cnt;
+  int16_t axis[3];
+} lsm6dsv32x_fifo_xl;
+
+/* Temperature data format in FIFO */
+typedef struct
+{
+  uint16_t temperature;
+} lsm6dsv32x_fifo_temperature;
+
+/* Timestamp  format in FIFO */
+typedef struct
+{
+  uint32_t timestamp;
+} lsm6dsv32x_fifo_timestamp;
+
+/* Step counter data format in FIFO */
+typedef struct
+{
+  uint16_t steps;
+  uint32_t timestamp;
+} lsm6dsv32x_fifo_step_counter;
+
+typedef enum
+{
+  LSM6DSV32X_FIFO_EMPTY                    = 0x0,
+  LSM6DSV32X_GY_NC_TAG                     = 0x1,
+  LSM6DSV32X_XL_NC_TAG                     = 0x2,
+  LSM6DSV32X_TEMPERATURE_TAG               = 0x3,
+  LSM6DSV32X_TIMESTAMP_TAG                 = 0x4,
+  LSM6DSV32X_CFG_CHANGE_TAG                = 0x5,
+  LSM6DSV32X_XL_NC_T_2_TAG                 = 0x6,
+  LSM6DSV32X_XL_NC_T_1_TAG                 = 0x7,
+  LSM6DSV32X_XL_2XC_TAG                    = 0x8,
+  LSM6DSV32X_XL_3XC_TAG                    = 0x9,
+  LSM6DSV32X_GY_NC_T_2_TAG                 = 0xA,
+  LSM6DSV32X_GY_NC_T_1_TAG                 = 0xB,
+  LSM6DSV32X_GY_2XC_TAG                    = 0xC,
+  LSM6DSV32X_GY_3XC_TAG                    = 0xD,
+  LSM6DSV32X_SENSORHUB_SLAVE0_TAG          = 0xE,
+  LSM6DSV32X_SENSORHUB_SLAVE1_TAG          = 0xF,
+  LSM6DSV32X_SENSORHUB_SLAVE2_TAG          = 0x10,
+  LSM6DSV32X_SENSORHUB_SLAVE3_TAG          = 0x11,
+  LSM6DSV32X_STEP_COUNTER_TAG              = 0x12,
+  LSM6DSV32X_SFLP_GAME_ROTATION_VECTOR_TAG = 0x13,
+  LSM6DSV32X_SFLP_GYROSCOPE_BIAS_TAG       = 0x16,
+  LSM6DSV32X_SFLP_GRAVITY_VECTOR_TAG       = 0x17,
+  LSM6DSV32X_SENSORHUB_NACK_TAG            = 0x19,
+  LSM6DSV32X_MLC_RESULT_TAG                = 0x1A,
+  LSM6DSV32X_MLC_FILTER                    = 0x1B,
+  LSM6DSV32X_MLC_FEATURE                   = 0x1C,
+  LSM6DSV32X_XL_DUAL_CORE                  = 0x1D,
+  LSM6DSV32X_GY_ENHANCED_EIS               = 0x1E,
+} lsm6dsv32x_fifo_tag;
+
+typedef struct
+{
+  uint8_t tag  : 5;
+  uint8_t cnt  : 2;
+  uint8_t rsvd : 1;
   uint8_t data[6];
 } lsm6dsv32x_fifo_out_raw_t;
 int32_t lsm6dsv32x_fifo_out_raw_get(const stmdev_ctx_t *ctx,

--- a/sensor/stmemsc/lsm6dsv_STdC/driver/lsm6dsv_reg.c
+++ b/sensor/stmemsc/lsm6dsv_STdC/driver/lsm6dsv_reg.c
@@ -184,6 +184,60 @@ float_t lsm6dsv_from_lsb_to_nsec(uint32_t lsb)
   return ((float_t)lsb * 21750.0f);
 }
 
+/*
+ * Original conversion routines taken from: https://github.com/numpy/numpy
+ *
+ * Converts from half-precision (16-bit) float number to single precision (32-bit).
+ *
+ * uint32_t  static uint32_t ToFloatBits(uint16_t h);
+ * Released under BSD-3-Clause License
+ */
+static uint32_t ToFloatBits(uint16_t h)
+{
+  uint16_t h_exp = (h & 0x7c00u);
+  uint32_t f_sgn = ((uint32_t)h & 0x8000u) << 16;
+  switch (h_exp)
+  {
+    case 0x0000u:   // 0 or subnormal
+    {
+      uint16_t h_sig = (h & 0x03ffu);
+      // Signed zero
+      if (h_sig == 0)
+      {
+        return f_sgn;
+      }
+      // Subnormal
+      h_sig <<= 1;
+      while ((h_sig & 0x0400u) == 0)
+      {
+        h_sig <<= 1;
+        h_exp++;
+      }
+      uint32_t f_exp = ((uint32_t)(127 - 15 - h_exp)) << 23;
+      uint32_t f_sig = ((uint32_t)(h_sig & 0x03ffu)) << 13;
+      return f_sgn + f_exp + f_sig;
+    }
+    case 0x7c00u: // inf or NaN
+      // All-ones exponent and a copy of the significand
+      return f_sgn + 0x7f800000u + (((uint32_t)(h & 0x03ffu)) << 13);
+    default: // normalized
+      // Just need to adjust the exponent and shift
+      return f_sgn + (((uint32_t)(h & 0x7fffu) + 0x1c000u) << 13);
+  }
+}
+
+/**
+  * @brief  Convert from 16-bit to 32-bit float number
+  *
+  * @param  val      Batching in FIFO buffer of SFLP values.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+uint32_t lsm6dsv_from_f16_to_f32(uint16_t val)
+{
+  return ToFloatBits(val);
+}
+
 /**
   * @}
   *
@@ -1993,7 +2047,7 @@ int32_t lsm6dsv_pin_int1_route_get(const stmdev_ctx_t *ctx,
   * @brief   Select the signal that need to route on int2 pad[set]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    the signals to route on int1 pin.
+  * @param  val    the signals to route on int2 pin.
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
@@ -2058,7 +2112,7 @@ int32_t lsm6dsv_pin_int2_route_set(const stmdev_ctx_t *ctx,
   * @brief  Select the signal that need to route on int2 pad.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    the signals that are routed on int1 pin.(ptr)
+  * @param  val    the signals that are routed on int2 pin.(ptr)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
@@ -2107,6 +2161,269 @@ int32_t lsm6dsv_pin_int2_route_get(const stmdev_ctx_t *ctx,
   val->wakeup         = md2_cfg.int2_wu;
   val->freefall       = md2_cfg.int2_ff;
   val->sleep_change   = md2_cfg.int2_sleep_change;
+
+  return ret;
+}
+
+/**
+  * @brief  routes embedded func interrupt signals on INT 1 pin.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      routes embedded func interrupt signals on INT 1 pin.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv_emb_pin_int1_route_set(const stmdev_ctx_t *ctx,
+                                       const lsm6dsv_emb_pin_int_route_t *val)
+{
+  lsm6dsv_emb_func_int1_t emb_func_int1;
+  lsm6dsv_md1_cfg_t md1_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_INT1, (uint8_t *)&emb_func_int1, 1);
+  }
+
+  if (ret == 0)
+  {
+    emb_func_int1.int1_tilt = val->tilt;
+    emb_func_int1.int1_sig_mot = val->sig_mot;
+    emb_func_int1.int1_step_detector = val->step_det;
+    emb_func_int1.int1_fsm_lc = val->fsm_lc;
+
+    ret = lsm6dsv_write_reg(ctx, LSM6DSV_EMB_FUNC_INT1, (uint8_t *)&emb_func_int1, 1);
+  }
+  ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
+
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  if (ret == 0)
+  {
+    md1_cfg.int1_emb_func = 1;
+    ret = lsm6dsv_write_reg(ctx, LSM6DSV_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  routes embedded func interrupt signals on INT 1 pin.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      routes embedded func interrupt signals on INT 1 pin.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv_emb_pin_int1_route_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv_emb_pin_int_route_t *val)
+{
+  lsm6dsv_emb_func_int1_t emb_func_int1;
+  int32_t ret;
+
+  ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_INT1, (uint8_t *)&emb_func_int1, 1);
+  }
+
+  if (ret == 0)
+  {
+    val->tilt = emb_func_int1.int1_tilt;
+    val->sig_mot = emb_func_int1.int1_sig_mot;
+    val->step_det = emb_func_int1.int1_step_detector;
+    val->fsm_lc = emb_func_int1.int1_fsm_lc;
+  }
+  ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  routes embedded func interrupt signals on INT 2 pin.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      routes embedded func interrupt signals on INT 2 pin.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv_emb_pin_int2_route_set(const stmdev_ctx_t *ctx,
+                                       const lsm6dsv_emb_pin_int_route_t *val)
+{
+  lsm6dsv_emb_func_int2_t emb_func_int2;
+  lsm6dsv_md2_cfg_t md2_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_INT2, (uint8_t *)&emb_func_int2, 1);
+  }
+
+  if (ret == 0)
+  {
+    emb_func_int2.int2_tilt = val->tilt;
+    emb_func_int2.int2_sig_mot = val->sig_mot;
+    emb_func_int2.int2_step_detector = val->step_det;
+    emb_func_int2.int2_fsm_lc = val->fsm_lc;
+
+    ret = lsm6dsv_write_reg(ctx, LSM6DSV_EMB_FUNC_INT2, (uint8_t *)&emb_func_int2, 1);
+  }
+  ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
+
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  if (ret == 0)
+  {
+    md2_cfg.int2_emb_func = 1;
+    ret = lsm6dsv_write_reg(ctx, LSM6DSV_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  routes embedded func interrupt signals on INT 2 pin.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      routes embedded func interrupt signals on INT 2 pin.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv_emb_pin_int2_route_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv_emb_pin_int_route_t *val)
+{
+  lsm6dsv_emb_func_int2_t emb_func_int2;
+  int32_t ret;
+
+  ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_INT2, (uint8_t *)&emb_func_int2, 1);
+  }
+
+  if (ret == 0)
+  {
+    val->tilt = emb_func_int2.int2_tilt;
+    val->sig_mot = emb_func_int2.int2_sig_mot;
+    val->step_det = emb_func_int2.int2_step_detector;
+    val->fsm_lc = emb_func_int2.int2_fsm_lc;
+  }
+  ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Embedded Interrupt configuration mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      INT_PULSED, INT_LATCHED
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv_embedded_int_cfg_set(const stmdev_ctx_t *ctx, lsm6dsv_embedded_int_config_t val)
+{
+  lsm6dsv_page_rw_t page_rw;
+  int32_t ret;
+
+  ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = lsm6dsv_read_reg(ctx, LSM6DSV_PAGE_RW, (uint8_t *)&page_rw, 1);
+
+    switch (val)
+    {
+      case LSM6DSV_INT_LATCH_DISABLE:
+        page_rw.emb_func_lir = 0;
+        break;
+
+      case LSM6DSV_INT_LATCH_ENABLE:
+      default:
+        page_rw.emb_func_lir = 1;
+        break;
+    }
+
+    ret += lsm6dsv_write_reg(ctx, LSM6DSV_PAGE_RW, (uint8_t *)&page_rw, 1);
+  }
+
+  ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt configuration mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      INT_DISABLED, INT_PULSED, INT_LATCHED
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv_embedded_int_cfg_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv_embedded_int_config_t *val)
+{
+  lsm6dsv_page_rw_t page_rw;
+  int32_t ret;
+
+  ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = lsm6dsv_read_reg(ctx, LSM6DSV_PAGE_RW, (uint8_t *)&page_rw, 1);
+
+    if (page_rw.emb_func_lir == 0U)
+    {
+      *val = LSM6DSV_INT_LATCH_DISABLE;
+    }
+    else
+    {
+      *val = LSM6DSV_INT_LATCH_ENABLE;
+    }
+  }
+
+  ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Get the status of embedded functions.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lsm6dsv_embedded_status_t ptr
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv_embedded_status_get(const stmdev_ctx_t *ctx,
+                                    lsm6dsv_embedded_status_t *val)
+{
+  lsm6dsv_emb_func_status_mainpage_t emb_func_status;
+  lsm6dsv_emb_func_src_t emb_func_src;
+  int32_t ret;
+
+  ret = lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_STATUS_MAINPAGE, (uint8_t *)&emb_func_status, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->step_detector = emb_func_status.is_step_det;
+  val->tilt = emb_func_status.is_tilt;
+  val->sig_mot = emb_func_status.is_sigmot;
+  val->fsm_lc = emb_func_status.is_fsm_lc;
+
+  /* embedded func */
+  ret = lsm6dsv_mem_bank_set(ctx, LSM6DSV_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv_read_reg(ctx, LSM6DSV_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
+  ret += lsm6dsv_mem_bank_set(ctx, LSM6DSV_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->step_count_inc = emb_func_src.stepcounter_bit_set;
+  val->step_count_overflow = emb_func_src.step_overflow;
+  val->step_on_delta_time = emb_func_src.step_count_delta_ia;
+  val->step_detector = emb_func_src.step_detected;
 
   return ret;
 }
@@ -3199,13 +3516,8 @@ int32_t lsm6dsv_fifo_watermark_set(const stmdev_ctx_t *ctx, uint8_t val)
   lsm6dsv_fifo_ctrl1_t fifo_ctrl1;
   int32_t ret;
 
-  ret = lsm6dsv_read_reg(ctx, LSM6DSV_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
-
-  if (ret == 0)
-  {
-    fifo_ctrl1.wtm = val;
-    ret = lsm6dsv_write_reg(ctx, LSM6DSV_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
-  }
+  fifo_ctrl1.wtm = val;
+  ret = lsm6dsv_write_reg(ctx, LSM6DSV_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
 
   return ret;
 }

--- a/sensor/stmemsc/lsm6dsv_STdC/driver/lsm6dsv_reg.h
+++ b/sensor/stmemsc/lsm6dsv_STdC/driver/lsm6dsv_reg.h
@@ -3686,6 +3686,8 @@ float_t lsm6dsv_from_lsb_to_celsius(int16_t lsb);
 
 float_t lsm6dsv_from_lsb_to_nsec(uint32_t lsb);
 
+uint32_t lsm6dsv_from_f16_to_f32(uint16_t val);
+
 int32_t lsm6dsv_xl_offset_on_out_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv_xl_offset_on_out_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
@@ -3988,6 +3990,45 @@ int32_t lsm6dsv_pin_int2_route_get(const stmdev_ctx_t *ctx,
 
 typedef struct
 {
+  uint8_t step_det                     : 1; /* route step detection event on INT pad */
+  uint8_t tilt                         : 1; /* route tilt event on INT pad */
+  uint8_t sig_mot                      : 1; /* route significant motion event on INT pad */
+  uint8_t fsm_lc                       : 1; /* route FSM long counter event on INT pad */
+} lsm6dsv_emb_pin_int_route_t;
+int32_t lsm6dsv_emb_pin_int1_route_set(const stmdev_ctx_t *ctx,
+                                       const lsm6dsv_emb_pin_int_route_t *val);
+int32_t lsm6dsv_emb_pin_int1_route_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv_emb_pin_int_route_t *val);
+int32_t lsm6dsv_emb_pin_int2_route_set(const stmdev_ctx_t *ctx,
+                                       const lsm6dsv_emb_pin_int_route_t *val);
+int32_t lsm6dsv_emb_pin_int2_route_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv_emb_pin_int_route_t *val);
+
+typedef enum
+{
+  LSM6DSV_INT_LATCH_DISABLE         = 0x0,
+  LSM6DSV_INT_LATCH_ENABLE          = 0x1,
+} lsm6dsv_embedded_int_config_t;
+int32_t lsm6dsv_embedded_int_cfg_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv_embedded_int_config_t val);
+int32_t lsm6dsv_embedded_int_cfg_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv_embedded_int_config_t *val);
+
+typedef struct
+{
+  uint8_t tilt                 : 1;
+  uint8_t sig_mot              : 1;
+  uint8_t fsm_lc               : 1;
+  uint8_t step_detector        : 1;
+  uint8_t step_count_inc       : 1;
+  uint8_t step_count_overflow  : 1;
+  uint8_t step_on_delta_time   : 1;
+} lsm6dsv_embedded_status_t;
+int32_t lsm6dsv_embedded_status_get(const stmdev_ctx_t *ctx,
+                                    lsm6dsv_embedded_status_t *val);
+
+typedef struct
+{
   uint8_t drdy_xl              : 1;
   uint8_t drdy_gy              : 1;
   uint8_t drdy_temp            : 1;
@@ -4220,37 +4261,65 @@ typedef struct
 int32_t lsm6dsv_fifo_status_get(const stmdev_ctx_t *ctx,
                                 lsm6dsv_fifo_status_t *val);
 
+/* Accel data format in FIFO */
 typedef struct
 {
-  enum
-  {
-    LSM6DSV_FIFO_EMPTY                    = 0x0,
-    LSM6DSV_GY_NC_TAG                     = 0x1,
-    LSM6DSV_XL_NC_TAG                     = 0x2,
-    LSM6DSV_TEMPERATURE_TAG               = 0x3,
-    LSM6DSV_TIMESTAMP_TAG                 = 0x4,
-    LSM6DSV_CFG_CHANGE_TAG                = 0x5,
-    LSM6DSV_XL_NC_T_2_TAG                 = 0x6,
-    LSM6DSV_XL_NC_T_1_TAG                 = 0x7,
-    LSM6DSV_XL_2XC_TAG                    = 0x8,
-    LSM6DSV_XL_3XC_TAG                    = 0x9,
-    LSM6DSV_GY_NC_T_2_TAG                 = 0xA,
-    LSM6DSV_GY_NC_T_1_TAG                 = 0xB,
-    LSM6DSV_GY_2XC_TAG                    = 0xC,
-    LSM6DSV_GY_3XC_TAG                    = 0xD,
-    LSM6DSV_SENSORHUB_SLAVE0_TAG          = 0xE,
-    LSM6DSV_SENSORHUB_SLAVE1_TAG          = 0xF,
-    LSM6DSV_SENSORHUB_SLAVE2_TAG          = 0x10,
-    LSM6DSV_SENSORHUB_SLAVE3_TAG          = 0x11,
-    LSM6DSV_STEP_COUNTER_TAG              = 0x12,
-    LSM6DSV_SFLP_GAME_ROTATION_VECTOR_TAG = 0x13,
-    LSM6DSV_SFLP_GYROSCOPE_BIAS_TAG       = 0x16,
-    LSM6DSV_SFLP_GRAVITY_VECTOR_TAG       = 0x17,
-    LSM6DSV_SENSORHUB_NACK_TAG            = 0x19,
-    LSM6DSV_XL_DUAL_CORE                  = 0x1D,
-    LSM6DSV_GY_ENHANCED_EIS               = 0x1E,
-  } tag;
-  uint8_t cnt;
+  int16_t axis[3];
+} lsm6dsv_fifo_xl;
+
+/* Temperature data format in FIFO */
+typedef struct
+{
+  uint16_t temperature;
+} lsm6dsv_fifo_temperature;
+
+/* Timestamp  format in FIFO */
+typedef struct
+{
+  uint32_t timestamp;
+} lsm6dsv_fifo_timestamp;
+
+/* Step counter data format in FIFO */
+typedef struct
+{
+  uint16_t steps;
+  uint32_t timestamp;
+} lsm6dsv_fifo_step_counter;
+
+typedef enum
+{
+  LSM6DSV_FIFO_EMPTY                    = 0x0,
+  LSM6DSV_GY_NC_TAG                     = 0x1,
+  LSM6DSV_XL_NC_TAG                     = 0x2,
+  LSM6DSV_TEMPERATURE_TAG               = 0x3,
+  LSM6DSV_TIMESTAMP_TAG                 = 0x4,
+  LSM6DSV_CFG_CHANGE_TAG                = 0x5,
+  LSM6DSV_XL_NC_T_2_TAG                 = 0x6,
+  LSM6DSV_XL_NC_T_1_TAG                 = 0x7,
+  LSM6DSV_XL_2XC_TAG                    = 0x8,
+  LSM6DSV_XL_3XC_TAG                    = 0x9,
+  LSM6DSV_GY_NC_T_2_TAG                 = 0xA,
+  LSM6DSV_GY_NC_T_1_TAG                 = 0xB,
+  LSM6DSV_GY_2XC_TAG                    = 0xC,
+  LSM6DSV_GY_3XC_TAG                    = 0xD,
+  LSM6DSV_SENSORHUB_SLAVE0_TAG          = 0xE,
+  LSM6DSV_SENSORHUB_SLAVE1_TAG          = 0xF,
+  LSM6DSV_SENSORHUB_SLAVE2_TAG          = 0x10,
+  LSM6DSV_SENSORHUB_SLAVE3_TAG          = 0x11,
+  LSM6DSV_STEP_COUNTER_TAG              = 0x12,
+  LSM6DSV_SFLP_GAME_ROTATION_VECTOR_TAG = 0x13,
+  LSM6DSV_SFLP_GYROSCOPE_BIAS_TAG       = 0x16,
+  LSM6DSV_SFLP_GRAVITY_VECTOR_TAG       = 0x17,
+  LSM6DSV_SENSORHUB_NACK_TAG            = 0x19,
+  LSM6DSV_XL_DUAL_CORE                  = 0x1D,
+  LSM6DSV_GY_ENHANCED_EIS               = 0x1E,
+} lsm6dsv_fifo_tag;
+
+typedef struct
+{
+  uint8_t tag  : 5;
+  uint8_t cnt  : 2;
+  uint8_t rsvd : 1;
   uint8_t data[6];
 } lsm6dsv_fifo_out_raw_t;
 int32_t lsm6dsv_fifo_out_raw_get(const stmdev_ctx_t *ctx,

--- a/sensor/stmemsc/st1vafe3bx_STdC/driver/st1vafe3bx_reg.c
+++ b/sensor/stmemsc/st1vafe3bx_STdC/driver/st1vafe3bx_reg.c
@@ -1,0 +1,4421 @@
+/*
+ ******************************************************************************
+ * @file    st1vafe3bx_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   ST1VAFE3BX driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; Copyright (c) 2024 STMicroelectronics.
+ * All rights reserved.</center></h2>
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+ */
+
+#include "st1vafe3bx_reg.h"
+
+/**
+  * @defgroup    ST1VAFE3BX
+  * @brief       This file provides a set of functions needed to drive the
+  *              st1vafe3bx sensor.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup    ST1VAFE3BX_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t __weak st1vafe3bx_read_reg(const stmdev_ctx_t *ctx, uint8_t reg,
+                                   uint8_t *data, uint16_t len)
+{
+  if (ctx == NULL)
+  {
+    return -1;
+  }
+
+  return ctx->read_reg(ctx->handle, reg, data, len);
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t __weak st1vafe3bx_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
+                                    uint8_t *data, uint16_t len)
+{
+  if (ctx == NULL)
+  {
+    return -1;
+  }
+
+  return ctx->write_reg(ctx->handle, reg, data, len);
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    ST1VAFE3BX_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float_t st1vafe3bx_from_fs2g_to_mg(int16_t lsb)
+{
+  return (float_t)lsb * 0.061f;
+}
+
+float_t st1vafe3bx_from_fs4g_to_mg(int16_t lsb)
+{
+  return (float_t)lsb * 0.122f;
+}
+
+float_t st1vafe3bx_from_fs8g_to_mg(int16_t lsb)
+{
+  return (float_t)lsb * 0.244f;
+}
+
+float_t st1vafe3bx_from_fs16g_to_mg(int16_t lsb)
+{
+  return (float_t)lsb * 0.488f;
+}
+
+float_t st1vafe3bx_from_lsb_to_mv(int16_t lsb)
+{
+  return ((float_t)lsb) / 1311.0f;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup Common
+  * @brief    Common
+  * @{/
+  *
+  */
+/**
+  * @brief  Device ID.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Device ID.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_device_id_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_WHO_AM_I, val, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Configures the bus operating mode.[get]
+  *
+  * @param  ctx   communication interface handler.(ptr)
+  * @param  val   configures the bus operating mode.(ptr)
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_init_set(const stmdev_ctx_t *ctx, st1vafe3bx_init_t val)
+{
+  st1vafe3bx_ctrl1_t ctrl1;
+  st1vafe3bx_ctrl4_t ctrl4;
+  st1vafe3bx_status_t status;
+  st1vafe3bx_ctrl3_t ctrl3;
+  st1vafe3bx_ah_bio_cfg2_t ah_bio_cfg2;
+  st1vafe3bx_ah_bio_cfg3_t ah_bio_cfg3;
+  uint8_t cnt = 0;
+  uint8_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_CTRL1, (uint8_t *)&ctrl1, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_CTRL4, (uint8_t *)&ctrl4, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_AH_BIO_CFG2,
+                             (uint8_t *)&ah_bio_cfg2, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_AH_BIO_CFG3,
+                             (uint8_t *)&ah_bio_cfg3, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_CTRL3, (uint8_t *)&ctrl3, 1);
+
+  switch (val)
+  {
+    case ST1VAFE3BX_BOOT:
+      ctrl4.boot = PROPERTY_ENABLE;
+      ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_CTRL4, (uint8_t *)&ctrl4, 1);
+      if (ret != 0)
+      {
+        break;
+      }
+
+      do
+      {
+        ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_CTRL4, (uint8_t *)&ctrl4, 1);
+        if (ret != 0)
+        {
+          break;
+        }
+
+        /* boot procedure ended correctly */
+        if (ctrl4.boot == 0U)
+        {
+          break;
+        }
+
+        if (ctx->mdelay != NULL)
+        {
+          ctx->mdelay(25); /* 25 ms of boot time */
+        }
+      } while (cnt++ < 5U);
+
+      if (cnt >= 5U)
+      {
+        ret = -1;  /* boot procedure failed */
+      }
+      break;
+    case ST1VAFE3BX_RESET:
+      ctrl1.sw_reset = PROPERTY_ENABLE;
+      ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_CTRL1, (uint8_t *)&ctrl1, 1);
+      if (ret != 0)
+      {
+        break;
+      }
+
+      do
+      {
+        ret = st1vafe3bx_status_get(ctx, &status);
+        if (ret != 0)
+        {
+          break;
+        }
+
+        /* sw-reset procedure ended correctly */
+        if (status.sw_reset == 0U)
+        {
+          break;
+        }
+
+        if (ctx->mdelay != NULL)
+        {
+          ctx->mdelay(1); /* should be 50 us */
+        }
+      } while (cnt++ < 5U);
+
+      if (cnt >= 5U)
+      {
+        ret = -1;  /* sw-reset procedure failed */
+      }
+      break;
+    case ST1VAFE3BX_SENSOR_ONLY_ON:
+      /* no embedded funcs are used */
+      ctrl4.emb_func_en = PROPERTY_DISABLE;
+      ctrl4.bdu = PROPERTY_ENABLE;
+      ctrl1.if_add_inc = PROPERTY_ENABLE;
+      ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_CTRL4, (uint8_t *)&ctrl4, 1);
+      ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_CTRL1, (uint8_t *)&ctrl1, 1);
+      break;
+    case ST1VAFE3BX_SENSOR_EMB_FUNC_ON:
+      /* complete configuration is used */
+      ctrl4.emb_func_en = PROPERTY_ENABLE;
+      ctrl4.bdu = PROPERTY_ENABLE;
+      ctrl1.if_add_inc = PROPERTY_ENABLE;
+      ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_CTRL4, (uint8_t *)&ctrl4, 1);
+      ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_CTRL1, (uint8_t *)&ctrl1, 1);
+      break;
+    case ST1VAFE3BX_VAFE_ONLY_LP:
+    case ST1VAFE3BX_VAFE_ONLY_HP:
+      /*
+        * when the device is in the AH / vAFE only state, the embedded low power
+        * features are not available
+        */
+      ctrl4.bdu = PROPERTY_ENABLE;
+      ctrl1.if_add_inc = PROPERTY_ENABLE;
+      ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_CTRL4, (uint8_t *)&ctrl4, 1);
+      ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_CTRL1, (uint8_t *)&ctrl1, 1);
+
+      ah_bio_cfg2.ah_bio_en = PROPERTY_ENABLE;
+      ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_AH_BIO_CFG2,
+                                  (uint8_t *)&ah_bio_cfg2, 1);
+
+      ah_bio_cfg3.ah_bio_active = PROPERTY_ENABLE;
+      ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_AH_BIO_CFG3,
+                                  (uint8_t *)&ah_bio_cfg3, 1);
+
+      if (ctx->mdelay != NULL)
+      {
+        ctx->mdelay(10);
+      }
+
+      if (val == ST1VAFE3BX_VAFE_ONLY_HP)
+      {
+        ctrl3.hp_en = PROPERTY_ENABLE;
+      }
+      else
+      {
+        ctrl3.hp_en = PROPERTY_DISABLE;
+      }
+
+      ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_CTRL3, (uint8_t *)&ctrl3, 1);
+
+      ah_bio_cfg3.ah_bio_active = PROPERTY_DISABLE;
+      ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_AH_BIO_CFG3,
+                                  (uint8_t *)&ah_bio_cfg3, 1);
+
+      if (ctx->mdelay != NULL)
+      {
+        ctx->mdelay(10);
+      }
+      break;
+    default:
+      ctrl1.sw_reset = PROPERTY_ENABLE;
+      ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_CTRL1, (uint8_t *)&ctrl1, 1);
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Smart mode configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      st1vafe3bx_smart_power_t (pwr_en, pwr_win, pwr_dur)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_smart_power_set(const stmdev_ctx_t *ctx, st1vafe3bx_smart_power_t val)
+{
+  st1vafe3bx_ctrl1_t ctrl1;
+  st1vafe3bx_smart_power_ctrl_t pwr_ctrl;
+  int32_t ret;
+
+  /* Configure smart power */
+  pwr_ctrl.smart_power_ctrl_win = val.pwr_ctrl_win;
+  pwr_ctrl.smart_power_ctrl_dur = val.pwr_ctrl_dur;
+  ret = st1vafe3bx_ln_pg_write(ctx, ST1VAFE3BX_SMART_POWER_CTRL, (uint8_t *)&pwr_ctrl, 1);
+
+  /* Enable smart power */
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_CTRL1, (uint8_t *)&ctrl1, 1);
+
+  if (ret == 0)
+  {
+    ctrl1.smart_power_en = val.pwr_en;
+    ret = st1vafe3bx_write_reg(ctx, ST1VAFE3BX_CTRL1, (uint8_t *)&ctrl1, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Smart mode configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      st1vafe3bx_smart_power_t (pwr_en, pwr_win, pwr_dur)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_smart_power_get(const stmdev_ctx_t *ctx, st1vafe3bx_smart_power_t *val)
+{
+  st1vafe3bx_ctrl1_t ctrl1;
+  st1vafe3bx_smart_power_ctrl_t pwr_ctrl;
+  int32_t ret;
+
+  /* Read smart power configuration */
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_CTRL1, (uint8_t *)&ctrl1, 1);
+  ret += st1vafe3bx_ln_pg_read(ctx, ST1VAFE3BX_SMART_POWER_CTRL, (uint8_t *)&pwr_ctrl, 1);
+
+  if (ret == 0)
+  {
+    val->pwr_en = ctrl1.smart_power_en;
+    val->pwr_ctrl_win = pwr_ctrl.smart_power_ctrl_win;
+    val->pwr_ctrl_dur = pwr_ctrl.smart_power_ctrl_dur;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Get the status of the device.[get]
+  *
+  * @param  ctx   communication interface handler.(ptr)
+  * @param  val   the status of the device.(ptr)
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_status_get(const stmdev_ctx_t *ctx, st1vafe3bx_status_t *val)
+{
+  st1vafe3bx_status_register_t status_register;
+  st1vafe3bx_ctrl1_t ctrl1;
+  st1vafe3bx_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_STATUS,
+                            (uint8_t *)&status_register, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_CTRL1, (uint8_t *)&ctrl1, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_CTRL4, (uint8_t *)&ctrl4, 1);
+
+  val->sw_reset = ctrl1.sw_reset;
+  val->boot     = ctrl4.boot;
+  val->drdy     = status_register.drdy;
+
+  return ret;
+}
+
+/**
+  * @brief  Get drdy status flag of the device.[get]
+  *
+  * @param  ctx   communication interface handler.(ptr)
+  * @param  val   the drdy status flag of the device .(ptr)
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_drdy_status_get(const stmdev_ctx_t *ctx, st1vafe3bx_status_t *val)
+{
+  st1vafe3bx_status_register_t status_register;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_STATUS, (uint8_t *)&status_register, 1);
+  val->drdy     = status_register.drdy;
+
+  return ret;
+}
+
+/**
+  * @brief  Get the status of the embedded funcs.[get]
+  *
+  * @param  ctx   communication interface handler.(ptr)
+  * @param  val   the status of the embedded funcs.(ptr)
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_embedded_status_get(const stmdev_ctx_t *ctx,
+                                       st1vafe3bx_embedded_status_t *val)
+{
+  st1vafe3bx_emb_func_status_t status;
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_EMB_FUNC_STATUS,
+                             (uint8_t *)&status, 1);
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  val->is_step_det = status.is_step_det;
+  val->is_tilt = status.is_tilt;
+  val->is_sigmot = status.is_sigmot;
+  val->is_fsm_lc = status.is_fsm_lc;
+
+  return ret;
+}
+
+/**
+  * @brief  Enables pulsed data-ready mode (~75 us).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      DRDY_LATCHED, DRDY_PULSED,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_data_ready_mode_set(const stmdev_ctx_t *ctx,
+                                       st1vafe3bx_data_ready_mode_t val)
+{
+  st1vafe3bx_ctrl1_t ctrl1;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_CTRL1, (uint8_t *)&ctrl1, 1);
+
+  if (ret == 0)
+  {
+    ctrl1.drdy_pulsed = ((uint8_t)val & 0x1U);
+    ret = st1vafe3bx_write_reg(ctx, ST1VAFE3BX_CTRL1, (uint8_t *)&ctrl1, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables pulsed data-ready mode (~75 us).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      DRDY_LATCHED, DRDY_PULSED,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_data_ready_mode_get(const stmdev_ctx_t *ctx,
+                                       st1vafe3bx_data_ready_mode_t *val)
+{
+  st1vafe3bx_ctrl1_t ctrl1;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_CTRL1, (uint8_t *)&ctrl1, 1);
+
+  switch ((ctrl1.drdy_pulsed))
+  {
+    case ST1VAFE3BX_DRDY_LATCHED:
+      *val = ST1VAFE3BX_DRDY_LATCHED;
+      break;
+
+    case ST1VAFE3BX_DRDY_PULSED:
+      *val = ST1VAFE3BX_DRDY_PULSED;
+      break;
+
+    default:
+      *val = ST1VAFE3BX_DRDY_LATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor mode.[set]
+  *
+  * @param  ctx   communication interface handler.(ptr)
+  * @param  val   set the sensor FS and ODR.(ptr)
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_mode_set(const stmdev_ctx_t *ctx, const st1vafe3bx_md_t *val)
+{
+  st1vafe3bx_ctrl3_t ctrl3;
+  st1vafe3bx_ctrl5_t ctrl5;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_CTRL5, (uint8_t *)&ctrl5, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_CTRL3, (uint8_t *)&ctrl3, 1);
+
+  ctrl5.odr = (uint8_t)val->odr & 0xFU;
+  ctrl5.fs = (uint8_t)val->fs;
+
+  /* select high performance mode */
+  switch (val->odr & 0x30U)
+  {
+    case 0x30U:
+    case 0x10U:
+      /* high performance mode */
+      ctrl3.hp_en = 1U;
+      break;
+    case 0x00U:
+    case 0x20U:
+    default:
+      /* low power mode */
+      ctrl3.hp_en = 0U;
+      break;
+  }
+
+  /* set the bandwidth */
+  switch (val->odr)
+  {
+    /* no anti-aliasing filter present */
+    default:
+    case ST1VAFE3BX_OFF:
+    case ST1VAFE3BX_1Hz6_ULP:
+    case ST1VAFE3BX_3Hz_ULP:
+    case ST1VAFE3BX_25Hz_ULP:
+      ctrl5.bw = 0x0;
+      break;
+
+    /* low-power mode with ODR < 50 Hz */
+    case ST1VAFE3BX_6Hz_LP:
+    case ST1VAFE3BX_12Hz5_LP:
+    case ST1VAFE3BX_25Hz_LP:
+      switch (val->bw)
+      {
+        default:
+          /* value not allowed */
+          ret = -1;
+          break;
+        case ST1VAFE3BX_BW_LP_12Hz5:
+          ctrl5.bw = 0x1;
+          break;
+        case ST1VAFE3BX_BW_LP_6Hz:
+          ctrl5.bw = 0x2;
+          break;
+        case ST1VAFE3BX_BW_LP_3Hz:
+          ctrl5.bw = 0x3;
+          break;
+      }
+      break;
+
+    /* High Performance cases */
+    case ST1VAFE3BX_800Hz_VAFE_HP:
+    case ST1VAFE3BX_3200Hz_VAFE_LP:
+    case ST1VAFE3BX_50Hz_LP:
+    case ST1VAFE3BX_100Hz_LP:
+    case ST1VAFE3BX_200Hz_LP:
+    case ST1VAFE3BX_400Hz_LP:
+    case ST1VAFE3BX_800Hz_LP:
+    case ST1VAFE3BX_TRIG_PIN:
+    case ST1VAFE3BX_TRIG_SW:
+    case ST1VAFE3BX_6Hz_HP:
+    case ST1VAFE3BX_12Hz5_HP:
+    case ST1VAFE3BX_25Hz_HP:
+    case ST1VAFE3BX_50Hz_HP:
+    case ST1VAFE3BX_100Hz_HP:
+    case ST1VAFE3BX_200Hz_HP:
+    case ST1VAFE3BX_400Hz_HP:
+    case ST1VAFE3BX_800Hz_HP:
+      ctrl5.bw = (uint8_t)val->bw;
+      break;
+  }
+
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_write_reg(ctx, ST1VAFE3BX_CTRL5, (uint8_t *)&ctrl5, 1);
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_CTRL3, (uint8_t *)&ctrl3, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor mode.[get]
+  *
+  * @param  ctx   communication interface handler.(ptr)
+  * @param  val   get the sensor FS and ODR.(ptr)
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_mode_get(const stmdev_ctx_t *ctx, st1vafe3bx_md_t *val)
+{
+  st1vafe3bx_ah_bio_cfg2_t ah_bio_cfg2;
+  st1vafe3bx_ctrl3_t ctrl3;
+  st1vafe3bx_ctrl5_t ctrl5;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_CTRL5, (uint8_t *)&ctrl5, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_CTRL3, (uint8_t *)&ctrl3, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_AH_BIO_CFG2, (uint8_t *)&ah_bio_cfg2, 1);
+
+  val->hp_en = ctrl3.hp_en;
+
+  switch (ctrl5.odr)
+  {
+    case 0x00:
+      val->odr = ST1VAFE3BX_OFF;
+      break;
+    case 0x01:
+      val->odr = ST1VAFE3BX_1Hz6_ULP;
+      break;
+    case 0x02:
+      val->odr = ST1VAFE3BX_3Hz_ULP;
+      break;
+    case 0x03:
+      val->odr = ST1VAFE3BX_25Hz_ULP;
+      break;
+    case 0x04:
+      val->odr = ST1VAFE3BX_6Hz_LP;
+      break;
+    case 0x05:
+      val->odr = (ctrl3.hp_en == 0x1U) ? ST1VAFE3BX_12Hz5_HP : ST1VAFE3BX_12Hz5_LP;
+      break;
+    case 0x06:
+      val->odr = (ctrl3.hp_en == 0x1U) ? ST1VAFE3BX_25Hz_HP : ST1VAFE3BX_25Hz_LP;
+      break;
+    case 0x07:
+      val->odr = (ctrl3.hp_en == 0x1U) ? ST1VAFE3BX_50Hz_HP : ST1VAFE3BX_50Hz_LP;
+      break;
+    case 0x08:
+      val->odr = (ctrl3.hp_en == 0x1U) ? ST1VAFE3BX_100Hz_HP : ST1VAFE3BX_100Hz_LP;
+      break;
+    case 0x09:
+      val->odr = (ctrl3.hp_en == 0x1U) ? ST1VAFE3BX_200Hz_HP : ST1VAFE3BX_200Hz_LP;
+      break;
+    case 0x0A:
+      val->odr = (ctrl3.hp_en == 0x1U) ? ST1VAFE3BX_400Hz_HP : ST1VAFE3BX_400Hz_LP;
+      break;
+    case 0x0B:
+      if (ah_bio_cfg2.ah_bio_en == 0x1U)
+      {
+        val->odr = (ctrl3.hp_en == 0x1U) ?
+                   ST1VAFE3BX_800Hz_VAFE_HP : ST1VAFE3BX_3200Hz_VAFE_LP;
+      }
+      else
+      {
+        val->odr = (ctrl3.hp_en == 0x1U) ?
+                   ST1VAFE3BX_800Hz_HP : ST1VAFE3BX_800Hz_LP;
+      }
+      break;
+    case 0xe:
+      val->odr = ST1VAFE3BX_TRIG_PIN;
+      break;
+    case 0xf:
+      val->odr = ST1VAFE3BX_TRIG_SW;
+      break;
+    default:
+      val->odr = ST1VAFE3BX_OFF;
+      break;
+  }
+
+  switch (ctrl5.fs)
+  {
+    case 0:
+      val->fs = ST1VAFE3BX_2g;
+      break;
+    case 1:
+      val->fs = ST1VAFE3BX_4g;
+      break;
+    case 2:
+      val->fs = ST1VAFE3BX_8g;
+      break;
+    case 3:
+      val->fs = ST1VAFE3BX_16g;
+      break;
+    default:
+      val->fs = ST1VAFE3BX_2g;
+      break;
+  }
+
+  if (ah_bio_cfg2.ah_bio_en == 0x1U)
+  {
+    switch (ctrl5.bw)
+    {
+      case 0:
+        val->bw = (ctrl3.hp_en == 0x1U) ?
+                  ST1VAFE3BX_BW_VAFE_360Hz : ST1VAFE3BX_BW_VAFE_1600Hz;
+        break;
+      case 1:
+        val->bw = (ctrl3.hp_en == 0x1U) ?
+                  ST1VAFE3BX_BW_VAFE_180Hz : ST1VAFE3BX_BW_VAFE_700Hz;
+        break;
+      case 2:
+        val->bw = (ctrl3.hp_en == 0x1U) ?
+                  ST1VAFE3BX_BW_VAFE_90Hz : ST1VAFE3BX_BW_VAFE_360Hz;
+        break;
+      case 3:
+        val->bw = (ctrl3.hp_en == 0x1U) ?
+                  ST1VAFE3BX_BW_VAFE_45Hz : ST1VAFE3BX_BW_VAFE_180Hz;
+        break;
+      default:
+        val->bw = (ctrl3.hp_en == 0x1U) ?
+                  ST1VAFE3BX_BW_VAFE_360Hz : ST1VAFE3BX_BW_VAFE_1600Hz;
+        break;
+    }
+  }
+  else
+  {
+    if (ctrl5.odr == ST1VAFE3BX_6Hz_LP || ctrl5.odr == ST1VAFE3BX_12Hz5_LP
+        || ctrl5.odr == ST1VAFE3BX_25Hz_LP)
+    {
+      switch (ctrl5.bw)
+      {
+        case 1:
+          val->bw = ST1VAFE3BX_BW_LP_12Hz5;
+          break;
+        case 2:
+          val->bw = ST1VAFE3BX_BW_LP_6Hz;
+          break;
+        case 3:
+          val->bw = ST1VAFE3BX_BW_LP_3Hz;
+          break;
+        default:
+          /* value not allowed */
+          ret = -1;
+          break;
+      }
+    }
+    else
+    {
+
+      switch (ctrl5.bw)
+      {
+        case 0:
+          val->bw = ST1VAFE3BX_BW_ODR_div_2;
+          break;
+        case 1:
+          val->bw = ST1VAFE3BX_BW_ODR_div_4;
+          break;
+        case 2:
+          val->bw = ST1VAFE3BX_BW_ODR_div_8;
+          break;
+        case 3:
+          val->bw = ST1VAFE3BX_BW_ODR_div_16;
+          break;
+        default:
+          val->bw = ST1VAFE3BX_BW_ODR_div_2;
+          break;
+      }
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enter soft power down in SPI case[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enter soft power down in SPI case
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_exit_deep_power_down(const stmdev_ctx_t *ctx)
+{
+  st1vafe3bx_en_device_config_t en_device_config = {0};
+  int32_t ret;
+
+  en_device_config.en_dev_conf = PROPERTY_ENABLE;
+  ret = st1vafe3bx_write_reg(ctx, ST1VAFE3BX_EN_DEVICE_CONFIG,
+                             (uint8_t *)&en_device_config, 1);
+
+  if (ctx->mdelay != NULL)
+  {
+    ctx->mdelay(25);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Software trigger for One-Shot.[get]
+  *
+  * @param  ctx   communication interface handler.(ptr)
+  * @param  md    the sensor conversion parameters.(ptr)
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_trigger_sw(const stmdev_ctx_t *ctx,
+                              const st1vafe3bx_md_t *md)
+{
+  st1vafe3bx_ctrl4_t ctrl4;
+  int32_t ret = 0;
+
+  if (md->odr == ST1VAFE3BX_TRIG_SW)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_CTRL4, (uint8_t *)&ctrl4, 1);
+    ctrl4.soc = PROPERTY_ENABLE;
+    if (ret == 0)
+    {
+      ret = st1vafe3bx_write_reg(ctx, ST1VAFE3BX_CTRL4, (uint8_t *)&ctrl4, 1);
+    }
+  }
+  return ret;
+}
+
+int32_t st1vafe3bx_all_sources_get(const stmdev_ctx_t *ctx,
+                                   st1vafe3bx_all_sources_t *val)
+{
+  st1vafe3bx_status_register_t status;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_STATUS, (uint8_t *)&status, 1);
+  val->drdy = status.drdy;
+
+  if (ret == 0 && status.int_global == 0x1U)
+  {
+    st1vafe3bx_wake_up_src_t wu_src;
+    st1vafe3bx_tap_src_t tap_src;
+    st1vafe3bx_sixd_src_t sixd_src;
+
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_SIXD_SRC,
+                              (uint8_t *)&sixd_src, 1);
+    ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_WAKE_UP_SRC,
+                               (uint8_t *)&wu_src, 1);
+    ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_TAP_SRC,
+                               (uint8_t *)&tap_src, 1);
+
+    val->six_d    = sixd_src.d6d_ia;
+    val->six_d_xl = sixd_src.xl;
+    val->six_d_xh = sixd_src.xh;
+    val->six_d_yl = sixd_src.yl;
+    val->six_d_yh = sixd_src.yh;
+    val->six_d_zl = sixd_src.zl;
+    val->six_d_zh = sixd_src.zh;
+
+    val->wake_up      = wu_src.wu_ia;
+    val->wake_up_z    = wu_src.z_wu;
+    val->wake_up_y    = wu_src.y_wu;
+    val->wake_up_x    = wu_src.x_wu;
+    val->free_fall    = wu_src.ff_ia;
+    val->sleep_change = wu_src.sleep_change_ia;
+    val->sleep_state  = wu_src.sleep_state;
+
+    val->single_tap = tap_src.single_tap_ia;
+    val->double_tap = tap_src.double_tap_ia;
+    val->triple_tap = tap_src.triple_tap_ia;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data.[get]
+  *
+  * @param  ctx   communication interface handler.(ptr)
+  * @param  md    the sensor conversion parameters.(ptr)
+  * @param  data  data retrived from the sensor.(ptr)
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_xl_data_get(const stmdev_ctx_t *ctx,
+                               const st1vafe3bx_md_t *md,
+                               st1vafe3bx_xl_data_t *data)
+{
+  uint8_t buff[6];
+  int32_t ret;
+  uint8_t i;
+  uint8_t j;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_OUT_X_L, buff, 6);
+
+  /* acceleration conversion */
+  j = 0U;
+  for (i = 0U; i < 3U; i++)
+  {
+    data->raw[i] = (int16_t)buff[j + 1U];
+    data->raw[i] = (data->raw[i] * 256U) + (int16_t) buff[j];
+    j += 2U;
+    switch (md->fs)
+    {
+      case ST1VAFE3BX_2g:
+        data->mg[i] = st1vafe3bx_from_fs2g_to_mg(data->raw[i]);
+        break;
+      case ST1VAFE3BX_4g:
+        data->mg[i] = st1vafe3bx_from_fs4g_to_mg(data->raw[i]);
+        break;
+      case ST1VAFE3BX_8g:
+        data->mg[i] = st1vafe3bx_from_fs8g_to_mg(data->raw[i]);
+        break;
+      case ST1VAFE3BX_16g:
+        data->mg[i] = st1vafe3bx_from_fs16g_to_mg(data->raw[i]);
+        break;
+      default:
+        data->mg[i] = 0.0f;
+        break;
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  AH_BIO data.[get]
+  *
+  * @param  ctx   communication interface handler.(ptr)
+  * @param  data  data retrived from the sensor.(ptr)
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_ah_bio_data_get(const stmdev_ctx_t *ctx,
+                                   st1vafe3bx_ah_bio_data_t *data)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_OUT_AH_BIO_L, buff, 2);
+
+  data->raw = (int16_t)buff[1];
+  data->raw = (data->raw * 256U) + (int16_t)buff[0];
+
+  data->mv = st1vafe3bx_from_lsb_to_mv(data->raw);
+
+  return ret;
+}
+
+/**
+  * @brief  Configures the self test.[set]
+  *
+  * @param  ctx   communication interface handler.(ptr)
+  * @param  val   self test mode.(ptr)
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_self_test_sign_set(const stmdev_ctx_t *ctx,
+                                      st1vafe3bx_xl_self_test_t val)
+{
+  st1vafe3bx_ctrl3_t ctrl3;
+  st1vafe3bx_wake_up_dur_t wkup_dur;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_CTRL3, (uint8_t *)&ctrl3, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_WAKE_UP_DUR,
+                             (uint8_t *)&wkup_dur, 1);
+
+  switch (val)
+  {
+    case ST1VAFE3BX_XL_ST_POSITIVE:
+      ctrl3.st_sign_x = 1;
+      ctrl3.st_sign_y = 1;
+      wkup_dur.st_sign_z = 0;
+      break;
+
+    case ST1VAFE3BX_XL_ST_NEGATIVE:
+      ctrl3.st_sign_x = 0;
+      ctrl3.st_sign_y = 0;
+      wkup_dur.st_sign_z = 1;
+      break;
+
+    case ST1VAFE3BX_XL_ST_DISABLE:
+    default:
+      ret = -1;
+      break;
+  }
+
+
+  ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_CTRL3, (uint8_t *)&ctrl3, 1);
+  ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_WAKE_UP_DUR,
+                              (uint8_t *)&wkup_dur, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Configures the self test.[start]
+  *
+  * @param  ctx   communication interface handler.(ptr)
+  * @param  val   valid values 2 (1st step) or 1 (2nd step)
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_self_test_start(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  st1vafe3bx_ah_bio_cfg3_t ah_bio_cfg3;
+  int32_t ret;
+
+  if (val != 1U && val != 2U)
+  {
+    return -1;
+  }
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_AH_BIO_CFG3,
+                            (uint8_t *)&ah_bio_cfg3, 1);
+  if (ret == 0)
+  {
+    ah_bio_cfg3.st = (uint8_t)val;
+    ret = st1vafe3bx_write_reg(ctx, ST1VAFE3BX_AH_BIO_CFG3,
+                               (uint8_t *)&ah_bio_cfg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configures the self test.[stop]
+  *
+  * @param  ctx   communication interface handler.(ptr)
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_self_test_stop(const stmdev_ctx_t *ctx)
+{
+  st1vafe3bx_ah_bio_cfg3_t ah_bio_cfg3;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_AH_BIO_CFG3,
+                            (uint8_t *)&ah_bio_cfg3, 1);
+  if (ret == 0)
+  {
+    ah_bio_cfg3.st = 0;
+    ret = st1vafe3bx_write_reg(ctx, ST1VAFE3BX_AH_BIO_CFG3,
+                               (uint8_t *)&ah_bio_cfg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configures I3C bus.[set]
+  *
+  * @param  ctx   communication interface handler.(ptr)
+  * @param  val   configuration params
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_i3c_configure_set(const stmdev_ctx_t *ctx,
+                                     const st1vafe3bx_i3c_cfg_t *val)
+{
+  st1vafe3bx_i3c_if_ctrl_t i3c_cfg;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_I3C_IF_CTRL,
+                            (uint8_t *)&i3c_cfg, 1);
+
+  if (ret == 0)
+  {
+    i3c_cfg.bus_act_sel = (uint8_t)val->bus_act_sel;
+    i3c_cfg.dis_drstdaa = val->drstdaa_en;
+    i3c_cfg.asf_on = val->asf_on;
+    ret = st1vafe3bx_write_reg(ctx, ST1VAFE3BX_I3C_IF_CTRL,
+                               (uint8_t *)&i3c_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Configures I3C bus.[get]
+  *
+  * @param  ctx   communication interface handler.(ptr)
+  * @param  val   configuration params
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */int32_t st1vafe3bx_i3c_configure_get(const stmdev_ctx_t *ctx,
+                                         st1vafe3bx_i3c_cfg_t *val)
+{
+  st1vafe3bx_i3c_if_ctrl_t i3c_cfg;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_I3C_IF_CTRL,
+                            (uint8_t *)&i3c_cfg, 1);
+
+  val->drstdaa_en = i3c_cfg.dis_drstdaa;
+  val->asf_on = i3c_cfg.asf_on;
+
+  switch (val->bus_act_sel)
+  {
+    case ST1VAFE3BX_I3C_BUS_AVAIL_TIME_20US:
+      val->bus_act_sel = ST1VAFE3BX_I3C_BUS_AVAIL_TIME_20US;
+      break;
+
+    case ST1VAFE3BX_I3C_BUS_AVAIL_TIME_50US:
+      val->bus_act_sel = ST1VAFE3BX_I3C_BUS_AVAIL_TIME_50US;
+      break;
+
+    case ST1VAFE3BX_I3C_BUS_AVAIL_TIME_1MS:
+      val->bus_act_sel = ST1VAFE3BX_I3C_BUS_AVAIL_TIME_1MS;
+      break;
+
+    case ST1VAFE3BX_I3C_BUS_AVAIL_TIME_25MS:
+    default:
+      val->bus_act_sel = ST1VAFE3BX_I3C_BUS_AVAIL_TIME_25MS;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Change memory bank.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      MAIN_MEM_BANK, EMBED_FUNC_MEM_BANK, SENSOR_HUB_MEM_BANK,
+  *                  STRED_MEM_BANK,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_mem_bank_set(const stmdev_ctx_t *ctx,
+                                st1vafe3bx_mem_bank_t val)
+{
+  st1vafe3bx_func_cfg_access_t func_cfg_access;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_FUNC_CFG_ACCESS,
+                            (uint8_t *)&func_cfg_access, 1);
+
+  if (ret == 0)
+  {
+    func_cfg_access.emb_func_reg_access = ((uint8_t)val & 0x1U);
+    ret = st1vafe3bx_write_reg(ctx, ST1VAFE3BX_FUNC_CFG_ACCESS,
+                               (uint8_t *)&func_cfg_access, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Change memory bank.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      MAIN_MEM_BANK, EMBED_FUNC_MEM_BANK, SENSOR_HUB_MEM_BANK,
+  *                  STRED_MEM_BANK,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_mem_bank_get(const stmdev_ctx_t *ctx,
+                                st1vafe3bx_mem_bank_t *val)
+{
+  st1vafe3bx_func_cfg_access_t func_cfg_access;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_FUNC_CFG_ACCESS,
+                            (uint8_t *)&func_cfg_access, 1);
+
+  switch ((func_cfg_access.emb_func_reg_access))
+  {
+    case 0x0:
+      *val = ST1VAFE3BX_MAIN_MEM_BANK;
+      break;
+
+    case 0x1:
+      *val = ST1VAFE3BX_EMBED_FUNC_MEM_BANK;
+      break;
+
+    default:
+      *val = ST1VAFE3BX_MAIN_MEM_BANK;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Write buffer in a page.
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  address  Address of page register to be written (page number in
+  *                  8-bit msb, register address in 8-bit lsb).
+  * @param  buf      Pointer to data buffer.
+  * @param  len      Buffer len.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t address,
+                               uint8_t *buf, uint8_t len)
+{
+  st1vafe3bx_page_address_t  page_address;
+  st1vafe3bx_page_sel_t page_sel;
+  st1vafe3bx_page_rw_t page_rw;
+  uint8_t msb;
+  uint8_t lsb;
+  int32_t ret;
+  uint8_t i ;
+
+  msb = ((uint8_t)(address >> 8) & 0x0FU);
+  lsb = (uint8_t)address & 0xFFU;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_PAGE_RW, (uint8_t *)&page_rw, 1);
+    page_rw.page_read = PROPERTY_DISABLE;
+    page_rw.page_write = PROPERTY_ENABLE;
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_PAGE_RW,
+                                (uint8_t *)&page_rw, 1);
+
+    ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_PAGE_SEL,
+                               (uint8_t *)&page_sel, 1);
+    page_sel.page_sel = msb;
+    page_sel.not_used0 = 1; // Default value
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_PAGE_SEL,
+                                (uint8_t *)&page_sel, 1);
+
+    page_address.page_addr = lsb;
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_PAGE_ADDRESS,
+                                (uint8_t *)&page_address, 1);
+
+    for (i = 0; i < len; i++)
+    {
+      ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_PAGE_VALUE, &buf[i], 1);
+      lsb++;
+
+      /* Check if page wrap */
+      if (((lsb & 0xFFU) == 0x00U) && (ret == 0))
+      {
+        msb++;
+        ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_PAGE_SEL,
+                                   (uint8_t *)&page_sel, 1);
+        page_sel.page_sel = msb;
+        page_sel.not_used0 = 1; // Default value
+        ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_PAGE_SEL,
+                                    (uint8_t *)&page_sel, 1);
+      }
+
+      if (ret != 0)
+      {
+        break;
+      }
+    }
+
+    page_sel.page_sel = 0;
+    page_sel.not_used0 = 1;// Default value
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_PAGE_SEL,
+                                (uint8_t *)&page_sel, 1);
+
+    ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_PAGE_RW, (uint8_t *)&page_rw, 1);
+    page_rw.page_read = PROPERTY_DISABLE;
+    page_rw.page_write = PROPERTY_DISABLE;
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_PAGE_RW,
+                                (uint8_t *)&page_rw, 1);
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Read buffer in a page.
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  address  Address of page register to be read (page number in 8-bit
+  *                  msb, register address in 8-bit lsb).
+  * @param  buf      Pointer to data buffer.
+  * @param  len      Buffer len.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_ln_pg_read(const stmdev_ctx_t *ctx, uint16_t address,
+                              uint8_t *buf, uint8_t len)
+{
+  st1vafe3bx_page_address_t  page_address;
+  st1vafe3bx_page_sel_t page_sel;
+  st1vafe3bx_page_rw_t page_rw;
+  uint8_t msb;
+  uint8_t lsb;
+  int32_t ret;
+  uint8_t i ;
+
+  msb = ((uint8_t)(address >> 8) & 0x0FU);
+  lsb = (uint8_t)address & 0xFFU;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_PAGE_RW, (uint8_t *)&page_rw, 1);
+    page_rw.page_read = PROPERTY_ENABLE;
+    page_rw.page_write = PROPERTY_DISABLE;
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_PAGE_RW,
+                                (uint8_t *)&page_rw, 1);
+
+    ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_PAGE_SEL,
+                               (uint8_t *)&page_sel, 1);
+    page_sel.page_sel = msb;
+    page_sel.not_used0 = 1; // Default value
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_PAGE_SEL,
+                                (uint8_t *)&page_sel, 1);
+
+    page_address.page_addr = lsb;
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_PAGE_ADDRESS,
+                                (uint8_t *)&page_address, 1);
+
+    for (i = 0; i < len; i++)
+    {
+      ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_PAGE_VALUE, &buf[i], 1);
+      lsb++;
+
+      /* Check if page wrap */
+      if (((lsb & 0xFFU) == 0x00U) && (ret == 0))
+      {
+        msb++;
+        ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_PAGE_SEL,
+                                   (uint8_t *)&page_sel, 1);
+        page_sel.page_sel = msb;
+        page_sel.not_used0 = 1; // Default value
+        ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_PAGE_SEL,
+                                    (uint8_t *)&page_sel, 1);
+      }
+
+      if (ret != 0)
+      {
+        break;
+      }
+    }
+
+    page_sel.page_sel = 0;
+    page_sel.not_used0 = 1;// Default value
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_PAGE_SEL,
+                                (uint8_t *)&page_sel, 1);
+
+    ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_PAGE_RW, (uint8_t *)&page_rw, 1);
+    page_rw.page_read = PROPERTY_DISABLE;
+    page_rw.page_write = PROPERTY_DISABLE;
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_PAGE_RW,
+                                (uint8_t *)&page_rw, 1);
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup Interrupt PINs
+  * @brief    Interrupt PINs
+  * @{/
+  *
+  */
+
+/**
+  * @brief       External Clock Enable/Disable on INT pin.[set]
+  *
+  * @param  ctx  read / write interface definitions
+  * @param  val  0: disable ext_clk - 1: enable ext_clk
+  * @retval      interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_ext_clk_en_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  st1vafe3bx_ext_clk_cfg_t clk;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_EXT_CLK_CFG, (uint8_t *)&clk, 1);
+  clk.ext_clk_en = val;
+  ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_EXT_CLK_CFG, (uint8_t *)&clk, 1);
+
+  return ret;
+}
+
+/**
+  * @brief       External Clock Enable/Disable on INT pin.[get]
+  *
+  * @param  ctx  read / write interface definitions
+  * @param  val  0: disable ext_clk - 1: enable ext_clk
+  * @retval      interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_ext_clk_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  st1vafe3bx_ext_clk_cfg_t clk;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_EXT_CLK_CFG, (uint8_t *)&clk, 1);
+  *val = clk.ext_clk_en;
+
+  return ret;
+}
+
+/**
+  * @brief       Electrical pin configuration.[set]
+  *
+  * @param  ctx  read / write interface definitions
+  * @param  val  the electrical settings for the configurable pins.(ptr)
+  * @retval      interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_pin_conf_set(const stmdev_ctx_t *ctx,
+                                const st1vafe3bx_pin_conf_t *val)
+{
+  st1vafe3bx_pin_ctrl_t pin_ctrl;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+
+  if (ret == 0)
+  {
+    pin_ctrl.cs_pu_dis = ~val->cs_pull_up;
+    pin_ctrl.sda_pu_en = val->sda_pull_up;
+    pin_ctrl.sdo_pu_en = val->sdo_pull_up;
+    pin_ctrl.pp_od = ~val->int_push_pull;
+
+    ret = st1vafe3bx_write_reg(ctx, ST1VAFE3BX_PIN_CTRL,
+                               (uint8_t *)&pin_ctrl, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief       Electrical pin configuration.[get]
+  *
+  * @param  ctx  read / write interface definitions
+  * @param  val  the electrical settings for the configurable pins.(ptr)
+  * @retval      interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_pin_conf_get(const stmdev_ctx_t *ctx,
+                                st1vafe3bx_pin_conf_t *val)
+{
+  st1vafe3bx_pin_ctrl_t pin_ctrl;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+
+  val->cs_pull_up = ~pin_ctrl.cs_pu_dis;
+  val->sda_pull_up = pin_ctrl.sda_pu_en;
+  val->sdo_pull_up = pin_ctrl.sdo_pu_en;
+  val->int_push_pull = ~pin_ctrl.pp_od;
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt activation level.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      ACTIVE_HIGH, ACTIVE_LOW,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_int_pin_polarity_set(const stmdev_ctx_t *ctx,
+                                        st1vafe3bx_int_pin_polarity_t val)
+{
+  st1vafe3bx_pin_ctrl_t pin_ctrl;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+
+  if (ret == 0)
+  {
+    pin_ctrl.h_lactive = (uint8_t)val;
+    ret = st1vafe3bx_write_reg(ctx, ST1VAFE3BX_PIN_CTRL,
+                               (uint8_t *)&pin_ctrl, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt activation level.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      ACTIVE_HIGH, ACTIVE_LOW,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_int_pin_polarity_get(const stmdev_ctx_t *ctx,
+                                        st1vafe3bx_int_pin_polarity_t *val)
+{
+  st1vafe3bx_pin_ctrl_t pin_ctrl;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+
+  switch ((pin_ctrl.h_lactive))
+  {
+    case 0x0:
+      *val = ST1VAFE3BX_ACTIVE_HIGH;
+      break;
+
+    case 0x1:
+      *val = ST1VAFE3BX_ACTIVE_LOW;
+      break;
+
+    default:
+      *val = ST1VAFE3BX_ACTIVE_HIGH;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  SPI mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SPI_4_WIRE, SPI_3_WIRE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_spi_mode_set(const stmdev_ctx_t *ctx,
+                                st1vafe3bx_spi_mode val)
+{
+  st1vafe3bx_pin_ctrl_t pin_ctrl;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+
+  if (ret == 0)
+  {
+    pin_ctrl.sim = (uint8_t)val;
+    ret = st1vafe3bx_write_reg(ctx, ST1VAFE3BX_PIN_CTRL,
+                               (uint8_t *)&pin_ctrl, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  SPI mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SPI_4_WIRE, SPI_3_WIRE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_spi_mode_get(const stmdev_ctx_t *ctx,
+                                st1vafe3bx_spi_mode *val)
+{
+  st1vafe3bx_pin_ctrl_t pin_ctrl;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+
+  switch ((pin_ctrl.sim))
+  {
+    case 0x0:
+      *val = ST1VAFE3BX_SPI_4_WIRE;
+      break;
+
+    case 0x1:
+      *val = ST1VAFE3BX_SPI_3_WIRE;
+      break;
+
+    default:
+      *val = ST1VAFE3BX_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  routes interrupt signals on INT pin.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      routes interrupt signals on INT pin.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_pin_int_route_set(const stmdev_ctx_t *ctx,
+                                     const st1vafe3bx_pin_int_route_t *val)
+{
+  st1vafe3bx_ctrl1_t ctrl1;
+  st1vafe3bx_ctrl2_t ctrl2;
+  st1vafe3bx_md1_cfg_t md1_cfg;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_CTRL1, (uint8_t *)&ctrl1, 1);
+  ctrl1.int_pin_en = PROPERTY_ENABLE;
+  ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_CTRL1, (uint8_t *)&ctrl1, 1);
+
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_CTRL2, (uint8_t *)&ctrl2, 1);
+
+    if (ret == 0)
+    {
+      ctrl2.int_drdy = val->drdy;
+      ctrl2.int_fifo_ovr = val->fifo_ovr;
+      ctrl2.int_fifo_th = val->fifo_th;
+      ctrl2.int_fifo_full = val->fifo_full;
+      ctrl2.int_boot = val->boot;
+
+      ret = st1vafe3bx_write_reg(ctx, ST1VAFE3BX_CTRL2, (uint8_t *)&ctrl2, 1);
+    }
+  }
+
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+
+    if (ret == 0)
+    {
+      md1_cfg.int_ff = val->free_fall;
+      md1_cfg.int_6d = val->six_d;
+      md1_cfg.int_tap = val->tap;
+      md1_cfg.int_wu = val->wake_up;
+      md1_cfg.int_sleep_change = val->sleep_change;
+      md1_cfg.int_emb_func = val->emb_function;
+      md1_cfg.int_timestamp = val->timestamp;
+
+      ret = st1vafe3bx_write_reg(ctx, ST1VAFE3BX_MD1_CFG,
+                                 (uint8_t *)&md1_cfg, 1);
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  routes interrupt signals on INT pin.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get interrupt signals routing on INT pin.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_pin_int_route_get(const stmdev_ctx_t *ctx,
+                                     st1vafe3bx_pin_int_route_t *val)
+{
+  st1vafe3bx_ctrl2_t ctrl2;
+  st1vafe3bx_md1_cfg_t md1_cfg;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_CTRL2, (uint8_t *)&ctrl2, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+
+  if (ret == 0)
+  {
+    val->drdy = ctrl2.int_drdy;
+    val->fifo_ovr = ctrl2.int_fifo_ovr;
+    val->fifo_th = ctrl2.int_fifo_th;
+    val->fifo_full = ctrl2.int_fifo_full;
+    val->boot = ctrl2.int_boot;
+
+    val->free_fall = md1_cfg.int_ff;
+    val->six_d = md1_cfg.int_6d;
+    val->tap = md1_cfg.int_tap;
+    val->wake_up = md1_cfg.int_wu;
+    val->sleep_change = md1_cfg.int_sleep_change;
+    val->emb_function = md1_cfg.int_emb_func;
+    val->timestamp = md1_cfg.int_timestamp;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  routes embedded func interrupt signals on INT pin.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      routes embedded func interrupt signals on INT 1 pin.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_emb_pin_int_route_set(const stmdev_ctx_t *ctx,
+                                         const st1vafe3bx_emb_pin_int_route_t *val)
+{
+  st1vafe3bx_emb_func_int_t emb_func_int;
+  st1vafe3bx_md1_cfg_t md1_cfg;
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_EMB_FUNC_INT,
+                              (uint8_t *)&emb_func_int, 1);
+  }
+
+  if (ret == 0)
+  {
+    emb_func_int.int_tilt = val->tilt;
+    emb_func_int.int_sig_mot = val->sig_mot;
+    emb_func_int.int_step_det = val->step_det;
+    emb_func_int.int_fsm_lc = val->fsm_lc;
+
+    ret = st1vafe3bx_write_reg(ctx, ST1VAFE3BX_EMB_FUNC_INT,
+                               (uint8_t *)&emb_func_int, 1);
+  }
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  if (ret == 0)
+  {
+    md1_cfg.int_emb_func = 1;
+    ret = st1vafe3bx_write_reg(ctx, ST1VAFE3BX_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  routes embedded func interrupt signals on INT pin.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      routes embedded func interrupt signals on INT 1 pin.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_emb_pin_int_route_get(const stmdev_ctx_t *ctx,
+                                         st1vafe3bx_emb_pin_int_route_t *val)
+{
+  st1vafe3bx_emb_func_int_t emb_func_int;
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_EMB_FUNC_INT,
+                              (uint8_t *)&emb_func_int, 1);
+  }
+
+  if (ret == 0)
+  {
+    val->tilt = emb_func_int.int_tilt;
+    val->sig_mot = emb_func_int.int_sig_mot;
+    val->step_det = emb_func_int.int_step_det;
+    val->fsm_lc = emb_func_int.int_fsm_lc;
+  }
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt configuration mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      INT_DISABLED, INT_LEVEL, INT_LATCHED
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_int_config_set(const stmdev_ctx_t *ctx,
+                                  const st1vafe3bx_int_config_t *val)
+{
+  st1vafe3bx_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_INTERRUPT_CFG,
+                            (uint8_t *)&interrupt_cfg, 1);
+
+  if (ret == 0)
+  {
+    switch (val->int_cfg)
+    {
+      case ST1VAFE3BX_INT_DISABLED:
+        interrupt_cfg.interrupts_enable = 0;
+        break;
+
+      case ST1VAFE3BX_INT_LEVEL:
+        interrupt_cfg.interrupts_enable = 1;
+        interrupt_cfg.lir = 0;
+        break;
+
+      case ST1VAFE3BX_INT_LATCHED:
+      default:
+        interrupt_cfg.interrupts_enable = 1;
+        interrupt_cfg.lir = 1;
+        break;
+    }
+
+    interrupt_cfg.dis_rst_lir_all_int = val->dis_rst_lir_all_int;
+    interrupt_cfg.sleep_status_on_int = val->sleep_status_on_int;
+
+    ret = st1vafe3bx_write_reg(ctx, ST1VAFE3BX_INTERRUPT_CFG,
+                               (uint8_t *)&interrupt_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt configuration mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      INT_DISABLED, INT_LEVEL, INT_LATCHED
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_int_config_get(const stmdev_ctx_t *ctx,
+                                  st1vafe3bx_int_config_t *val)
+{
+  st1vafe3bx_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_INTERRUPT_CFG,
+                            (uint8_t *)&interrupt_cfg, 1);
+
+  if (ret == 0)
+  {
+    val->dis_rst_lir_all_int = interrupt_cfg.dis_rst_lir_all_int;
+    val->sleep_status_on_int = interrupt_cfg.sleep_status_on_int;
+
+    if (interrupt_cfg.interrupts_enable == 0U)
+    {
+      val->int_cfg = ST1VAFE3BX_INT_DISABLED;
+    }
+    else if (interrupt_cfg.lir == 0U)
+    {
+      val->int_cfg = ST1VAFE3BX_INT_LEVEL;
+    }
+    else
+    {
+      val->int_cfg = ST1VAFE3BX_INT_LATCHED;
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Embedded Interrupt configuration mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      INT_PULSED, INT_LATCHED
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_embedded_int_cfg_set(const stmdev_ctx_t *ctx,
+                                        st1vafe3bx_embedded_int_config_t val)
+{
+  st1vafe3bx_page_rw_t page_rw;
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_PAGE_RW, (uint8_t *)&page_rw, 1);
+
+    switch (val)
+    {
+      case ST1VAFE3BX_EMBEDDED_INT_LEVEL:
+        page_rw.emb_func_lir = 0;
+        break;
+
+      case ST1VAFE3BX_EMBEDDED_INT_LATCHED:
+      default:
+        page_rw.emb_func_lir = 1;
+        break;
+    }
+
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_PAGE_RW,
+                                (uint8_t *)&page_rw, 1);
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt configuration mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      INT_DISABLED, INT_PULSED, INT_LATCHED
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_embedded_int_cfg_get(const stmdev_ctx_t *ctx,
+                                        st1vafe3bx_embedded_int_config_t *val)
+{
+  st1vafe3bx_page_rw_t page_rw;
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_PAGE_RW, (uint8_t *)&page_rw, 1);
+
+    if (page_rw.emb_func_lir == 0U)
+    {
+      *val = ST1VAFE3BX_EMBEDDED_INT_LEVEL;
+    }
+    else
+    {
+      *val = ST1VAFE3BX_EMBEDDED_INT_LATCHED;
+    }
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup FIFO
+  * @brief    FIFO
+  * @{/
+  *
+  */
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      BYPASS_MODE, FIFO_MODE, STREAM_TO_FIFO_MODE,
+  *                  BYPASS_TO_STREAM_MODE, STREAM_MODE, BYPASS_TO_FIFO_MODE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_fifo_mode_set(const stmdev_ctx_t *ctx,
+                                 st1vafe3bx_fifo_mode_t val)
+{
+  st1vafe3bx_ctrl4_t ctrl4;
+  st1vafe3bx_fifo_ctrl_t fifo_ctrl;
+  st1vafe3bx_fifo_wtm_t fifo_wtm;
+  st1vafe3bx_fifo_batch_dec_t fifo_batch;
+  st1vafe3bx_ah_bio_cfg2_t ah_bio_cfg2;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_CTRL4, (uint8_t *)&ctrl4, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_FIFO_CTRL,
+                             (uint8_t *)&fifo_ctrl, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_FIFO_BATCH_DEC,
+                             (uint8_t *)&fifo_batch, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_FIFO_WTM, (uint8_t *)&fifo_wtm, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_AH_BIO_CFG2,
+                             (uint8_t *)&ah_bio_cfg2, 1);
+
+  if (ret == 0)
+  {
+    /* set FIFO mode */
+    if (val.operation != ST1VAFE3BX_FIFO_OFF)
+    {
+      ctrl4.fifo_en = 1;
+      fifo_ctrl.fifo_mode = ((uint8_t)val.operation & 0x7U);
+
+      /*
+       * fifo_en_adv must be set to 1 when the embedded function results and/or
+       * the AH / vAFE data at 3200 Hz ODR are intended to be stored in FIFO.
+       * It can be set to 0 in the other cases
+       */
+      if (ah_bio_cfg2.ah_bio_en == 0x1U)
+      {
+        fifo_ctrl.fifo_en_adv = 0x1U;
+      }
+      else
+      {
+        fifo_ctrl.fifo_en_adv = 0x0U;
+      }
+    }
+    else
+    {
+      ctrl4.fifo_en = 0;
+    }
+
+    /* set fifo depth (1X/2X) */
+    fifo_ctrl.fifo_depth = (uint8_t)val.store;
+
+    /* set xl_only_fifo */
+    fifo_wtm.xl_only_fifo = val.xl_only;
+
+    /* set batching info */
+    if (val.batch.dec_ts != ST1VAFE3BX_DEC_TS_OFF)
+    {
+      fifo_batch.dec_ts_batch = (uint8_t)val.batch.dec_ts;
+      fifo_batch.bdr_xl = (uint8_t)val.batch.bdr_xl;
+    }
+
+    fifo_ctrl.cfg_chg_en = val.cfg_change_in_fifo;
+
+    /* set watermark */
+    if (val.watermark > 0U)
+    {
+      fifo_ctrl.stop_on_fth = 1;
+      fifo_wtm.fth = val.watermark;
+    }
+
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_FIFO_BATCH_DEC,
+                                (uint8_t *)&fifo_batch, 1);
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_FIFO_WTM,
+                                (uint8_t *)&fifo_wtm, 1);
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_FIFO_CTRL,
+                                (uint8_t *)&fifo_ctrl, 1);
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_CTRL4, (uint8_t *)&ctrl4, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      BYPASS_MODE, FIFO_MODE, STREAM_TO_FIFO_MODE,
+  *                  BYPASS_TO_STREAM_MODE, STREAM_MODE, BYPASS_TO_FIFO_MODE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_fifo_mode_get(const stmdev_ctx_t *ctx,
+                                 st1vafe3bx_fifo_mode_t *val)
+{
+  st1vafe3bx_ctrl4_t ctrl4;
+  st1vafe3bx_fifo_ctrl_t fifo_ctrl;
+  st1vafe3bx_fifo_wtm_t fifo_wtm;
+  st1vafe3bx_fifo_batch_dec_t fifo_batch;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_CTRL4, (uint8_t *)&ctrl4, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_FIFO_CTRL,
+                             (uint8_t *)&fifo_ctrl, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_FIFO_BATCH_DEC,
+                             (uint8_t *)&fifo_batch, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_FIFO_WTM, (uint8_t *)&fifo_wtm, 1);
+
+  if (ret == 0)
+  {
+    /* get FIFO mode */
+    if (ctrl4.fifo_en == 0U)
+    {
+      val->operation = ST1VAFE3BX_FIFO_OFF;
+    }
+    else
+    {
+      val->operation = (enum st1vafe3bx_operation_t)fifo_ctrl.fifo_mode;
+    }
+    val->cfg_change_in_fifo = fifo_ctrl.cfg_chg_en;
+
+    /* get fifo depth (1X/2X) */
+    val->store = (enum st1vafe3bx_store_t)fifo_ctrl.fifo_depth;
+
+    /* Get xl_only_fifo */
+    val->xl_only = fifo_wtm.xl_only_fifo;
+
+    /* get batching info */
+    val->batch.dec_ts = (enum st1vafe3bx_dec_ts_t)fifo_batch.dec_ts_batch;
+    val->batch.bdr_xl = (enum st1vafe3bx_bdr_xl_t)fifo_batch.bdr_xl;
+
+    /* get watermark */
+    val->watermark = fifo_wtm.fth;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Number of unread sensor data (TAG + 6 bytes) stored in FIFO.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Number of unread sensor data (TAG + 6 bytes) stored in FIFO.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_fifo_data_level_get(const stmdev_ctx_t *ctx, uint16_t *val)
+{
+  uint8_t buff;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_FIFO_STATUS2, &buff, 1);
+
+  *val = buff;
+
+  return ret;
+}
+
+int32_t st1vafe3bx_fifo_wtm_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  st1vafe3bx_fifo_status1_t fifo_status1;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_FIFO_STATUS1, (uint8_t *)&fifo_status1, 1);
+
+  *val = fifo_status1.fifo_wtm_ia;
+
+  return ret;
+}
+
+int32_t st1vafe3bx_fifo_sensor_tag_get(const stmdev_ctx_t *ctx,
+                                       st1vafe3bx_fifo_sensor_tag_t *val)
+{
+  st1vafe3bx_fifo_data_out_tag_t fifo_tag;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_FIFO_DATA_OUT_TAG,
+                            (uint8_t *)&fifo_tag, 1);
+
+  *val = (st1vafe3bx_fifo_sensor_tag_t) fifo_tag.tag_sensor;
+
+  return ret;
+}
+
+int32_t st1vafe3bx_fifo_out_raw_get(const stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_FIFO_DATA_OUT_X_L, buff, 6);
+
+  return ret;
+}
+
+int32_t st1vafe3bx_fifo_data_get(const stmdev_ctx_t *ctx,
+                                 const st1vafe3bx_md_t *md,
+                                 const st1vafe3bx_fifo_mode_t *fmd,
+                                 st1vafe3bx_fifo_data_t *data)
+{
+  st1vafe3bx_fifo_data_out_tag_t fifo_tag;
+  uint8_t fifo_raw[6];
+  int32_t ret, i;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_FIFO_DATA_OUT_TAG,
+                            (uint8_t *)&fifo_tag, 1);
+  data->tag = fifo_tag.tag_sensor;
+
+  switch (fifo_tag.tag_sensor)
+  {
+    case ST1VAFE3BX_TIMESTAMP_CFG_CHG_TAG:
+      ret = st1vafe3bx_fifo_out_raw_get(ctx, fifo_raw);
+
+      data->cfg_chg.cfg_change = fifo_raw[0] >> 7;
+      data->cfg_chg.odr = (fifo_raw[0] >> 3) & 0xFU;
+      data->cfg_chg.bw = (fifo_raw[0] >> 1) & 0x3U;
+      data->cfg_chg.lp_hp = fifo_raw[0] & 0x1U;
+      data->cfg_chg.ah_en = fifo_raw[1] >> 7;
+      data->cfg_chg.fs = (fifo_raw[1] >> 5) & 0x3U;
+      data->cfg_chg.dec_ts = (fifo_raw[1] >> 3) & 0x3U;
+      data->cfg_chg.odr_xl_batch = fifo_raw[1] & 0x7U;
+
+      data->cfg_chg.timestamp = fifo_raw[5];
+      data->cfg_chg.timestamp = (data->cfg_chg.timestamp * 256U) +  fifo_raw[4];
+      data->cfg_chg.timestamp = (data->cfg_chg.timestamp * 256U) +  fifo_raw[3];
+      data->cfg_chg.timestamp = (data->cfg_chg.timestamp * 256U) +  fifo_raw[2];
+      break;
+    case ST1VAFE3BX_XL_ONLY_2X_TAG:
+      /*
+       * Accelerometer only data (2x depth mode), a FIFO sample consists
+       * of 2 x 8-bits 3-axis XL at ODR/2
+       */
+      ret = st1vafe3bx_fifo_out_raw_get(ctx, fifo_raw);
+      for (i = 0; i < 3; i++)
+      {
+        data->xl[0].raw[i] = (int16_t)fifo_raw[i] * 256U;
+        data->xl[1].raw[i] = (int16_t)fifo_raw[3 + i] * 256U;
+      }
+      break;
+    case ST1VAFE3BX_STEP_COUNTER_TAG:
+      /* step counted + timestamp */
+      ret = st1vafe3bx_fifo_out_raw_get(ctx, fifo_raw);
+
+      data->pedo.steps = fifo_raw[1];
+      data->pedo.steps = (data->pedo.steps * 256U) +  fifo_raw[0];
+
+      data->pedo.timestamp = fifo_raw[5];
+      data->pedo.timestamp = (data->pedo.timestamp * 256U) +  fifo_raw[4];
+      data->pedo.timestamp = (data->pedo.timestamp * 256U) +  fifo_raw[3];
+      data->pedo.timestamp = (data->pedo.timestamp * 256U) +  fifo_raw[2];
+      break;
+    case ST1VAFE3BX_AH_VAFE_ONLY_TAG:
+      /* vAFE data (16 bit) if vafe_only mode is enabled */
+      ret = st1vafe3bx_fifo_out_raw_get(ctx, fifo_raw);
+
+      data->ah_bio.raw = (int16_t)fifo_raw[0] + (int16_t)fifo_raw[1] * 256U;
+      data->ah_bio.mv = st1vafe3bx_from_lsb_to_mv(data->ah_bio.raw);
+      break;
+    case ST1VAFE3BX_XL_ONLY:
+    case ST1VAFE3BX_XL_AND_AH_VAFE1_TAG:
+      ret = st1vafe3bx_fifo_out_raw_get(ctx, fifo_raw);
+
+      /*
+       * XL data(12bit) + vAFE(12bit) if xl_only bit in FIFO WTM
+       * is set else XL data only(16 bit)
+       */
+      if (fmd->xl_only == 0x0U)
+      {
+        /*
+         * data packaging in FIFO when XL and vAFE available:
+         *                 ------------- -------------
+         *                |    LSB0     | LSN1 | MSN0 |
+         *                 ------------- -------------
+         *                |    MSB1     |    LSB2     |
+         *                 ------------- -------------
+         *                | LSN3 | MSN2 |    MSB3     |
+         *                 ------------- -------------
+         *
+         *  ------------- ------------- ------------- -------------
+         * |      X      |      Y      |      Z      |   vAFE      |
+         *  ------------- ------------- ------------- -------------
+         * | MSN0 | LSB0 | MSB1 | LSN1 | MSN2 | LSB2 | MSB3 | LSN3 |
+         *  ------ ------ ------ ------ ------ ------ ------ ------
+         */
+        data->xl[0].raw[0] = (int16_t)fifo_raw[0];
+        data->xl[0].raw[0] = (data->xl[0].raw[0] +
+                              ((int16_t)fifo_raw[1] * 256U)) * 16U;
+
+        data->xl[0].raw[1] = (int16_t)fifo_raw[1] / 16U;
+        data->xl[0].raw[1] = (data->xl[0].raw[1] +
+                              (int16_t)fifo_raw[2] * 16U) * 16U;
+
+        data->xl[0].raw[2] = (int16_t)fifo_raw[3];
+        data->xl[0].raw[2] = (data->xl[0].raw[2] +
+                              ((int16_t)fifo_raw[4] * 256U)) * 16U;
+
+        data->ah_bio.raw = (int16_t)fifo_raw[4] / 16U;
+        data->ah_bio.raw = (data->ah_bio.raw +
+                            ((int16_t)fifo_raw[5] * 16U)) * 16U;
+        data->ah_bio.mv = st1vafe3bx_from_lsb_to_mv(data->ah_bio.raw);
+      }
+      else
+      {
+        data->xl[0].raw[0] = (int16_t)fifo_raw[0] + (int16_t)fifo_raw[1] * 256U;
+        data->xl[0].raw[1] = (int16_t)fifo_raw[1] + (int16_t)fifo_raw[3] * 256U;
+        data->xl[0].raw[2] = (int16_t)fifo_raw[2] + (int16_t)fifo_raw[5] * 256U;
+      }
+      break;
+    default:
+      /* do nothing */
+      break;
+  }
+
+  for (i = 0; i < 3; i++)
+  {
+    switch (md->fs)
+    {
+      case ST1VAFE3BX_2g:
+        data->xl[0].mg[i] = st1vafe3bx_from_fs2g_to_mg(data->xl[0].raw[i]);
+        data->xl[1].mg[i] = st1vafe3bx_from_fs2g_to_mg(data->xl[1].raw[i]);
+        break;
+      case ST1VAFE3BX_4g:
+        data->xl[0].mg[i] = st1vafe3bx_from_fs4g_to_mg(data->xl[0].raw[i]);
+        data->xl[1].mg[i] = st1vafe3bx_from_fs4g_to_mg(data->xl[1].raw[i]);
+        break;
+      case ST1VAFE3BX_8g:
+        data->xl[0].mg[i] = st1vafe3bx_from_fs8g_to_mg(data->xl[0].raw[i]);
+        data->xl[1].mg[i] = st1vafe3bx_from_fs8g_to_mg(data->xl[1].raw[i]);
+        break;
+      case ST1VAFE3BX_16g:
+        data->xl[0].mg[i] = st1vafe3bx_from_fs16g_to_mg(data->xl[0].raw[i]);
+        data->xl[1].mg[i] = st1vafe3bx_from_fs16g_to_mg(data->xl[1].raw[i]);
+        break;
+      default:
+        data->xl[0].mg[i] = 0.0f;
+        data->xl[1].mg[i] = 0.0f;
+        break;
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Configures AH_BIO chain.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Configures AH_BIO chain.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_ah_bio_config_set(const stmdev_ctx_t *ctx,
+                                     st1vafe3bx_ah_bio_config_t val)
+{
+  st1vafe3bx_ah_bio_cfg1_t cfg1;
+  st1vafe3bx_ah_bio_cfg2_t cfg2;
+  st1vafe3bx_ah_bio_cfg3_t cfg3;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_AH_BIO_CFG1, (uint8_t *)&cfg1, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_AH_BIO_CFG2, (uint8_t *)&cfg2, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_AH_BIO_CFG3, (uint8_t *)&cfg3, 1);
+
+  if (ret == 0)
+  {
+    cfg1.ah_bio_zin_dis_ah2_bio1 = val.ah_bio_zin_dis_1;
+    cfg1.ah_bio_zin_dis_ah2_bio2 = val.ah_bio_zin_dis_2;
+
+    switch (val.mode)
+    {
+      case ST1VAFE3BX_DIFFERENTIAL_MODE:
+        cfg2.ah_bio_mode = 0x0U;
+        break;
+      case ST1VAFE3BX_SINGLE_MODE_01:
+        cfg2.ah_bio_mode = 0x1U;
+        break;
+      case ST1VAFE3BX_SINGLE_MODE_10:
+        cfg2.ah_bio_mode = 0x2U;
+        break;
+      case ST1VAFE3BX_FORCED_RESET:
+        cfg2.ah_bio_mode = 0x3U;
+        break;
+      default:
+        cfg2.ah_bio_mode = 0x0U;
+        break;
+    }
+
+    switch (val.gain)
+    {
+      case ST1VAFE3BX_GAIN_2:
+        cfg2.ah_bio_gain = 0x0U;
+        break;
+      case ST1VAFE3BX_GAIN_4:
+        cfg2.ah_bio_gain = 0x1U;
+        break;
+      case ST1VAFE3BX_GAIN_8:
+        cfg2.ah_bio_gain = 0x2U;
+        break;
+      case ST1VAFE3BX_GAIN_16:
+        cfg2.ah_bio_gain = 0x3U;
+        break;
+      default:
+        cfg2.ah_bio_gain = 0x0U;
+        break;
+    }
+
+    switch (val.zin)
+    {
+      case ST1VAFE3BX_100MOhm:
+        cfg2.ah_bio_c_zin = 0x0U;
+        break;
+      case ST1VAFE3BX_200MOhm:
+        cfg2.ah_bio_c_zin = 0x1U;
+        break;
+      case ST1VAFE3BX_500MOhm:
+        cfg2.ah_bio_c_zin = 0x2U;
+        break;
+      case ST1VAFE3BX_1GOhm:
+        cfg2.ah_bio_c_zin = 0x3U;
+        break;
+      default:
+        cfg2.ah_bio_c_zin = 0x0U;
+        break;
+    }
+  }
+
+  ret = st1vafe3bx_write_reg(ctx, ST1VAFE3BX_AH_BIO_CFG1, (uint8_t *)&cfg1, 1);
+  ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_AH_BIO_CFG2, (uint8_t *)&cfg2, 1);
+  ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_AH_BIO_CFG3, (uint8_t *)&cfg3, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Configures AH_BIO chain.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Configures AH_BIO chain.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_ah_bio_config_get(const stmdev_ctx_t *ctx,
+                                     st1vafe3bx_ah_bio_config_t *val)
+{
+  st1vafe3bx_ah_bio_cfg1_t cfg1;
+  st1vafe3bx_ah_bio_cfg2_t cfg2;
+  st1vafe3bx_ah_bio_cfg3_t cfg3;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_AH_BIO_CFG1, (uint8_t *)&cfg1, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_AH_BIO_CFG2, (uint8_t *)&cfg2, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_AH_BIO_CFG3, (uint8_t *)&cfg3, 1);
+
+  if (ret == 0)
+  {
+
+    val->ah_bio_zin_dis_1 = cfg1.ah_bio_zin_dis_ah2_bio1;
+    val->ah_bio_zin_dis_2 = cfg1.ah_bio_zin_dis_ah2_bio2;
+
+    switch (cfg2.ah_bio_mode)
+    {
+      case 0x0:
+        val->mode = ST1VAFE3BX_DIFFERENTIAL_MODE;
+        break;
+      case 0x1:
+        val->mode = ST1VAFE3BX_SINGLE_MODE_01;
+        break;
+      case 0x2:
+        val->mode = ST1VAFE3BX_SINGLE_MODE_10;
+        break;
+      case 0x3:
+        val->mode = ST1VAFE3BX_FORCED_RESET;
+        break;
+      default:
+        val->mode = ST1VAFE3BX_DIFFERENTIAL_MODE;
+        break;
+    }
+  }
+
+  switch (cfg2.ah_bio_c_zin)
+  {
+    case 0x0:
+      val->zin = ST1VAFE3BX_100MOhm;
+      break;
+    case 0x1:
+      val->zin = ST1VAFE3BX_200MOhm;
+      break;
+    case 0x2:
+      val->zin = ST1VAFE3BX_500MOhm;
+      break;
+    case 0x3:
+      val->zin = ST1VAFE3BX_1GOhm;
+      break;
+    default:
+      val->zin = ST1VAFE3BX_100MOhm;
+      break;
+  }
+
+  switch (cfg2.ah_bio_gain)
+  {
+    case 0x0:
+      val->gain = ST1VAFE3BX_GAIN_2;
+      break;
+    case 0x1:
+      val->gain = ST1VAFE3BX_GAIN_4;
+      break;
+    case 0x2:
+      val->gain = ST1VAFE3BX_GAIN_8;
+      break;
+    case 0x3:
+      val->gain = ST1VAFE3BX_GAIN_16;
+      break;
+    default:
+      val->gain = ST1VAFE3BX_GAIN_2;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enter vafe-only state (must be called in power-down)
+  *
+  * @param  ctx      read / write interface definitions
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_enter_vafe_only(const stmdev_ctx_t *ctx)
+{
+  st1vafe3bx_ah_bio_cfg2_t cfg2;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_AH_BIO_CFG2, (uint8_t *)&cfg2, 1);
+  cfg2.ah_bio_en = 1;
+  ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_AH_BIO_CFG2, (uint8_t *)&cfg2, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Enter vafe-only state (must be called in power-down)
+  *
+  * @param  ctx      read / write interface definitions
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_exit_vafe_only(const stmdev_ctx_t *ctx)
+{
+  st1vafe3bx_ah_bio_cfg2_t cfg2;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_AH_BIO_CFG2, (uint8_t *)&cfg2, 1);
+  cfg2.ah_bio_en = 0;
+  ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_AH_BIO_CFG2, (uint8_t *)&cfg2, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Device active mode when it is set in the AH / vAFE only state[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      1: enable active state - 0: disable active state
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_ah_bio_active(const stmdev_ctx_t *ctx, uint8_t filter_on)
+{
+  st1vafe3bx_ah_bio_cfg3_t cfg3;
+  st1vafe3bx_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_AH_BIO_CFG3, (uint8_t *)&cfg3, 1);
+  cfg3.ah_bio_active = 0;
+  ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_AH_BIO_CFG3, (uint8_t *)&cfg3, 1);
+
+  if (ctx->mdelay != NULL)
+  {
+    ctx->mdelay(10);
+  }
+
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_CTRL3, (uint8_t *)&ctrl3, 1);
+  ctrl3.hp_en = filter_on;
+  ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_CTRL3, (uint8_t *)&ctrl3, 1);
+
+  cfg3.ah_bio_active = 0;
+  ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_AH_BIO_CFG3, (uint8_t *)&cfg3, 1);
+
+  if (ctx->mdelay != NULL)
+  {
+    ctx->mdelay(10);
+  }
+
+  return ret;
+}
+
+/**
+  * @defgroup Step Counter (Pedometer)
+  * @brief    Step Counter (Pedometer)
+  * @{/
+  *
+  */
+/**
+  * @brief  Step counter mode[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Step counter mode
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_stpcnt_mode_set(const stmdev_ctx_t *ctx,
+                                   st1vafe3bx_stpcnt_mode_t val)
+{
+  st1vafe3bx_emb_func_en_a_t emb_func_en_a;
+  st1vafe3bx_emb_func_en_b_t emb_func_en_b;
+  st1vafe3bx_emb_func_fifo_en_t emb_func_fifo_en;
+  st1vafe3bx_pedo_cmd_reg_t pedo_cmd_reg;
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_EMB_FUNC_EN_A,
+                             (uint8_t *)&emb_func_en_a, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_EMB_FUNC_EN_B,
+                             (uint8_t *)&emb_func_en_b, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_EMB_FUNC_FIFO_EN,
+                             (uint8_t *)&emb_func_fifo_en, 1);
+
+  if ((val.false_step_rej == PROPERTY_ENABLE)
+      && ((emb_func_en_a.mlc_before_fsm_en &
+           emb_func_en_b.mlc_en) == PROPERTY_DISABLE))
+  {
+    emb_func_en_a.mlc_before_fsm_en = PROPERTY_ENABLE;
+  }
+
+  emb_func_fifo_en.step_counter_fifo_en = val.step_counter_in_fifo;
+  ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_EMB_FUNC_FIFO_EN,
+                              (uint8_t *)&emb_func_fifo_en, 1);
+
+  emb_func_en_a.pedo_en = val.step_counter_enable;
+  ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_EMB_FUNC_EN_A,
+                              (uint8_t *)&emb_func_en_a, 1);
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+  ret += st1vafe3bx_ln_pg_read(ctx, ST1VAFE3BX_EMB_ADV_PG_0 +
+                               ST1VAFE3BX_PEDO_CMD_REG,
+                               (uint8_t *)&pedo_cmd_reg, 1);
+
+  if (ret == 0)
+  {
+    pedo_cmd_reg.fp_rejection_en = val.false_step_rej;
+    ret += st1vafe3bx_ln_pg_write(ctx, ST1VAFE3BX_EMB_ADV_PG_0 +
+                                  ST1VAFE3BX_PEDO_CMD_REG,
+                                  (uint8_t *)&pedo_cmd_reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Step counter mode[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Step counter mode
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_stpcnt_mode_get(const stmdev_ctx_t *ctx,
+                                   st1vafe3bx_stpcnt_mode_t *val)
+{
+  st1vafe3bx_emb_func_en_a_t emb_func_en_a;
+  st1vafe3bx_pedo_cmd_reg_t pedo_cmd_reg;
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_EMB_FUNC_EN_A,
+                             (uint8_t *)&emb_func_en_a, 1);
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  ret += st1vafe3bx_ln_pg_read(ctx, ST1VAFE3BX_EMB_ADV_PG_0 +
+                               ST1VAFE3BX_PEDO_CMD_REG,
+                               (uint8_t *)&pedo_cmd_reg, 1);
+  val->false_step_rej = pedo_cmd_reg.fp_rejection_en;
+  val->step_counter_enable = emb_func_en_a.pedo_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Step counter output, number of detected steps.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Step counter output, number of detected steps.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_stpcnt_steps_get(const stmdev_ctx_t *ctx, uint16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_STEP_COUNTER_L, &buff[0], 2);
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  *val = buff[1];
+  *val = (*val * 256U) + buff[0];
+
+  return ret;
+}
+
+/**
+  * @brief  Reset step counter.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Reset step counter.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_stpcnt_rst_step_set(const stmdev_ctx_t *ctx)
+{
+  st1vafe3bx_emb_func_src_t emb_func_src;
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_EMB_FUNC_SRC,
+                              (uint8_t *)&emb_func_src, 1);
+    emb_func_src.pedo_rst_step = 1;
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_EMB_FUNC_SRC,
+                                (uint8_t *)&emb_func_src, 1);
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Pedometer debounce configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Pedometer debounce configuration.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_stpcnt_debounce_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  st1vafe3bx_pedo_deb_steps_conf_t pedo_deb_steps_conf;
+  int32_t ret;
+
+  pedo_deb_steps_conf.deb_step = val;
+  ret = st1vafe3bx_ln_pg_write(ctx, ST1VAFE3BX_EMB_ADV_PG_0 +
+                               ST1VAFE3BX_PEDO_DEB_STEPS_CONF,
+                               (uint8_t *)&pedo_deb_steps_conf, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Pedometer debounce configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Pedometer debounce configuration.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_stpcnt_debounce_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  st1vafe3bx_pedo_deb_steps_conf_t pedo_deb_steps_conf;
+  int32_t ret;
+
+  ret = st1vafe3bx_ln_pg_read(ctx, ST1VAFE3BX_EMB_ADV_PG_0 +
+                              ST1VAFE3BX_PEDO_DEB_STEPS_CONF,
+                              (uint8_t *)&pedo_deb_steps_conf, 1);
+  *val = pedo_deb_steps_conf.deb_step;
+
+  return ret;
+}
+
+/**
+  * @brief  Time period register for step detection on delta time.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Time period register for step detection on delta time.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_stpcnt_period_set(const stmdev_ctx_t *ctx, uint16_t val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  buff[1] = (uint8_t)(val / 256U);
+  buff[0] = (uint8_t)(val - (buff[1] * 256U));
+
+  ret = st1vafe3bx_ln_pg_write(ctx, ST1VAFE3BX_EMB_ADV_PG_0 +
+                               ST1VAFE3BX_PEDO_SC_DELTAT_L,
+                               (uint8_t *)buff, 2);
+
+  return ret;
+}
+
+/**
+  * @brief  Time period register for step detection on delta time.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Time period register for step detection on delta time.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_stpcnt_period_get(const stmdev_ctx_t *ctx, uint16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = st1vafe3bx_ln_pg_read(ctx, ST1VAFE3BX_EMB_ADV_PG_0 +
+                              ST1VAFE3BX_PEDO_SC_DELTAT_L,
+                              (uint8_t *)buff, 2);
+  *val = buff[1];
+  *val = (*val * 256U) + buff[0];
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup Tilt
+  * @brief    Tilt
+  * @{/
+  *
+  */
+/**
+  * @brief  Tilt calculation.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Tilt calculation.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_tilt_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  st1vafe3bx_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_EMB_FUNC_EN_A,
+                              (uint8_t *)&emb_func_en_a, 1);
+    emb_func_en_a.tilt_en = val;
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_EMB_FUNC_EN_A,
+                                (uint8_t *)&emb_func_en_a, 1);
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Tilt calculation.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Tilt calculation.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_tilt_mode_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  st1vafe3bx_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_EMB_FUNC_EN_A,
+                              (uint8_t *)&emb_func_en_a, 1);
+    *val = emb_func_en_a.tilt_en;
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup Significant motion detection
+  * @brief    Significant motion detection
+  * @{/
+  *
+  */
+/**
+  * @brief  Enables significant motion detection function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables significant motion detection function.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_sigmot_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  st1vafe3bx_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_EMB_FUNC_EN_A,
+                              (uint8_t *)&emb_func_en_a, 1);
+    emb_func_en_a.sign_motion_en = val;
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_EMB_FUNC_EN_A,
+                                (uint8_t *)&emb_func_en_a, 1);
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Enables significant motion detection function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables significant motion detection function.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_sigmot_mode_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  st1vafe3bx_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_EMB_FUNC_EN_A,
+                              (uint8_t *)&emb_func_en_a, 1);
+    *val = emb_func_en_a.sign_motion_en;
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+
+/**
+  * @defgroup Free Fall
+  * @brief    Free Fall
+  * @{/
+  *
+  */
+/**
+  * @brief  Time windows configuration for Free Fall detection 1 LSB = 1/ODR_XL
+  *         time[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Time windows configuration for Free Fall detection
+  *                  1 LSB = 1/ODR_XL time
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_ff_duration_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  st1vafe3bx_wake_up_dur_t wake_up_dur;
+  st1vafe3bx_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_WAKE_UP_DUR,
+                            (uint8_t *)&wake_up_dur, 1);
+
+  if (ret == 0)
+  {
+    wake_up_dur.ff_dur = (val >> 5) & 0x1U;
+    ret = st1vafe3bx_write_reg(ctx, ST1VAFE3BX_WAKE_UP_DUR,
+                               (uint8_t *)&wake_up_dur, 1);
+  }
+
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_FREE_FALL,
+                              (uint8_t *)&free_fall, 1);
+    free_fall.ff_dur = val & 0x1FU;
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_FREE_FALL,
+                                (uint8_t *)&free_fall, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Time windows configuration for Free Fall detection
+  *         1 LSB = 1/ODR_XL time[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Time windows configuration for Free Fall detection
+  *                  1 LSB = 1/ODR_XL time
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_ff_duration_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  st1vafe3bx_wake_up_dur_t wake_up_dur;
+  st1vafe3bx_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_WAKE_UP_DUR,
+                            (uint8_t *)&wake_up_dur, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_FREE_FALL,
+                             (uint8_t *)&free_fall, 1);
+
+  *val = (wake_up_dur.ff_dur << 5) | free_fall.ff_dur;
+
+  return ret;
+}
+
+/**
+  * @brief  Free fall threshold setting.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      156_mg, 219_mg, 250_mg, 312_mg, 344_mg, 406_mg, 469_mg,
+  *                  500_mg,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_ff_thresholds_set(const stmdev_ctx_t *ctx,
+                                     st1vafe3bx_ff_thresholds_t val)
+{
+  st1vafe3bx_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_FREE_FALL,
+                            (uint8_t *)&free_fall, 1);
+  free_fall.ff_ths = ((uint8_t)val & 0x7U);
+  ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_FREE_FALL,
+                              (uint8_t *)&free_fall, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Free fall threshold setting.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      156_mg, 219_mg, 250_mg, 312_mg, 344_mg, 406_mg, 469_mg,
+  *                  500_mg,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_ff_thresholds_get(const stmdev_ctx_t *ctx,
+                                     st1vafe3bx_ff_thresholds_t *val)
+{
+  st1vafe3bx_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_FREE_FALL,
+                            (uint8_t *)&free_fall, 1);
+
+  switch (free_fall.ff_ths)
+  {
+    case 0x0:
+      *val = ST1VAFE3BX_156_mg;
+      break;
+
+    case 0x1:
+      *val = ST1VAFE3BX_219_mg;
+      break;
+
+    case 0x2:
+      *val = ST1VAFE3BX_250_mg;
+      break;
+
+    case 0x3:
+      *val = ST1VAFE3BX_312_mg;
+      break;
+
+    case 0x4:
+      *val = ST1VAFE3BX_344_mg;
+      break;
+
+    case 0x5:
+      *val = ST1VAFE3BX_406_mg;
+      break;
+
+    case 0x6:
+      *val = ST1VAFE3BX_469_mg;
+      break;
+
+    case 0x7:
+      *val = ST1VAFE3BX_500_mg;
+      break;
+
+    default:
+      *val = ST1VAFE3BX_156_mg;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+
+/**
+  * @defgroup Orientation 6D (and 4D)
+  * @brief    Orientation 6D (and 4D)
+  * @{/
+  *
+  */
+/**
+  * @brief  configuration for 4D/6D function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      4D/6D, DEG_80, DEG_70, DEG_60, DEG_50,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_sixd_config_set(const stmdev_ctx_t *ctx,
+                                   st1vafe3bx_sixd_config_t val)
+{
+  st1vafe3bx_sixd_t sixd;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_SIXD, (uint8_t *)&sixd, 1);
+
+  if (ret == 0)
+  {
+    sixd.d4d_en = ((uint8_t)val.mode);
+    sixd.d6d_ths = ((uint8_t)val.threshold);
+    ret = st1vafe3bx_write_reg(ctx, ST1VAFE3BX_SIXD, (uint8_t *)&sixd, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  configuration for 4D/6D function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      4D/6D, DEG_80, DEG_70, DEG_60, DEG_50,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_sixd_config_get(const stmdev_ctx_t *ctx,
+                                   st1vafe3bx_sixd_config_t *val)
+{
+  st1vafe3bx_sixd_t sixd;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_SIXD, (uint8_t *)&sixd, 1);
+
+  val->mode = (st1vafe3bx_mode_t)sixd.d4d_en;
+
+  switch ((sixd.d6d_ths))
+  {
+    case 0x0:
+      val->threshold = ST1VAFE3BX_DEG_80;
+      break;
+
+    case 0x1:
+      val->threshold = ST1VAFE3BX_DEG_70;
+      break;
+
+    case 0x2:
+      val->threshold = ST1VAFE3BX_DEG_60;
+      break;
+
+    case 0x3:
+      val->threshold = ST1VAFE3BX_DEG_50;
+      break;
+
+    default:
+      val->threshold = ST1VAFE3BX_DEG_80;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup wakeup configuration
+  * @brief    wakeup configuration
+  * @{/
+  *
+  */
+
+/**
+  * @brief  configuration for wakeup function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      threshold, duration, ...
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_wakeup_config_set(const stmdev_ctx_t *ctx,
+                                     st1vafe3bx_wakeup_config_t val)
+{
+  st1vafe3bx_wake_up_ths_t wup_ths;
+  st1vafe3bx_wake_up_dur_t wup_dur;
+  st1vafe3bx_wake_up_dur_ext_t wup_dur_ext;
+  st1vafe3bx_interrupt_cfg_t int_cfg;
+  st1vafe3bx_ctrl1_t ctrl1;
+  st1vafe3bx_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_WAKE_UP_THS,
+                            (uint8_t *)&wup_ths, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_WAKE_UP_DUR,
+                             (uint8_t *)&wup_dur, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_WAKE_UP_DUR_EXT,
+                             (uint8_t *)&wup_dur_ext, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_INTERRUPT_CFG,
+                             (uint8_t *)&int_cfg, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_CTRL1, (uint8_t *)&ctrl1, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_CTRL4, (uint8_t *)&ctrl4, 1);
+
+  if (ret == 0)
+  {
+    wup_dur.wake_dur = (uint8_t)val.wake_dur & 0x3U;
+    wup_dur_ext.wu_dur_extended = (uint8_t)val.wake_dur >> 2;
+    wup_dur.sleep_dur = val.sleep_dur;
+
+    int_cfg.wake_ths_w = val.wake_ths_weight;
+    wup_ths.wk_ths = val.wake_ths;
+    wup_ths.sleep_on = (uint8_t)val.wake_enable;
+    ctrl4.inact_odr = (uint8_t)val.inact_odr;
+
+    if (val.wake_enable == ST1VAFE3BX_SLEEP_ON)
+    {
+      ctrl1.wu_x_en = 1;
+      ctrl1.wu_y_en = 1;
+      ctrl1.wu_z_en = 1;
+    }
+    else
+    {
+      ctrl1.wu_x_en = 0;
+      ctrl1.wu_y_en = 0;
+      ctrl1.wu_z_en = 0;
+    }
+
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_WAKE_UP_THS,
+                                (uint8_t *)&wup_ths, 1);
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_WAKE_UP_DUR,
+                                (uint8_t *)&wup_dur, 1);
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_WAKE_UP_DUR_EXT,
+                                (uint8_t *)&wup_dur_ext, 1);
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_INTERRUPT_CFG,
+                                (uint8_t *)&int_cfg, 1);
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_CTRL1, (uint8_t *)&ctrl1, 1);
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_CTRL4, (uint8_t *)&ctrl4, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  configuration for wakeup function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      threshold, duration, ...
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t st1vafe3bx_wakeup_config_get(const stmdev_ctx_t *ctx,
+                                     st1vafe3bx_wakeup_config_t *val)
+{
+  st1vafe3bx_wake_up_ths_t wup_ths;
+  st1vafe3bx_wake_up_dur_t wup_dur;
+  st1vafe3bx_wake_up_dur_ext_t wup_dur_ext;
+  st1vafe3bx_interrupt_cfg_t int_cfg;
+  st1vafe3bx_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_WAKE_UP_THS,
+                            (uint8_t *)&wup_ths, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_WAKE_UP_DUR,
+                             (uint8_t *)&wup_dur, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_WAKE_UP_DUR_EXT,
+                             (uint8_t *)&wup_dur_ext, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_INTERRUPT_CFG,
+                             (uint8_t *)&int_cfg, 1);
+  ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_CTRL4, (uint8_t *)&ctrl4, 1);
+
+  if (ret == 0)
+  {
+    switch (wup_dur.wake_dur)
+    {
+      case 0x0:
+        val->wake_dur = (wup_dur_ext.wu_dur_extended == 1U) ?
+                        ST1VAFE3BX_3_ODR : ST1VAFE3BX_0_ODR;
+        break;
+
+      case 0x1:
+        val->wake_dur = (wup_dur_ext.wu_dur_extended == 1U) ?
+                        ST1VAFE3BX_7_ODR : ST1VAFE3BX_1_ODR;
+        break;
+
+      case 0x2:
+        val->wake_dur = (wup_dur_ext.wu_dur_extended == 1U) ?
+                        ST1VAFE3BX_11_ODR : ST1VAFE3BX_2_ODR;
+        break;
+
+      case 0x3:
+      default:
+        val->wake_dur = ST1VAFE3BX_15_ODR;
+        break;
+    }
+
+    val->sleep_dur = wup_dur.sleep_dur;
+
+    val->wake_ths_weight = int_cfg.wake_ths_w;
+    val->wake_ths = wup_ths.wk_ths;
+    val->wake_enable = (st1vafe3bx_wake_enable_t)wup_ths.sleep_on;
+    val->inact_odr = (st1vafe3bx_inact_odr_t)ctrl4.inact_odr;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+int32_t st1vafe3bx_tap_config_set(const stmdev_ctx_t *ctx,
+                                  st1vafe3bx_tap_config_t val)
+{
+  st1vafe3bx_tap_cfg0_t tap_cfg0;
+  st1vafe3bx_tap_cfg1_t tap_cfg1;
+  st1vafe3bx_tap_cfg2_t tap_cfg2;
+  st1vafe3bx_tap_cfg3_t tap_cfg3;
+  st1vafe3bx_tap_cfg4_t tap_cfg4;
+  st1vafe3bx_tap_cfg5_t tap_cfg5;
+  st1vafe3bx_tap_cfg6_t tap_cfg6;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_TAP_CFG3, (uint8_t *)&tap_cfg3, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_TAP_CFG4, (uint8_t *)&tap_cfg4, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_TAP_CFG5, (uint8_t *)&tap_cfg5, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_TAP_CFG6, (uint8_t *)&tap_cfg6, 1);
+
+  if (ret == 0)
+  {
+    tap_cfg0.axis = (uint8_t)val.axis;
+    tap_cfg0.invert_t = val.inverted_peak_time;
+    tap_cfg1.pre_still_ths = val.pre_still_ths;
+    tap_cfg3.post_still_ths = val.post_still_ths;
+    tap_cfg1.post_still_t = val.post_still_time & 0xFU;
+    tap_cfg2.post_still_t = val.post_still_time >> 4;
+    tap_cfg2.wait_t = val.shock_wait_time;
+    tap_cfg3.latency_t = val.latency;
+    tap_cfg4.wait_end_latency = val.wait_end_latency;
+    tap_cfg4.peak_ths = val.peak_ths;
+    tap_cfg5.rebound_t = val.rebound;
+    tap_cfg5.single_tap_en = val.single_tap_on;
+    tap_cfg5.double_tap_en = val.double_tap_on;
+    tap_cfg5.triple_tap_en = val.triple_tap_on;
+    tap_cfg6.pre_still_st = val.pre_still_start;
+    tap_cfg6.pre_still_n = val.pre_still_n;
+
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_TAP_CFG0,
+                                (uint8_t *)&tap_cfg0, 1);
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_TAP_CFG1,
+                                (uint8_t *)&tap_cfg1, 1);
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_TAP_CFG2,
+                                (uint8_t *)&tap_cfg2, 1);
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_TAP_CFG3,
+                                (uint8_t *)&tap_cfg3, 1);
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_TAP_CFG4,
+                                (uint8_t *)&tap_cfg4, 1);
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_TAP_CFG5,
+                                (uint8_t *)&tap_cfg5, 1);
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_TAP_CFG6,
+                                (uint8_t *)&tap_cfg6, 1);
+  }
+
+  return ret;
+}
+
+int32_t st1vafe3bx_tap_config_get(const stmdev_ctx_t *ctx,
+                                  st1vafe3bx_tap_config_t *val)
+{
+  st1vafe3bx_tap_cfg0_t tap_cfg0;
+  st1vafe3bx_tap_cfg1_t tap_cfg1;
+  st1vafe3bx_tap_cfg2_t tap_cfg2;
+  st1vafe3bx_tap_cfg3_t tap_cfg3;
+  st1vafe3bx_tap_cfg4_t tap_cfg4;
+  st1vafe3bx_tap_cfg5_t tap_cfg5;
+  st1vafe3bx_tap_cfg6_t tap_cfg6;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_TAP_CFG3, (uint8_t *)&tap_cfg3, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_TAP_CFG4, (uint8_t *)&tap_cfg4, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_TAP_CFG5, (uint8_t *)&tap_cfg5, 1);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_TAP_CFG6, (uint8_t *)&tap_cfg6, 1);
+
+  if (ret == 0)
+  {
+    val->axis = (st1vafe3bx_axis_t)tap_cfg0.axis;
+    val->inverted_peak_time = tap_cfg0.invert_t;
+    val->pre_still_ths = tap_cfg1.pre_still_ths;
+    val->post_still_ths = tap_cfg3.post_still_ths;
+    val->post_still_time = (tap_cfg2.post_still_t << 4) | tap_cfg1.post_still_t;
+    val->shock_wait_time = tap_cfg2.wait_t;
+    val->latency = tap_cfg3.latency_t;
+    val->wait_end_latency = tap_cfg4.wait_end_latency;
+    val->peak_ths = tap_cfg4.peak_ths;
+    val->rebound = tap_cfg5.rebound_t;
+    val->single_tap_on = tap_cfg5.single_tap_en;
+    val->double_tap_on = tap_cfg5.double_tap_en;
+    val->triple_tap_on = tap_cfg5.triple_tap_en;
+    val->pre_still_start = tap_cfg6.pre_still_st;
+    val->pre_still_n = tap_cfg6.pre_still_n;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   st1vafe3bx_Timestamp
+  * @brief      This section groups all the functions that manage the
+  *             timestamp generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enables timestamp counter.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of timestamp_en in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t st1vafe3bx_timestamp_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  st1vafe3bx_interrupt_cfg_t int_cfg;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_INTERRUPT_CFG,
+                            (uint8_t *)&int_cfg, 1);
+
+  if (ret == 0)
+  {
+    int_cfg.timestamp_en = (uint8_t)val;
+    ret = st1vafe3bx_write_reg(ctx, ST1VAFE3BX_INTERRUPT_CFG,
+                               (uint8_t *)&int_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables timestamp counter.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of timestamp_en in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t st1vafe3bx_timestamp_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  st1vafe3bx_interrupt_cfg_t int_cfg;
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_INTERRUPT_CFG,
+                            (uint8_t *)&int_cfg, 1);
+  *val = int_cfg.timestamp_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Timestamp first data output register (r).
+  *         The value is expressed as a 32-bit word and the bit resolution
+  *         is 10 us.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t st1vafe3bx_timestamp_raw_get(const stmdev_ctx_t *ctx, uint32_t *val)
+{
+  uint8_t buff[4];
+  int32_t ret;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_TIMESTAMP0, buff, 4);
+  *val = buff[3];
+  *val = (*val * 256U) +  buff[2];
+  *val = (*val * 256U) +  buff[1];
+  *val = (*val * 256U) +  buff[0];
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ST1VAFE3BX_finite_state_machine
+  * @brief      This section groups all the functions that manage the
+  *             state_machine.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Interrupt status bit for FSM long counter timeout interrupt
+  *         event.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of is_fsm_lc in reg EMB_FUNC_STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t st1vafe3bx_long_cnt_flag_data_ready_get(const stmdev_ctx_t *ctx,
+                                                uint8_t *val)
+{
+  st1vafe3bx_emb_func_status_t emb_func_status;
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_EMB_FUNC_STATUS,
+                              (uint8_t *)&emb_func_status, 1);
+
+    *val = emb_func_status.is_fsm_lc;
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Embedded final state machine functions mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fsm_en in reg EMB_FUNC_EN_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t st1vafe3bx_emb_fsm_en_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  int32_t ret;
+
+  st1vafe3bx_emb_func_en_b_t emb_func_en_b;
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_EMB_FUNC_EN_B,
+                              (uint8_t *)&emb_func_en_b, 1);
+
+    emb_func_en_b.fsm_en = (uint8_t)val;
+
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_EMB_FUNC_EN_B,
+                                (uint8_t *)&emb_func_en_b, 1);
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Embedded final state machine functions mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fsm_en in reg EMB_FUNC_EN_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t st1vafe3bx_emb_fsm_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  int32_t ret;
+
+  st1vafe3bx_emb_func_en_b_t emb_func_en_b;
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_EMB_FUNC_EN_B,
+                              (uint8_t *)&emb_func_en_b, 1);
+
+    *val = emb_func_en_b.fsm_en;
+
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_EMB_FUNC_EN_B,
+                                (uint8_t *)&emb_func_en_b, 1);
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Embedded final state machine functions mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers from FSM_ENABLE_A to FSM_ENABLE_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t st1vafe3bx_fsm_enable_set(const stmdev_ctx_t *ctx,
+                                  st1vafe3bx_emb_fsm_enable_t *val)
+{
+  st1vafe3bx_emb_func_en_b_t emb_func_en_b;
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_write_reg(ctx, ST1VAFE3BX_FSM_ENABLE,
+                               (uint8_t *)&val->fsm_enable, 1);
+  }
+
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_EMB_FUNC_EN_B,
+                              (uint8_t *)&emb_func_en_b, 1);
+
+    if ((val->fsm_enable.fsm1_en |
+         val->fsm_enable.fsm2_en |
+         val->fsm_enable.fsm3_en |
+         val->fsm_enable.fsm4_en |
+         val->fsm_enable.fsm5_en |
+         val->fsm_enable.fsm6_en |
+         val->fsm_enable.fsm7_en |
+         val->fsm_enable.fsm8_en) != PROPERTY_DISABLE)
+    {
+      emb_func_en_b.fsm_en = PROPERTY_ENABLE;
+    }
+    else
+    {
+      emb_func_en_b.fsm_en = PROPERTY_DISABLE;
+    }
+
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_EMB_FUNC_EN_B,
+                                (uint8_t *)&emb_func_en_b, 1);
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Embedded final state machine functions mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers from FSM_ENABLE_A to FSM_ENABLE_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t st1vafe3bx_fsm_enable_get(const stmdev_ctx_t *ctx,
+                                  st1vafe3bx_emb_fsm_enable_t *val)
+{
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_FSM_ENABLE,
+                              (uint8_t *)&val->fsm_enable, 1);
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  FSM long counter status register. Long counter value is an
+  *         unsigned integer value (16-bit format).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t st1vafe3bx_long_cnt_set(const stmdev_ctx_t *ctx, uint16_t val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    buff[1] = (uint8_t)(val / 256U);
+    buff[0] = (uint8_t)(val - (buff[1] * 256U));
+    ret = st1vafe3bx_write_reg(ctx, ST1VAFE3BX_FSM_LONG_COUNTER_L, buff, 2);
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  FSM long counter status register. Long counter value is an
+  *         unsigned integer value (16-bit format).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t st1vafe3bx_long_cnt_get(const stmdev_ctx_t *ctx, uint16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_FSM_LONG_COUNTER_L, buff, 2);
+    *val = buff[1];
+    *val = (*val * 256U) + buff[0];
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  FSM status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register FSM_STATUS_MAINPAGE
+  *
+  */
+int32_t st1vafe3bx_fsm_status_get(const stmdev_ctx_t *ctx,
+                                  st1vafe3bx_fsm_status_mainpage_t *val)
+{
+  return st1vafe3bx_read_reg(ctx, ST1VAFE3BX_FSM_STATUS_MAINPAGE,
+                             (uint8_t *) val, 1);
+}
+
+/**
+  * @brief  FSM output registers.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers from FSM_OUTS1 to FSM_OUTS16
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t st1vafe3bx_fsm_out_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_FSM_OUTS1, val, 8);
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Finite State Machine ODR configuration.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fsm_odr in reg EMB_FUNC_ODR_CFG_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t st1vafe3bx_fsm_data_rate_set(const stmdev_ctx_t *ctx,
+                                     st1vafe3bx_fsm_val_odr_t val)
+{
+  st1vafe3bx_ah_bio_cfg2_t ah_bio_cfg2;
+  st1vafe3bx_fsm_odr_t fsm_odr_reg;
+  int32_t ret = 0;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_AH_BIO_CFG2,
+                            (uint8_t *)&ah_bio_cfg2, 1);
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_FSM_ODR,
+                              (uint8_t *)&fsm_odr_reg, 1);
+
+    fsm_odr_reg.fsm_odr = (uint8_t)val & 0xfU;
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_FSM_ODR,
+                                (uint8_t *)&fsm_odr_reg, 1);
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Finite State Machine ODR configuration.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fsm_odr in reg EMB_FUNC_ODR_CFG_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t st1vafe3bx_fsm_data_rate_get(const stmdev_ctx_t *ctx,
+                                     st1vafe3bx_fsm_val_odr_t *val)
+{
+  st1vafe3bx_ah_bio_cfg2_t ah_bio_cfg2;
+  st1vafe3bx_fsm_odr_t fsm_odr_reg;
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_FSM_ODR,
+                             (uint8_t *)&fsm_odr_reg, 1);
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+  ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_AH_BIO_CFG2,
+                             (uint8_t *)&ah_bio_cfg2, 1);
+
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  /* depends on vAFE mode only enabled */
+  if (ah_bio_cfg2.ah_bio_en == 0x1U)
+  {
+    switch (fsm_odr_reg.fsm_odr)
+    {
+      case 0:
+        *val = ST1VAFE3BX_ODR_FSM_VAFE_50Hz;
+        break;
+      case 1:
+        *val = ST1VAFE3BX_ODR_FSM_VAFE_100Hz;
+        break;
+      case 2:
+        *val = ST1VAFE3BX_ODR_FSM_VAFE_200Hz;
+        break;
+      case 3:
+        *val = ST1VAFE3BX_ODR_FSM_VAFE_400Hz;
+        break;
+      case 4:
+        *val = ST1VAFE3BX_ODR_FSM_VAFE_800Hz;
+        break;
+      case 5:
+        *val = ST1VAFE3BX_ODR_FSM_VAFE_1600Hz;
+        break;
+      default:
+        *val = ST1VAFE3BX_ODR_FSM_VAFE_50Hz;
+        break;
+    }
+  }
+  else
+  {
+    switch (fsm_odr_reg.fsm_odr)
+    {
+      case 0:
+        *val = ST1VAFE3BX_ODR_FSM_12Hz5;
+        break;
+      case 1:
+        *val = ST1VAFE3BX_ODR_FSM_25Hz;
+        break;
+      case 2:
+        *val = ST1VAFE3BX_ODR_FSM_50Hz;
+        break;
+      case 3:
+        *val = ST1VAFE3BX_ODR_FSM_100Hz;
+        break;
+      case 4:
+        *val = ST1VAFE3BX_ODR_FSM_200Hz;
+        break;
+      case 5:
+        *val = ST1VAFE3BX_ODR_FSM_400Hz;
+        break;
+      case 6:
+        *val = ST1VAFE3BX_ODR_FSM_800Hz;
+        break;
+      default:
+        *val = ST1VAFE3BX_ODR_FSM_12Hz5;
+        break;
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FSM initialization request.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fsm_init in reg FSM_INIT
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t st1vafe3bx_fsm_init_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  st1vafe3bx_emb_func_init_b_t emb_func_init_b;
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_EMB_FUNC_INIT_B,
+                              (uint8_t *)&emb_func_init_b, 1);
+
+    emb_func_init_b.fsm_init = (uint8_t)val;
+
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_EMB_FUNC_INIT_B,
+                                (uint8_t *)&emb_func_init_b, 1);
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  FSM initialization request.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fsm_init in reg FSM_INIT
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t st1vafe3bx_fsm_init_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  st1vafe3bx_emb_func_init_b_t emb_func_init_b;
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_EMB_FUNC_INIT_B,
+                              (uint8_t *)&emb_func_init_b, 1);
+
+    *val = emb_func_init_b.fsm_init;
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  FSM FIFO en bit.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the value of fsm_fifo_en in reg ST1VAFE3BX_EMB_FUNC_FIFO_EN
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t st1vafe3bx_fsm_fifo_en_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  st1vafe3bx_emb_func_fifo_en_t fifo_reg;
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_EMB_FUNC_FIFO_EN,
+                              (uint8_t *)&fifo_reg, 1);
+    fifo_reg.fsm_fifo_en = val;
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_EMB_FUNC_FIFO_EN,
+                                (uint8_t *)&fifo_reg, 1);
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  FSM FIFO en bit.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the value of fsm_fifo_en in reg ST1VAFE3BX_EMB_FUNC_FIFO_EN
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t st1vafe3bx_fsm_fifo_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  st1vafe3bx_emb_func_fifo_en_t fifo_reg;
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_EMB_FUNC_FIFO_EN,
+                              (uint8_t *)&fifo_reg, 1);
+    *val = fifo_reg.fsm_fifo_en;
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  FSM long counter timeout register (r/w). The long counter
+  *         timeout value is an unsigned integer value (16-bit format).
+  *         When the long counter value reached this value, the FSM
+  *         generates an interrupt.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t st1vafe3bx_long_cnt_int_value_set(const stmdev_ctx_t *ctx,
+                                          uint16_t val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  buff[1] = (uint8_t)(val / 256U);
+  buff[0] = (uint8_t)(val - (buff[1] * 256U));
+  ret = st1vafe3bx_ln_pg_write(ctx, ST1VAFE3BX_FSM_LC_TIMEOUT_L, buff, 2);
+
+  return ret;
+}
+
+/**
+  * @brief  FSM long counter timeout register (r/w). The long counter
+  *         timeout value is an unsigned integer value (16-bit format).
+  *         When the long counter value reached this value, the FSM generates
+  *         an interrupt.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t st1vafe3bx_long_cnt_int_value_get(const stmdev_ctx_t *ctx,
+                                          uint16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = st1vafe3bx_ln_pg_read(ctx, ST1VAFE3BX_FSM_LC_TIMEOUT_L, buff, 2);
+  *val = buff[1];
+  *val = (*val * 256U) + buff[0];
+
+  return ret;
+}
+
+/**
+  * @brief  FSM number of programs register.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t st1vafe3bx_fsm_programs_num_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  int32_t ret;
+
+  ret = st1vafe3bx_ln_pg_write(ctx, ST1VAFE3BX_FSM_PROGRAMS, &val, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  FSM number of programs register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t st1vafe3bx_fsm_programs_num_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  int32_t ret;
+
+  ret = st1vafe3bx_ln_pg_read(ctx, ST1VAFE3BX_FSM_PROGRAMS, val, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  FSM start address register (r/w). First available address is
+  *         0x033C.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t st1vafe3bx_fsm_start_address_set(const stmdev_ctx_t *ctx,
+                                         uint16_t val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  buff[1] = (uint8_t)(val / 256U);
+  buff[0] = (uint8_t)(val - (buff[1] * 256U));
+  ret = st1vafe3bx_ln_pg_write(ctx, ST1VAFE3BX_FSM_START_ADD_L, buff, 2);
+
+  return ret;
+}
+
+/**
+  * @brief  FSM start address register (r/w). First available address
+  *         is 0x033C.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t st1vafe3bx_fsm_start_address_get(const stmdev_ctx_t *ctx,
+                                         uint16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = st1vafe3bx_ln_pg_read(ctx, ST1VAFE3BX_FSM_START_ADD_L, buff, 2);
+  *val = buff[1];
+  *val = (*val * 256U) +  buff[0];
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @addtogroup  Machine Learning Core
+  * @brief   This section group all the functions concerning the
+  *          usage of Machine Learning Core
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable Machine Learning Core.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of mlc_en in
+  *                  reg EMB_FUNC_EN_B and mlc_before_fsm_en
+  *                  in EMB_FUNC_INIT_A
+  *
+  */
+int32_t st1vafe3bx_mlc_set(const stmdev_ctx_t *ctx, st1vafe3bx_mlc_mode_t val)
+{
+  st1vafe3bx_emb_func_en_a_t emb_en_a;
+  st1vafe3bx_emb_func_en_b_t emb_en_b;
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_EMB_FUNC_EN_A,
+                              (uint8_t *)&emb_en_a, 1);
+    ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_EMB_FUNC_EN_B,
+                               (uint8_t *)&emb_en_b, 1);
+
+    switch (val)
+    {
+      case ST1VAFE3BX_MLC_OFF:
+        emb_en_a.mlc_before_fsm_en = 0;
+        emb_en_b.mlc_en = 0;
+        break;
+      case ST1VAFE3BX_MLC_ON:
+        emb_en_a.mlc_before_fsm_en = 0;
+        emb_en_b.mlc_en = 1;
+        break;
+      case ST1VAFE3BX_MLC_ON_BEFORE_FSM:
+        emb_en_a.mlc_before_fsm_en = 1;
+        emb_en_b.mlc_en = 0;
+        break;
+      default:
+        /* do nothing */
+        break;
+    }
+
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_EMB_FUNC_EN_A,
+                                (uint8_t *)&emb_en_a, 1);
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_EMB_FUNC_EN_B,
+                                (uint8_t *)&emb_en_b, 1);
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Enable Machine Learning Core.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of mlc_en in
+  *                  reg EMB_FUNC_EN_B and mlc_before_fsm_en
+  *                  in EMB_FUNC_INIT_A
+  *
+  */
+int32_t st1vafe3bx_mlc_get(const stmdev_ctx_t *ctx, st1vafe3bx_mlc_mode_t *val)
+{
+  st1vafe3bx_emb_func_en_a_t emb_en_a;
+  st1vafe3bx_emb_func_en_b_t emb_en_b;
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_EMB_FUNC_EN_A,
+                              (uint8_t *)&emb_en_a, 1);
+    ret += st1vafe3bx_read_reg(ctx, ST1VAFE3BX_EMB_FUNC_EN_B,
+                               (uint8_t *)&emb_en_b, 1);
+
+    if (emb_en_a.mlc_before_fsm_en == 0U && emb_en_b.mlc_en == 0U)
+    {
+      *val = ST1VAFE3BX_MLC_OFF;
+    }
+    else if (emb_en_a.mlc_before_fsm_en == 0U && emb_en_b.mlc_en == 1U)
+    {
+      *val = ST1VAFE3BX_MLC_ON;
+    }
+    else if (emb_en_a.mlc_before_fsm_en == 1U)
+    {
+      *val = ST1VAFE3BX_MLC_ON_BEFORE_FSM;
+    }
+    else
+    {
+      /* Do nothing */
+    }
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Machine Learning Core status register[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register MLC_STATUS_MAINPAGE
+  *
+  */
+int32_t st1vafe3bx_mlc_status_get(const stmdev_ctx_t *ctx,
+                                  st1vafe3bx_mlc_status_mainpage_t *val)
+{
+  return st1vafe3bx_read_reg(ctx, ST1VAFE3BX_MLC_STATUS_MAINPAGE,
+                             (uint8_t *) val, 1);
+}
+
+/**
+  * @brief  prgsens_out: [get] Output value of all MLCx decision trees.
+  *
+  * @param  ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t st1vafe3bx_mlc_out_get(const stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_MLC1_SRC, buff, 4);
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Machine Learning Core data rate selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of mlc_odr in
+  *                  reg EMB_FUNC_ODR_CFG_C
+  *
+  */
+int32_t st1vafe3bx_mlc_data_rate_set(const stmdev_ctx_t *ctx,
+                                     st1vafe3bx_mlc_odr_val_t val)
+{
+  st1vafe3bx_ah_bio_cfg2_t ah_bio_cfg2;
+  st1vafe3bx_mlc_odr_t reg;
+  int32_t ret = 0;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_AH_BIO_CFG2,
+                            (uint8_t *)&ah_bio_cfg2, 1);
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_MLC_ODR, (uint8_t *)&reg, 1);
+
+    reg.mlc_odr = (uint8_t)val & 0xfU;
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_MLC_ODR, (uint8_t *)&reg, 1);
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Machine Learning Core data rate selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of mlc_odr in
+  *                  reg EMB_FUNC_ODR_CFG_C
+  *
+  */
+int32_t st1vafe3bx_mlc_data_rate_get(const stmdev_ctx_t *ctx,
+                                     st1vafe3bx_mlc_odr_val_t *val)
+{
+  st1vafe3bx_ah_bio_cfg2_t ah_bio_cfg2;
+  st1vafe3bx_mlc_odr_t reg;
+  int32_t ret = 0;
+
+  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_AH_BIO_CFG2,
+                            (uint8_t *)&ah_bio_cfg2, 1);
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_MLC_ODR, (uint8_t *)&reg, 1);
+
+    /* depends on vAFE mode only enabled */
+    if (ah_bio_cfg2.ah_bio_en == 0x1U)
+    {
+      switch (reg.mlc_odr)
+      {
+        case 0:
+          *val = ST1VAFE3BX_ODR_PRGS_VAFE_50Hz;
+          break;
+        case 1:
+          *val = ST1VAFE3BX_ODR_PRGS_VAFE_100Hz;
+          break;
+        case 2:
+          *val = ST1VAFE3BX_ODR_PRGS_VAFE_200Hz;
+          break;
+        case 3:
+          *val = ST1VAFE3BX_ODR_PRGS_VAFE_400Hz;
+          break;
+        case 4:
+          *val = ST1VAFE3BX_ODR_PRGS_VAFE_800Hz;
+          break;
+        case 5:
+          *val = ST1VAFE3BX_ODR_PRGS_VAFE_1600Hz;
+          break;
+        default:
+          *val = ST1VAFE3BX_ODR_PRGS_VAFE_50Hz;
+          break;
+      }
+    }
+    else
+    {
+      switch (reg.mlc_odr)
+      {
+        case 0:
+          *val = ST1VAFE3BX_ODR_PRGS_12Hz5;
+          break;
+        case 1:
+          *val = ST1VAFE3BX_ODR_PRGS_25Hz;
+          break;
+        case 2:
+          *val = ST1VAFE3BX_ODR_PRGS_50Hz;
+          break;
+        case 3:
+          *val = ST1VAFE3BX_ODR_PRGS_100Hz;
+          break;
+        case 4:
+          *val = ST1VAFE3BX_ODR_PRGS_200Hz;
+          break;
+        default:
+          *val = ST1VAFE3BX_ODR_PRGS_12Hz5;
+          break;
+      }
+    }
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  MLC FIFO en bit.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the value of mlc_fifo_en in reg ST1VAFE3BX_EMB_FUNC_FIFO_EN
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t st1vafe3bx_mlc_fifo_en_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  st1vafe3bx_emb_func_fifo_en_t fifo_reg;
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_EMB_FUNC_FIFO_EN,
+                              (uint8_t *)&fifo_reg, 1);
+    fifo_reg.mlc_fifo_en = val;
+    ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_EMB_FUNC_FIFO_EN,
+                                (uint8_t *)&fifo_reg, 1);
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  MLC FIFO en bit.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the value of mlc_fifo_en in reg ST1VAFE3BX_EMB_FUNC_FIFO_EN
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t st1vafe3bx_mlc_fifo_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  st1vafe3bx_emb_func_fifo_en_t fifo_reg;
+  int32_t ret;
+
+  ret = st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_EMBED_FUNC_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_EMB_FUNC_FIFO_EN,
+                              (uint8_t *)&fifo_reg, 1);
+    *val = fifo_reg.mlc_fifo_en;
+  }
+
+  ret += st1vafe3bx_mem_bank_set(ctx, ST1VAFE3BX_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/st1vafe3bx_STdC/driver/st1vafe3bx_reg.h
+++ b/sensor/stmemsc/st1vafe3bx_STdC/driver/st1vafe3bx_reg.h
@@ -1,13 +1,13 @@
 /*
  ******************************************************************************
- * @file    lis2duxs12_reg.h
+ * @file    st1vafe3bx_reg.h
  * @author  Sensors Software Solution Team
  * @brief   This file contains all the functions prototypes for the
- *          lis2duxs12_reg.c driver.
+ *          st1vafe3bx_reg.c driver.
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; Copyright (c) 2022 STMicroelectronics.
+ * <h2><center>&copy; Copyright (c) 2024 STMicroelectronics.
  * All rights reserved.</center></h2>
  *
  * This software component is licensed by ST under BSD 3-Clause license,
@@ -19,8 +19,8 @@
  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
-#ifndef LIS2DUXS12_REGS_H
-#define LIS2DUXS12_REGS_H
+#ifndef ST1VAFE3BX_REGS_H
+#define ST1VAFE3BX_REGS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -31,7 +31,7 @@ extern "C" {
 #include <stddef.h>
 #include <math.h>
 
-/** @addtogroup LIS2DUXS12
+/** @addtogroup ST1VAFE3BX
   * @{
   *
   */
@@ -109,8 +109,10 @@ typedef struct
   *
   */
 
-typedef int32_t (*stmdev_write_ptr)(void *ctx, uint8_t reg, const uint8_t *data, uint16_t len);
-typedef int32_t (*stmdev_read_ptr)(void *ctx, uint8_t reg, uint8_t *data, uint16_t len);
+typedef int32_t (*stmdev_write_ptr)(void *ctx, uint8_t reg,
+                                    const uint8_t *data, uint16_t len);
+typedef int32_t (*stmdev_read_ptr)(void *ctx, uint8_t reg,
+                                   uint8_t *data, uint16_t len);
 typedef void (*stmdev_mdelay_ptr)(uint32_t millisec);
 
 typedef struct
@@ -163,24 +165,24 @@ typedef struct
   *
   */
 
-/** @defgroup LIS2DUXS12_Infos
+/** @defgroup ST1VAFE3BX_Infos
   * @{
   *
   */
 
 /** I2C Device Address 8 bit format  if SA0=0 -> 0x if SA0=1 -> 0x **/
-#define LIS2DUXS12_I2C_ADD_L                            0x31U
-#define LIS2DUXS12_I2C_ADD_H                            0x33U
+#define ST1VAFE3BX_I2C_ADD_L                            0x41U
+#define ST1VAFE3BX_I2C_ADD_H                            0x43U
 
 /** Device Identification (Who am I) **/
-#define LIS2DUXS12_ID                                   0x47U
+#define ST1VAFE3BX_ID                                   0x48U
 
 /**
   * @}
   *
   */
 
-#define LIS2DUXS12_EXT_CLK_CFG                          0x08U
+#define ST1VAFE3BX_EXT_CLK_CFG                          0x08U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -190,9 +192,9 @@ typedef struct
   uint8_t ext_clk_en                   : 1;
   uint8_t not_used0                    : 7;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_ext_clk_cfg_t;
+} st1vafe3bx_ext_clk_cfg_t;
 
-#define LIS2DUXS12_PIN_CTRL                             0x0CU
+#define ST1VAFE3BX_PIN_CTRL                             0x0CU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -200,23 +202,21 @@ typedef struct
   uint8_t pp_od                        : 1;
   uint8_t cs_pu_dis                    : 1;
   uint8_t h_lactive                    : 1;
-  uint8_t pd_dis_int1                  : 1;
-  uint8_t pd_dis_int2                  : 1;
+  uint8_t not_used0                    : 2;
   uint8_t sda_pu_en                    : 1;
   uint8_t sdo_pu_en                    : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t sdo_pu_en                    : 1;
   uint8_t sda_pu_en                    : 1;
-  uint8_t pd_dis_int2                  : 1;
-  uint8_t pd_dis_int1                  : 1;
+  uint8_t not_used0                    : 2;
   uint8_t h_lactive                    : 1;
   uint8_t cs_pu_dis                    : 1;
   uint8_t pp_od                        : 1;
   uint8_t sim                          : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_pin_ctrl_t;
+} st1vafe3bx_pin_ctrl_t;
 
-#define LIS2DUXS12_WAKE_UP_DUR_EXT                      0x0EU
+#define ST1VAFE3BX_WAKE_UP_DUR_EXT                      0x0EU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -228,9 +228,9 @@ typedef struct
   uint8_t wu_dur_extended              : 1;
   uint8_t not_used0                    : 4;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_wake_up_dur_ext_t;
+} st1vafe3bx_wake_up_dur_ext_t;
 
-#define LIS2DUXS12_WHO_AM_I                             0x0FU
+#define ST1VAFE3BX_WHO_AM_I                             0x0FU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -238,9 +238,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t id                           : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_who_am_i_t;
+} st1vafe3bx_who_am_i_t;
 
-#define LIS2DUXS12_CTRL1                                0x10U
+#define ST1VAFE3BX_CTRL1                                0x10U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -250,11 +250,11 @@ typedef struct
   uint8_t drdy_pulsed                  : 1;
   uint8_t if_add_inc                   : 1;
   uint8_t sw_reset                     : 1;
-  uint8_t int1_on_res                  : 1;
+  uint8_t int_pin_en                   : 1;
   uint8_t smart_power_en               : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t smart_power_en               : 1;
-  uint8_t int1_on_res                  : 1;
+  uint8_t int_pin_en                   : 1;
   uint8_t sw_reset                     : 1;
   uint8_t if_add_inc                   : 1;
   uint8_t drdy_pulsed                  : 1;
@@ -262,53 +262,45 @@ typedef struct
   uint8_t wu_y_en                      : 1;
   uint8_t wu_z_en                      : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_ctrl1_t;
+} st1vafe3bx_ctrl1_t;
 
-#define LIS2DUXS12_CTRL2                                0x11U
+#define ST1VAFE3BX_CTRL2                                0x11U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0                    : 3;
-  uint8_t int1_drdy                    : 1;
-  uint8_t int1_fifo_ovr                : 1;
-  uint8_t int1_fifo_th                 : 1;
-  uint8_t int1_fifo_full               : 1;
-  uint8_t int1_boot                    : 1;
+  uint8_t int_drdy                     : 1;
+  uint8_t int_fifo_ovr                 : 1;
+  uint8_t int_fifo_th                  : 1;
+  uint8_t int_fifo_full                : 1;
+  uint8_t int_boot                     : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t int1_boot                    : 1;
-  uint8_t int1_fifo_full               : 1;
-  uint8_t int1_fifo_th                 : 1;
-  uint8_t int1_fifo_ovr                : 1;
-  uint8_t int1_drdy                    : 1;
+  uint8_t int_boot                     : 1;
+  uint8_t int_fifo_full                : 1;
+  uint8_t int_fifo_th                  : 1;
+  uint8_t int_fifo_ovr                 : 1;
+  uint8_t int_drdy                     : 1;
   uint8_t not_used0                    : 3;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_ctrl2_t;
+} st1vafe3bx_ctrl2_t;
 
-#define LIS2DUXS12_CTRL3                                0x12U
+#define ST1VAFE3BX_CTRL3                                0x12U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t st_sign_x                    : 1;
   uint8_t st_sign_y                    : 1;
   uint8_t hp_en                        : 1;
-  uint8_t int2_drdy                    : 1;
-  uint8_t int2_fifo_ovr                : 1;
-  uint8_t int2_fifo_th                 : 1;
-  uint8_t int2_fifo_full               : 1;
-  uint8_t int2_boot                    : 1;
+  uint8_t not_used0                    : 5;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t int2_boot                    : 1;
-  uint8_t int2_fifo_full               : 1;
-  uint8_t int2_fifo_th                 : 1;
-  uint8_t int2_fifo_ovr                : 1;
-  uint8_t int2_drdy                    : 1;
+  uint8_t not_used0                    : 5;
   uint8_t hp_en                        : 1;
   uint8_t st_sign_y                    : 1;
   uint8_t st_sign_x                    : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_ctrl3_t;
+} st1vafe3bx_ctrl3_t;
 
-#define LIS2DUXS12_CTRL4                                0x13U
+#define ST1VAFE3BX_CTRL4                                0x13U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -328,9 +320,9 @@ typedef struct
   uint8_t soc                          : 1;
   uint8_t boot                         : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_ctrl4_t;
+} st1vafe3bx_ctrl4_t;
 
-#define LIS2DUXS12_CTRL5                                0x14U
+#define ST1VAFE3BX_CTRL5                                0x14U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -342,27 +334,29 @@ typedef struct
   uint8_t bw                           : 2;
   uint8_t fs                           : 2;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_ctrl5_t;
+} st1vafe3bx_ctrl5_t;
 
-#define LIS2DUXS12_FIFO_CTRL                            0x15U
+#define ST1VAFE3BX_FIFO_CTRL                            0x15U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fifo_mode                    : 3;
   uint8_t stop_on_fth                  : 1;
-  uint8_t not_used0                    : 2;
+  uint8_t fifo_en_adv                  : 1;
+  uint8_t not_used0                    : 1;
   uint8_t fifo_depth                   : 1;
   uint8_t cfg_chg_en                   : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t cfg_chg_en                   : 1;
   uint8_t fifo_depth                   : 1;
-  uint8_t not_used0                    : 2;
+  uint8_t not_used0                    : 1;
+  uint8_t fifo_en_adv                  : 1;
   uint8_t stop_on_fth                  : 1;
   uint8_t fifo_mode                    : 3;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fifo_ctrl_t;
+} st1vafe3bx_fifo_ctrl_t;
 
-#define LIS2DUXS12_FIFO_WTM                             0x16U
+#define ST1VAFE3BX_FIFO_WTM                             0x16U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -372,9 +366,9 @@ typedef struct
   uint8_t xl_only_fifo                 : 1;
   uint8_t fth                          : 7;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fifo_wtm_t;
+} st1vafe3bx_fifo_wtm_t;
 
-#define LIS2DUXS12_INTERRUPT_CFG                        0x17U
+#define ST1VAFE3BX_INTERRUPT_CFG                        0x17U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -396,9 +390,9 @@ typedef struct
   uint8_t lir                          : 1;
   uint8_t interrupts_enable            : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_interrupt_cfg_t;
+} st1vafe3bx_interrupt_cfg_t;
 
-#define LIS2DUXS12_SIXD                                 0x18U
+#define ST1VAFE3BX_SIXD                                 0x18U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -410,9 +404,9 @@ typedef struct
   uint8_t d6d_ths                      : 2;
   uint8_t not_used0                    : 5;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_sixd_t;
+} st1vafe3bx_sixd_t;
 
-#define LIS2DUXS12_WAKE_UP_THS                          0x1CU
+#define ST1VAFE3BX_WAKE_UP_THS                          0x1CU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -424,9 +418,9 @@ typedef struct
   uint8_t sleep_on                     : 1;
   uint8_t wk_ths                       : 6;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_wake_up_ths_t;
+} st1vafe3bx_wake_up_ths_t;
 
-#define LIS2DUXS12_WAKE_UP_DUR                          0x1DU
+#define ST1VAFE3BX_WAKE_UP_DUR                          0x1DU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -440,9 +434,9 @@ typedef struct
   uint8_t st_sign_z                    : 1;
   uint8_t sleep_dur                    : 4;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_wake_up_dur_t;
+} st1vafe3bx_wake_up_dur_t;
 
-#define LIS2DUXS12_FREE_FALL                            0x1EU
+#define ST1VAFE3BX_FREE_FALL                            0x1EU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -452,57 +446,33 @@ typedef struct
   uint8_t ff_dur                       : 5;
   uint8_t ff_ths                       : 3;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_free_fall_t;
+} st1vafe3bx_free_fall_t;
 
-#define LIS2DUXS12_MD1_CFG                              0x1FU
+#define ST1VAFE3BX_MD1_CFG                              0x1FU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t int1_emb_func                : 1;
-  uint8_t int1_timestamp               : 1;
-  uint8_t int1_6d                      : 1;
-  uint8_t int1_tap                     : 1;
-  uint8_t int1_ff                      : 1;
-  uint8_t int1_wu                      : 1;
+  uint8_t int_emb_func                 : 1;
+  uint8_t int_timestamp                : 1;
+  uint8_t int_6d                       : 1;
+  uint8_t int_tap                      : 1;
+  uint8_t int_ff                       : 1;
+  uint8_t int_wu                       : 1;
   uint8_t not_used0                    : 1;
-  uint8_t int1_sleep_change            : 1;
+  uint8_t int_sleep_change             : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t int1_sleep_change            : 1;
+  uint8_t int_sleep_change             : 1;
   uint8_t not_used0                    : 1;
-  uint8_t int1_wu                      : 1;
-  uint8_t int1_ff                      : 1;
-  uint8_t int1_tap                     : 1;
-  uint8_t int1_6d                      : 1;
-  uint8_t int1_timestamp               : 1;
-  uint8_t int1_emb_func                : 1;
+  uint8_t int_wu                       : 1;
+  uint8_t int_ff                       : 1;
+  uint8_t int_tap                      : 1;
+  uint8_t int_6d                       : 1;
+  uint8_t int_timestamp                : 1;
+  uint8_t int_emb_func                 : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_md1_cfg_t;
+} st1vafe3bx_md1_cfg_t;
 
-#define LIS2DUXS12_MD2_CFG                              0x20U
-typedef struct
-{
-#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t int2_emb_func                : 1;
-  uint8_t int2_timestamp               : 1;
-  uint8_t int2_6d                      : 1;
-  uint8_t int2_tap                     : 1;
-  uint8_t int2_ff                      : 1;
-  uint8_t int2_wu                      : 1;
-  uint8_t not_used0                    : 1;
-  uint8_t int2_sleep_change            : 1;
-#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t int2_sleep_change            : 1;
-  uint8_t not_used0                    : 1;
-  uint8_t int2_wu                      : 1;
-  uint8_t int2_ff                      : 1;
-  uint8_t int2_tap                     : 1;
-  uint8_t int2_6d                      : 1;
-  uint8_t int2_timestamp               : 1;
-  uint8_t int2_emb_func                : 1;
-#endif /* DRV_BYTE_ORDER */
-} lis2duxs12_md2_cfg_t;
-
-#define LIS2DUXS12_WAKE_UP_SRC                          0x21U
+#define ST1VAFE3BX_WAKE_UP_SRC                          0x21U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -524,9 +494,9 @@ typedef struct
   uint8_t y_wu                         : 1;
   uint8_t z_wu                         : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_wake_up_src_t;
+} st1vafe3bx_wake_up_src_t;
 
-#define LIS2DUXS12_TAP_SRC                              0x22U
+#define ST1VAFE3BX_TAP_SRC                              0x22U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -542,9 +512,9 @@ typedef struct
   uint8_t triple_tap_ia                : 1;
   uint8_t not_used0                    : 4;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_tap_src_t;
+} st1vafe3bx_tap_src_t;
 
-#define LIS2DUXS12_SIXD_SRC                             0x23U
+#define ST1VAFE3BX_SIXD_SRC                             0x23U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -566,9 +536,9 @@ typedef struct
   uint8_t xh                           : 1;
   uint8_t xl                           : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_sixd_src_t;
+} st1vafe3bx_sixd_src_t;
 
-#define LIS2DUXS12_ALL_INT_SRC                          0x24U
+#define ST1VAFE3BX_ALL_INT_SRC                          0x24U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -590,9 +560,9 @@ typedef struct
   uint8_t wu_ia_all                    : 1;
   uint8_t ff_ia_all                    : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_all_int_src_t;
+} st1vafe3bx_all_int_src_t;
 
-#define LIS2DUXS12_STATUS                               0x25U
+#define ST1VAFE3BX_STATUS                               0x25U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -606,9 +576,9 @@ typedef struct
   uint8_t not_used0                    : 4;
   uint8_t drdy                         : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_status_register_t;
+} st1vafe3bx_status_register_t;
 
-#define LIS2DUXS12_FIFO_STATUS1                         0x26U
+#define ST1VAFE3BX_FIFO_STATUS1                         0x26U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -620,9 +590,9 @@ typedef struct
   uint8_t fifo_ovr_ia                  : 1;
   uint8_t not_used0                    : 6;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fifo_status1_t;
+} st1vafe3bx_fifo_status1_t;
 
-#define LIS2DUXS12_FIFO_STATUS2                         0x27U
+#define ST1VAFE3BX_FIFO_STATUS2                         0x27U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -630,9 +600,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fss                          : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fifo_status2_t;
+} st1vafe3bx_fifo_status2_t;
 
-#define LIS2DUXS12_OUT_X_L                              0x28U
+#define ST1VAFE3BX_OUT_X_L                              0x28U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -640,9 +610,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t outx                         : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_out_x_l_t;
+} st1vafe3bx_out_x_l_t;
 
-#define LIS2DUXS12_OUT_X_H                              0x29U
+#define ST1VAFE3BX_OUT_X_H                              0x29U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -650,9 +620,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t outx                         : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_out_x_h_t;
+} st1vafe3bx_out_x_h_t;
 
-#define LIS2DUXS12_OUT_Y_L                              0x2AU
+#define ST1VAFE3BX_OUT_Y_L                              0x2AU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -660,9 +630,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t outy                         : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_out_y_l_t;
+} st1vafe3bx_out_y_l_t;
 
-#define LIS2DUXS12_OUT_Y_H                              0x2BU
+#define ST1VAFE3BX_OUT_Y_H                              0x2BU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -670,9 +640,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t outy                         : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_out_y_h_t;
+} st1vafe3bx_out_y_h_t;
 
-#define LIS2DUXS12_OUT_Z_L                              0x2CU
+#define ST1VAFE3BX_OUT_Z_L                              0x2CU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -680,9 +650,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t outz                         : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_out_z_l_t;
+} st1vafe3bx_out_z_l_t;
 
-#define LIS2DUXS12_OUT_Z_H                              0x2DU
+#define ST1VAFE3BX_OUT_Z_H                              0x2DU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -690,53 +660,67 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t outz                         : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_out_z_h_t;
+} st1vafe3bx_out_z_h_t;
 
-#define LIS2DUXS12_OUT_T_AH_QVAR_L                      0x2EU
+#define ST1VAFE3BX_OUT_AH_BIO_L                         0x2EU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t outt                         : 8;
+  uint8_t out_ah_bio                   : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t outt                         : 8;
+  uint8_t out_ah_bio                   : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_out_t_ah_qvar_l_t;
+} st1vafe3bx_out_ah_bio_l_t;
 
-#define LIS2DUXS12_OUT_T_AH_QVAR_H                      0x2FU
+#define ST1VAFE3BX_OUT_AH_BIO_H                         0x2FU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t outt                         : 8;
+  uint8_t out_ah_bio                   : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t outt                         : 8;
+  uint8_t out_ah_bio                   : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_out_t_ah_qvar_h_t;
+} st1vafe3bx_out_ah_bio_h_t;
 
-#define LIS2DUXS12_AH_QVAR_CFG                          0x31U
+#define ST1VAFE3BX_AH_BIO_CFG1                          0x30U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 3;
+  uint8_t ah_bio_zin_dis_ah2_bio1      : 1;
+  uint8_t ah_bio_zin_dis_ah2_bio2      : 1;
+  uint8_t not_used1                    : 3;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 3;
+  uint8_t ah_bio_zin_dis_ah2_bio2      : 1;
+  uint8_t ah_bio_zin_dis_ah2_bio1      : 1;
+  uint8_t not_used0                    : 3;
+#endif /* DRV_BYTE_ORDER */
+} st1vafe3bx_ah_bio_cfg1_t;
+
+#define ST1VAFE3BX_AH_BIO_CFG2                          0x31U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ah_bio_en                    : 1;
+  uint8_t ah_bio_gain                  : 2;
+  uint8_t ah_bio_c_zin                 : 2;
+  uint8_t ah_bio_mode                  : 2;
   uint8_t not_used0                    : 1;
-  uint8_t ah_qvar_gain                 : 2;
-  uint8_t ah_qvar_c_zin                : 2;
-  uint8_t ah_qvar_notch_cutoff         : 1;
-  uint8_t ah_qvar_notch_en             : 1;
-  uint8_t ah_qvar_en                   : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t ah_qvar_en                   : 1;
-  uint8_t ah_qvar_notch_en             : 1;
-  uint8_t ah_qvar_notch_cutoff         : 1;
-  uint8_t ah_qvar_c_zin                : 2;
-  uint8_t ah_qvar_gain                 : 2;
   uint8_t not_used0                    : 1;
+  uint8_t ah_bio_mode                  : 2;
+  uint8_t ah_bio_c_zin                 : 2;
+  uint8_t ah_bio_gain                  : 2;
+  uint8_t ah_bio_en                    : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_ah_qvar_cfg_t;
+} st1vafe3bx_ah_bio_cfg2_t;
 
-#define LIS2DUXS12_SELF_TEST                            0x32U
+#define ST1VAFE3BX_AH_BIO_CFG3                          0x32U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t t_ah_qvar_dis                : 1;
+  uint8_t ah_bio_active                : 1;
   uint8_t not_used0                    : 3;
   uint8_t st                           : 2;
   uint8_t not_used1                    : 2;
@@ -744,29 +728,29 @@ typedef struct
   uint8_t not_used1                    : 2;
   uint8_t st                           : 2;
   uint8_t not_used0                    : 3;
-  uint8_t t_ah_qvar_dis                : 1;
+  uint8_t ah_bio_active                : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_self_test_t;
+} st1vafe3bx_ah_bio_cfg3_t;
 
-#define LIS2DUXS12_I3C_IF_CTRL                          0x33U
+#define ST1VAFE3BX_I3C_IF_CTRL                          0x33U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t bus_act_sel                  : 2;
   uint8_t not_used0                    : 3;
   uint8_t asf_on                       : 1;
-  uint8_t dis_drstdaa                  : 1;
   uint8_t not_used1                    : 1;
+  uint8_t dis_drstdaa                  : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t not_used1                    : 1;
   uint8_t dis_drstdaa                  : 1;
+  uint8_t not_used1                    : 1;
   uint8_t asf_on                       : 1;
   uint8_t not_used0                    : 3;
   uint8_t bus_act_sel                  : 2;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_i3c_if_ctrl_t;
+} st1vafe3bx_i3c_if_ctrl_t;
 
-#define LIS2DUXS12_EMB_FUNC_STATUS_MAINPAGE             0x34U
+#define ST1VAFE3BX_EMB_FUNC_STATUS_MAINPAGE             0x34U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -784,9 +768,9 @@ typedef struct
   uint8_t is_step_det                  : 1;
   uint8_t not_used0                    : 3;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_emb_func_status_mainpage_t;
+} st1vafe3bx_emb_func_status_mainpage_t;
 
-#define LIS2DUXS12_FSM_STATUS_MAINPAGE                  0x35U
+#define ST1VAFE3BX_FSM_STATUS_MAINPAGE                  0x35U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -808,9 +792,9 @@ typedef struct
   uint8_t is_fsm2                      : 1;
   uint8_t is_fsm1                      : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fsm_status_mainpage_t;
+} st1vafe3bx_fsm_status_mainpage_t;
 
-#define LIS2DUXS12_MLC_STATUS_MAINPAGE                  0x36U
+#define ST1VAFE3BX_MLC_STATUS_MAINPAGE                  0x36U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -826,33 +810,21 @@ typedef struct
   uint8_t is_mlc2                      : 1;
   uint8_t is_mlc1                      : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_mlc_status_mainpage_t;
+} st1vafe3bx_mlc_status_mainpage_t;
 
-#define LIS2DUXS12_SLEEP                                0x3DU
+#define ST1VAFE3BX_EN_DEVICE_CONFIG                     0x3EU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t deep_pd                      : 1;
+  uint8_t en_dev_conf                  : 1;
   uint8_t not_used0                    : 7;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t not_used0                    : 7;
-  uint8_t deep_pd                      : 1;
+  uint8_t en_dev_conf                  : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_sleep_t;
+} st1vafe3bx_en_device_config_t;
 
-#define LIS2DUXS12_EN_DEVICE_CONFIG                     0x3EU
-typedef struct
-{
-#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t soft_pd                      : 1;
-  uint8_t not_used0                    : 7;
-#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t not_used0                    : 7;
-  uint8_t soft_pd                      : 1;
-#endif /* DRV_BYTE_ORDER */
-} lis2duxs12_en_device_config_t;
-
-#define LIS2DUXS12_FUNC_CFG_ACCESS                      0x3FU
+#define ST1VAFE3BX_FUNC_CFG_ACCESS                      0x3FU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -864,9 +836,9 @@ typedef struct
   uint8_t not_used0                    : 6;
   uint8_t fsm_wr_ctrl_en               : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_func_cfg_access_t;
+} st1vafe3bx_func_cfg_access_t;
 
-#define LIS2DUXS12_FIFO_DATA_OUT_TAG                    0x40U
+#define ST1VAFE3BX_FIFO_DATA_OUT_TAG                    0x40U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -876,9 +848,9 @@ typedef struct
   uint8_t tag_sensor                   : 5;
   uint8_t not_used0                    : 3;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fifo_data_out_tag_t;
+} st1vafe3bx_fifo_data_out_tag_t;
 
-#define LIS2DUXS12_FIFO_DATA_OUT_X_L                    0x41U
+#define ST1VAFE3BX_FIFO_DATA_OUT_X_L                    0x41U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -886,9 +858,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fifo_data_out                : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fifo_data_out_x_l_t;
+} st1vafe3bx_fifo_data_out_x_l_t;
 
-#define LIS2DUXS12_FIFO_DATA_OUT_X_H                    0x42U
+#define ST1VAFE3BX_FIFO_DATA_OUT_X_H                    0x42U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -896,9 +868,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fifo_data_out                : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fifo_data_out_x_h_t;
+} st1vafe3bx_fifo_data_out_x_h_t;
 
-#define LIS2DUXS12_FIFO_DATA_OUT_Y_L                    0x43U
+#define ST1VAFE3BX_FIFO_DATA_OUT_Y_L                    0x43U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -906,9 +878,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fifo_data_out                : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fifo_data_out_y_l_t;
+} st1vafe3bx_fifo_data_out_y_l_t;
 
-#define LIS2DUXS12_FIFO_DATA_OUT_Y_H                    0x44U
+#define ST1VAFE3BX_FIFO_DATA_OUT_Y_H                    0x44U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -916,9 +888,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fifo_data_out                : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fifo_data_out_y_h_t;
+} st1vafe3bx_fifo_data_out_y_h_t;
 
-#define LIS2DUXS12_FIFO_DATA_OUT_Z_L                    0x45U
+#define ST1VAFE3BX_FIFO_DATA_OUT_Z_L                    0x45U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -926,9 +898,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fifo_data_out                : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fifo_data_out_z_l_t;
+} st1vafe3bx_fifo_data_out_z_l_t;
 
-#define LIS2DUXS12_FIFO_DATA_OUT_Z_H                    0x46U
+#define ST1VAFE3BX_FIFO_DATA_OUT_Z_H                    0x46U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -936,9 +908,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fifo_data_out                : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fifo_data_out_z_h_t;
+} st1vafe3bx_fifo_data_out_z_h_t;
 
-#define LIS2DUXS12_FIFO_BATCH_DEC                       0x47U
+#define ST1VAFE3BX_FIFO_BATCH_DEC                       0x47U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -950,9 +922,9 @@ typedef struct
   uint8_t dec_ts_batch                 : 2;
   uint8_t bdr_xl                       : 3;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fifo_batch_dec_t;
+} st1vafe3bx_fifo_batch_dec_t;
 
-#define LIS2DUXS12_TAP_CFG0                             0x6FU
+#define ST1VAFE3BX_TAP_CFG0                             0x6FU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -964,9 +936,9 @@ typedef struct
   uint8_t invert_t                     : 5;
   uint8_t not_used0                    : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_tap_cfg0_t;
+} st1vafe3bx_tap_cfg0_t;
 
-#define LIS2DUXS12_TAP_CFG1                             0x70U
+#define ST1VAFE3BX_TAP_CFG1                             0x70U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -976,9 +948,9 @@ typedef struct
   uint8_t pre_still_ths                : 4;
   uint8_t post_still_t                 : 4;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_tap_cfg1_t;
+} st1vafe3bx_tap_cfg1_t;
 
-#define LIS2DUXS12_TAP_CFG2                             0x71U
+#define ST1VAFE3BX_TAP_CFG2                             0x71U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -988,9 +960,9 @@ typedef struct
   uint8_t post_still_t                 : 2;
   uint8_t wait_t                       : 6;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_tap_cfg2_t;
+} st1vafe3bx_tap_cfg2_t;
 
-#define LIS2DUXS12_TAP_CFG3                             0x72U
+#define ST1VAFE3BX_TAP_CFG3                             0x72U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1000,9 +972,9 @@ typedef struct
   uint8_t post_still_ths               : 4;
   uint8_t latency_t                    : 4;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_tap_cfg3_t;
+} st1vafe3bx_tap_cfg3_t;
 
-#define LIS2DUXS12_TAP_CFG4                             0x73U
+#define ST1VAFE3BX_TAP_CFG4                             0x73U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1014,9 +986,9 @@ typedef struct
   uint8_t not_used0                    : 1;
   uint8_t peak_ths                     : 6;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_tap_cfg4_t;
+} st1vafe3bx_tap_cfg4_t;
 
-#define LIS2DUXS12_TAP_CFG5                             0x74U
+#define ST1VAFE3BX_TAP_CFG5                             0x74U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1030,9 +1002,9 @@ typedef struct
   uint8_t single_tap_en                : 1;
   uint8_t rebound_t                    : 5;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_tap_cfg5_t;
+} st1vafe3bx_tap_cfg5_t;
 
-#define LIS2DUXS12_TAP_CFG6                             0x75U
+#define ST1VAFE3BX_TAP_CFG6                             0x75U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1042,9 +1014,9 @@ typedef struct
   uint8_t pre_still_st                 : 4;
   uint8_t pre_still_n                  : 4;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_tap_cfg6_t;
+} st1vafe3bx_tap_cfg6_t;
 
-#define LIS2DUXS12_TIMESTAMP0                           0x7AU
+#define ST1VAFE3BX_TIMESTAMP0                           0x7AU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1052,9 +1024,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t timestamp                    : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_timestamp0_t;
+} st1vafe3bx_timestamp0_t;
 
-#define LIS2DUXS12_TIMESTAMP1                           0x7BU
+#define ST1VAFE3BX_TIMESTAMP1                           0x7BU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1062,9 +1034,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t timestamp                    : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_timestamp1_t;
+} st1vafe3bx_timestamp1_t;
 
-#define LIS2DUXS12_TIMESTAMP2                           0x7CU
+#define ST1VAFE3BX_TIMESTAMP2                           0x7CU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1072,9 +1044,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t timestamp                    : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_timestamp2_t;
+} st1vafe3bx_timestamp2_t;
 
-#define LIS2DUXS12_TIMESTAMP3                           0x7DU
+#define ST1VAFE3BX_TIMESTAMP3                           0x7DU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1082,7 +1054,7 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t timestamp                    : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_timestamp3_t;
+} st1vafe3bx_timestamp3_t;
 
 /**
   * @}
@@ -1094,7 +1066,7 @@ typedef struct
   *
   */
 
-#define LIS2DUXS12_PAGE_SEL                             0x2U
+#define ST1VAFE3BX_PAGE_SEL                             0x2U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1104,9 +1076,9 @@ typedef struct
   uint8_t page_sel                     : 4;
   uint8_t not_used0                    : 4;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_page_sel_t;
+} st1vafe3bx_page_sel_t;
 
-#define LIS2DUXS12_EMB_FUNC_EN_A                        0x4U
+#define ST1VAFE3BX_EMB_FUNC_EN_A                        0x4U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1124,9 +1096,9 @@ typedef struct
   uint8_t pedo_en                      : 1;
   uint8_t not_used0                    : 3;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_emb_func_en_a_t;
+} st1vafe3bx_emb_func_en_a_t;
 
-#define LIS2DUXS12_EMB_FUNC_EN_B                        0x5U
+#define ST1VAFE3BX_EMB_FUNC_EN_B                        0x5U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1140,9 +1112,9 @@ typedef struct
   uint8_t not_used0                    : 3;
   uint8_t fsm_en                       : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_emb_func_en_b_t;
+} st1vafe3bx_emb_func_en_b_t;
 
-#define LIS2DUXS12_EMB_FUNC_EXEC_STATUS                 0x7U
+#define ST1VAFE3BX_EMB_FUNC_EXEC_STATUS                 0x7U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1154,9 +1126,9 @@ typedef struct
   uint8_t emb_func_exec_ovr            : 1;
   uint8_t emb_func_endop               : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_emb_func_exec_status_t;
+} st1vafe3bx_emb_func_exec_status_t;
 
-#define LIS2DUXS12_PAGE_ADDRESS                         0x8U
+#define ST1VAFE3BX_PAGE_ADDRESS                         0x8U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1164,9 +1136,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t page_addr                    : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_page_address_t;
+} st1vafe3bx_page_address_t;
 
-#define LIS2DUXS12_PAGE_VALUE                           0x9U
+#define ST1VAFE3BX_PAGE_VALUE                           0x9U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1174,133 +1146,71 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t page_value                   : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_page_value_t;
+} st1vafe3bx_page_value_t;
 
-#define LIS2DUXS12_EMB_FUNC_INT1                        0x0AU
+#define ST1VAFE3BX_EMB_FUNC_INT                         0x0AU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0                    : 3;
-  uint8_t int1_step_det                : 1;
-  uint8_t int1_tilt                    : 1;
-  uint8_t int1_sig_mot                 : 1;
+  uint8_t int_step_det                 : 1;
+  uint8_t int_tilt                     : 1;
+  uint8_t int_sig_mot                  : 1;
   uint8_t not_used1                    : 1;
-  uint8_t int1_fsm_lc                  : 1;
+  uint8_t int_fsm_lc                   : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t int1_fsm_lc                  : 1;
+  uint8_t int_fsm_lc                   : 1;
   uint8_t not_used1                    : 1;
-  uint8_t int1_sig_mot                 : 1;
-  uint8_t int1_tilt                    : 1;
-  uint8_t int1_step_det                : 1;
+  uint8_t int_sig_mot                  : 1;
+  uint8_t int_tilt                     : 1;
+  uint8_t int_step_det                 : 1;
   uint8_t not_used0                    : 3;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_emb_func_int1_t;
+} st1vafe3bx_emb_func_int_t;
 
-#define LIS2DUXS12_FSM_INT1                             0x0BU
+#define ST1VAFE3BX_FSM_INT                              0x0BU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t int1_fsm1                    : 1;
-  uint8_t int1_fsm2                    : 1;
-  uint8_t int1_fsm3                    : 1;
-  uint8_t int1_fsm4                    : 1;
-  uint8_t int1_fsm5                    : 1;
-  uint8_t int1_fsm6                    : 1;
-  uint8_t int1_fsm7                    : 1;
-  uint8_t int1_fsm8                    : 1;
+  uint8_t int_fsm1                     : 1;
+  uint8_t int_fsm2                     : 1;
+  uint8_t int_fsm3                     : 1;
+  uint8_t int_fsm4                     : 1;
+  uint8_t int_fsm5                     : 1;
+  uint8_t int_fsm6                     : 1;
+  uint8_t int_fsm7                     : 1;
+  uint8_t int_fsm8                     : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t int1_fsm8                    : 1;
-  uint8_t int1_fsm7                    : 1;
-  uint8_t int1_fsm6                    : 1;
-  uint8_t int1_fsm5                    : 1;
-  uint8_t int1_fsm4                    : 1;
-  uint8_t int1_fsm3                    : 1;
-  uint8_t int1_fsm2                    : 1;
-  uint8_t int1_fsm1                    : 1;
+  uint8_t int_fsm8                     : 1;
+  uint8_t int_fsm7                     : 1;
+  uint8_t int_fsm6                     : 1;
+  uint8_t int_fsm5                     : 1;
+  uint8_t int_fsm4                     : 1;
+  uint8_t int_fsm3                     : 1;
+  uint8_t int_fsm2                     : 1;
+  uint8_t int_fsm1                     : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fsm_int1_t;
+} st1vafe3bx_fsm_int_t;
 
-#define LIS2DUXS12_MLC_INT1                             0x0DU
+#define ST1VAFE3BX_MLC_INT                              0x0DU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t int1_mlc1                    : 1;
-  uint8_t int1_mlc2                    : 1;
-  uint8_t int1_mlc3                    : 1;
-  uint8_t int1_mlc4                    : 1;
+  uint8_t int_mlc1                     : 1;
+  uint8_t int_mlc2                     : 1;
+  uint8_t int_mlc3                     : 1;
+  uint8_t int_mlc4                     : 1;
   uint8_t not_used0                    : 4;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t not_used0                    : 4;
-  uint8_t int1_mlc4                    : 1;
-  uint8_t int1_mlc3                    : 1;
-  uint8_t int1_mlc2                    : 1;
-  uint8_t int1_mlc1                    : 1;
+  uint8_t int_mlc4                     : 1;
+  uint8_t int_mlc3                     : 1;
+  uint8_t int_mlc2                     : 1;
+  uint8_t int_mlc1                     : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_mlc_int1_t;
+} st1vafe3bx_mlc_int_t;
 
-#define LIS2DUXS12_EMB_FUNC_INT2                        0x0EU
-typedef struct
-{
-#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t not_used0                    : 3;
-  uint8_t int2_step_det                : 1;
-  uint8_t int2_tilt                    : 1;
-  uint8_t int2_sig_mot                 : 1;
-  uint8_t not_used1                    : 1;
-  uint8_t int2_fsm_lc                  : 1;
-#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t int2_fsm_lc                  : 1;
-  uint8_t not_used1                    : 1;
-  uint8_t int2_sig_mot                 : 1;
-  uint8_t int2_tilt                    : 1;
-  uint8_t int2_step_det                : 1;
-  uint8_t not_used0                    : 3;
-#endif /* DRV_BYTE_ORDER */
-} lis2duxs12_emb_func_int2_t;
-
-#define LIS2DUXS12_FSM_INT2                             0x0FU
-typedef struct
-{
-#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t int2_fsm1                    : 1;
-  uint8_t int2_fsm2                    : 1;
-  uint8_t int2_fsm3                    : 1;
-  uint8_t int2_fsm4                    : 1;
-  uint8_t int2_fsm5                    : 1;
-  uint8_t int2_fsm6                    : 1;
-  uint8_t int2_fsm7                    : 1;
-  uint8_t int2_fsm8                    : 1;
-#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t int2_fsm8                    : 1;
-  uint8_t int2_fsm7                    : 1;
-  uint8_t int2_fsm6                    : 1;
-  uint8_t int2_fsm5                    : 1;
-  uint8_t int2_fsm4                    : 1;
-  uint8_t int2_fsm3                    : 1;
-  uint8_t int2_fsm2                    : 1;
-  uint8_t int2_fsm1                    : 1;
-#endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fsm_int2_t;
-
-#define LIS2DUXS12_MLC_INT2                             0x11U
-typedef struct
-{
-#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t int2_mlc1                    : 1;
-  uint8_t int2_mlc2                    : 1;
-  uint8_t int2_mlc3                    : 1;
-  uint8_t int2_mlc4                    : 1;
-  uint8_t not_used0                    : 4;
-#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t not_used0                    : 4;
-  uint8_t int2_mlc4                    : 1;
-  uint8_t int2_mlc3                    : 1;
-  uint8_t int2_mlc2                    : 1;
-  uint8_t int2_mlc1                    : 1;
-#endif /* DRV_BYTE_ORDER */
-} lis2duxs12_mlc_int2_t;
-
-#define LIS2DUXS12_EMB_FUNC_STATUS                      0x12U
+#define ST1VAFE3BX_EMB_FUNC_STATUS                      0x12U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1318,9 +1228,9 @@ typedef struct
   uint8_t is_step_det                  : 1;
   uint8_t not_used0                    : 3;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_emb_func_status_t;
+} st1vafe3bx_emb_func_status_t;
 
-#define LIS2DUXS12_FSM_STATUS                           0x13U
+#define ST1VAFE3BX_FSM_STATUS                           0x13U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1342,9 +1252,9 @@ typedef struct
   uint8_t is_fsm2                      : 1;
   uint8_t is_fsm1                      : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fsm_status_t;
+} st1vafe3bx_fsm_status_t;
 
-#define LIS2DUXS12_MLC_STATUS                           0x15U
+#define ST1VAFE3BX_MLC_STATUS                           0x15U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1360,9 +1270,9 @@ typedef struct
   uint8_t is_mlc2                      : 1;
   uint8_t is_mlc1                      : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_mlc_status_t;
+} st1vafe3bx_mlc_status_t;
 
-#define LIS2DUXS12_PAGE_RW                              0x17U
+#define ST1VAFE3BX_PAGE_RW                              0x17U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1376,9 +1286,9 @@ typedef struct
   uint8_t page_read                    : 1;
   uint8_t not_used0                    : 5;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_page_rw_t;
+} st1vafe3bx_page_rw_t;
 
-#define LIS2DUXS12_EMB_FUNC_FIFO_EN                     0x18U
+#define ST1VAFE3BX_EMB_FUNC_FIFO_EN                     0x18U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1394,9 +1304,9 @@ typedef struct
   uint8_t mlc_fifo_en                  : 1;
   uint8_t step_counter_fifo_en         : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_emb_func_fifo_en_t;
+} st1vafe3bx_emb_func_fifo_en_t;
 
-#define LIS2DUXS12_FSM_ENABLE                           0x1AU
+#define ST1VAFE3BX_FSM_ENABLE                           0x1AU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1418,9 +1328,9 @@ typedef struct
   uint8_t fsm2_en                      : 1;
   uint8_t fsm1_en                      : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fsm_enable_t;
+} st1vafe3bx_fsm_enable_t;
 
-#define LIS2DUXS12_FSM_LONG_COUNTER_L                   0x1CU
+#define ST1VAFE3BX_FSM_LONG_COUNTER_L                   0x1CU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1428,9 +1338,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fsm_lc                       : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fsm_long_counter_l_t;
+} st1vafe3bx_fsm_long_counter_l_t;
 
-#define LIS2DUXS12_FSM_LONG_COUNTER_H                   0x1DU
+#define ST1VAFE3BX_FSM_LONG_COUNTER_H                   0x1DU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1438,9 +1348,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fsm_lc                       : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fsm_long_counter_h_t;
+} st1vafe3bx_fsm_long_counter_h_t;
 
-#define LIS2DUXS12_INT_ACK_MASK                         0x1FU
+#define ST1VAFE3BX_INT_ACK_MASK                         0x1FU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1462,9 +1372,9 @@ typedef struct
   uint8_t iack_mask1                   : 1;
   uint8_t iack_mask0                   : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_int_ack_mask_t;
+} st1vafe3bx_int_ack_mask_t;
 
-#define LIS2DUXS12_FSM_OUTS1                            0x20U
+#define ST1VAFE3BX_FSM_OUTS1                            0x20U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1486,9 +1396,9 @@ typedef struct
   uint8_t p_v                          : 1;
   uint8_t n_v                          : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fsm_outs1_t;
+} st1vafe3bx_fsm_outs1_t;
 
-#define LIS2DUXS12_FSM_OUTS2                            0x21U
+#define ST1VAFE3BX_FSM_OUTS2                            0x21U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1510,9 +1420,9 @@ typedef struct
   uint8_t p_v                          : 1;
   uint8_t n_v                          : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fsm_outs2_t;
+} st1vafe3bx_fsm_outs2_t;
 
-#define LIS2DUXS12_FSM_OUTS3                            0x22U
+#define ST1VAFE3BX_FSM_OUTS3                            0x22U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1534,9 +1444,9 @@ typedef struct
   uint8_t p_v                          : 1;
   uint8_t n_v                          : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fsm_outs3_t;
+} st1vafe3bx_fsm_outs3_t;
 
-#define LIS2DUXS12_FSM_OUTS4                            0x23U
+#define ST1VAFE3BX_FSM_OUTS4                            0x23U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1558,9 +1468,9 @@ typedef struct
   uint8_t p_v                          : 1;
   uint8_t n_v                          : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fsm_outs4_t;
+} st1vafe3bx_fsm_outs4_t;
 
-#define LIS2DUXS12_FSM_OUTS5                            0x24U
+#define ST1VAFE3BX_FSM_OUTS5                            0x24U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1582,9 +1492,9 @@ typedef struct
   uint8_t p_v                          : 1;
   uint8_t n_v                          : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fsm_outs5_t;
+} st1vafe3bx_fsm_outs5_t;
 
-#define LIS2DUXS12_FSM_OUTS6                            0x25U
+#define ST1VAFE3BX_FSM_OUTS6                            0x25U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1606,9 +1516,9 @@ typedef struct
   uint8_t p_v                          : 1;
   uint8_t n_v                          : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fsm_outs6_t;
+} st1vafe3bx_fsm_outs6_t;
 
-#define LIS2DUXS12_FSM_OUTS7                            0x26U
+#define ST1VAFE3BX_FSM_OUTS7                            0x26U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1630,9 +1540,9 @@ typedef struct
   uint8_t p_v                          : 1;
   uint8_t n_v                          : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fsm_outs7_t;
+} st1vafe3bx_fsm_outs7_t;
 
-#define LIS2DUXS12_FSM_OUTS8                            0x27U
+#define ST1VAFE3BX_FSM_OUTS8                            0x27U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1654,19 +1564,9 @@ typedef struct
   uint8_t p_v                          : 1;
   uint8_t n_v                          : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fsm_outs8_t;
+} st1vafe3bx_fsm_outs8_t;
 
-#define LIS2DUXS12_STEP_COUNTER_L                       0x28U
-typedef struct
-{
-#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t step                         : 8;
-#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t step                         : 8;
-#endif /* DRV_BYTE_ORDER */
-} lis2duxs12_step_counter_l_t;
-
-#define LIS2DUXS12_STEP_COUNTER_H                       0x29U
+#define ST1VAFE3BX_STEP_COUNTER_L                       0x28U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1674,9 +1574,19 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t step                         : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_step_counter_h_t;
+} st1vafe3bx_step_counter_l_t;
 
-#define LIS2DUXS12_EMB_FUNC_SRC                         0x2AU
+#define ST1VAFE3BX_STEP_COUNTER_H                       0x29U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t step                         : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t step                         : 8;
+#endif /* DRV_BYTE_ORDER */
+} st1vafe3bx_step_counter_h_t;
+
+#define ST1VAFE3BX_EMB_FUNC_SRC                         0x2AU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1696,9 +1606,9 @@ typedef struct
   uint8_t stepcounter_bit_set          : 1;
   uint8_t not_used0                    : 2;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_emb_func_src_t;
+} st1vafe3bx_emb_func_src_t;
 
-#define LIS2DUXS12_EMB_FUNC_INIT_A                      0x2CU
+#define ST1VAFE3BX_EMB_FUNC_INIT_A                      0x2CU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1716,9 +1626,9 @@ typedef struct
   uint8_t step_det_init                : 1;
   uint8_t not_used0                    : 3;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_emb_func_init_a_t;
+} st1vafe3bx_emb_func_init_a_t;
 
-#define LIS2DUXS12_EMB_FUNC_INIT_B                      0x2DU
+#define ST1VAFE3BX_EMB_FUNC_INIT_B                      0x2DU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1732,9 +1642,9 @@ typedef struct
   uint8_t not_used0                    : 3;
   uint8_t fsm_init                     : 1;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_emb_func_init_b_t;
+} st1vafe3bx_emb_func_init_b_t;
 
-#define LIS2DUXS12_MLC1_SRC                             0x34U
+#define ST1VAFE3BX_MLC1_SRC                             0x34U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1742,9 +1652,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t mlc1_src                     : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_mlc1_src_t;
+} st1vafe3bx_mlc1_src_t;
 
-#define LIS2DUXS12_MLC2_SRC                             0x35U
+#define ST1VAFE3BX_MLC2_SRC                             0x35U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1752,9 +1662,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t mlc2_src                     : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_mlc2_src_t;
+} st1vafe3bx_mlc2_src_t;
 
-#define LIS2DUXS12_MLC3_SRC                             0x36U
+#define ST1VAFE3BX_MLC3_SRC                             0x36U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1762,9 +1672,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t mlc3_src                     : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_mlc3_src_t;
+} st1vafe3bx_mlc3_src_t;
 
-#define LIS2DUXS12_MLC4_SRC                             0x37U
+#define ST1VAFE3BX_MLC4_SRC                             0x37U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1772,9 +1682,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t mlc4_src                     : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_mlc4_src_t;
+} st1vafe3bx_mlc4_src_t;
 
-#define LIS2DUXS12_FSM_ODR                              0x39U
+#define ST1VAFE3BX_FSM_ODR                              0x39U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1786,9 +1696,9 @@ typedef struct
   uint8_t fsm_odr                      : 3;
   uint8_t not_used0                    : 3;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fsm_odr_t;
+} st1vafe3bx_fsm_odr_t;
 
-#define LIS2DUXS12_MLC_ODR                              0x3AU
+#define ST1VAFE3BX_MLC_ODR                              0x3AU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1800,7 +1710,7 @@ typedef struct
   uint8_t mlc_odr                      : 3;
   uint8_t not_used0                    : 4;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_mlc_odr_t;
+} st1vafe3bx_mlc_odr_t;
 
 /**
   * @}
@@ -1811,9 +1721,9 @@ typedef struct
   * @{
   *
   */
-#define LIS2DUXS12_EMB_ADV_PG_0                         0x000U
+#define ST1VAFE3BX_EMB_ADV_PG_0                         0x000U
 
-#define LIS2DUXS12_FSM_LC_TIMEOUT_L                     0x54U
+#define ST1VAFE3BX_FSM_LC_TIMEOUT_L                     0x54U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1821,9 +1731,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fsm_lc_timeout               : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fsm_lc_timeout_l_t;
+} st1vafe3bx_fsm_lc_timeout_l_t;
 
-#define LIS2DUXS12_FSM_LC_TIMEOUT_H                     0x55U
+#define ST1VAFE3BX_FSM_LC_TIMEOUT_H                     0x55U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1831,9 +1741,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fsm_lc_timeout               : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fsm_lc_timeout_h_t;
+} st1vafe3bx_fsm_lc_timeout_h_t;
 
-#define LIS2DUXS12_FSM_PROGRAMS                         0x56U
+#define ST1VAFE3BX_FSM_PROGRAMS                         0x56U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1841,9 +1751,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fsm_n_prog                   : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fsm_programs_t;
+} st1vafe3bx_fsm_programs_t;
 
-#define LIS2DUXS12_FSM_START_ADD_L                      0x58U
+#define ST1VAFE3BX_FSM_START_ADD_L                      0x58U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1851,9 +1761,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fsm_start                    : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fsm_start_add_l_t;
+} st1vafe3bx_fsm_start_add_l_t;
 
-#define LIS2DUXS12_FSM_START_ADD_H                      0x59U
+#define ST1VAFE3BX_FSM_START_ADD_H                      0x59U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1861,9 +1771,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fsm_start                    : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_fsm_start_add_h_t;
+} st1vafe3bx_fsm_start_add_h_t;
 
-#define LIS2DUXS12_PEDO_CMD_REG                         0x5DU
+#define ST1VAFE3BX_PEDO_CMD_REG                         0x5DU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1877,9 +1787,9 @@ typedef struct
   uint8_t fp_rejection_en              : 1;
   uint8_t not_used0                    : 2;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_pedo_cmd_reg_t;
+} st1vafe3bx_pedo_cmd_reg_t;
 
-#define LIS2DUXS12_PEDO_DEB_STEPS_CONF                  0x5EU
+#define ST1VAFE3BX_PEDO_DEB_STEPS_CONF                  0x5EU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1887,9 +1797,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t deb_step                     : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_pedo_deb_steps_conf_t;
+} st1vafe3bx_pedo_deb_steps_conf_t;
 
-#define LIS2DUXS12_PEDO_SC_DELTAT_L                     0xAAU
+#define ST1VAFE3BX_PEDO_SC_DELTAT_L                     0xAAU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1897,9 +1807,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t pd_sc                        : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_pedo_sc_deltat_l_t;
+} st1vafe3bx_pedo_sc_deltat_l_t;
 
-#define LIS2DUXS12_PEDO_SC_DELTAT_H                     0xABU
+#define ST1VAFE3BX_PEDO_SC_DELTAT_H                     0xABU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1907,29 +1817,29 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t pd_sc                        : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_pedo_sc_deltat_h_t;
+} st1vafe3bx_pedo_sc_deltat_h_t;
 
-#define LIS2DUXS12_T_AH_QVAR_SENSITIVITY_L              0xB6U
+#define ST1VAFE3BX_AH_BIO_SENSITIVITY_L                 0xB6U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t t_ah_qvar_s                  : 8;
+  uint8_t ah_bio_s                     : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t t_ah_qvar_s                  : 8;
+  uint8_t ah_bio_s                     : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_t_ah_qvar_sensitivity_l_t;
+} st1vafe3bx_ah_bio_sensitivity_l_t;
 
-#define LIS2DUXS12_T_AH_QVAR_SENSITIVITY_H              0xB7U
+#define ST1VAFE3BX_AH_BIO_SENSITIVITY_H                 0xB7U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t t_ah_qvar_s                  : 8;
+  uint8_t ah_bio_s                     : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t t_ah_qvar_s                  : 8;
+  uint8_t ah_bio_s                     : 8;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_t_ah_qvar_sensitivity_h_t;
+} st1vafe3bx_ah_bio_sensitivity_h_t;
 
-#define LIS2DUXS12_SMART_POWER_CTRL                     0xD2U
+#define ST1VAFE3BX_SMART_POWER_CTRL                     0xD2U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1939,7 +1849,7 @@ typedef struct
   uint8_t smart_power_ctrl_dur         : 4;
   uint8_t smart_power_ctrl_win         : 4;
 #endif /* DRV_BYTE_ORDER */
-} lis2duxs12_smart_power_ctrl_t;
+} st1vafe3bx_smart_power_ctrl_t;
 
 /**
   * @}
@@ -1948,121 +1858,118 @@ typedef struct
 
 typedef union
 {
-  lis2duxs12_pin_ctrl_t    pin_ctrl;
-  lis2duxs12_wake_up_dur_ext_t    wake_up_dur_ext;
-  lis2duxs12_who_am_i_t    who_am_i;
-  lis2duxs12_ctrl1_t    ctrl1;
-  lis2duxs12_ctrl2_t    ctrl2;
-  lis2duxs12_ctrl3_t    ctrl3;
-  lis2duxs12_ctrl4_t    ctrl4;
-  lis2duxs12_ctrl5_t    ctrl5;
-  lis2duxs12_fifo_ctrl_t    fifo_ctrl;
-  lis2duxs12_fifo_wtm_t    fifo_wtm;
-  lis2duxs12_interrupt_cfg_t    interrupt_cfg;
-  lis2duxs12_sixd_t    sixd;
-  lis2duxs12_wake_up_ths_t    wake_up_ths;
-  lis2duxs12_wake_up_dur_t    wake_up_dur;
-  lis2duxs12_free_fall_t    free_fall;
-  lis2duxs12_md1_cfg_t    md1_cfg;
-  lis2duxs12_md2_cfg_t    md2_cfg;
-  lis2duxs12_wake_up_src_t    wake_up_src;
-  lis2duxs12_tap_src_t    tap_src;
-  lis2duxs12_sixd_src_t    sixd_src;
-  lis2duxs12_all_int_src_t    all_int_src;
-  lis2duxs12_status_register_t    status;
-  lis2duxs12_fifo_status1_t    fifo_status1;
-  lis2duxs12_fifo_status2_t    fifo_status2;
-  lis2duxs12_out_x_l_t    out_x_l;
-  lis2duxs12_out_x_h_t    out_x_h;
-  lis2duxs12_out_y_l_t    out_y_l;
-  lis2duxs12_out_y_h_t    out_y_h;
-  lis2duxs12_out_z_l_t    out_z_l;
-  lis2duxs12_out_z_h_t    out_z_h;
-  lis2duxs12_out_t_ah_qvar_l_t    out_t_ah_qvar_l;
-  lis2duxs12_out_t_ah_qvar_h_t    out_t_ah_qvar_h;
-  lis2duxs12_ah_qvar_cfg_t    ah_qvar_cfg;
-  lis2duxs12_self_test_t    self_test;
-  lis2duxs12_i3c_if_ctrl_t    i3c_if_ctrl;
-  lis2duxs12_emb_func_status_mainpage_t    emb_func_status_mainpage;
-  lis2duxs12_fsm_status_mainpage_t    fsm_status_mainpage;
-  lis2duxs12_mlc_status_mainpage_t    mlc_status_mainpage;
-  lis2duxs12_sleep_t    sleep;
-  lis2duxs12_en_device_config_t    en_device_config;
-  lis2duxs12_func_cfg_access_t    func_cfg_access;
-  lis2duxs12_fifo_data_out_tag_t    fifo_data_out_tag;
-  lis2duxs12_fifo_data_out_x_l_t    fifo_data_out_x_l;
-  lis2duxs12_fifo_data_out_x_h_t    fifo_data_out_x_h;
-  lis2duxs12_fifo_data_out_y_l_t    fifo_data_out_y_l;
-  lis2duxs12_fifo_data_out_y_h_t    fifo_data_out_y_h;
-  lis2duxs12_fifo_data_out_z_l_t    fifo_data_out_z_l;
-  lis2duxs12_fifo_data_out_z_h_t    fifo_data_out_z_h;
-  lis2duxs12_fifo_batch_dec_t    fifo_batch_dec;
-  lis2duxs12_tap_cfg0_t    tap_cfg0;
-  lis2duxs12_tap_cfg1_t    tap_cfg1;
-  lis2duxs12_tap_cfg2_t    tap_cfg2;
-  lis2duxs12_tap_cfg3_t    tap_cfg3;
-  lis2duxs12_tap_cfg4_t    tap_cfg4;
-  lis2duxs12_tap_cfg5_t    tap_cfg5;
-  lis2duxs12_tap_cfg6_t    tap_cfg6;
-  lis2duxs12_timestamp0_t    timestamp0;
-  lis2duxs12_timestamp1_t    timestamp1;
-  lis2duxs12_timestamp2_t    timestamp2;
-  lis2duxs12_timestamp3_t    timestamp3;
-  lis2duxs12_page_sel_t    page_sel;
-  lis2duxs12_emb_func_en_a_t    emb_func_en_a;
-  lis2duxs12_emb_func_en_b_t    emb_func_en_b;
-  lis2duxs12_emb_func_exec_status_t    emb_func_exec_status;
-  lis2duxs12_page_address_t    page_address;
-  lis2duxs12_page_value_t    page_value;
-  lis2duxs12_emb_func_int1_t    emb_func_int1;
-  lis2duxs12_fsm_int1_t    fsm_int1;
-  lis2duxs12_mlc_int1_t    mlc_int1;
-  lis2duxs12_emb_func_int2_t    emb_func_int2;
-  lis2duxs12_fsm_int2_t    fsm_int2;
-  lis2duxs12_mlc_int2_t    mlc_int2;
-  lis2duxs12_emb_func_status_t    emb_func_status;
-  lis2duxs12_fsm_status_t    fsm_status;
-  lis2duxs12_mlc_status_t    mlc_status;
-  lis2duxs12_page_rw_t    page_rw;
-  lis2duxs12_emb_func_fifo_en_t    emb_func_fifo_en;
-  lis2duxs12_fsm_enable_t    fsm_enable;
-  lis2duxs12_fsm_long_counter_l_t    fsm_long_counter_l;
-  lis2duxs12_fsm_long_counter_h_t    fsm_long_counter_h;
-  lis2duxs12_int_ack_mask_t    int_ack_mask;
-  lis2duxs12_fsm_outs1_t    fsm_outs1;
-  lis2duxs12_fsm_outs2_t    fsm_outs2;
-  lis2duxs12_fsm_outs3_t    fsm_outs3;
-  lis2duxs12_fsm_outs4_t    fsm_outs4;
-  lis2duxs12_fsm_outs5_t    fsm_outs5;
-  lis2duxs12_fsm_outs6_t    fsm_outs6;
-  lis2duxs12_fsm_outs7_t    fsm_outs7;
-  lis2duxs12_fsm_outs8_t    fsm_outs8;
-  lis2duxs12_step_counter_l_t    step_counter_l;
-  lis2duxs12_step_counter_h_t    step_counter_h;
-  lis2duxs12_emb_func_src_t    emb_func_src;
-  lis2duxs12_emb_func_init_a_t    emb_func_init_a;
-  lis2duxs12_emb_func_init_b_t    emb_func_init_b;
-  lis2duxs12_mlc1_src_t    mlc1_src;
-  lis2duxs12_mlc2_src_t    mlc2_src;
-  lis2duxs12_mlc3_src_t    mlc3_src;
-  lis2duxs12_mlc4_src_t    mlc4_src;
-  lis2duxs12_fsm_odr_t    fsm_odr;
-  lis2duxs12_mlc_odr_t    mlc_odr;
-  lis2duxs12_fsm_lc_timeout_l_t    fsm_lc_timeout_l;
-  lis2duxs12_fsm_lc_timeout_h_t    fsm_lc_timeout_h;
-  lis2duxs12_fsm_programs_t    fsm_programs;
-  lis2duxs12_fsm_start_add_l_t    fsm_start_add_l;
-  lis2duxs12_fsm_start_add_h_t    fsm_start_add_h;
-  lis2duxs12_pedo_cmd_reg_t    pedo_cmd_reg;
-  lis2duxs12_pedo_deb_steps_conf_t    pedo_deb_steps_conf;
-  lis2duxs12_pedo_sc_deltat_l_t    pedo_sc_deltat_l;
-  lis2duxs12_pedo_sc_deltat_h_t    pedo_sc_deltat_h;
-  lis2duxs12_t_ah_qvar_sensitivity_l_t    t_ah_qvar_sensitivity_l;
-  lis2duxs12_t_ah_qvar_sensitivity_h_t    t_ah_qvar_sensitivity_h;
-  lis2duxs12_smart_power_ctrl_t   smart_power_ctrl;
+  st1vafe3bx_ext_clk_cfg_t                 ext_clk_cfg;
+  st1vafe3bx_pin_ctrl_t                    pin_ctrl;
+  st1vafe3bx_wake_up_dur_ext_t             wake_up_dur_ext;
+  st1vafe3bx_who_am_i_t                    who_am_i;
+  st1vafe3bx_ctrl1_t                       ctrl1;
+  st1vafe3bx_ctrl2_t                       ctrl2;
+  st1vafe3bx_ctrl3_t                       ctrl3;
+  st1vafe3bx_ctrl4_t                       ctrl4;
+  st1vafe3bx_ctrl5_t                       ctrl5;
+  st1vafe3bx_fifo_ctrl_t                   fifo_ctrl;
+  st1vafe3bx_fifo_wtm_t                    fifo_wtm;
+  st1vafe3bx_interrupt_cfg_t               interrupt_cfg;
+  st1vafe3bx_sixd_t                        sixd;
+  st1vafe3bx_wake_up_ths_t                 wake_up_ths;
+  st1vafe3bx_wake_up_dur_t                 wake_up_dur;
+  st1vafe3bx_free_fall_t                   free_fall;
+  st1vafe3bx_md1_cfg_t                     md1_cfg;
+  st1vafe3bx_wake_up_src_t                 wake_up_src;
+  st1vafe3bx_tap_src_t                     tap_src;
+  st1vafe3bx_sixd_src_t                    sixd_src;
+  st1vafe3bx_all_int_src_t                 all_int_src;
+  st1vafe3bx_status_register_t             status;
+  st1vafe3bx_fifo_status1_t                fifo_status1;
+  st1vafe3bx_fifo_status2_t                fifo_status2;
+  st1vafe3bx_out_x_l_t                     out_x_l;
+  st1vafe3bx_out_x_h_t                     out_x_h;
+  st1vafe3bx_out_y_l_t                     out_y_l;
+  st1vafe3bx_out_y_h_t                     out_y_h;
+  st1vafe3bx_out_z_l_t                     out_z_l;
+  st1vafe3bx_out_z_h_t                     out_z_h;
+  st1vafe3bx_out_ah_bio_l_t                out_ah_bio_l;
+  st1vafe3bx_out_ah_bio_h_t                out_ah_bio_h;
+  st1vafe3bx_ah_bio_cfg1_t                 ah_bio_cfg1;
+  st1vafe3bx_ah_bio_cfg2_t                 ah_bio_cfg2;
+  st1vafe3bx_ah_bio_cfg3_t                 ah_bio_cfg3;
+  st1vafe3bx_i3c_if_ctrl_t                 i3c_if_ctrl;
+  st1vafe3bx_emb_func_status_mainpage_t    emb_func_status_mainpage;
+  st1vafe3bx_fsm_status_mainpage_t         fsm_status_mainpage;
+  st1vafe3bx_mlc_status_mainpage_t         mlc_status_mainpage;
+  st1vafe3bx_en_device_config_t            en_device_config;
+  st1vafe3bx_func_cfg_access_t             func_cfg_access;
+  st1vafe3bx_fifo_data_out_tag_t           fifo_data_out_tag;
+  st1vafe3bx_fifo_data_out_x_l_t           fifo_data_out_x_l;
+  st1vafe3bx_fifo_data_out_x_h_t           fifo_data_out_x_h;
+  st1vafe3bx_fifo_data_out_y_l_t           fifo_data_out_y_l;
+  st1vafe3bx_fifo_data_out_y_h_t           fifo_data_out_y_h;
+  st1vafe3bx_fifo_data_out_z_l_t           fifo_data_out_z_l;
+  st1vafe3bx_fifo_data_out_z_h_t           fifo_data_out_z_h;
+  st1vafe3bx_fifo_batch_dec_t              fifo_batch_dec;
+  st1vafe3bx_tap_cfg0_t                    tap_cfg0;
+  st1vafe3bx_tap_cfg1_t                    tap_cfg1;
+  st1vafe3bx_tap_cfg2_t                    tap_cfg2;
+  st1vafe3bx_tap_cfg3_t                    tap_cfg3;
+  st1vafe3bx_tap_cfg4_t                    tap_cfg4;
+  st1vafe3bx_tap_cfg5_t                    tap_cfg5;
+  st1vafe3bx_tap_cfg6_t                    tap_cfg6;
+  st1vafe3bx_timestamp0_t                  timestamp0;
+  st1vafe3bx_timestamp1_t                  timestamp1;
+  st1vafe3bx_timestamp2_t                  timestamp2;
+  st1vafe3bx_timestamp3_t                  timestamp3;
+  st1vafe3bx_page_sel_t                    page_sel;
+  st1vafe3bx_emb_func_en_a_t               emb_func_en_a;
+  st1vafe3bx_emb_func_en_b_t               emb_func_en_b;
+  st1vafe3bx_emb_func_exec_status_t        emb_func_exec_status;
+  st1vafe3bx_page_address_t                page_address;
+  st1vafe3bx_page_value_t                  page_value;
+  st1vafe3bx_emb_func_int_t                emb_func_int;
+  st1vafe3bx_fsm_int_t                     fsm_int;
+  st1vafe3bx_mlc_int_t                     mlc_int;
+  st1vafe3bx_emb_func_status_t             emb_func_status;
+  st1vafe3bx_fsm_status_t                  fsm_status;
+  st1vafe3bx_mlc_status_t                  mlc_status;
+  st1vafe3bx_page_rw_t                     page_rw;
+  st1vafe3bx_emb_func_fifo_en_t            emb_func_fifo_en;
+  st1vafe3bx_fsm_enable_t                  fsm_enable;
+  st1vafe3bx_fsm_long_counter_l_t          fsm_long_counter_l;
+  st1vafe3bx_fsm_long_counter_h_t          fsm_long_counter_h;
+  st1vafe3bx_int_ack_mask_t                int_ack_mask;
+  st1vafe3bx_fsm_outs1_t                   fsm_outs1;
+  st1vafe3bx_fsm_outs2_t                   fsm_outs2;
+  st1vafe3bx_fsm_outs3_t                   fsm_outs3;
+  st1vafe3bx_fsm_outs4_t                   fsm_outs4;
+  st1vafe3bx_fsm_outs5_t                   fsm_outs5;
+  st1vafe3bx_fsm_outs6_t                   fsm_outs6;
+  st1vafe3bx_fsm_outs7_t                   fsm_outs7;
+  st1vafe3bx_fsm_outs8_t                   fsm_outs8;
+  st1vafe3bx_step_counter_l_t              step_counter_l;
+  st1vafe3bx_step_counter_h_t              step_counter_h;
+  st1vafe3bx_emb_func_src_t                emb_func_src;
+  st1vafe3bx_emb_func_init_a_t             emb_func_init_a;
+  st1vafe3bx_emb_func_init_b_t             emb_func_init_b;
+  st1vafe3bx_mlc1_src_t                    mlc1_src;
+  st1vafe3bx_mlc2_src_t                    mlc2_src;
+  st1vafe3bx_mlc3_src_t                    mlc3_src;
+  st1vafe3bx_mlc4_src_t                    mlc4_src;
+  st1vafe3bx_fsm_odr_t                     fsm_odr;
+  st1vafe3bx_mlc_odr_t                     mlc_odr;
+  st1vafe3bx_fsm_lc_timeout_l_t            fsm_lc_timeout_l;
+  st1vafe3bx_fsm_lc_timeout_h_t            fsm_lc_timeout_h;
+  st1vafe3bx_fsm_programs_t                fsm_programs;
+  st1vafe3bx_fsm_start_add_l_t             fsm_start_add_l;
+  st1vafe3bx_fsm_start_add_h_t             fsm_start_add_h;
+  st1vafe3bx_pedo_cmd_reg_t                pedo_cmd_reg;
+  st1vafe3bx_pedo_deb_steps_conf_t         pedo_deb_steps_conf;
+  st1vafe3bx_pedo_sc_deltat_l_t            pedo_sc_deltat_l;
+  st1vafe3bx_pedo_sc_deltat_h_t            pedo_sc_deltat_h;
+  st1vafe3bx_ah_bio_sensitivity_l_t        ah_bio_sensitivity_l;
+  st1vafe3bx_ah_bio_sensitivity_h_t        ah_bio_sensitivity_h;
+  st1vafe3bx_smart_power_ctrl_t            smart_power_ctrl;
   bitwise_t    bitwise;
   uint8_t    byte;
-} lis2duxs12_reg_t;
+} st1vafe3bx_reg_t;
 
 /**
   * @}
@@ -2082,31 +1989,42 @@ typedef union
  * them with a custom implementation.
  */
 
-int32_t lis2duxs12_read_reg(const stmdev_ctx_t *ctx, uint8_t reg,
+int32_t st1vafe3bx_read_reg(const stmdev_ctx_t *ctx, uint8_t reg,
                             uint8_t *data,
                             uint16_t len);
-int32_t lis2duxs12_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
+int32_t st1vafe3bx_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
                              uint8_t *data,
                              uint16_t len);
 
-float_t lis2duxs12_from_fs2g_to_mg(int16_t lsb);
-float_t lis2duxs12_from_fs4g_to_mg(int16_t lsb);
-float_t lis2duxs12_from_fs8g_to_mg(int16_t lsb);
-float_t lis2duxs12_from_fs16g_to_mg(int16_t lsb);
-float_t lis2duxs12_from_lsb_to_celsius(int16_t lsb);
-float_t lis2duxs12_from_lsb_to_mv(int16_t lsb);
+float_t st1vafe3bx_from_fs2g_to_mg(int16_t lsb);
+float_t st1vafe3bx_from_fs4g_to_mg(int16_t lsb);
+float_t st1vafe3bx_from_fs8g_to_mg(int16_t lsb);
+float_t st1vafe3bx_from_fs16g_to_mg(int16_t lsb);
+float_t st1vafe3bx_from_lsb_to_celsius(int16_t lsb);
+float_t st1vafe3bx_from_lsb_to_mv(int16_t lsb);
 
-int32_t lis2duxs12_device_id_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t st1vafe3bx_device_id_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum
 {
-  LIS2DUXS12_SENSOR_ONLY_ON     = 0x00, /* Initialize the driver for sensor usage */
-  LIS2DUXS12_BOOT               = 0x01, /* Restore calib. param. (it takes 10ms) */
-  LIS2DUXS12_RESET              = 0x02, /* Reset configuration registers */
-  LIS2DUXS12_SENSOR_EMB_FUNC_ON = 0x03, /* Initialize the driver for sensor and/or
+  ST1VAFE3BX_SENSOR_ONLY_ON     = 0x00, /* Initialize the driver for sensor usage */
+  ST1VAFE3BX_BOOT               = 0x01, /* Restore calib. param. (it takes 10ms) */
+  ST1VAFE3BX_RESET              = 0x02, /* Reset configuration registers */
+  ST1VAFE3BX_SENSOR_EMB_FUNC_ON = 0x03, /* Initialize the driver for sensor and/or
                                            embedded functions usage (it takes 10ms) */
-} lis2duxs12_init_t;
-int32_t lis2duxs12_init_set(const stmdev_ctx_t *ctx, lis2duxs12_init_t val);
+  ST1VAFE3BX_VAFE_ONLY_LP       = 0x04, /* Enable sensor in vAFE only mode - low performance */
+  ST1VAFE3BX_VAFE_ONLY_HP       = 0x05, /* Enable sensor in vAFE only mode - high performance */
+} st1vafe3bx_init_t;
+int32_t st1vafe3bx_init_set(const stmdev_ctx_t *ctx, st1vafe3bx_init_t val);
+
+typedef struct
+{
+  uint8_t pwr_en                       : 1; /* Smart power enable */
+  uint8_t pwr_ctrl_win                 : 4; /* Number of consecutive windows */
+  uint8_t pwr_ctrl_dur                 : 4; /* Duration threshold */
+} st1vafe3bx_smart_power_t;
+int32_t st1vafe3bx_smart_power_set(const stmdev_ctx_t *ctx, st1vafe3bx_smart_power_t val);
+int32_t st1vafe3bx_smart_power_get(const stmdev_ctx_t *ctx, st1vafe3bx_smart_power_t *val);
 
 typedef struct
 {
@@ -2114,80 +2032,94 @@ typedef struct
   uint8_t boot                         : 1; /* Restoring calibration parameters */
   uint8_t drdy                         : 1; /* Accelerometer data ready */
   uint8_t power_down                   : 1; /* Monitors power-down. */
-} lis2duxs12_status_t;
-int32_t lis2duxs12_status_get(const stmdev_ctx_t *ctx, lis2duxs12_status_t *val);
+} st1vafe3bx_status_t;
+int32_t st1vafe3bx_status_get(const stmdev_ctx_t *ctx, st1vafe3bx_status_t *val);
+int32_t st1vafe3bx_drdy_status_get(const stmdev_ctx_t *ctx, st1vafe3bx_status_t *val);
 
 typedef struct
 {
   uint8_t is_step_det                  : 1; /* Step detected */
   uint8_t is_tilt                      : 1; /* Tilt detected */
   uint8_t is_sigmot                    : 1; /* Significant motion detected */
-} lis2duxs12_embedded_status_t;
-int32_t lis2duxs12_embedded_status_get(const stmdev_ctx_t *ctx, lis2duxs12_embedded_status_t *val);
+  uint8_t is_fsm_lc                    : 1; /* FSM long counter timeout */
+} st1vafe3bx_embedded_status_t;
+int32_t st1vafe3bx_embedded_status_get(const stmdev_ctx_t *ctx, st1vafe3bx_embedded_status_t *val);
 
 typedef enum
 {
-  LIS2DUXS12_DRDY_LATCHED = 0x0,
-  LIS2DUXS12_DRDY_PULSED  = 0x1,
-} lis2duxs12_data_ready_mode_t;
-int32_t lis2duxs12_data_ready_mode_set(const stmdev_ctx_t *ctx, lis2duxs12_data_ready_mode_t val);
-int32_t lis2duxs12_data_ready_mode_get(const stmdev_ctx_t *ctx, lis2duxs12_data_ready_mode_t *val);
+  ST1VAFE3BX_DRDY_LATCHED = 0x0,
+  ST1VAFE3BX_DRDY_PULSED  = 0x1,
+} st1vafe3bx_data_ready_mode_t;
+int32_t st1vafe3bx_data_ready_mode_set(const stmdev_ctx_t *ctx, st1vafe3bx_data_ready_mode_t val);
+int32_t st1vafe3bx_data_ready_mode_get(const stmdev_ctx_t *ctx, st1vafe3bx_data_ready_mode_t *val);
 
 typedef enum
 {
-  LIS2DUXS12_OFF               = 0x00, /* in power down */
-  LIS2DUXS12_1Hz6_ULP          = 0x01, /* @1Hz6 (ultra low power) */
-  LIS2DUXS12_3Hz_ULP           = 0x02, /* @3Hz (ultra low power) */
-  LIS2DUXS12_25Hz_ULP          = 0x03, /* @25Hz (ultra low power) */
-  LIS2DUXS12_6Hz_LP            = 0x04, /* @6Hz (low power) */
-  LIS2DUXS12_12Hz5_LP          = 0x05, /* @12Hz5 (low power) */
-  LIS2DUXS12_25Hz_LP           = 0x06, /* @25Hz  (low power ) */
-  LIS2DUXS12_50Hz_LP           = 0x07, /* @50Hz  (low power) */
-  LIS2DUXS12_100Hz_LP          = 0x08, /* @100Hz (low power) */
-  LIS2DUXS12_200Hz_LP          = 0x09, /* @200Hz (low power) */
-  LIS2DUXS12_400Hz_LP          = 0x0A, /* @400Hz (low power) */
-  LIS2DUXS12_800Hz_LP          = 0x0B, /* @800Hz (low power) */
-  LIS2DUXS12_6Hz_HP            = 0x14, /* @6Hz (high performance) */
-  LIS2DUXS12_12Hz5_HP          = 0x15, /* @12Hz5 (high performance) */
-  LIS2DUXS12_25Hz_HP           = 0x16, /* @25Hz  (high performance ) */
-  LIS2DUXS12_50Hz_HP           = 0x17, /* @50Hz  (high performance) */
-  LIS2DUXS12_100Hz_HP          = 0x18, /* @100Hz (high performance) */
-  LIS2DUXS12_200Hz_HP          = 0x19, /* @200Hz (high performance) */
-  LIS2DUXS12_400Hz_HP          = 0x1A, /* @400Hz (high performance) */
-  LIS2DUXS12_800Hz_HP          = 0x1B, /* @800Hz (high performance) */
-  LIS2DUXS12_TRIG_PIN          = 0x2E, /* Single-shot high latency by INT2 */
-  LIS2DUXS12_TRIG_SW           = 0x2F, /* Single-shot high latency by IF */
-} lis2duxs12_odr_t;
+  ST1VAFE3BX_OFF               = 0x00, /* in power down */
+  ST1VAFE3BX_1Hz6_ULP          = 0x01, /* @1Hz6 (ultra low power) */
+  ST1VAFE3BX_3Hz_ULP           = 0x02, /* @3Hz (ultra low power) */
+  ST1VAFE3BX_25Hz_ULP          = 0x03, /* @25Hz (ultra low power) */
+  ST1VAFE3BX_6Hz_LP            = 0x04, /* @6Hz (low power) */
+  ST1VAFE3BX_12Hz5_LP          = 0x05, /* @12Hz5 (low power) */
+  ST1VAFE3BX_25Hz_LP           = 0x06, /* @25Hz  (low power ) */
+  ST1VAFE3BX_50Hz_LP           = 0x07, /* @50Hz  (low power) */
+  ST1VAFE3BX_100Hz_LP          = 0x08, /* @100Hz (low power) */
+  ST1VAFE3BX_200Hz_LP          = 0x09, /* @200Hz (low power) */
+  ST1VAFE3BX_400Hz_LP          = 0x0A, /* @400Hz (low power) */
+  ST1VAFE3BX_800Hz_LP          = 0x0B, /* @800Hz (low power) */
+  ST1VAFE3BX_6Hz_HP            = 0x14, /* @6Hz (high performance) */
+  ST1VAFE3BX_12Hz5_HP          = 0x15, /* @12Hz5 (high performance) */
+  ST1VAFE3BX_25Hz_HP           = 0x16, /* @25Hz  (high performance ) */
+  ST1VAFE3BX_50Hz_HP           = 0x17, /* @50Hz  (high performance) */
+  ST1VAFE3BX_100Hz_HP          = 0x18, /* @100Hz (high performance) */
+  ST1VAFE3BX_200Hz_HP          = 0x19, /* @200Hz (high performance) */
+  ST1VAFE3BX_400Hz_HP          = 0x1A, /* @400Hz (high performance) */
+  ST1VAFE3BX_800Hz_HP          = 0x1B, /* @800Hz (high performance) */
+  ST1VAFE3BX_TRIG_PIN          = 0x2E, /* Single-shot high latency by INT2 */
+  ST1VAFE3BX_TRIG_SW           = 0x2F, /* Single-shot high latency by IF */
+  ST1VAFE3BX_3200Hz_VAFE_LP    = 0x2B, /* @3200Hz (vAFE only low power) */
+  ST1VAFE3BX_800Hz_VAFE_HP     = 0x3B, /* @800Hz (vAFE only high performance) */
+} st1vafe3bx_odr_t;
 
 typedef enum
 {
-  LIS2DUXS12_2g   = 0,
-  LIS2DUXS12_4g   = 1,
-  LIS2DUXS12_8g   = 2,
-  LIS2DUXS12_16g  = 3,
-} lis2duxs12_fs_t;
+  ST1VAFE3BX_2g   = 0,
+  ST1VAFE3BX_4g   = 1,
+  ST1VAFE3BX_8g   = 2,
+  ST1VAFE3BX_16g  = 3,
+} st1vafe3bx_fs_t;
 
 typedef enum
 {
-  LIS2DUXS12_ODR_div_2   = 0,
-  LIS2DUXS12_ODR_div_4   = 1,
-  LIS2DUXS12_ODR_div_8   = 2,
-  LIS2DUXS12_ODR_div_16  = 3,
-} lis2duxs12_bw_t;
+  ST1VAFE3BX_BW_VAFE_45Hz      = 0,
+  ST1VAFE3BX_BW_VAFE_90Hz      = 1,
+  ST1VAFE3BX_BW_VAFE_180Hz     = 2,
+  ST1VAFE3BX_BW_VAFE_360Hz     = 3,
+  ST1VAFE3BX_BW_VAFE_700Hz     = 4,
+  ST1VAFE3BX_BW_VAFE_1600Hz    = 5,
+  ST1VAFE3BX_BW_ODR_div_2      = 7,
+  ST1VAFE3BX_BW_ODR_div_4      = 8,
+  ST1VAFE3BX_BW_ODR_div_8      = 9,
+  ST1VAFE3BX_BW_ODR_div_16     = 10,
+  ST1VAFE3BX_BW_LP_3Hz         = 11,
+  ST1VAFE3BX_BW_LP_6Hz         = 12,
+  ST1VAFE3BX_BW_LP_12Hz5       = 13,
+} st1vafe3bx_bw_t;
 
 typedef struct
 {
-  lis2duxs12_odr_t odr;
-  lis2duxs12_fs_t fs;
-  lis2duxs12_bw_t bw;
-} lis2duxs12_md_t;
-int32_t lis2duxs12_mode_set(const stmdev_ctx_t *ctx, const lis2duxs12_md_t *val);
-int32_t lis2duxs12_mode_get(const stmdev_ctx_t *ctx, lis2duxs12_md_t *val);
+  /* if the hp_en bit is set the AH / vAFE data are in 14-bit format */
+  uint8_t hp_en                        : 1;
+  st1vafe3bx_fs_t fs                 : 2;
+  st1vafe3bx_odr_t odr;
+  st1vafe3bx_bw_t bw;
+} st1vafe3bx_md_t;
+int32_t st1vafe3bx_mode_set(const stmdev_ctx_t *ctx,
+                            const st1vafe3bx_md_t *val);
+int32_t st1vafe3bx_mode_get(const stmdev_ctx_t *ctx, st1vafe3bx_md_t *val);
 
-int32_t lis2duxs12_t_ah_qvar_dis_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lis2duxs12_t_ah_qvar_dis_get(const stmdev_ctx_t *ctx, uint8_t *val);
-
-int32_t lis2duxs12_trigger_sw(const stmdev_ctx_t *ctx, const lis2duxs12_md_t *md);
+int32_t st1vafe3bx_trigger_sw(const stmdev_ctx_t *ctx,
+                              const st1vafe3bx_md_t *md);
 
 typedef struct
 {
@@ -2215,113 +2147,110 @@ typedef struct
   uint8_t fifo_full                    : 1;
   uint8_t fifo_ovr                     : 1;
   uint8_t fifo_th                      : 1;
-} lis2duxs12_all_sources_t;
-int32_t lis2duxs12_all_sources_get(const stmdev_ctx_t *ctx, lis2duxs12_all_sources_t *val);
+} st1vafe3bx_all_sources_t;
+int32_t st1vafe3bx_all_sources_get(const stmdev_ctx_t *ctx,
+                                   st1vafe3bx_all_sources_t *val);
 
 typedef struct
 {
   float_t mg[3];
   int16_t raw[3];
-} lis2duxs12_xl_data_t;
-int32_t lis2duxs12_xl_data_get(const stmdev_ctx_t *ctx, const lis2duxs12_md_t *md,
-                               lis2duxs12_xl_data_t *data);
-
-typedef struct
-{
-  struct
-  {
-    float_t deg_c;
-    int16_t raw;
-  } heat;
-} lis2duxs12_outt_data_t;
-int32_t lis2duxs12_outt_data_get(const stmdev_ctx_t *ctx,
-                                 lis2duxs12_outt_data_t *data);
+} st1vafe3bx_xl_data_t;
+int32_t st1vafe3bx_xl_data_get(const stmdev_ctx_t *ctx,
+                               const st1vafe3bx_md_t *md,
+                               st1vafe3bx_xl_data_t *data);
 
 typedef struct
 {
   float_t mv;
   int16_t raw;
-} lis2duxs12_ah_qvar_data_t;
-int32_t lis2duxs12_ah_qvar_data_get(const stmdev_ctx_t *ctx,
-                                    lis2duxs12_ah_qvar_data_t *data);
+} st1vafe3bx_ah_bio_data_t;
+int32_t st1vafe3bx_ah_bio_data_get(const stmdev_ctx_t *ctx,
+                                   st1vafe3bx_ah_bio_data_t *data);
 
 typedef enum
 {
-  LIS2DUXS12_XL_ST_DISABLE  = 0x0,
-  LIS2DUXS12_XL_ST_POSITIVE = 0x1,
-  LIS2DUXS12_XL_ST_NEGATIVE = 0x2,
-} lis2duxs12_xl_self_test_t;
-int32_t lis2duxs12_self_test_sign_set(const stmdev_ctx_t *ctx, lis2duxs12_xl_self_test_t val);
-int32_t lis2duxs12_self_test_start(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lis2duxs12_self_test_stop(const stmdev_ctx_t *ctx);
+  ST1VAFE3BX_XL_ST_DISABLE  = 0x0,
+  ST1VAFE3BX_XL_ST_POSITIVE = 0x1,
+  ST1VAFE3BX_XL_ST_NEGATIVE = 0x2,
+} st1vafe3bx_xl_self_test_t;
+int32_t st1vafe3bx_self_test_sign_set(const stmdev_ctx_t *ctx,
+                                      st1vafe3bx_xl_self_test_t val);
+int32_t st1vafe3bx_self_test_start(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t st1vafe3bx_self_test_stop(const stmdev_ctx_t *ctx);
 
-int32_t lis2duxs12_enter_deep_power_down(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lis2duxs12_exit_deep_power_down(const stmdev_ctx_t *ctx);
-
-typedef enum
-{
-  LIS2DUXS12_I3C_BUS_AVAIL_TIME_20US = 0x0,
-  LIS2DUXS12_I3C_BUS_AVAIL_TIME_50US = 0x1,
-  LIS2DUXS12_I3C_BUS_AVAIL_TIME_1MS  = 0x2,
-  LIS2DUXS12_I3C_BUS_AVAIL_TIME_25MS = 0x3,
-} lis2duxs12_bus_act_sel_t;
+int32_t st1vafe3bx_enter_deep_power_down(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t st1vafe3bx_exit_deep_power_down(const stmdev_ctx_t *ctx);
 
 typedef struct
 {
-  lis2duxs12_bus_act_sel_t bus_act_sel;
+  enum
+  {
+    ST1VAFE3BX_I3C_BUS_AVAIL_TIME_20US = 0x0,
+    ST1VAFE3BX_I3C_BUS_AVAIL_TIME_50US = 0x1,
+    ST1VAFE3BX_I3C_BUS_AVAIL_TIME_1MS  = 0x2,
+    ST1VAFE3BX_I3C_BUS_AVAIL_TIME_25MS = 0x3,
+  } bus_act_sel;
   uint8_t asf_on                       : 1;
   uint8_t drstdaa_en                   : 1;
-} lis2duxs12_i3c_cfg_t;
-int32_t lis2duxs12_i3c_configure_set(const stmdev_ctx_t *ctx, const lis2duxs12_i3c_cfg_t *val);
-int32_t lis2duxs12_i3c_configure_get(const stmdev_ctx_t *ctx, lis2duxs12_i3c_cfg_t *val);
+} st1vafe3bx_i3c_cfg_t;
+int32_t st1vafe3bx_i3c_configure_set(const stmdev_ctx_t *ctx,
+                                     const st1vafe3bx_i3c_cfg_t *val);
+int32_t st1vafe3bx_i3c_configure_get(const stmdev_ctx_t *ctx,
+                                     st1vafe3bx_i3c_cfg_t *val);
 
 typedef enum
 {
-  LIS2DUXS12_MAIN_MEM_BANK       = 0x0,
-  LIS2DUXS12_EMBED_FUNC_MEM_BANK = 0x1,
-} lis2duxs12_mem_bank_t;
-int32_t lis2duxs12_mem_bank_set(const stmdev_ctx_t *ctx, lis2duxs12_mem_bank_t val);
-int32_t lis2duxs12_mem_bank_get(const stmdev_ctx_t *ctx, lis2duxs12_mem_bank_t *val);
+  ST1VAFE3BX_MAIN_MEM_BANK       = 0x0,
+  ST1VAFE3BX_EMBED_FUNC_MEM_BANK = 0x1,
+} st1vafe3bx_mem_bank_t;
+int32_t st1vafe3bx_mem_bank_set(const stmdev_ctx_t *ctx,
+                                st1vafe3bx_mem_bank_t val);
+int32_t st1vafe3bx_mem_bank_get(const stmdev_ctx_t *ctx,
+                                st1vafe3bx_mem_bank_t *val);
 
-int32_t lis2duxs12_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t address, uint8_t *buf,
-                               uint8_t len);
-int32_t lis2duxs12_ln_pg_read(const stmdev_ctx_t *ctx, uint16_t address, uint8_t *buf, uint8_t len);
+int32_t st1vafe3bx_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t address,
+                               uint8_t *buf, uint8_t len);
+int32_t st1vafe3bx_ln_pg_read(const stmdev_ctx_t *ctx, uint16_t address,
+                              uint8_t *buf, uint8_t len);
 
-int32_t lis2duxs12_ext_clk_en_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lis2duxs12_ext_clk_en_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t st1vafe3bx_ext_clk_en_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t st1vafe3bx_ext_clk_en_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef struct
 {
   uint8_t sdo_pull_up                  : 1; /* 1 = pull up enable */
   uint8_t sda_pull_up                  : 1; /* 1 = pull up enable */
   uint8_t cs_pull_up                   : 1; /* 1 = pull up enable */
-  uint8_t int1_int2_push_pull          : 1; /* 1 = push-pull / 0 = open-drain*/
-  uint8_t int1_pull_down               : 1; /* 1 = pull-down always disabled (0=auto) */
-  uint8_t int2_pull_down               : 1; /* 1 = pull-down always disabled (0=auto) */
-} lis2duxs12_pin_conf_t;
-int32_t lis2duxs12_pin_conf_set(const stmdev_ctx_t *ctx, const lis2duxs12_pin_conf_t *val);
-int32_t lis2duxs12_pin_conf_get(const stmdev_ctx_t *ctx, lis2duxs12_pin_conf_t *val);
+  uint8_t int_push_pull                : 1; /* 1 = push-pull / 0 = open-drain*/
+} st1vafe3bx_pin_conf_t;
+int32_t st1vafe3bx_pin_conf_set(const stmdev_ctx_t *ctx,
+                                const st1vafe3bx_pin_conf_t *val);
+int32_t st1vafe3bx_pin_conf_get(const stmdev_ctx_t *ctx,
+                                st1vafe3bx_pin_conf_t *val);
 
 typedef enum
 {
-  LIS2DUXS12_ACTIVE_HIGH = 0x0,
-  LIS2DUXS12_ACTIVE_LOW  = 0x1,
-} lis2duxs12_int_pin_polarity_t;
-int32_t lis2duxs12_int_pin_polarity_set(const stmdev_ctx_t *ctx, lis2duxs12_int_pin_polarity_t val);
-int32_t lis2duxs12_int_pin_polarity_get(const stmdev_ctx_t *ctx,
-                                        lis2duxs12_int_pin_polarity_t *val);
+  ST1VAFE3BX_ACTIVE_HIGH = 0x0,
+  ST1VAFE3BX_ACTIVE_LOW  = 0x1,
+} st1vafe3bx_int_pin_polarity_t;
+int32_t st1vafe3bx_int_pin_polarity_set(const stmdev_ctx_t *ctx,
+                                        st1vafe3bx_int_pin_polarity_t val);
+int32_t st1vafe3bx_int_pin_polarity_get(const stmdev_ctx_t *ctx,
+                                        st1vafe3bx_int_pin_polarity_t *val);
 
 typedef enum
 {
-  LIS2DUXS12_SPI_4_WIRE  = 0x0, /* SPI 4 wires */
-  LIS2DUXS12_SPI_3_WIRE  = 0x1, /* SPI 3 wires */
-} lis2duxs12_spi_mode;
-int32_t lis2duxs12_spi_mode_set(const stmdev_ctx_t *ctx, lis2duxs12_spi_mode val);
-int32_t lis2duxs12_spi_mode_get(const stmdev_ctx_t *ctx, lis2duxs12_spi_mode *val);
+  ST1VAFE3BX_SPI_4_WIRE  = 0x0, /* SPI 4 wires */
+  ST1VAFE3BX_SPI_3_WIRE  = 0x1, /* SPI 3 wires */
+} st1vafe3bx_spi_mode;
+int32_t st1vafe3bx_spi_mode_set(const stmdev_ctx_t *ctx,
+                                st1vafe3bx_spi_mode val);
+int32_t st1vafe3bx_spi_mode_get(const stmdev_ctx_t *ctx,
+                                st1vafe3bx_spi_mode *val);
 
 typedef struct
 {
-  uint8_t int_on_res                   : 1; /* Interrupt on RES pin */
   uint8_t drdy                         : 1; /* Accelerometer data ready */
   uint8_t boot                         : 1; /* Restoring calibration parameters */
   uint8_t fifo_th                      : 1; /* FIFO threshold reached */
@@ -2334,15 +2263,11 @@ typedef struct
   uint8_t sleep_change                 : 1; /* Act/Inact (or Vice-versa) status changed */
   uint8_t emb_function                 : 1; /* Embedded Function */
   uint8_t timestamp                    : 1; /* Timestamp */
-} lis2duxs12_pin_int_route_t;
-int32_t lis2duxs12_pin_int1_route_set(const stmdev_ctx_t *ctx,
-                                      const lis2duxs12_pin_int_route_t *val);
-int32_t lis2duxs12_pin_int1_route_get(const stmdev_ctx_t *ctx,
-                                      lis2duxs12_pin_int_route_t *val);
-int32_t lis2duxs12_pin_int2_route_set(const stmdev_ctx_t *ctx,
-                                      const lis2duxs12_pin_int_route_t *val);
-int32_t lis2duxs12_pin_int2_route_get(const stmdev_ctx_t *ctx,
-                                      lis2duxs12_pin_int_route_t *val);
+} st1vafe3bx_pin_int_route_t;
+int32_t st1vafe3bx_pin_int_route_set(const stmdev_ctx_t *ctx,
+                                     const st1vafe3bx_pin_int_route_t *val);
+int32_t st1vafe3bx_pin_int_route_get(const stmdev_ctx_t *ctx,
+                                     st1vafe3bx_pin_int_route_t *val);
 
 typedef struct
 {
@@ -2350,116 +2275,112 @@ typedef struct
   uint8_t tilt                         : 1; /* route tilt event on INT pad */
   uint8_t sig_mot                      : 1; /* route significant motion event on INT pad */
   uint8_t fsm_lc                       : 1; /* route FSM long counter event on INT pad */
-} lis2duxs12_emb_pin_int_route_t;
-int32_t lis2duxs12_emb_pin_int1_route_set(const stmdev_ctx_t *ctx,
-                                          const lis2duxs12_emb_pin_int_route_t *val);
-int32_t lis2duxs12_emb_pin_int1_route_get(const stmdev_ctx_t *ctx,
-                                          lis2duxs12_emb_pin_int_route_t *val);
-int32_t lis2duxs12_emb_pin_int2_route_set(const stmdev_ctx_t *ctx,
-                                          const lis2duxs12_emb_pin_int_route_t *val);
-int32_t lis2duxs12_emb_pin_int2_route_get(const stmdev_ctx_t *ctx,
-                                          lis2duxs12_emb_pin_int_route_t *val);
+} st1vafe3bx_emb_pin_int_route_t;
+int32_t st1vafe3bx_emb_pin_int_route_set(const stmdev_ctx_t *ctx,
+                                         const st1vafe3bx_emb_pin_int_route_t *val);
+int32_t st1vafe3bx_emb_pin_int_route_get(const stmdev_ctx_t *ctx,
+                                         st1vafe3bx_emb_pin_int_route_t *val);
 
 typedef enum
 {
-  LIS2DUXS12_INT_DISABLED             = 0x0,
-  LIS2DUXS12_INT_LEVEL                = 0x1,
-  LIS2DUXS12_INT_LATCHED              = 0x2,
-} lis2duxs12_int_cfg_t;
+  ST1VAFE3BX_INT_DISABLED             = 0x0,
+  ST1VAFE3BX_INT_LEVEL                = 0x1,
+  ST1VAFE3BX_INT_LATCHED              = 0x2,
+} st1vafe3bx_int_cfg_t;
 
 typedef struct
 {
-  lis2duxs12_int_cfg_t int_cfg;
+  st1vafe3bx_int_cfg_t int_cfg;
   uint8_t sleep_status_on_int          : 1;  /* route sleep_status on interrupt */
   uint8_t dis_rst_lir_all_int          : 1;  /* disable LIR reset when reading ALL_INT_SRC */
-} lis2duxs12_int_config_t;
-int32_t lis2duxs12_int_config_set(const stmdev_ctx_t *ctx, const lis2duxs12_int_config_t *val);
-int32_t lis2duxs12_int_config_get(const stmdev_ctx_t *ctx, lis2duxs12_int_config_t *val);
+} st1vafe3bx_int_config_t;
+int32_t st1vafe3bx_int_config_set(const stmdev_ctx_t *ctx,
+                                  const st1vafe3bx_int_config_t *val);
+int32_t st1vafe3bx_int_config_get(const stmdev_ctx_t *ctx,
+                                  st1vafe3bx_int_config_t *val);
 
 typedef enum
 {
-  LIS2DUXS12_EMBEDDED_INT_LEVEL         = 0x0,
-  LIS2DUXS12_EMBEDDED_INT_LATCHED       = 0x1,
-} lis2duxs12_embedded_int_config_t;
-int32_t lis2duxs12_embedded_int_cfg_set(const stmdev_ctx_t *ctx,
-                                        lis2duxs12_embedded_int_config_t val);
-int32_t lis2duxs12_embedded_int_cfg_get(const stmdev_ctx_t *ctx,
-                                        lis2duxs12_embedded_int_config_t *val);
-
-typedef enum
-{
-  LIS2DUXS12_BYPASS_MODE              = 0x0,
-  LIS2DUXS12_FIFO_MODE                = 0x1,
-  LIS2DUXS12_STREAM_TO_FIFO_MODE      = 0x3,
-  LIS2DUXS12_BYPASS_TO_STREAM_MODE    = 0x4,
-  LIS2DUXS12_STREAM_MODE              = 0x6,
-  LIS2DUXS12_BYPASS_TO_FIFO_MODE      = 0x7,
-  LIS2DUXS12_FIFO_OFF                 = 0x8,
-} lis2duxs12_operation_t;
-
-typedef enum
-{
-  LIS2DUXS12_FIFO_1X                  = 0,
-  LIS2DUXS12_FIFO_2X                  = 1,
-} lis2duxs12_store_t;
-
-typedef enum
-{
-  LIS2DUXS12_DEC_TS_OFF             = 0x0,
-  LIS2DUXS12_DEC_TS_1               = 0x1,
-  LIS2DUXS12_DEC_TS_8               = 0x2,
-  LIS2DUXS12_DEC_TS_32              = 0x3,
-} lis2duxs12_dec_ts_t;
-
-typedef enum
-{
-  LIS2DUXS12_BDR_XL_ODR             = 0x0,
-  LIS2DUXS12_BDR_XL_ODR_DIV_2       = 0x1,
-  LIS2DUXS12_BDR_XL_ODR_DIV_4       = 0x2,
-  LIS2DUXS12_BDR_XL_ODR_DIV_8       = 0x3,
-  LIS2DUXS12_BDR_XL_ODR_DIV_16      = 0x4,
-  LIS2DUXS12_BDR_XL_ODR_DIV_32      = 0x5,
-  LIS2DUXS12_BDR_XL_ODR_DIV_64      = 0x6,
-  LIS2DUXS12_BDR_XL_ODR_OFF         = 0x7,
-} lis2duxs12_bdr_xl_t;
+  ST1VAFE3BX_EMBEDDED_INT_LEVEL     = 0x0,
+  ST1VAFE3BX_EMBEDDED_INT_LATCHED   = 0x1,
+} st1vafe3bx_embedded_int_config_t;
+int32_t st1vafe3bx_embedded_int_cfg_set(const stmdev_ctx_t *ctx,
+                                        st1vafe3bx_embedded_int_config_t val);
+int32_t st1vafe3bx_embedded_int_cfg_get(const stmdev_ctx_t *ctx,
+                                        st1vafe3bx_embedded_int_config_t *val);
 
 typedef struct
 {
-  lis2duxs12_operation_t operation;
-  lis2duxs12_store_t store;
+  enum st1vafe3bx_operation_t
+  {
+    ST1VAFE3BX_BYPASS_MODE            = 0x0,
+    ST1VAFE3BX_FIFO_MODE              = 0x1,
+    ST1VAFE3BX_STREAM_TO_FIFO_MODE    = 0x3,
+    ST1VAFE3BX_BYPASS_TO_STREAM_MODE  = 0x4,
+    ST1VAFE3BX_STREAM_MODE            = 0x6,
+    ST1VAFE3BX_BYPASS_TO_FIFO_MODE    = 0x7,
+    ST1VAFE3BX_FIFO_OFF               = 0x8,
+  } operation;
+
+  enum st1vafe3bx_store_t
+  {
+    ST1VAFE3BX_FIFO_1X                = 0,
+    ST1VAFE3BX_FIFO_2X                = 1,
+  } store;
+
   uint8_t xl_only                      : 1; /* only XL samples (16-bit) are stored in FIFO */
+
   uint8_t watermark                    : 7; /* (0 disable) max 127 @16bit, even and max 256 @8bit.*/
   uint8_t cfg_change_in_fifo           : 1;
   struct
   {
-    lis2duxs12_dec_ts_t dec_ts; /* decimation for timestamp batching*/
-    lis2duxs12_bdr_xl_t bdr_xl; /* accelerometer batch data rate*/
-  } batch;
-} lis2duxs12_fifo_mode_t;
-int32_t lis2duxs12_fifo_mode_set(const stmdev_ctx_t *ctx, lis2duxs12_fifo_mode_t val);
-int32_t lis2duxs12_fifo_mode_get(const stmdev_ctx_t *ctx, lis2duxs12_fifo_mode_t *val);
+    enum st1vafe3bx_dec_ts_t
+    {
+      ST1VAFE3BX_DEC_TS_OFF             = 0x0,
+      ST1VAFE3BX_DEC_TS_1               = 0x1,
+      ST1VAFE3BX_DEC_TS_8               = 0x2,
+      ST1VAFE3BX_DEC_TS_32              = 0x3,
+    } dec_ts; /* decimation for timestamp batching*/
 
-int32_t lis2duxs12_fifo_data_level_get(const stmdev_ctx_t *ctx, uint16_t *val);
-int32_t lis2duxs12_fifo_wtm_flag_get(const stmdev_ctx_t *ctx, uint8_t *val);
+    enum st1vafe3bx_bdr_xl_t
+    {
+      ST1VAFE3BX_BDR_ODR               = 0x0,
+      ST1VAFE3BX_BDR_ODR_DIV_2         = 0x1,
+      ST1VAFE3BX_BDR_ODR_DIV_4         = 0x2,
+      ST1VAFE3BX_BDR_ODR_DIV_8         = 0x3,
+      ST1VAFE3BX_BDR_ODR_DIV_16        = 0x4,
+      ST1VAFE3BX_BDR_ODR_DIV_32        = 0x5,
+      ST1VAFE3BX_BDR_ODR_DIV_64        = 0x6,
+      ST1VAFE3BX_BDR_ODR_OFF           = 0x7,
+    } bdr_xl; /* accelerometer batch data rate*/
+  } batch;
+} st1vafe3bx_fifo_mode_t;
+int32_t st1vafe3bx_fifo_mode_set(const stmdev_ctx_t *ctx,
+                                 st1vafe3bx_fifo_mode_t val);
+int32_t st1vafe3bx_fifo_mode_get(const stmdev_ctx_t *ctx,
+                                 st1vafe3bx_fifo_mode_t *val);
+
+int32_t st1vafe3bx_fifo_data_level_get(const stmdev_ctx_t *ctx, uint16_t *val);
+int32_t st1vafe3bx_fifo_wtm_flag_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum
 {
-  LIS2DUXS12_FIFO_EMPTY                 = 0x0,
-  LIS2DUXS12_XL_TEMP_TAG                = 0x2,
-  LIS2DUXS12_XL_ONLY_2X_TAG             = 0x3,
-  LIS2DUXS12_TIMESTAMP_TAG              = 0x4,
-  LIS2DUXS12_STEP_COUNTER_TAG           = 0x12,
-  LIS2DUXS12_MLC_RESULT_TAG             = 0x1A,
-  LIS2DUXS12_MLC_FILTER_TAG             = 0x1B,
-  LIS2DUXS12_MLC_FEATURE                = 0x1C,
-  LIS2DUXS12_FSM_RESULT_TAG             = 0x1D,
-  LIS2DUXS12_XL_ONLY_2X_TAG_2ND         = 0x1E,
-  LIS2DUXS12_XL_AND_QVAR                = 0x1F,
-} lis2duxs12_fifo_sensor_tag_t;
-int32_t lis2duxs12_fifo_sensor_tag_get(const stmdev_ctx_t *ctx,
-                                       lis2duxs12_fifo_sensor_tag_t *val);
+  ST1VAFE3BX_FIFO_EMPTY_TAG             = 0x0,
+  ST1VAFE3BX_XL_ONLY                    = 0x2,
+  ST1VAFE3BX_XL_ONLY_2X_TAG             = 0x3,
+  ST1VAFE3BX_TIMESTAMP_CFG_CHG_TAG      = 0x4,
+  ST1VAFE3BX_STEP_COUNTER_TAG           = 0x12,
+  ST1VAFE3BX_MLC_RESULT_TAG             = 0x1A,
+  ST1VAFE3BX_MLC_FILTER_TAG             = 0x1B,
+  ST1VAFE3BX_MLC_FEATURE_TAG            = 0x1C,
+  ST1VAFE3BX_FSM_RESULT_TAG             = 0x1D,
+  ST1VAFE3BX_AH_VAFE_ONLY_TAG           = 0x1E,
+  ST1VAFE3BX_XL_AND_AH_VAFE1_TAG        = 0x1F,
+} st1vafe3bx_fifo_sensor_tag_t;
+int32_t st1vafe3bx_fifo_sensor_tag_get(const stmdev_ctx_t *ctx,
+                                       st1vafe3bx_fifo_sensor_tag_t *val);
 
-int32_t lis2duxs12_fifo_out_raw_get(const stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t st1vafe3bx_fifo_out_raw_get(const stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef struct
 {
@@ -2473,12 +2394,8 @@ typedef struct
   {
     float_t mv;
     int16_t raw;
-  } ah_qvar;
-  struct
-  {
-    float_t deg_c;
-    int16_t raw;
-  } heat;
+  } ah_bio;
+
   struct
   {
     uint32_t steps;
@@ -2490,175 +2407,179 @@ typedef struct
     uint8_t odr                        : 4; /* ODR */
     uint8_t bw                         : 2; /* BW */
     uint8_t lp_hp                      : 1; /* Power: 0 for LP, 1 for HP */
-    uint8_t qvar_en                    : 1; /* QVAR is enabled */
+    uint8_t ah_en                      : 1; /* AH is enabled */
     uint8_t fs                         : 2; /* FS */
     uint8_t dec_ts                     : 2; /* Timestamp decimator value */
     uint8_t odr_xl_batch               : 1; /* Accelerometer ODR is batched */
     uint32_t timestamp;
   } cfg_chg;
-} lis2duxs12_fifo_data_t;
-int32_t lis2duxs12_fifo_data_get(const stmdev_ctx_t *ctx, const lis2duxs12_md_t *md,
-                                 const lis2duxs12_fifo_mode_t *fmd,
-                                 lis2duxs12_fifo_data_t *data);
+} st1vafe3bx_fifo_data_t;
+int32_t st1vafe3bx_fifo_data_get(const stmdev_ctx_t *ctx,
+                                 const st1vafe3bx_md_t *md,
+                                 const st1vafe3bx_fifo_mode_t *fmd,
+                                 st1vafe3bx_fifo_data_t *data);
 
-typedef enum
-{
-  LIS2DUXS12_NOTCH_50HZ       = 0x0,
-  LIS2DUXS12_NOTCH_60HZ       = 0x1,
-} lis2duxs12_ah_qvar_notch_t;
-
-typedef enum
-{
-  LIS2DUXS12_520MOhm          = 0x0,
-  LIS2DUXS12_175MOhm          = 0x1,
-  LIS2DUXS12_310MOhm          = 0x2,
-  LIS2DUXS12_75MOhm           = 0x3,
-} lis2duxs12_ah_qvar_zin_t;
-
-typedef enum
-{
-  LIS2DUXS12_GAIN_0_5         = 0x0,
-  LIS2DUXS12_GAIN_1           = 0x1,
-  LIS2DUXS12_GAIN_2           = 0x2,
-  LIS2DUXS12_GAIN_4           = 0x3,
-} lis2duxs12_ah_qvar_gain_t;
 
 typedef struct
 {
-  uint8_t ah_qvar_en                   : 1;
-  uint8_t ah_qvar_notch_en             : 1;
-  lis2duxs12_ah_qvar_notch_t ah_qvar_notch;
-  lis2duxs12_ah_qvar_zin_t ah_qvar_zin;
-  lis2duxs12_ah_qvar_gain_t ah_qvar_gain;
-} lis2duxs12_ah_qvar_mode_t;
-int32_t lis2duxs12_ah_qvar_mode_set(const stmdev_ctx_t *ctx,
-                                    lis2duxs12_ah_qvar_mode_t val);
-int32_t lis2duxs12_ah_qvar_mode_get(const stmdev_ctx_t *ctx,
-                                    lis2duxs12_ah_qvar_mode_t *val);
+  uint8_t ah_bio_zin_dis_1                    : 1;
+  uint8_t ah_bio_zin_dis_2                    : 1;
+
+  enum
+  {
+    ST1VAFE3BX_DIFFERENTIAL_MODE            = 0x0,
+    ST1VAFE3BX_SINGLE_MODE_01               = 0x1,
+    ST1VAFE3BX_SINGLE_MODE_10               = 0x2,
+    ST1VAFE3BX_FORCED_RESET                 = 0x3,
+  } mode;
+
+  enum
+  {
+    ST1VAFE3BX_100MOhm                      = 0x0,
+    ST1VAFE3BX_200MOhm                      = 0x1,
+    ST1VAFE3BX_500MOhm                      = 0x2,
+    ST1VAFE3BX_1GOhm                        = 0x3,
+  } zin;
+
+  enum
+  {
+    ST1VAFE3BX_GAIN_2                       = 0x0,
+    ST1VAFE3BX_GAIN_4                       = 0x1,
+    ST1VAFE3BX_GAIN_8                       = 0x2,
+    ST1VAFE3BX_GAIN_16                      = 0x3,
+  } gain;
+} st1vafe3bx_ah_bio_config_t;
+int32_t st1vafe3bx_ah_bio_config_set(const stmdev_ctx_t *ctx,
+                                     st1vafe3bx_ah_bio_config_t val);
+int32_t st1vafe3bx_ah_bio_config_get(const stmdev_ctx_t *ctx,
+                                     st1vafe3bx_ah_bio_config_t *val);
+
+int32_t st1vafe3bx_enter_vafe_only(const stmdev_ctx_t *ctx);
+int32_t st1vafe3bx_exit_vafe_only(const stmdev_ctx_t *ctx);
+int32_t st1vafe3bx_ah_bio_active(const stmdev_ctx_t *ctx, uint8_t filter_on);
 
 typedef struct
 {
   uint8_t false_step_rej               : 1;
   uint8_t step_counter_enable          : 1;
   uint8_t step_counter_in_fifo         : 1;
-} lis2duxs12_stpcnt_mode_t;
-int32_t lis2duxs12_stpcnt_mode_set(const stmdev_ctx_t *ctx, lis2duxs12_stpcnt_mode_t val);
-int32_t lis2duxs12_stpcnt_mode_get(const stmdev_ctx_t *ctx, lis2duxs12_stpcnt_mode_t *val);
+} st1vafe3bx_stpcnt_mode_t;
+int32_t st1vafe3bx_stpcnt_mode_set(const stmdev_ctx_t *ctx,
+                                   st1vafe3bx_stpcnt_mode_t val);
+int32_t st1vafe3bx_stpcnt_mode_get(const stmdev_ctx_t *ctx,
+                                   st1vafe3bx_stpcnt_mode_t *val);
 
-int32_t lis2duxs12_stpcnt_steps_get(const stmdev_ctx_t *ctx, uint16_t *val);
+int32_t st1vafe3bx_stpcnt_steps_get(const stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t lis2duxs12_stpcnt_rst_step_set(const stmdev_ctx_t *ctx);
+int32_t st1vafe3bx_stpcnt_rst_step_set(const stmdev_ctx_t *ctx);
 
-int32_t lis2duxs12_stpcnt_debounce_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lis2duxs12_stpcnt_debounce_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t st1vafe3bx_stpcnt_debounce_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t st1vafe3bx_stpcnt_debounce_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2duxs12_stpcnt_period_set(const stmdev_ctx_t *ctx, uint16_t val);
-int32_t lis2duxs12_stpcnt_period_get(const stmdev_ctx_t *ctx, uint16_t *val);
+int32_t st1vafe3bx_stpcnt_period_set(const stmdev_ctx_t *ctx, uint16_t val);
+int32_t st1vafe3bx_stpcnt_period_get(const stmdev_ctx_t *ctx, uint16_t *val);
+
+int32_t st1vafe3bx_tilt_mode_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t st1vafe3bx_tilt_mode_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t st1vafe3bx_sigmot_mode_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t st1vafe3bx_sigmot_mode_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+
+int32_t st1vafe3bx_ff_duration_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t st1vafe3bx_ff_duration_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  ST1VAFE3BX_156_mg = 0x0,
+  ST1VAFE3BX_219_mg = 0x1,
+  ST1VAFE3BX_250_mg = 0x2,
+  ST1VAFE3BX_312_mg = 0x3,
+  ST1VAFE3BX_344_mg = 0x4,
+  ST1VAFE3BX_406_mg = 0x5,
+  ST1VAFE3BX_469_mg = 0x6,
+  ST1VAFE3BX_500_mg = 0x7,
+} st1vafe3bx_ff_thresholds_t;
+int32_t st1vafe3bx_ff_thresholds_set(const stmdev_ctx_t *ctx,
+                                     st1vafe3bx_ff_thresholds_t val);
+int32_t st1vafe3bx_ff_thresholds_get(const stmdev_ctx_t *ctx,
+                                     st1vafe3bx_ff_thresholds_t *val);
+
+typedef enum
+{
+  ST1VAFE3BX_DEG_80 = 0x0,
+  ST1VAFE3BX_DEG_70 = 0x1,
+  ST1VAFE3BX_DEG_60 = 0x2,
+  ST1VAFE3BX_DEG_50 = 0x3,
+} st1vafe3bx_threshold_t;
+
+typedef enum
+{
+  ST1VAFE3BX_6D = 0x0,
+  ST1VAFE3BX_4D = 0x1,
+} st1vafe3bx_mode_t;
 
 typedef struct
 {
-  uint8_t enable                       : 1;
-  uint8_t window                       : 1;
-  uint8_t duration                     : 1;
-} lis2duxs12_smart_power_cfg_t;
-int32_t lis2duxs12_smart_power_set(const stmdev_ctx_t *ctx, lis2duxs12_smart_power_cfg_t val);
-int32_t lis2duxs12_smart_power_get(const stmdev_ctx_t *ctx, lis2duxs12_smart_power_cfg_t *val);
+  st1vafe3bx_threshold_t threshold;
+  st1vafe3bx_mode_t mode;
+} st1vafe3bx_sixd_config_t;
 
-int32_t lis2duxs12_tilt_mode_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lis2duxs12_tilt_mode_get(const stmdev_ctx_t *ctx, uint8_t *val);
-int32_t lis2duxs12_sigmot_mode_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lis2duxs12_sigmot_mode_get(const stmdev_ctx_t *ctx, uint8_t *val);
-
-
-int32_t lis2duxs12_ff_duration_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lis2duxs12_ff_duration_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t st1vafe3bx_sixd_config_set(const stmdev_ctx_t *ctx,
+                                   st1vafe3bx_sixd_config_t val);
+int32_t st1vafe3bx_sixd_config_get(const stmdev_ctx_t *ctx,
+                                   st1vafe3bx_sixd_config_t *val);
 
 typedef enum
 {
-  LIS2DUXS12_156_mg = 0x0,
-  LIS2DUXS12_219_mg = 0x1,
-  LIS2DUXS12_250_mg = 0x2,
-  LIS2DUXS12_312_mg = 0x3,
-  LIS2DUXS12_344_mg = 0x4,
-  LIS2DUXS12_406_mg = 0x5,
-  LIS2DUXS12_469_mg = 0x6,
-  LIS2DUXS12_500_mg = 0x7,
-} lis2duxs12_ff_thresholds_t;
-int32_t lis2duxs12_ff_thresholds_set(const stmdev_ctx_t *ctx, lis2duxs12_ff_thresholds_t val);
-int32_t lis2duxs12_ff_thresholds_get(const stmdev_ctx_t *ctx, lis2duxs12_ff_thresholds_t *val);
+  ST1VAFE3BX_0_ODR  = 0x000, /* 0 ODR time */
+  ST1VAFE3BX_1_ODR  = 0x001, /* 1 ODR time */
+  ST1VAFE3BX_2_ODR  = 0x002, /* 2 ODR time */
+  ST1VAFE3BX_3_ODR  = 0x100, /* 3 ODR time */
+  ST1VAFE3BX_7_ODR  = 0x101, /* 7 ODR time */
+  ST1VAFE3BX_11_ODR = 0x102, /* 11 ODR time */
+  ST1VAFE3BX_15_ODR = 0x103, /* 15 ODR time */
+} st1vafe3bx_wake_dur_t;
 
 typedef enum
 {
-  LIS2DUXS12_DEG_80 = 0x0,
-  LIS2DUXS12_DEG_70 = 0x1,
-  LIS2DUXS12_DEG_60 = 0x2,
-  LIS2DUXS12_DEG_50 = 0x3,
-} lis2duxs12_threshold_t;
+  ST1VAFE3BX_SLEEP_OFF = 0,
+  ST1VAFE3BX_SLEEP_ON  = 1,
+} st1vafe3bx_wake_enable_t;
 
 typedef enum
 {
-  LIS2DUXS12_6D = 0x0,
-  LIS2DUXS12_4D = 0x1,
-} lis2duxs12_mode_t;
+  ST1VAFE3BX_ODR_NO_CHANGE       = 0,  /* no odr change during inactivity state */
+  ST1VAFE3BX_ODR_1_6_HZ          = 1,  /* set odr to 1.6Hz during inactivity state */
+  ST1VAFE3BX_ODR_3_HZ            = 1,  /* set odr to 3Hz during inactivity state */
+  ST1VAFE3BX_ODR_25_HZ           = 1,  /* set odr to 25Hz during inactivity state */
+} st1vafe3bx_inact_odr_t;
 
 typedef struct
 {
-  lis2duxs12_threshold_t threshold;
-  lis2duxs12_mode_t mode;
-} lis2duxs12_sixd_config_t;
-
-int32_t lis2duxs12_sixd_config_set(const stmdev_ctx_t *ctx, lis2duxs12_sixd_config_t val);
-int32_t lis2duxs12_sixd_config_get(const stmdev_ctx_t *ctx, lis2duxs12_sixd_config_t *val);
-
-typedef enum
-{
-  LIS2DUXS12_0_ODR  = 0x000, /* 0 ODR time */
-  LIS2DUXS12_1_ODR  = 0x001, /* 1 ODR time */
-  LIS2DUXS12_2_ODR  = 0x002, /* 2 ODR time */
-  LIS2DUXS12_3_ODR  = 0x100, /* 3 ODR time */
-  LIS2DUXS12_7_ODR  = 0x101, /* 7 ODR time */
-  LIS2DUXS12_11_ODR = 0x102, /* 11 ODR time */
-  LIS2DUXS12_15_ODR = 0x103, /* 15 ODR time */
-} lis2duxs12_wake_dur_t;
-
-typedef enum
-{
-  LIS2DUXS12_SLEEP_OFF = 0,
-  LIS2DUXS12_SLEEP_ON  = 1,
-} lis2duxs12_wake_enable_t;
-
-typedef enum
-{
-  LIS2DUXS12_ODR_NO_CHANGE       = 0,  /* no odr change during inactivity state */
-  LIS2DUXS12_ODR_1_6_HZ          = 1,  /* set odr to 1.6Hz during inactivity state */
-  LIS2DUXS12_ODR_3_HZ            = 1,  /* set odr to 3Hz during inactivity state */
-  LIS2DUXS12_ODR_25_HZ           = 1,  /* set odr to 25Hz during inactivity state */
-} lis2duxs12_inact_odr_t;
-
-typedef struct
-{
-  lis2duxs12_wake_dur_t wake_dur;
+  st1vafe3bx_wake_dur_t wake_dur;
   uint8_t sleep_dur                    : 4;       /* 1 LSB == 512 ODR time */
   uint8_t wake_ths                     : 7;       /* wakeup threshold */
   uint8_t wake_ths_weight              : 1;       /* 0: 1LSB = FS_XL/2^6, 1: 1LSB = FS_XL/2^8 */
-  lis2duxs12_wake_enable_t wake_enable;
-  lis2duxs12_inact_odr_t inact_odr;
-} lis2duxs12_wakeup_config_t;
+  st1vafe3bx_wake_enable_t wake_enable;
+  st1vafe3bx_inact_odr_t inact_odr;
+} st1vafe3bx_wakeup_config_t;
 
-int32_t lis2duxs12_wakeup_config_set(const stmdev_ctx_t *ctx, lis2duxs12_wakeup_config_t val);
-int32_t lis2duxs12_wakeup_config_get(const stmdev_ctx_t *ctx, lis2duxs12_wakeup_config_t *val);
+int32_t st1vafe3bx_wakeup_config_set(const stmdev_ctx_t *ctx,
+                                     st1vafe3bx_wakeup_config_t val);
+int32_t st1vafe3bx_wakeup_config_get(const stmdev_ctx_t *ctx,
+                                     st1vafe3bx_wakeup_config_t *val);
 
 typedef enum
 {
-  LIS2DUXS12_TAP_NONE  = 0x0, /* No axis */
-  LIS2DUXS12_TAP_ON_X  = 0x1, /* Detect tap on X axis */
-  LIS2DUXS12_TAP_ON_Y  = 0x2, /* Detect tap on Y axis */
-  LIS2DUXS12_TAP_ON_Z  = 0x3, /* Detect tap on Z axis */
-} lis2duxs12_axis_t;
+  ST1VAFE3BX_TAP_NONE  = 0x0, /* No axis */
+  ST1VAFE3BX_TAP_ON_X  = 0x1, /* Detect tap on X axis */
+  ST1VAFE3BX_TAP_ON_Y  = 0x2, /* Detect tap on Y axis */
+  ST1VAFE3BX_TAP_ON_Z  = 0x3, /* Detect tap on Z axis */
+} st1vafe3bx_axis_t;
 
 typedef struct
 {
-  lis2duxs12_axis_t axis;
+  st1vafe3bx_axis_t axis;
   uint8_t inverted_peak_time           : 5; /* 1 LSB == 1 sample */
   uint8_t pre_still_ths                : 4; /* 1 LSB == 62.5 mg */
   uint8_t post_still_ths               : 4; /* 1 LSB == 62.5 mg */
@@ -2673,106 +2594,120 @@ typedef struct
   uint8_t single_tap_on                : 1; /* enable single tap */
   uint8_t double_tap_on                : 1; /* enable double tap */
   uint8_t triple_tap_on                : 1; /* enable triple tap */
-} lis2duxs12_tap_config_t;
+} st1vafe3bx_tap_config_t;
 
-int32_t lis2duxs12_tap_config_set(const stmdev_ctx_t *ctx, lis2duxs12_tap_config_t val);
-int32_t lis2duxs12_tap_config_get(const stmdev_ctx_t *ctx, lis2duxs12_tap_config_t *val);
+int32_t st1vafe3bx_tap_config_set(const stmdev_ctx_t *ctx,
+                                  st1vafe3bx_tap_config_t val);
+int32_t st1vafe3bx_tap_config_get(const stmdev_ctx_t *ctx,
+                                  st1vafe3bx_tap_config_t *val);
 
-int32_t lis2duxs12_timestamp_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lis2duxs12_timestamp_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t st1vafe3bx_timestamp_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t st1vafe3bx_timestamp_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2duxs12_timestamp_raw_get(const stmdev_ctx_t *ctx, uint32_t *val);
+int32_t st1vafe3bx_timestamp_raw_get(const stmdev_ctx_t *ctx, uint32_t *val);
 
-int32_t lis2duxs12_long_cnt_flag_data_ready_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_long_cnt_flag_data_ready_get(const stmdev_ctx_t *ctx,
                                                 uint8_t *val);
 
-int32_t lis2duxs12_emb_fsm_en_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lis2duxs12_emb_fsm_en_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t st1vafe3bx_emb_fsm_en_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t st1vafe3bx_emb_fsm_en_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef struct
 {
-  lis2duxs12_fsm_enable_t          fsm_enable;
-} lis2duxs12_emb_fsm_enable_t;
-int32_t lis2duxs12_fsm_enable_set(const stmdev_ctx_t *ctx,
-                                  lis2duxs12_emb_fsm_enable_t *val);
-int32_t lis2duxs12_fsm_enable_get(const stmdev_ctx_t *ctx,
-                                  lis2duxs12_emb_fsm_enable_t *val);
+  st1vafe3bx_fsm_enable_t fsm_enable;
+} st1vafe3bx_emb_fsm_enable_t;
+int32_t st1vafe3bx_fsm_enable_set(const stmdev_ctx_t *ctx,
+                                  st1vafe3bx_emb_fsm_enable_t *val);
+int32_t st1vafe3bx_fsm_enable_get(const stmdev_ctx_t *ctx,
+                                  st1vafe3bx_emb_fsm_enable_t *val);
 
-int32_t lis2duxs12_long_cnt_set(const stmdev_ctx_t *ctx, uint16_t val);
-int32_t lis2duxs12_long_cnt_get(const stmdev_ctx_t *ctx, uint16_t *val);
+int32_t st1vafe3bx_long_cnt_set(const stmdev_ctx_t *ctx, uint16_t val);
+int32_t st1vafe3bx_long_cnt_get(const stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t lis2duxs12_fsm_status_get(const stmdev_ctx_t *ctx,
-                                  lis2duxs12_fsm_status_mainpage_t *val);
-int32_t lis2duxs12_fsm_out_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t st1vafe3bx_fsm_status_get(const stmdev_ctx_t *ctx,
+                                  st1vafe3bx_fsm_status_mainpage_t *val);
+int32_t st1vafe3bx_fsm_out_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum
 {
-  LIS2DUXS12_ODR_FSM_12Hz5 = 0,
-  LIS2DUXS12_ODR_FSM_25Hz  = 1,
-  LIS2DUXS12_ODR_FSM_50Hz  = 2,
-  LIS2DUXS12_ODR_FSM_100Hz = 3,
-  LIS2DUXS12_ODR_FSM_200Hz = 4,
-  LIS2DUXS12_ODR_FSM_400Hz = 5,
-  LIS2DUXS12_ODR_FSM_800Hz = 6,
-} lis2duxs12_fsm_val_odr_t;
-int32_t lis2duxs12_fsm_data_rate_set(const stmdev_ctx_t *ctx,
-                                     lis2duxs12_fsm_val_odr_t val);
-int32_t lis2duxs12_fsm_data_rate_get(const stmdev_ctx_t *ctx,
-                                     lis2duxs12_fsm_val_odr_t *val);
+  ST1VAFE3BX_ODR_FSM_12Hz5       = 0x00,
+  ST1VAFE3BX_ODR_FSM_25Hz        = 0x01,
+  ST1VAFE3BX_ODR_FSM_50Hz        = 0x02,
+  ST1VAFE3BX_ODR_FSM_100Hz       = 0x03,
+  ST1VAFE3BX_ODR_FSM_200Hz       = 0x04,
+  ST1VAFE3BX_ODR_FSM_400Hz       = 0x05,
+  ST1VAFE3BX_ODR_FSM_800Hz       = 0x06,
+  ST1VAFE3BX_ODR_FSM_VAFE_50Hz   = 0x10,
+  ST1VAFE3BX_ODR_FSM_VAFE_100Hz  = 0x11,
+  ST1VAFE3BX_ODR_FSM_VAFE_200Hz  = 0x12,
+  ST1VAFE3BX_ODR_FSM_VAFE_400Hz  = 0x13,
+  ST1VAFE3BX_ODR_FSM_VAFE_800Hz  = 0x14,
+  ST1VAFE3BX_ODR_FSM_VAFE_1600Hz = 0x15,
+} st1vafe3bx_fsm_val_odr_t;
+int32_t st1vafe3bx_fsm_data_rate_set(const stmdev_ctx_t *ctx,
+                                     st1vafe3bx_fsm_val_odr_t val);
+int32_t st1vafe3bx_fsm_data_rate_get(const stmdev_ctx_t *ctx,
+                                     st1vafe3bx_fsm_val_odr_t *val);
 
-int32_t lis2duxs12_fsm_init_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lis2duxs12_fsm_init_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t st1vafe3bx_fsm_init_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t st1vafe3bx_fsm_init_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2duxs12_fsm_fifo_en_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lis2duxs12_fsm_fifo_en_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t st1vafe3bx_fsm_fifo_en_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t st1vafe3bx_fsm_fifo_en_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2duxs12_long_cnt_int_value_set(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_long_cnt_int_value_set(const stmdev_ctx_t *ctx,
                                           uint16_t val);
-int32_t lis2duxs12_long_cnt_int_value_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_long_cnt_int_value_get(const stmdev_ctx_t *ctx,
                                           uint16_t *val);
 
-int32_t lis2duxs12_fsm_programs_num_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lis2duxs12_fsm_programs_num_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t st1vafe3bx_fsm_programs_num_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t st1vafe3bx_fsm_programs_num_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2duxs12_fsm_start_address_set(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_fsm_start_address_set(const stmdev_ctx_t *ctx,
                                          uint16_t val);
-int32_t lis2duxs12_fsm_start_address_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_fsm_start_address_get(const stmdev_ctx_t *ctx,
                                          uint16_t *val);
 
 typedef enum
 {
-  LIS2DUXS12_MLC_OFF                    = 0,
-  LIS2DUXS12_MLC_ON                     = 1,
-  LIS2DUXS12_MLC_ON_BEFORE_FSM          = 2,
-} lis2duxs12_mlc_mode_t;
-int32_t lis2duxs12_mlc_set(const stmdev_ctx_t *ctx, lis2duxs12_mlc_mode_t val);
-int32_t lis2duxs12_mlc_get(const stmdev_ctx_t *ctx, lis2duxs12_mlc_mode_t *val);
+  ST1VAFE3BX_MLC_OFF              = 0,
+  ST1VAFE3BX_MLC_ON               = 1,
+  ST1VAFE3BX_MLC_ON_BEFORE_FSM    = 2,
+} st1vafe3bx_mlc_mode_t;
+int32_t st1vafe3bx_mlc_set(const stmdev_ctx_t *ctx, st1vafe3bx_mlc_mode_t val);
+int32_t st1vafe3bx_mlc_get(const stmdev_ctx_t *ctx, st1vafe3bx_mlc_mode_t *val);
 
-int32_t lis2duxs12_mlc_status_get(const stmdev_ctx_t *ctx,
-                                  lis2duxs12_mlc_status_mainpage_t *val);
+int32_t st1vafe3bx_mlc_status_get(const stmdev_ctx_t *ctx,
+                                  st1vafe3bx_mlc_status_mainpage_t *val);
 
-int32_t lis2duxs12_mlc_out_get(const stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t st1vafe3bx_mlc_out_get(const stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum
 {
-  LIS2DUXS12_ODR_PRGS_12Hz5 = 0,
-  LIS2DUXS12_ODR_PRGS_25Hz  = 1,
-  LIS2DUXS12_ODR_PRGS_50Hz  = 2,
-  LIS2DUXS12_ODR_PRGS_100Hz = 3,
-  LIS2DUXS12_ODR_PRGS_200Hz = 4,
-} lis2duxs12_mlc_odr_val_t;
-int32_t lis2duxs12_mlc_data_rate_set(const stmdev_ctx_t *ctx,
-                                     lis2duxs12_mlc_odr_val_t val);
-int32_t lis2duxs12_mlc_data_rate_get(const stmdev_ctx_t *ctx,
-                                     lis2duxs12_mlc_odr_val_t *val);
+  ST1VAFE3BX_ODR_PRGS_12Hz5       = 0x00,
+  ST1VAFE3BX_ODR_PRGS_25Hz        = 0x01,
+  ST1VAFE3BX_ODR_PRGS_50Hz        = 0x02,
+  ST1VAFE3BX_ODR_PRGS_100Hz       = 0x03,
+  ST1VAFE3BX_ODR_PRGS_200Hz       = 0x04,
+  ST1VAFE3BX_ODR_PRGS_VAFE_50Hz   = 0x10,
+  ST1VAFE3BX_ODR_PRGS_VAFE_100Hz  = 0x11,
+  ST1VAFE3BX_ODR_PRGS_VAFE_200Hz  = 0x12,
+  ST1VAFE3BX_ODR_PRGS_VAFE_400Hz  = 0x13,
+  ST1VAFE3BX_ODR_PRGS_VAFE_800Hz  = 0x14,
+  ST1VAFE3BX_ODR_PRGS_VAFE_1600Hz = 0x15,
+} st1vafe3bx_mlc_odr_val_t;
+int32_t st1vafe3bx_mlc_data_rate_set(const stmdev_ctx_t *ctx,
+                                     st1vafe3bx_mlc_odr_val_t val);
+int32_t st1vafe3bx_mlc_data_rate_get(const stmdev_ctx_t *ctx,
+                                     st1vafe3bx_mlc_odr_val_t *val);
 
-int32_t lis2duxs12_mlc_fifo_en_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t lis2duxs12_mlc_fifo_en_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t st1vafe3bx_mlc_fifo_en_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t st1vafe3bx_mlc_fifo_en_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* LIS2DUXS12_REGS_H */
+#endif /* ST1VAFE3BX_REGS_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/st1vafe6ax_STdC/driver/st1vafe6ax_reg.c
+++ b/sensor/stmemsc/st1vafe6ax_STdC/driver/st1vafe6ax_reg.c
@@ -7423,7 +7423,7 @@ int32_t st1vafe6ax_mlc_out_get(const stmdev_ctx_t *ctx, st1vafe6ax_mlc_out_t *va
   ret = st1vafe6ax_mem_bank_set(ctx, ST1VAFE6AX_EMBED_FUNC_MEM_BANK);
   if (ret == 0)
   {
-    ret = st1vafe6ax_read_reg(ctx, ST1VAFE6AX_MLC1_SRC, (uint8_t *)&val, 4);
+    ret = st1vafe6ax_read_reg(ctx, ST1VAFE6AX_MLC1_SRC, (uint8_t *)val, 4);
   }
 
   ret += st1vafe6ax_mem_bank_set(ctx, ST1VAFE6AX_MAIN_MEM_BANK);


### PR DESCRIPTION
Align stmemsc HAL i/f to v2.8

(Required by https://github.com/zephyrproject-rtos/zephyr/pull/83094)
