### PR TITLE
sensor/stmemsc: Align stmemsc i/f to v2.9.1

### DIFF
--- a/sensor/stmemsc/CMakeLists.txt
+++ b/sensor/stmemsc/CMakeLists.txt
@@ -22,6 +22,7 @@ set(stmems_pids
   i3g4250d
   iis2dh
   iis2dlpc
+  iis2dulpx
   iis2iclx
   iis2mdc
   iis328dq
@@ -75,7 +76,9 @@ set(stmems_pids
   lsm6dsv16b
   lsm6dsv16bx
   lsm6dsv16x
+  lsm6dsv320x
   lsm6dsv32x
+  lsm6dsv80x
   lsm6dsv
   lsm9ds1
   st1vafe3bx

--- a/sensor/stmemsc/README
+++ b/sensor/stmemsc/README
@@ -6,7 +6,7 @@ Origin:
    https://www.st.com/en/embedded-software/c-driver-mems.html
 
 Status:
-   version v2.8
+   version v2.9.1
 
 Purpose:
    ST Microelectronics standard C platform-independent drivers for MEMS
@@ -62,21 +62,22 @@ Description:
      - asm330lhhxg1_STdC    v2.0.1
      - h3lis100dl_STdC      v2.0.1
      - h3lis331dl_STdC      v2.0.1
-     - hts221_STdC          v2.0.1
+     - hts221_STdC          v2.1.0
      - i3g4250d_STdC        v2.0.1
      - iis2dh_STdC          v2.0.1
      - iis2dlpc_STdC        v2.0.1
+     - iis2dulpx_STdC       v1.0.2
      - iis2iclx_STdC        v2.0.1
-     - iis2mdc_STdC         v2.0.2
+     - iis2mdc_STdC         v2.0.3
      - iis328dq_STdC        v2.0.1
      - iis3dhhc_STdC        v2.0.1
      - iis3dwb_STdC         v2.0.1
      - ilps22qs_STdC        v3.1.1
      - ilps28qsw_STdC       v2.2.0
      - ism303dac_STdC       v2.0.1
-     - ism330bx_STdC        v3.0.1
-     - ism330dhcx_STdC      v2.1.0
-     - ism330dlc_STdC       v2.0.1
+     - ism330bx_STdC        v3.0.2
+     - ism330dhcx_STdC      v2.1.1
+     - ism330dlc_STdC       v2.0.2
      - ism330is_STdC        v3.0.1
      - l3gd20h_STdC         v2.0.1
      - lis25ba_STdC         v2.0.1
@@ -85,20 +86,20 @@ Description:
      - lis2ds12_STdC        v2.0.1
      - lis2dtw12_STdC       v2.0.1
      - lis2du12_STdC        v2.0.1
-     - lis2dux12_STdC       v2.3.0
-     - lis2duxs12_STdC      v2.3.0
+     - lis2dux12_STdC       v2.4.1
+     - lis2duxs12_STdC      v2.4.1
      - lis2dw12_STdC        v2.0.1
      - lis2hh12_STdC        v2.0.1
      - lis2mdl_STdC         v2.0.1
      - lis331dlh_STdC       v2.0.1
      - lis3de_STdC          v2.0.1
      - lis3dh_STdC          v2.0.1
-     - lis3dhh_STdC         v2.0.1
+     - lis3dhh_STdC         v2.0.2
      - lis3mdl_STdC         v2.0.1
      - lps22ch_STdC         v2.0.1
      - lps22df_STdC         v2.2.0
-     - lps22hb_STdC         v2.0.1
-     - lps22hh_STdC         v3.0.1
+     - lps22hb_STdC         v2.0.2
+     - lps22hh_STdC         v3.0.2
      - lps25hb_STdC         v2.0.1
      - lps27hhtw_STdC       v2.0.1
      - lps27hhw_STdC        v2.0.1
@@ -112,20 +113,22 @@ Description:
      - lsm6dso16is_STdC     v3.0.1
      - lsm6dso32_STdC       v2.1.0
      - lsm6dso32x_STdC      v2.1.0
-     - lsm6dso_STdC         v3.1.0
+     - lsm6dso_STdC         v3.1.1
      - lsm6dsox_STdC        v3.1.0
      - lsm6dsr_STdC         v2.1.0
      - lsm6dsrx_STdC        v2.1.0
-     - lsm6dsv16b_STdC      v3.0.0
-     - lsm6dsv16bx_STdC     v5.0.1
+     - lsm6dsv16b_STdC      v3.0.1
+     - lsm6dsv16bx_STdC     v5.0.2
      - lsm6dsv16x_STdC      v4.3.0
+     - lsm6dsv320x_STdC     v1.1.0
      - lsm6dsv32x_STdC      v2.3.0
+     - lsm6dsv80x_STdC      v1.1.0
      - lsm6dsv_STdC         v3.3.0
      - lsm9ds1_STdC         v2.0.1
-     - st1vafe3bx_STdC      v2.0.0
-     - st1vafe6ax_STdC      v2.0.1
+     - st1vafe3bx_STdC      v2.1.1
+     - st1vafe6ax_STdC      v2.0.2
      - sths34pf80_STdC      v3.0.1
-     - stts22h_STdC         v2.1.0
+     - stts22h_STdC         v2.1.1
      - stts751_STdC         v2.0.1
 
 Dependencies:
@@ -133,10 +136,10 @@ Dependencies:
 
 URL:
    https://www.st.com/en/embedded-software/c-driver-mems.html
-   https://github.com/STMicroelectronics/STMems_Standard_C_drivers/tree/v2.8
+   https://github.com/STMicroelectronics/STMems_Standard_C_drivers/tree/v2.9.1
 
 commit:
-   1609395 (tag v2.8)
+   0c1759e4 (tag v2.9.1)
 
 Maintained-by:
    ST Microelectronics

--- a/sensor/stmemsc/hts221_STdC/driver/hts221_reg.c
+++ b/sensor/stmemsc/hts221_STdC/driver/hts221_reg.c
@@ -50,7 +50,10 @@ int32_t __weak hts221_read_reg(const stmdev_ctx_t *ctx, uint8_t reg, uint8_t *da
 {
   int32_t ret;
 
-  if (ctx == NULL) return -1;
+  if (ctx == NULL)
+  {
+    return -1;
+  }
 
   ret = ctx->read_reg(ctx->handle, reg, data, len);
 
@@ -68,12 +71,15 @@ int32_t __weak hts221_read_reg(const stmdev_ctx_t *ctx, uint8_t reg, uint8_t *da
   *
   */
 int32_t __weak hts221_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
-                                uint8_t *data,
+                                const uint8_t *data,
                                 uint16_t len)
 {
   int32_t ret;
 
-  if (ctx == NULL) return -1;
+  if (ctx == NULL)
+  {
+    return -1;
+  }
 
   ret = ctx->write_reg(ctx->handle, reg, data, len);
 
@@ -857,7 +863,7 @@ int32_t hts221_hum_rh_point_0_get(const stmdev_ctx_t *ctx, float_t *val)
   int32_t ret;
 
   ret = hts221_read_reg(ctx, HTS221_H0_RH_X2, &coeff, 1);
-  *val = coeff / 2.0f;
+  *val = (float_t)coeff / 2.0f;
 
   return ret;
 }
@@ -876,7 +882,7 @@ int32_t hts221_hum_rh_point_1_get(const stmdev_ctx_t *ctx, float_t *val)
   int32_t ret;
 
   ret = hts221_read_reg(ctx, HTS221_H1_RH_X2, &coeff, 1);
-  *val = coeff / 2.0f;
+  *val = (float_t)coeff / 2.0f;
 
   return ret;
 }
@@ -902,7 +908,7 @@ int32_t hts221_temp_deg_point_0_get(const stmdev_ctx_t *ctx, float_t *val)
   {
     ret = hts221_read_reg(ctx, HTS221_T1_T0_MSB, (uint8_t *) &reg, 1);
     coeff_h = reg.t0_msb;
-    *val = ((coeff_h * 256) + coeff_l) / 8.0f;
+    *val = (((float_t)coeff_h * 256.0f) + (float_t)coeff_l) / 8.0f;
   }
 
   return ret;
@@ -929,7 +935,7 @@ int32_t hts221_temp_deg_point_1_get(const stmdev_ctx_t *ctx, float_t *val)
   {
     ret = hts221_read_reg(ctx, HTS221_T1_T0_MSB, (uint8_t *) &reg, 1);
     coeff_h = reg.t1_msb;
-    *val = ((coeff_h * 256) + coeff_l) / 8.0f;
+    *val = (((float_t)coeff_h * 256.0f) + (float_t)coeff_l) / 8.0f;
   }
 
   return ret;
@@ -950,8 +956,8 @@ int32_t hts221_hum_adc_point_0_get(const stmdev_ctx_t *ctx, float_t *val)
   int32_t ret;
 
   ret = hts221_read_reg(ctx, HTS221_H0_T0_OUT_L, coeff_p, 2);
-  coeff = (coeff_p[1] * 256) + coeff_p[0];
-  *val = coeff * 1.0f;
+  coeff = ((int16_t)coeff_p[1] * 256) + (int16_t)coeff_p[0];
+  *val = (float_t)coeff * 1.0f;
 
   return ret;
 }
@@ -971,8 +977,8 @@ int32_t hts221_hum_adc_point_1_get(const stmdev_ctx_t *ctx, float_t *val)
   int32_t ret;
 
   ret = hts221_read_reg(ctx, HTS221_H1_T0_OUT_L, coeff_p, 2);
-  coeff = (coeff_p[1] * 256) + coeff_p[0];
-  *val = coeff * 1.0f;
+  coeff = ((int16_t)coeff_p[1] * 256) + (int16_t)coeff_p[0];
+  *val = (float_t)coeff * 1.0f;
 
   return ret;
 }
@@ -992,8 +998,8 @@ int32_t hts221_temp_adc_point_0_get(const stmdev_ctx_t *ctx, float_t *val)
   int32_t ret;
 
   ret = hts221_read_reg(ctx, HTS221_T0_OUT_L, coeff_p, 2);
-  coeff = (coeff_p[1] * 256) + coeff_p[0];
-  *val = coeff * 1.0f;
+  coeff = ((int16_t)coeff_p[1] * 256) + (int16_t)coeff_p[0];
+  *val = (float_t)coeff * 1.0f;
 
   return ret;
 }
@@ -1013,8 +1019,8 @@ int32_t hts221_temp_adc_point_1_get(const stmdev_ctx_t *ctx, float_t *val)
   int32_t ret;
 
   ret = hts221_read_reg(ctx, HTS221_T1_OUT_L, coeff_p, 2);
-  coeff = (coeff_p[1] * 256) + coeff_p[0];
-  *val = coeff * 1.0f;
+  coeff = ((int16_t)coeff_p[1] * 256) + (int16_t)coeff_p[0];
+  *val = (float_t)coeff * 1.0f;
 
   return ret;
 }

--- a/sensor/stmemsc/hts221_STdC/driver/hts221_reg.h
+++ b/sensor/stmemsc/hts221_STdC/driver/hts221_reg.h
@@ -131,33 +131,6 @@ typedef struct
 
 #endif /* MEMS_SHARED_TYPES */
 
-#ifndef MEMS_UCF_SHARED_TYPES
-#define MEMS_UCF_SHARED_TYPES
-
-/** @defgroup    Generic address-data structure definition
-  * @brief       This structure is useful to load a predefined configuration
-  *              of a sensor.
-  *              You can create a sensor configuration by your own or using
-  *              Unico / Unicleo tools available on STMicroelectronics
-  *              web site.
-  *
-  * @{
-  *
-  */
-
-typedef struct
-{
-  uint8_t address;
-  uint8_t data;
-} ucf_line_t;
-
-/**
-  * @}
-  *
-  */
-
-#endif /* MEMS_UCF_SHARED_TYPES */
-
 /**
   * @}
   *
@@ -290,30 +263,6 @@ typedef struct
 #define HTS221_T1_OUT_H            0x3FU
 
 /**
-  * @defgroup HTS221_Register_Union
-  * @brief    This union group all the registers having a bit-field
-  *           description.
-  *           This union is useful but it's not needed by the driver.
-  *
-  *           REMOVING this union you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-typedef union
-{
-  hts221_av_conf_t        av_conf;
-  hts221_ctrl_reg1_t      ctrl_reg1;
-  hts221_ctrl_reg2_t      ctrl_reg2;
-  hts221_ctrl_reg3_t      ctrl_reg3;
-  hts221_status_reg_t     status_reg;
-  hts221_t1_t0_msb_t      t1_t0_msb;
-  bitwise_t               bitwise;
-  uint8_t                 byte;
-} hts221_reg_t;
-
-/**
   * @}
   *
   */
@@ -334,7 +283,7 @@ int32_t hts221_read_reg(const stmdev_ctx_t *ctx, uint8_t reg,
                         uint8_t *data,
                         uint16_t len);
 int32_t hts221_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
-                         uint8_t *data,
+                         const uint8_t *data,
                          uint16_t len);
 
 typedef enum

--- a/sensor/stmemsc/iis2dulpx_STdC/driver/iis2dulpx_reg.c
+++ b/sensor/stmemsc/iis2dulpx_STdC/driver/iis2dulpx_reg.c
@@ -1,8 +1,8 @@
 /*
  ******************************************************************************
- * @file    lis2duxs12_reg.c
+ * @file    iis2dulpx_reg.c
  * @author  Sensors Software Solution Team
- * @brief   LIS2DUXS12 driver file
+ * @brief   IIS2DULPX driver file
  ******************************************************************************
  * @attention
  *
@@ -17,18 +17,18 @@
  ******************************************************************************
  */
 
-#include "lis2duxs12_reg.h"
+#include "iis2dulpx_reg.h"
 
 /**
-  * @defgroup    LIS2DUXS12
+  * @defgroup    IIS2DULPX
   * @brief       This file provides a set of functions needed to drive the
-  *              lis2duxs12 sensor.
+  *              iis2dulpx sensor.
   * @{
   *
   */
 
 /**
-  * @defgroup    LIS2DUXS12_Interfaces_Functions
+  * @defgroup    IIS2DULPX_Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -46,8 +46,8 @@
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t __weak lis2duxs12_read_reg(const stmdev_ctx_t *ctx, uint8_t reg, uint8_t *data,
-                                   uint16_t len)
+int32_t __weak iis2dulpx_read_reg(const stmdev_ctx_t *ctx, uint8_t reg, uint8_t *data,
+                                  uint16_t len)
 {
   if (ctx == NULL)
   {
@@ -67,8 +67,8 @@ int32_t __weak lis2duxs12_read_reg(const stmdev_ctx_t *ctx, uint8_t reg, uint8_t
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t __weak lis2duxs12_write_reg(const stmdev_ctx_t *ctx, uint8_t reg, uint8_t *data,
-                                    uint16_t len)
+int32_t __weak iis2dulpx_write_reg(const stmdev_ctx_t *ctx, uint8_t reg, uint8_t *data,
+                                   uint16_t len)
 {
   if (ctx == NULL)
   {
@@ -84,38 +84,38 @@ int32_t __weak lis2duxs12_write_reg(const stmdev_ctx_t *ctx, uint8_t reg, uint8_
   */
 
 /**
-  * @defgroup    LIS2DUXS12_Sensitivity
+  * @defgroup    IIS2DULPX_Sensitivity
   * @brief       These functions convert raw-data into engineering units.
   * @{
   *
   */
 
-float_t lis2duxs12_from_fs2g_to_mg(int16_t lsb)
+float_t iis2dulpx_from_fs2g_to_mg(int16_t lsb)
 {
   return (float_t)lsb * 0.061f;
 }
 
-float_t lis2duxs12_from_fs4g_to_mg(int16_t lsb)
+float_t iis2dulpx_from_fs4g_to_mg(int16_t lsb)
 {
   return (float_t)lsb * 0.122f;
 }
 
-float_t lis2duxs12_from_fs8g_to_mg(int16_t lsb)
+float_t iis2dulpx_from_fs8g_to_mg(int16_t lsb)
 {
   return (float_t)lsb * 0.244f;
 }
 
-float_t lis2duxs12_from_fs16g_to_mg(int16_t lsb)
+float_t iis2dulpx_from_fs16g_to_mg(int16_t lsb)
 {
   return (float_t)lsb * 0.488f;
 }
 
-float_t lis2duxs12_from_lsb_to_celsius(int16_t lsb)
+float_t iis2dulpx_from_lsb_to_celsius(int16_t lsb)
 {
   return ((float_t)lsb / 355.5f) + 25.0f;
 }
 
-float_t lis2duxs12_from_lsb_to_mv(int16_t lsb)
+float_t iis2dulpx_from_lsb_to_mv(int16_t lsb)
 {
   return ((float_t)lsb) / 74.4f;
 }
@@ -139,11 +139,11 @@ float_t lis2duxs12_from_lsb_to_mv(int16_t lsb)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_device_id_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t iis2dulpx_device_id_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_WHO_AM_I, val, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_WHO_AM_I, val, 1);
 
   return ret;
 }
@@ -156,21 +156,21 @@ int32_t lis2duxs12_device_id_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_init_set(const stmdev_ctx_t *ctx, lis2duxs12_init_t val)
+int32_t iis2dulpx_init_set(const stmdev_ctx_t *ctx, iis2dulpx_init_t val)
 {
-  lis2duxs12_ctrl1_t ctrl1;
-  lis2duxs12_ctrl4_t ctrl4;
-  lis2duxs12_status_t status;
+  iis2dulpx_ctrl1_t ctrl1;
+  iis2dulpx_ctrl4_t ctrl4;
+  iis2dulpx_status_t status;
   uint8_t cnt = 0;
   int32_t ret = 0;
 
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL1, (uint8_t *)&ctrl1, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL4, (uint8_t *)&ctrl4, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_CTRL1, (uint8_t *)&ctrl1, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_CTRL4, (uint8_t *)&ctrl4, 1);
   switch (val)
   {
-    case LIS2DUXS12_BOOT:
+    case IIS2DULPX_BOOT:
       ctrl4.boot = PROPERTY_ENABLE;
-      ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_CTRL4, (uint8_t *)&ctrl4, 1);
+      ret += iis2dulpx_write_reg(ctx, IIS2DULPX_CTRL4, (uint8_t *)&ctrl4, 1);
       if (ret != 0)
       {
         break;
@@ -178,7 +178,7 @@ int32_t lis2duxs12_init_set(const stmdev_ctx_t *ctx, lis2duxs12_init_t val)
 
       do
       {
-        ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL4, (uint8_t *)&ctrl4, 1);
+        ret = iis2dulpx_read_reg(ctx, IIS2DULPX_CTRL4, (uint8_t *)&ctrl4, 1);
         if (ret != 0)
         {
           break;
@@ -201,9 +201,9 @@ int32_t lis2duxs12_init_set(const stmdev_ctx_t *ctx, lis2duxs12_init_t val)
         ret = -1;  /* boot procedure failed */
       }
       break;
-    case LIS2DUXS12_RESET:
+    case IIS2DULPX_RESET:
       ctrl1.sw_reset = PROPERTY_ENABLE;
-      ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_CTRL1, (uint8_t *)&ctrl1, 1);
+      ret += iis2dulpx_write_reg(ctx, IIS2DULPX_CTRL1, (uint8_t *)&ctrl1, 1);
       if (ret != 0)
       {
         break;
@@ -216,7 +216,7 @@ int32_t lis2duxs12_init_set(const stmdev_ctx_t *ctx, lis2duxs12_init_t val)
           ctx->mdelay(1); /* should be 50 us */
         }
 
-        ret = lis2duxs12_status_get(ctx, &status);
+        ret = iis2dulpx_status_get(ctx, &status);
         if (ret != 0)
         {
           break;
@@ -234,25 +234,25 @@ int32_t lis2duxs12_init_set(const stmdev_ctx_t *ctx, lis2duxs12_init_t val)
         ret = -1;  /* sw-reset procedure failed */
       }
       break;
-    case LIS2DUXS12_SENSOR_ONLY_ON:
+    case IIS2DULPX_SENSOR_ONLY_ON:
       /* no embedded funcs are used */
       ctrl4.emb_func_en = PROPERTY_DISABLE;
       ctrl4.bdu = PROPERTY_ENABLE;
       ctrl1.if_add_inc = PROPERTY_ENABLE;
-      ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_CTRL4, (uint8_t *)&ctrl4, 1);
-      ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_CTRL1, (uint8_t *)&ctrl1, 1);
+      ret += iis2dulpx_write_reg(ctx, IIS2DULPX_CTRL4, (uint8_t *)&ctrl4, 1);
+      ret += iis2dulpx_write_reg(ctx, IIS2DULPX_CTRL1, (uint8_t *)&ctrl1, 1);
       break;
-    case LIS2DUXS12_SENSOR_EMB_FUNC_ON:
+    case IIS2DULPX_SENSOR_EMB_FUNC_ON:
       /* complete configuration is used */
       ctrl4.emb_func_en = PROPERTY_ENABLE;
       ctrl4.bdu = PROPERTY_ENABLE;
       ctrl1.if_add_inc = PROPERTY_ENABLE;
-      ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_CTRL4, (uint8_t *)&ctrl4, 1);
-      ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_CTRL1, (uint8_t *)&ctrl1, 1);
+      ret += iis2dulpx_write_reg(ctx, IIS2DULPX_CTRL4, (uint8_t *)&ctrl4, 1);
+      ret += iis2dulpx_write_reg(ctx, IIS2DULPX_CTRL1, (uint8_t *)&ctrl1, 1);
       break;
     default:
       ctrl1.sw_reset = PROPERTY_ENABLE;
-      ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_CTRL1, (uint8_t *)&ctrl1, 1);
+      ret += iis2dulpx_write_reg(ctx, IIS2DULPX_CTRL1, (uint8_t *)&ctrl1, 1);
       break;
   }
   return ret;
@@ -266,17 +266,17 @@ int32_t lis2duxs12_init_set(const stmdev_ctx_t *ctx, lis2duxs12_init_t val)
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_status_get(const stmdev_ctx_t *ctx, lis2duxs12_status_t *val)
+int32_t iis2dulpx_status_get(const stmdev_ctx_t *ctx, iis2dulpx_status_t *val)
 {
-  lis2duxs12_status_register_t status_register;
-  lis2duxs12_ctrl1_t ctrl1;
-  lis2duxs12_ctrl4_t ctrl4;
+  iis2dulpx_status_register_t status_register;
+  iis2dulpx_ctrl1_t ctrl1;
+  iis2dulpx_ctrl4_t ctrl4;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_STATUS,
-                            (uint8_t *)&status_register, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL1, (uint8_t *)&ctrl1, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL4, (uint8_t *)&ctrl4, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_STATUS,
+                           (uint8_t *)&status_register, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_CTRL1, (uint8_t *)&ctrl1, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_CTRL4, (uint8_t *)&ctrl4, 1);
 
   val->sw_reset = ctrl1.sw_reset;
   val->boot     = ctrl4.boot;
@@ -293,14 +293,14 @@ int32_t lis2duxs12_status_get(const stmdev_ctx_t *ctx, lis2duxs12_status_t *val)
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_embedded_status_get(const stmdev_ctx_t *ctx, lis2duxs12_embedded_status_t *val)
+int32_t iis2dulpx_embedded_status_get(const stmdev_ctx_t *ctx, iis2dulpx_embedded_status_t *val)
 {
-  lis2duxs12_emb_func_status_t status;
+  iis2dulpx_emb_func_status_t status;
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_STATUS, (uint8_t *)&status, 1);
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_EMB_FUNC_STATUS, (uint8_t *)&status, 1);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   val->is_step_det = status.is_step_det;
   val->is_tilt = status.is_tilt;
@@ -317,17 +317,17 @@ int32_t lis2duxs12_embedded_status_get(const stmdev_ctx_t *ctx, lis2duxs12_embed
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_data_ready_mode_set(const stmdev_ctx_t *ctx, lis2duxs12_data_ready_mode_t val)
+int32_t iis2dulpx_data_ready_mode_set(const stmdev_ctx_t *ctx, iis2dulpx_data_ready_mode_t val)
 {
-  lis2duxs12_ctrl1_t ctrl1;
+  iis2dulpx_ctrl1_t ctrl1;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL1, (uint8_t *)&ctrl1, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_CTRL1, (uint8_t *)&ctrl1, 1);
 
   if (ret == 0)
   {
     ctrl1.drdy_pulsed = ((uint8_t)val & 0x1U);
-    ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_CTRL1, (uint8_t *)&ctrl1, 1);
+    ret = iis2dulpx_write_reg(ctx, IIS2DULPX_CTRL1, (uint8_t *)&ctrl1, 1);
   }
 
   return ret;
@@ -341,25 +341,25 @@ int32_t lis2duxs12_data_ready_mode_set(const stmdev_ctx_t *ctx, lis2duxs12_data_
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_data_ready_mode_get(const stmdev_ctx_t *ctx, lis2duxs12_data_ready_mode_t *val)
+int32_t iis2dulpx_data_ready_mode_get(const stmdev_ctx_t *ctx, iis2dulpx_data_ready_mode_t *val)
 {
-  lis2duxs12_ctrl1_t ctrl1;
+  iis2dulpx_ctrl1_t ctrl1;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL1, (uint8_t *)&ctrl1, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_CTRL1, (uint8_t *)&ctrl1, 1);
 
   switch ((ctrl1.drdy_pulsed))
   {
     case 0x0:
-      *val = LIS2DUXS12_DRDY_LATCHED;
+      *val = IIS2DULPX_DRDY_LATCHED;
       break;
 
     case 0x1:
-      *val = LIS2DUXS12_DRDY_PULSED;
+      *val = IIS2DULPX_DRDY_PULSED;
       break;
 
     default:
-      *val = LIS2DUXS12_DRDY_LATCHED;
+      *val = IIS2DULPX_DRDY_LATCHED;
       break;
   }
   return ret;
@@ -373,13 +373,13 @@ int32_t lis2duxs12_data_ready_mode_get(const stmdev_ctx_t *ctx, lis2duxs12_data_
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_mode_set(const stmdev_ctx_t *ctx, const lis2duxs12_md_t *val)
+int32_t iis2dulpx_mode_set(const stmdev_ctx_t *ctx, const iis2dulpx_md_t *val)
 {
-  lis2duxs12_ctrl3_t ctrl3;
-  lis2duxs12_ctrl5_t ctrl5;
+  iis2dulpx_ctrl3_t ctrl3;
+  iis2dulpx_ctrl5_t ctrl5;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL5, (uint8_t *)&ctrl5, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_CTRL5, (uint8_t *)&ctrl5, 1);
 
   ctrl5.odr = (uint8_t)val->odr & 0xFU;
   ctrl5.fs = (uint8_t)val->fs;
@@ -388,82 +388,82 @@ int32_t lis2duxs12_mode_set(const stmdev_ctx_t *ctx, const lis2duxs12_md_t *val)
   switch (val->odr)
   {
     /* no anti-aliasing filter present */
-    case LIS2DUXS12_OFF:
-    case LIS2DUXS12_1Hz6_ULP:
-    case LIS2DUXS12_3Hz_ULP:
-    case LIS2DUXS12_25Hz_ULP:
+    case IIS2DULPX_OFF:
+    case IIS2DULPX_1Hz6_ULP:
+    case IIS2DULPX_3Hz_ULP:
+    case IIS2DULPX_25Hz_ULP:
       ctrl5.bw = 0x0;
       break;
 
     /* low-power mode with ODR < 50 Hz */
-    case LIS2DUXS12_6Hz_LP:
+    case IIS2DULPX_6Hz_LP:
       switch (val->bw)
       {
         default:
-        case LIS2DUXS12_ODR_div_2:
-        case LIS2DUXS12_ODR_div_4:
-        case LIS2DUXS12_ODR_div_8:
+        case IIS2DULPX_ODR_div_2:
+        case IIS2DULPX_ODR_div_4:
+        case IIS2DULPX_ODR_div_8:
           /* value not allowed */
           ret = -1;
           break;
-        case LIS2DUXS12_ODR_div_16:
+        case IIS2DULPX_ODR_div_16:
           ctrl5.bw = 0x3;
           break;
       }
       break;
-    case LIS2DUXS12_12Hz5_LP:
+    case IIS2DULPX_12Hz5_LP:
       switch (val->bw)
       {
         default:
-        case LIS2DUXS12_ODR_div_2:
-        case LIS2DUXS12_ODR_div_4:
+        case IIS2DULPX_ODR_div_2:
+        case IIS2DULPX_ODR_div_4:
           /* value not allowed */
           ret = -1;
           break;
-        case LIS2DUXS12_ODR_div_8:
+        case IIS2DULPX_ODR_div_8:
           ctrl5.bw = 0x2;
           break;
-        case LIS2DUXS12_ODR_div_16:
+        case IIS2DULPX_ODR_div_16:
           ctrl5.bw = 0x3;
           break;
       }
       break;
-    case LIS2DUXS12_25Hz_LP:
+    case IIS2DULPX_25Hz_LP:
       switch (val->bw)
       {
         default:
-        case LIS2DUXS12_ODR_div_2:
+        case IIS2DULPX_ODR_div_2:
           /* value not allowed */
           ret = -1;
           break;
-        case LIS2DUXS12_ODR_div_4:
+        case IIS2DULPX_ODR_div_4:
           ctrl5.bw = 0x1;
           break;
-        case LIS2DUXS12_ODR_div_8:
+        case IIS2DULPX_ODR_div_8:
           ctrl5.bw = 0x2;
           break;
-        case LIS2DUXS12_ODR_div_16:
+        case IIS2DULPX_ODR_div_16:
           ctrl5.bw = 0x3;
           break;
       }
       break;
 
     /* standard cases */
-    case LIS2DUXS12_50Hz_LP:
-    case LIS2DUXS12_100Hz_LP:
-    case LIS2DUXS12_200Hz_LP:
-    case LIS2DUXS12_400Hz_LP:
-    case LIS2DUXS12_800Hz_LP:
-    case LIS2DUXS12_TRIG_PIN:
-    case LIS2DUXS12_TRIG_SW:
-    case LIS2DUXS12_6Hz_HP:
-    case LIS2DUXS12_12Hz5_HP:
-    case LIS2DUXS12_25Hz_HP:
-    case LIS2DUXS12_50Hz_HP:
-    case LIS2DUXS12_100Hz_HP:
-    case LIS2DUXS12_200Hz_HP:
-    case LIS2DUXS12_400Hz_HP:
-    case LIS2DUXS12_800Hz_HP:
+    case IIS2DULPX_50Hz_LP:
+    case IIS2DULPX_100Hz_LP:
+    case IIS2DULPX_200Hz_LP:
+    case IIS2DULPX_400Hz_LP:
+    case IIS2DULPX_800Hz_LP:
+    case IIS2DULPX_TRIG_PIN:
+    case IIS2DULPX_TRIG_SW:
+    case IIS2DULPX_6Hz_HP:
+    case IIS2DULPX_12Hz5_HP:
+    case IIS2DULPX_25Hz_HP:
+    case IIS2DULPX_50Hz_HP:
+    case IIS2DULPX_100Hz_HP:
+    case IIS2DULPX_200Hz_HP:
+    case IIS2DULPX_400Hz_HP:
+    case IIS2DULPX_800Hz_HP:
     default:
       ctrl5.bw = (uint8_t)val->bw;
       break;
@@ -474,14 +474,14 @@ int32_t lis2duxs12_mode_set(const stmdev_ctx_t *ctx, const lis2duxs12_md_t *val)
     return ret;
   }
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL3, (uint8_t *)&ctrl3, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_CTRL3, (uint8_t *)&ctrl3, 1);
 
   ctrl3.hp_en = (((uint8_t)val->odr & 0x30U) == 0x10U) ? 1U : 0U;
 
   if (ret == 0)
   {
-    ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_CTRL5, (uint8_t *)&ctrl5, 1);
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_CTRL3, (uint8_t *)&ctrl3, 1);
+    ret = iis2dulpx_write_reg(ctx, IIS2DULPX_CTRL5, (uint8_t *)&ctrl5, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_CTRL3, (uint8_t *)&ctrl3, 1);
   }
 
   return ret;
@@ -495,99 +495,99 @@ int32_t lis2duxs12_mode_set(const stmdev_ctx_t *ctx, const lis2duxs12_md_t *val)
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_mode_get(const stmdev_ctx_t *ctx, lis2duxs12_md_t *val)
+int32_t iis2dulpx_mode_get(const stmdev_ctx_t *ctx, iis2dulpx_md_t *val)
 {
-  lis2duxs12_ctrl3_t ctrl3;
-  lis2duxs12_ctrl5_t ctrl5;
+  iis2dulpx_ctrl3_t ctrl3;
+  iis2dulpx_ctrl5_t ctrl5;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL5, (uint8_t *)&ctrl5, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL3, (uint8_t *)&ctrl3, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_CTRL5, (uint8_t *)&ctrl5, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_CTRL3, (uint8_t *)&ctrl3, 1);
 
   switch (ctrl5.odr)
   {
     case 0x00:
-      val->odr = LIS2DUXS12_OFF;
+      val->odr = IIS2DULPX_OFF;
       break;
     case 0x01:
-      val->odr = LIS2DUXS12_1Hz6_ULP;
+      val->odr = IIS2DULPX_1Hz6_ULP;
       break;
     case 0x02:
-      val->odr = LIS2DUXS12_3Hz_ULP;
+      val->odr = IIS2DULPX_3Hz_ULP;
       break;
     case 0x03:
-      val->odr = LIS2DUXS12_25Hz_ULP;
+      val->odr = IIS2DULPX_25Hz_ULP;
       break;
     case 0x04:
-      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUXS12_6Hz_HP : LIS2DUXS12_6Hz_LP;
+      val->odr = (ctrl3.hp_en == 0x1U) ? IIS2DULPX_6Hz_HP : IIS2DULPX_6Hz_LP;
       break;
     case 0x05:
-      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUXS12_12Hz5_HP : LIS2DUXS12_12Hz5_LP;
+      val->odr = (ctrl3.hp_en == 0x1U) ? IIS2DULPX_12Hz5_HP : IIS2DULPX_12Hz5_LP;
       break;
     case 0x06:
-      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUXS12_25Hz_HP : LIS2DUXS12_25Hz_LP;
+      val->odr = (ctrl3.hp_en == 0x1U) ? IIS2DULPX_25Hz_HP : IIS2DULPX_25Hz_LP;
       break;
     case 0x07:
-      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUXS12_50Hz_HP : LIS2DUXS12_50Hz_LP;
+      val->odr = (ctrl3.hp_en == 0x1U) ? IIS2DULPX_50Hz_HP : IIS2DULPX_50Hz_LP;
       break;
     case 0x08:
-      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUXS12_100Hz_HP : LIS2DUXS12_100Hz_LP;
+      val->odr = (ctrl3.hp_en == 0x1U) ? IIS2DULPX_100Hz_HP : IIS2DULPX_100Hz_LP;
       break;
     case 0x09:
-      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUXS12_200Hz_HP : LIS2DUXS12_200Hz_LP;
+      val->odr = (ctrl3.hp_en == 0x1U) ? IIS2DULPX_200Hz_HP : IIS2DULPX_200Hz_LP;
       break;
     case 0x0A:
-      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUXS12_400Hz_HP : LIS2DUXS12_400Hz_LP;
+      val->odr = (ctrl3.hp_en == 0x1U) ? IIS2DULPX_400Hz_HP : IIS2DULPX_400Hz_LP;
       break;
     case 0x0B:
-      val->odr = (ctrl3.hp_en == 0x1U) ? LIS2DUXS12_800Hz_HP : LIS2DUXS12_800Hz_LP;
+      val->odr = (ctrl3.hp_en == 0x1U) ? IIS2DULPX_800Hz_HP : IIS2DULPX_800Hz_LP;
       break;
     case 0xe:
-      val->odr = LIS2DUXS12_TRIG_PIN;
+      val->odr = IIS2DULPX_TRIG_PIN;
       break;
     case 0xf:
-      val->odr = LIS2DUXS12_TRIG_SW;
+      val->odr = IIS2DULPX_TRIG_SW;
       break;
     default:
-      val->odr = LIS2DUXS12_OFF;
+      val->odr = IIS2DULPX_OFF;
       break;
   }
 
   switch (ctrl5.fs)
   {
     case 0:
-      val->fs = LIS2DUXS12_2g;
+      val->fs = IIS2DULPX_2g;
       break;
     case 1:
-      val->fs = LIS2DUXS12_4g;
+      val->fs = IIS2DULPX_4g;
       break;
     case 2:
-      val->fs = LIS2DUXS12_8g;
+      val->fs = IIS2DULPX_8g;
       break;
     case 3:
-      val->fs = LIS2DUXS12_16g;
+      val->fs = IIS2DULPX_16g;
       break;
     default:
-      val->fs = LIS2DUXS12_2g;
+      val->fs = IIS2DULPX_2g;
       break;
   }
 
   switch (ctrl5.bw)
   {
     case 0:
-      val->bw = LIS2DUXS12_ODR_div_2;
+      val->bw = IIS2DULPX_ODR_div_2;
       break;
     case 1:
-      val->bw = LIS2DUXS12_ODR_div_4;
+      val->bw = IIS2DULPX_ODR_div_4;
       break;
     case 2:
-      val->bw = LIS2DUXS12_ODR_div_8;
+      val->bw = IIS2DULPX_ODR_div_8;
       break;
     case 3:
-      val->bw = LIS2DUXS12_ODR_div_16;
+      val->bw = IIS2DULPX_ODR_div_16;
       break;
     default:
-      val->bw = LIS2DUXS12_ODR_div_2;
+      val->bw = IIS2DULPX_ODR_div_2;
       break;
   }
 
@@ -602,17 +602,17 @@ int32_t lis2duxs12_mode_get(const stmdev_ctx_t *ctx, lis2duxs12_md_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_t_ah_qvar_dis_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t iis2dulpx_t_ah_qvar_dis_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2duxs12_self_test_t temp;
+  iis2dulpx_self_test_t temp;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_SELF_TEST, (uint8_t *)&temp, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_SELF_TEST, (uint8_t *)&temp, 1);
 
   if (ret == 0)
   {
     temp.t_ah_qvar_dis = val;
-    ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_SELF_TEST, (uint8_t *)&temp, 1);
+    ret = iis2dulpx_write_reg(ctx, IIS2DULPX_SELF_TEST, (uint8_t *)&temp, 1);
   }
 
   return ret;
@@ -626,12 +626,12 @@ int32_t lis2duxs12_t_ah_qvar_dis_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_t_ah_qvar_dis_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t iis2dulpx_t_ah_qvar_dis_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2duxs12_self_test_t temp;
+  iis2dulpx_self_test_t temp;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_SELF_TEST, (uint8_t *)&temp, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_SELF_TEST, (uint8_t *)&temp, 1);
   *val = temp.t_ah_qvar_dis;
 
   return ret;
@@ -645,17 +645,17 @@ int32_t lis2duxs12_t_ah_qvar_dis_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_enter_deep_power_down(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t iis2dulpx_enter_deep_power_down(const stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2duxs12_sleep_t sleep;
+  iis2dulpx_sleep_t sleep;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_SLEEP, (uint8_t *)&sleep, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_SLEEP, (uint8_t *)&sleep, 1);
 
   if (ret == 0)
   {
     sleep.deep_pd = val;
-    ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_SLEEP, (uint8_t *)&sleep, 1);
+    ret = iis2dulpx_write_reg(ctx, IIS2DULPX_SLEEP, (uint8_t *)&sleep, 1);
   }
 
   return ret;
@@ -669,13 +669,13 @@ int32_t lis2duxs12_enter_deep_power_down(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_exit_deep_power_down(const stmdev_ctx_t *ctx)
+int32_t iis2dulpx_exit_deep_power_down(const stmdev_ctx_t *ctx)
 {
-  lis2duxs12_en_device_config_t en_device_config = {0};
+  iis2dulpx_en_device_config_t en_device_config = {0};
   int32_t ret;
 
   en_device_config.soft_pd = PROPERTY_ENABLE;
-  ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_EN_DEVICE_CONFIG, (uint8_t *)&en_device_config, 1);
+  ret = iis2dulpx_write_reg(ctx, IIS2DULPX_EN_DEVICE_CONFIG, (uint8_t *)&en_device_config, 1);
 
   if (ctx->mdelay != NULL)
   {
@@ -692,14 +692,14 @@ int32_t lis2duxs12_exit_deep_power_down(const stmdev_ctx_t *ctx)
   * @param  md    0: enable hard-reset from CS, 1: disable hard-reset from CS
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   */
-int32_t lis2duxs12_disable_hard_reset_from_cs_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t iis2dulpx_disable_hard_reset_from_cs_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2duxs12_fifo_ctrl_t fifo_ctrl;
+  iis2dulpx_fifo_ctrl_t fifo_ctrl;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_FIFO_CTRL, (uint8_t *)&fifo_ctrl, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_FIFO_CTRL, (uint8_t *)&fifo_ctrl, 1);
   fifo_ctrl.dis_hard_rst_cs = (val == 1) ? PROPERTY_ENABLE : PROPERTY_DISABLE;
-  ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_FIFO_CTRL, (uint8_t *)&fifo_ctrl, 1);
+  ret += iis2dulpx_write_reg(ctx, IIS2DULPX_FIFO_CTRL, (uint8_t *)&fifo_ctrl, 1);
 
   return ret;
 }
@@ -711,12 +711,12 @@ int32_t lis2duxs12_disable_hard_reset_from_cs_set(const stmdev_ctx_t *ctx, uint8
   * @param  md    0: enable hard-reset from CS, 1: disable hard-reset from CS
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   */
-int32_t lis2duxs12_disable_hard_reset_from_cs_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t iis2dulpx_disable_hard_reset_from_cs_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2duxs12_fifo_ctrl_t fifo_ctrl;
+  iis2dulpx_fifo_ctrl_t fifo_ctrl;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_FIFO_CTRL, (uint8_t *)&fifo_ctrl, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_FIFO_CTRL, (uint8_t *)&fifo_ctrl, 1);
   *val = fifo_ctrl.dis_hard_rst_cs;
 
   return ret;
@@ -730,40 +730,40 @@ int32_t lis2duxs12_disable_hard_reset_from_cs_get(const stmdev_ctx_t *ctx, uint8
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_trigger_sw(const stmdev_ctx_t *ctx, const lis2duxs12_md_t *md)
+int32_t iis2dulpx_trigger_sw(const stmdev_ctx_t *ctx, const iis2dulpx_md_t *md)
 {
-  lis2duxs12_ctrl4_t ctrl4;
+  iis2dulpx_ctrl4_t ctrl4;
   int32_t ret = 0;
 
-  if (md->odr == LIS2DUXS12_TRIG_SW)
+  if (md->odr == IIS2DULPX_TRIG_SW)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL4, (uint8_t *)&ctrl4, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_CTRL4, (uint8_t *)&ctrl4, 1);
     ctrl4.soc = PROPERTY_ENABLE;
     if (ret == 0)
     {
-      ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_CTRL4, (uint8_t *)&ctrl4, 1);
+      ret = iis2dulpx_write_reg(ctx, IIS2DULPX_CTRL4, (uint8_t *)&ctrl4, 1);
     }
   }
   return ret;
 }
 
-int32_t lis2duxs12_all_sources_get(const stmdev_ctx_t *ctx, lis2duxs12_all_sources_t *val)
+int32_t iis2dulpx_all_sources_get(const stmdev_ctx_t *ctx, iis2dulpx_all_sources_t *val)
 {
-  lis2duxs12_status_register_t status;
+  iis2dulpx_status_register_t status;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_STATUS, (uint8_t *)&status, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_STATUS, (uint8_t *)&status, 1);
   val->drdy = status.drdy;
 
   if (ret == 0 && status.int_global == 0x1U)
   {
-    lis2duxs12_wake_up_src_t wu_src;
-    lis2duxs12_tap_src_t tap_src;
-    lis2duxs12_sixd_src_t sixd_src;
+    iis2dulpx_wake_up_src_t wu_src;
+    iis2dulpx_tap_src_t tap_src;
+    iis2dulpx_sixd_src_t sixd_src;
 
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_SIXD_SRC, (uint8_t *)&sixd_src, 1);
-    ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_WAKE_UP_SRC, (uint8_t *)&wu_src, 1);
-    ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_TAP_SRC, (uint8_t *)&tap_src, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_SIXD_SRC, (uint8_t *)&sixd_src, 1);
+    ret += iis2dulpx_read_reg(ctx, IIS2DULPX_WAKE_UP_SRC, (uint8_t *)&wu_src, 1);
+    ret += iis2dulpx_read_reg(ctx, IIS2DULPX_TAP_SRC, (uint8_t *)&tap_src, 1);
 
     val->six_d    = sixd_src.d6d_ia;
     val->six_d_xl = sixd_src.xl;
@@ -798,15 +798,15 @@ int32_t lis2duxs12_all_sources_get(const stmdev_ctx_t *ctx, lis2duxs12_all_sourc
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_xl_data_get(const stmdev_ctx_t *ctx, const lis2duxs12_md_t *md,
-                               lis2duxs12_xl_data_t *data)
+int32_t iis2dulpx_xl_data_get(const stmdev_ctx_t *ctx, const iis2dulpx_md_t *md,
+                              iis2dulpx_xl_data_t *data)
 {
   uint8_t buff[6];
   int32_t ret;
   uint8_t i;
   uint8_t j;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_OUT_X_L, buff, 6);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_OUT_X_L, buff, 6);
 
   /* acceleration conversion */
   j = 0U;
@@ -817,17 +817,17 @@ int32_t lis2duxs12_xl_data_get(const stmdev_ctx_t *ctx, const lis2duxs12_md_t *m
     j += 2U;
     switch (md->fs)
     {
-      case LIS2DUXS12_2g:
-        data->mg[i] = lis2duxs12_from_fs2g_to_mg(data->raw[i]);
+      case IIS2DULPX_2g:
+        data->mg[i] = iis2dulpx_from_fs2g_to_mg(data->raw[i]);
         break;
-      case LIS2DUXS12_4g:
-        data->mg[i] = lis2duxs12_from_fs4g_to_mg(data->raw[i]);
+      case IIS2DULPX_4g:
+        data->mg[i] = iis2dulpx_from_fs4g_to_mg(data->raw[i]);
         break;
-      case LIS2DUXS12_8g:
-        data->mg[i] = lis2duxs12_from_fs8g_to_mg(data->raw[i]);
+      case IIS2DULPX_8g:
+        data->mg[i] = iis2dulpx_from_fs8g_to_mg(data->raw[i]);
         break;
-      case LIS2DUXS12_16g:
-        data->mg[i] = lis2duxs12_from_fs16g_to_mg(data->raw[i]);
+      case IIS2DULPX_16g:
+        data->mg[i] = iis2dulpx_from_fs16g_to_mg(data->raw[i]);
         break;
       default:
         data->mg[i] = 0.0f;
@@ -847,18 +847,18 @@ int32_t lis2duxs12_xl_data_get(const stmdev_ctx_t *ctx, const lis2duxs12_md_t *m
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_outt_data_get(const stmdev_ctx_t *ctx,
-                                 lis2duxs12_outt_data_t *data)
+int32_t iis2dulpx_outt_data_get(const stmdev_ctx_t *ctx,
+                                iis2dulpx_outt_data_t *data)
 {
   uint8_t buff[2];
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_OUT_T_AH_QVAR_L, buff, 2);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_OUT_T_AH_QVAR_L, buff, 2);
 
   data->heat.raw = (int16_t)buff[1U];
   data->heat.raw = (data->heat.raw * 256) + (int16_t) buff[0];
   /* temperature conversion */
-  data->heat.deg_c = lis2duxs12_from_lsb_to_celsius(data->heat.raw);
+  data->heat.deg_c = iis2dulpx_from_lsb_to_celsius(data->heat.raw);
 
   return ret;
 }
@@ -872,19 +872,19 @@ int32_t lis2duxs12_outt_data_get(const stmdev_ctx_t *ctx,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_ah_qvar_data_get(const stmdev_ctx_t *ctx,
-                                    lis2duxs12_ah_qvar_data_t *data)
+int32_t iis2dulpx_ah_qvar_data_get(const stmdev_ctx_t *ctx,
+                                   iis2dulpx_ah_qvar_data_t *data)
 {
   uint8_t buff[3];
   int32_t ret;
 
   /* Read and discard also OUT_Z_H reg to clear drdy */
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_OUT_T_AH_QVAR_L - 1, buff, 3);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_OUT_T_AH_QVAR_L - 1, buff, 3);
 
   data->raw = (int16_t)buff[2U];
   data->raw = (data->raw * 256) + (int16_t) buff[1U];
 
-  data->mv = lis2duxs12_from_lsb_to_mv(data->raw);
+  data->mv = iis2dulpx_from_lsb_to_mv(data->raw);
   return ret;
 }
 
@@ -896,38 +896,38 @@ int32_t lis2duxs12_ah_qvar_data_get(const stmdev_ctx_t *ctx,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_self_test_sign_set(const stmdev_ctx_t *ctx, lis2duxs12_xl_self_test_t val)
+int32_t iis2dulpx_self_test_sign_set(const stmdev_ctx_t *ctx, iis2dulpx_xl_self_test_t val)
 {
-  lis2duxs12_ctrl3_t ctrl3;
-  lis2duxs12_wake_up_dur_t wkup_dur;
+  iis2dulpx_ctrl3_t ctrl3;
+  iis2dulpx_wake_up_dur_t wkup_dur;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL3, (uint8_t *)&ctrl3, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_WAKE_UP_DUR, (uint8_t *)&wkup_dur, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_CTRL3, (uint8_t *)&ctrl3, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_WAKE_UP_DUR, (uint8_t *)&wkup_dur, 1);
 
   switch (val)
   {
-    case LIS2DUXS12_XL_ST_POSITIVE:
+    case IIS2DULPX_XL_ST_POSITIVE:
       ctrl3.st_sign_x = 1;
       ctrl3.st_sign_y = 1;
       wkup_dur.st_sign_z = 0;
       break;
 
-    case LIS2DUXS12_XL_ST_NEGATIVE:
+    case IIS2DULPX_XL_ST_NEGATIVE:
       ctrl3.st_sign_x = 0;
       ctrl3.st_sign_y = 0;
       wkup_dur.st_sign_z = 1;
       break;
 
-    case LIS2DUXS12_XL_ST_DISABLE:
+    case IIS2DULPX_XL_ST_DISABLE:
     default:
       ret = -1;
       break;
   }
 
 
-  ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_CTRL3, (uint8_t *)&ctrl3, 1);
-  ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_WAKE_UP_DUR, (uint8_t *)&wkup_dur, 1);
+  ret += iis2dulpx_write_reg(ctx, IIS2DULPX_CTRL3, (uint8_t *)&ctrl3, 1);
+  ret += iis2dulpx_write_reg(ctx, IIS2DULPX_WAKE_UP_DUR, (uint8_t *)&wkup_dur, 1);
 
   return ret;
 }
@@ -940,9 +940,9 @@ int32_t lis2duxs12_self_test_sign_set(const stmdev_ctx_t *ctx, lis2duxs12_xl_sel
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_self_test_start(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t iis2dulpx_self_test_start(const stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2duxs12_self_test_t self_test;
+  iis2dulpx_self_test_t self_test;
   int32_t ret;
 
   if (val != 1U && val != 2U)
@@ -950,11 +950,11 @@ int32_t lis2duxs12_self_test_start(const stmdev_ctx_t *ctx, uint8_t val)
     return -1;
   }
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_SELF_TEST, (uint8_t *)&self_test, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_SELF_TEST, (uint8_t *)&self_test, 1);
   if (ret == 0)
   {
     self_test.st = (uint8_t) val;
-    ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_SELF_TEST, (uint8_t *)&self_test, 1);
+    ret = iis2dulpx_write_reg(ctx, IIS2DULPX_SELF_TEST, (uint8_t *)&self_test, 1);
   }
   return ret;
 }
@@ -966,16 +966,16 @@ int32_t lis2duxs12_self_test_start(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_self_test_stop(const stmdev_ctx_t *ctx)
+int32_t iis2dulpx_self_test_stop(const stmdev_ctx_t *ctx)
 {
-  lis2duxs12_self_test_t self_test;
+  iis2dulpx_self_test_t self_test;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_SELF_TEST, (uint8_t *)&self_test, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_SELF_TEST, (uint8_t *)&self_test, 1);
   if (ret == 0)
   {
     self_test.st = 0;
-    ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_SELF_TEST, (uint8_t *)&self_test, 1);
+    ret = iis2dulpx_write_reg(ctx, IIS2DULPX_SELF_TEST, (uint8_t *)&self_test, 1);
   }
   return ret;
 }
@@ -988,19 +988,19 @@ int32_t lis2duxs12_self_test_stop(const stmdev_ctx_t *ctx)
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_i3c_configure_set(const stmdev_ctx_t *ctx, const lis2duxs12_i3c_cfg_t *val)
+int32_t iis2dulpx_i3c_configure_set(const stmdev_ctx_t *ctx, const iis2dulpx_i3c_cfg_t *val)
 {
-  lis2duxs12_i3c_if_ctrl_t i3c_cfg;
+  iis2dulpx_i3c_if_ctrl_t i3c_cfg;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_I3C_IF_CTRL, (uint8_t *)&i3c_cfg, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_I3C_IF_CTRL, (uint8_t *)&i3c_cfg, 1);
 
   if (ret == 0)
   {
     i3c_cfg.bus_act_sel = (uint8_t)val->bus_act_sel;
     i3c_cfg.dis_drstdaa = val->drstdaa_en;
     i3c_cfg.asf_on = val->asf_on;
-    ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_I3C_IF_CTRL, (uint8_t *)&i3c_cfg, 1);
+    ret = iis2dulpx_write_reg(ctx, IIS2DULPX_I3C_IF_CTRL, (uint8_t *)&i3c_cfg, 1);
   }
 
   return ret;
@@ -1013,33 +1013,33 @@ int32_t lis2duxs12_i3c_configure_set(const stmdev_ctx_t *ctx, const lis2duxs12_i
   * @param  val   configuration params
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
-  */int32_t lis2duxs12_i3c_configure_get(const stmdev_ctx_t *ctx, lis2duxs12_i3c_cfg_t *val)
+  */int32_t iis2dulpx_i3c_configure_get(const stmdev_ctx_t *ctx, iis2dulpx_i3c_cfg_t *val)
 {
-  lis2duxs12_i3c_if_ctrl_t i3c_cfg;
+  iis2dulpx_i3c_if_ctrl_t i3c_cfg;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_I3C_IF_CTRL, (uint8_t *)&i3c_cfg, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_I3C_IF_CTRL, (uint8_t *)&i3c_cfg, 1);
 
   val->drstdaa_en = i3c_cfg.dis_drstdaa;
   val->asf_on = i3c_cfg.asf_on;
 
   switch (val->bus_act_sel)
   {
-    case LIS2DUXS12_I3C_BUS_AVAIL_TIME_20US:
-      val->bus_act_sel = LIS2DUXS12_I3C_BUS_AVAIL_TIME_20US;
+    case IIS2DULPX_I3C_BUS_AVAIL_TIME_20US:
+      val->bus_act_sel = IIS2DULPX_I3C_BUS_AVAIL_TIME_20US;
       break;
 
-    case LIS2DUXS12_I3C_BUS_AVAIL_TIME_50US:
-      val->bus_act_sel = LIS2DUXS12_I3C_BUS_AVAIL_TIME_50US;
+    case IIS2DULPX_I3C_BUS_AVAIL_TIME_50US:
+      val->bus_act_sel = IIS2DULPX_I3C_BUS_AVAIL_TIME_50US;
       break;
 
-    case LIS2DUXS12_I3C_BUS_AVAIL_TIME_1MS:
-      val->bus_act_sel = LIS2DUXS12_I3C_BUS_AVAIL_TIME_1MS;
+    case IIS2DULPX_I3C_BUS_AVAIL_TIME_1MS:
+      val->bus_act_sel = IIS2DULPX_I3C_BUS_AVAIL_TIME_1MS;
       break;
 
-    case LIS2DUXS12_I3C_BUS_AVAIL_TIME_25MS:
+    case IIS2DULPX_I3C_BUS_AVAIL_TIME_25MS:
     default:
-      val->bus_act_sel = LIS2DUXS12_I3C_BUS_AVAIL_TIME_25MS;
+      val->bus_act_sel = IIS2DULPX_I3C_BUS_AVAIL_TIME_25MS;
       break;
   }
 
@@ -1054,17 +1054,17 @@ int32_t lis2duxs12_i3c_configure_set(const stmdev_ctx_t *ctx, const lis2duxs12_i
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_mem_bank_set(const stmdev_ctx_t *ctx, lis2duxs12_mem_bank_t val)
+int32_t iis2dulpx_mem_bank_set(const stmdev_ctx_t *ctx, iis2dulpx_mem_bank_t val)
 {
-  lis2duxs12_func_cfg_access_t func_cfg_access;
+  iis2dulpx_func_cfg_access_t func_cfg_access;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
 
   if (ret == 0)
   {
     func_cfg_access.emb_func_reg_access = ((uint8_t)val & 0x1U);
-    ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+    ret = iis2dulpx_write_reg(ctx, IIS2DULPX_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
   }
 
   return ret;
@@ -1078,25 +1078,25 @@ int32_t lis2duxs12_mem_bank_set(const stmdev_ctx_t *ctx, lis2duxs12_mem_bank_t v
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_mem_bank_get(const stmdev_ctx_t *ctx, lis2duxs12_mem_bank_t *val)
+int32_t iis2dulpx_mem_bank_get(const stmdev_ctx_t *ctx, iis2dulpx_mem_bank_t *val)
 {
-  lis2duxs12_func_cfg_access_t func_cfg_access;
+  iis2dulpx_func_cfg_access_t func_cfg_access;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
 
   switch ((func_cfg_access.emb_func_reg_access))
   {
     case 0x0:
-      *val = LIS2DUXS12_MAIN_MEM_BANK;
+      *val = IIS2DULPX_MAIN_MEM_BANK;
       break;
 
     case 0x1:
-      *val = LIS2DUXS12_EMBED_FUNC_MEM_BANK;
+      *val = IIS2DULPX_EMBED_FUNC_MEM_BANK;
       break;
 
     default:
-      *val = LIS2DUXS12_MAIN_MEM_BANK;
+      *val = IIS2DULPX_MAIN_MEM_BANK;
       break;
   }
   return ret;
@@ -1113,11 +1113,11 @@ int32_t lis2duxs12_mem_bank_get(const stmdev_ctx_t *ctx, lis2duxs12_mem_bank_t *
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t address, uint8_t *buf, uint8_t len)
+int32_t iis2dulpx_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t address, uint8_t *buf, uint8_t len)
 {
-  lis2duxs12_page_address_t  page_address;
-  lis2duxs12_page_sel_t page_sel;
-  lis2duxs12_page_rw_t page_rw;
+  iis2dulpx_page_address_t  page_address;
+  iis2dulpx_page_sel_t page_sel;
+  iis2dulpx_page_rw_t page_rw;
   uint8_t msb;
   uint8_t lsb;
   int32_t ret;
@@ -1126,42 +1126,42 @@ int32_t lis2duxs12_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t address, uint8_
   msb = ((uint8_t)(address >> 8) & 0x0FU);
   lsb = (uint8_t)address & 0xFFU;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
   if (ret != 0)
   {
     goto exit;
   }
 
   /* page write */
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_RW, (uint8_t *)&page_rw, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_PAGE_RW, (uint8_t *)&page_rw, 1);
   page_rw.page_read = PROPERTY_DISABLE;
   page_rw.page_write = PROPERTY_ENABLE;
-  ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_RW, (uint8_t *)&page_rw, 1);
+  ret += iis2dulpx_write_reg(ctx, IIS2DULPX_PAGE_RW, (uint8_t *)&page_rw, 1);
 
   /* set page num */
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_PAGE_SEL, (uint8_t *)&page_sel, 1);
   page_sel.page_sel = msb;
   page_sel.not_used0 = 1; // Default value
-  ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  ret += iis2dulpx_write_reg(ctx, IIS2DULPX_PAGE_SEL, (uint8_t *)&page_sel, 1);
 
   /* set page addr */
   page_address.page_addr = lsb;
-  ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_ADDRESS, (uint8_t *)&page_address, 1);
+  ret += iis2dulpx_write_reg(ctx, IIS2DULPX_PAGE_ADDRESS, (uint8_t *)&page_address, 1);
 
   for (i = 0; i < len; i++)
   {
     /* read value */
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_VALUE, &buf[i], 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_PAGE_VALUE, &buf[i], 1);
     lsb++;
 
     /* Check if page wrap */
     if (((lsb & 0xFFU) == 0x00U) && (ret == 0))
     {
       msb++;
-      ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
+      ret += iis2dulpx_read_reg(ctx, IIS2DULPX_PAGE_SEL, (uint8_t *)&page_sel, 1);
       page_sel.page_sel = msb;
       page_sel.not_used0 = 1; // Default value
-      ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
+      ret += iis2dulpx_write_reg(ctx, IIS2DULPX_PAGE_SEL, (uint8_t *)&page_sel, 1);
     }
 
     if (ret != 0)
@@ -1172,15 +1172,15 @@ int32_t lis2duxs12_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t address, uint8_
 
   page_sel.page_sel = 0;
   page_sel.not_used0 = 1;// Default value
-  ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  ret += iis2dulpx_write_reg(ctx, IIS2DULPX_PAGE_SEL, (uint8_t *)&page_sel, 1);
 
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_RW, (uint8_t *)&page_rw, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_PAGE_RW, (uint8_t *)&page_rw, 1);
   page_rw.page_read = PROPERTY_DISABLE;
   page_rw.page_write = PROPERTY_DISABLE;
-  ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_RW, (uint8_t *)&page_rw, 1);
+  ret += iis2dulpx_write_reg(ctx, IIS2DULPX_PAGE_RW, (uint8_t *)&page_rw, 1);
 
 exit:
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -1196,11 +1196,11 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_ln_pg_read(const stmdev_ctx_t *ctx, uint16_t address, uint8_t *buf, uint8_t len)
+int32_t iis2dulpx_ln_pg_read(const stmdev_ctx_t *ctx, uint16_t address, uint8_t *buf, uint8_t len)
 {
-  lis2duxs12_page_address_t  page_address;
-  lis2duxs12_page_sel_t page_sel;
-  lis2duxs12_page_rw_t page_rw;
+  iis2dulpx_page_address_t  page_address;
+  iis2dulpx_page_sel_t page_sel;
+  iis2dulpx_page_rw_t page_rw;
   uint8_t msb;
   uint8_t lsb;
   int32_t ret;
@@ -1209,27 +1209,27 @@ int32_t lis2duxs12_ln_pg_read(const stmdev_ctx_t *ctx, uint16_t address, uint8_t
   msb = ((uint8_t)(address >> 8) & 0x0FU);
   lsb = (uint8_t)address & 0xFFU;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
   if (ret != 0)
   {
     goto exit;
   }
 
   /* page read */
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_RW, (uint8_t *)&page_rw, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_PAGE_RW, (uint8_t *)&page_rw, 1);
   page_rw.page_read = PROPERTY_ENABLE;
   page_rw.page_write = PROPERTY_DISABLE;
-  ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_RW, (uint8_t *)&page_rw, 1);
+  ret += iis2dulpx_write_reg(ctx, IIS2DULPX_PAGE_RW, (uint8_t *)&page_rw, 1);
   if (ret != 0)
   {
     goto exit;
   }
 
   /* set page num */
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_PAGE_SEL, (uint8_t *)&page_sel, 1);
   page_sel.page_sel = msb;
   page_sel.not_used0 = 1; // Default value
-  ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  ret += iis2dulpx_write_reg(ctx, IIS2DULPX_PAGE_SEL, (uint8_t *)&page_sel, 1);
   if (ret != 0)
   {
     goto exit;
@@ -1239,10 +1239,10 @@ int32_t lis2duxs12_ln_pg_read(const stmdev_ctx_t *ctx, uint16_t address, uint8_t
   {
     /* Sequential readings are not allowed. Set page address every loop */
     page_address.page_addr = lsb++;
-    ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_ADDRESS, (uint8_t *)&page_address, 1);
+    ret = iis2dulpx_write_reg(ctx, IIS2DULPX_PAGE_ADDRESS, (uint8_t *)&page_address, 1);
 
     /* read value */
-    ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_VALUE, &buf[i], 1);
+    ret += iis2dulpx_read_reg(ctx, IIS2DULPX_PAGE_VALUE, &buf[i], 1);
 
     /* Check if page wrap */
     if (((lsb & 0xFFU) == 0x00U) && (ret == 0))
@@ -1251,10 +1251,10 @@ int32_t lis2duxs12_ln_pg_read(const stmdev_ctx_t *ctx, uint16_t address, uint8_t
       lsb = 0;
 
       /* set page */
-      ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
+      ret += iis2dulpx_read_reg(ctx, IIS2DULPX_PAGE_SEL, (uint8_t *)&page_sel, 1);
       page_sel.page_sel = msb;
       page_sel.not_used0 = 1; // Default value
-      ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
+      ret += iis2dulpx_write_reg(ctx, IIS2DULPX_PAGE_SEL, (uint8_t *)&page_sel, 1);
     }
 
     if (ret != 0)
@@ -1265,15 +1265,15 @@ int32_t lis2duxs12_ln_pg_read(const stmdev_ctx_t *ctx, uint16_t address, uint8_t
 
   page_sel.page_sel = 0;
   page_sel.not_used0 = 1;// Default value
-  ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  ret += iis2dulpx_write_reg(ctx, IIS2DULPX_PAGE_SEL, (uint8_t *)&page_sel, 1);
 
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_RW, (uint8_t *)&page_rw, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_PAGE_RW, (uint8_t *)&page_rw, 1);
   page_rw.page_read = PROPERTY_DISABLE;
   page_rw.page_write = PROPERTY_DISABLE;
-  ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_RW, (uint8_t *)&page_rw, 1);
+  ret += iis2dulpx_write_reg(ctx, IIS2DULPX_PAGE_RW, (uint8_t *)&page_rw, 1);
 
 exit:
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -1298,14 +1298,14 @@ exit:
   * @retval      interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_ext_clk_en_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t iis2dulpx_ext_clk_en_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2duxs12_ext_clk_cfg_t clk;
+  iis2dulpx_ext_clk_cfg_t clk;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_EXT_CLK_CFG, (uint8_t *)&clk, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_EXT_CLK_CFG, (uint8_t *)&clk, 1);
   clk.ext_clk_en = val;
-  ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_EXT_CLK_CFG, (uint8_t *)&clk, 1);
+  ret += iis2dulpx_write_reg(ctx, IIS2DULPX_EXT_CLK_CFG, (uint8_t *)&clk, 1);
 
   return ret;
 }
@@ -1318,12 +1318,12 @@ int32_t lis2duxs12_ext_clk_en_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval      interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_ext_clk_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t iis2dulpx_ext_clk_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2duxs12_ext_clk_cfg_t clk;
+  iis2dulpx_ext_clk_cfg_t clk;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_EXT_CLK_CFG, (uint8_t *)&clk, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_EXT_CLK_CFG, (uint8_t *)&clk, 1);
   *val = clk.ext_clk_en;
 
   return ret;
@@ -1337,12 +1337,12 @@ int32_t lis2duxs12_ext_clk_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval      interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_pin_conf_set(const stmdev_ctx_t *ctx, const lis2duxs12_pin_conf_t *val)
+int32_t iis2dulpx_pin_conf_set(const stmdev_ctx_t *ctx, const iis2dulpx_pin_conf_t *val)
 {
-  lis2duxs12_pin_ctrl_t pin_ctrl;
+  iis2dulpx_pin_ctrl_t pin_ctrl;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
 
   if (ret == 0)
   {
@@ -1353,7 +1353,7 @@ int32_t lis2duxs12_pin_conf_set(const stmdev_ctx_t *ctx, const lis2duxs12_pin_co
     pin_ctrl.sdo_pu_en = val->sdo_pull_up;
     pin_ctrl.pp_od = ~val->int1_int2_push_pull;
 
-    ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+    ret = iis2dulpx_write_reg(ctx, IIS2DULPX_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
   }
 
   return ret;
@@ -1367,12 +1367,12 @@ int32_t lis2duxs12_pin_conf_set(const stmdev_ctx_t *ctx, const lis2duxs12_pin_co
   * @retval      interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_pin_conf_get(const stmdev_ctx_t *ctx, lis2duxs12_pin_conf_t *val)
+int32_t iis2dulpx_pin_conf_get(const stmdev_ctx_t *ctx, iis2dulpx_pin_conf_t *val)
 {
-  lis2duxs12_pin_ctrl_t pin_ctrl;
+  iis2dulpx_pin_ctrl_t pin_ctrl;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
 
   val->cs_pull_up = ~pin_ctrl.cs_pu_dis;
   val->int1_pull_down = ~pin_ctrl.pd_dis_int1;
@@ -1392,17 +1392,17 @@ int32_t lis2duxs12_pin_conf_get(const stmdev_ctx_t *ctx, lis2duxs12_pin_conf_t *
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_int_pin_polarity_set(const stmdev_ctx_t *ctx, lis2duxs12_int_pin_polarity_t val)
+int32_t iis2dulpx_int_pin_polarity_set(const stmdev_ctx_t *ctx, iis2dulpx_int_pin_polarity_t val)
 {
-  lis2duxs12_pin_ctrl_t pin_ctrl;
+  iis2dulpx_pin_ctrl_t pin_ctrl;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
 
   if (ret == 0)
   {
     pin_ctrl.h_lactive = (uint8_t)val;
-    ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+    ret = iis2dulpx_write_reg(ctx, IIS2DULPX_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
   }
 
   return ret;
@@ -1416,25 +1416,25 @@ int32_t lis2duxs12_int_pin_polarity_set(const stmdev_ctx_t *ctx, lis2duxs12_int_
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_int_pin_polarity_get(const stmdev_ctx_t *ctx, lis2duxs12_int_pin_polarity_t *val)
+int32_t iis2dulpx_int_pin_polarity_get(const stmdev_ctx_t *ctx, iis2dulpx_int_pin_polarity_t *val)
 {
-  lis2duxs12_pin_ctrl_t pin_ctrl;
+  iis2dulpx_pin_ctrl_t pin_ctrl;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
 
   switch ((pin_ctrl.h_lactive))
   {
     case 0x0:
-      *val = LIS2DUXS12_ACTIVE_HIGH;
+      *val = IIS2DULPX_ACTIVE_HIGH;
       break;
 
     case 0x1:
-      *val = LIS2DUXS12_ACTIVE_LOW;
+      *val = IIS2DULPX_ACTIVE_LOW;
       break;
 
     default:
-      *val = LIS2DUXS12_ACTIVE_HIGH;
+      *val = IIS2DULPX_ACTIVE_HIGH;
       break;
   }
   return ret;
@@ -1448,17 +1448,17 @@ int32_t lis2duxs12_int_pin_polarity_get(const stmdev_ctx_t *ctx, lis2duxs12_int_
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_spi_mode_set(const stmdev_ctx_t *ctx, lis2duxs12_spi_mode val)
+int32_t iis2dulpx_spi_mode_set(const stmdev_ctx_t *ctx, iis2dulpx_spi_mode val)
 {
-  lis2duxs12_pin_ctrl_t pin_ctrl;
+  iis2dulpx_pin_ctrl_t pin_ctrl;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
 
   if (ret == 0)
   {
     pin_ctrl.sim = (uint8_t)val;
-    ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+    ret = iis2dulpx_write_reg(ctx, IIS2DULPX_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
   }
 
   return ret;
@@ -1472,25 +1472,25 @@ int32_t lis2duxs12_spi_mode_set(const stmdev_ctx_t *ctx, lis2duxs12_spi_mode val
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_spi_mode_get(const stmdev_ctx_t *ctx, lis2duxs12_spi_mode *val)
+int32_t iis2dulpx_spi_mode_get(const stmdev_ctx_t *ctx, iis2dulpx_spi_mode *val)
 {
-  lis2duxs12_pin_ctrl_t pin_ctrl;
+  iis2dulpx_pin_ctrl_t pin_ctrl;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
 
   switch ((pin_ctrl.sim))
   {
     case 0x0:
-      *val = LIS2DUXS12_SPI_4_WIRE;
+      *val = IIS2DULPX_SPI_4_WIRE;
       break;
 
     case 0x1:
-      *val = LIS2DUXS12_SPI_3_WIRE;
+      *val = IIS2DULPX_SPI_3_WIRE;
       break;
 
     default:
-      *val = LIS2DUXS12_SPI_4_WIRE;
+      *val = IIS2DULPX_SPI_4_WIRE;
       break;
   }
   return ret;
@@ -1504,26 +1504,25 @@ int32_t lis2duxs12_spi_mode_get(const stmdev_ctx_t *ctx, lis2duxs12_spi_mode *va
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_pin_int1_route_set(const stmdev_ctx_t *ctx,
-                                      const lis2duxs12_pin_int_route_t *val)
+int32_t iis2dulpx_pin_int1_route_set(const stmdev_ctx_t *ctx, const iis2dulpx_pin_int_route_t *val)
 {
-  lis2duxs12_ctrl1_t ctrl1;
-  lis2duxs12_ctrl2_t ctrl2;
-  lis2duxs12_md1_cfg_t md1_cfg;
+  iis2dulpx_ctrl1_t ctrl1;
+  iis2dulpx_ctrl2_t ctrl2;
+  iis2dulpx_md1_cfg_t md1_cfg;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL1, (uint8_t *)&ctrl1, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_CTRL1, (uint8_t *)&ctrl1, 1);
 
   if (ret == 0)
   {
     ctrl1.int1_on_res = val->int_on_res;
 
-    ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_CTRL1, (uint8_t *)&ctrl1, 1);
+    ret = iis2dulpx_write_reg(ctx, IIS2DULPX_CTRL1, (uint8_t *)&ctrl1, 1);
   }
 
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL2, (uint8_t *)&ctrl2, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_CTRL2, (uint8_t *)&ctrl2, 1);
 
     if (ret == 0)
     {
@@ -1533,13 +1532,13 @@ int32_t lis2duxs12_pin_int1_route_set(const stmdev_ctx_t *ctx,
       ctrl2.int1_fifo_full = val->fifo_full;
       ctrl2.int1_boot = val->boot;
 
-      ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_CTRL2, (uint8_t *)&ctrl2, 1);
+      ret = iis2dulpx_write_reg(ctx, IIS2DULPX_CTRL2, (uint8_t *)&ctrl2, 1);
     }
   }
 
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_MD1_CFG, (uint8_t *)&md1_cfg, 1);
 
     if (ret == 0)
     {
@@ -1551,7 +1550,7 @@ int32_t lis2duxs12_pin_int1_route_set(const stmdev_ctx_t *ctx,
       md1_cfg.int1_emb_func = val->emb_function;
       md1_cfg.int1_timestamp = val->timestamp;
 
-      ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+      ret = iis2dulpx_write_reg(ctx, IIS2DULPX_MD1_CFG, (uint8_t *)&md1_cfg, 1);
     }
   }
 
@@ -1566,16 +1565,16 @@ int32_t lis2duxs12_pin_int1_route_set(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_pin_int1_route_get(const stmdev_ctx_t *ctx, lis2duxs12_pin_int_route_t *val)
+int32_t iis2dulpx_pin_int1_route_get(const stmdev_ctx_t *ctx, iis2dulpx_pin_int_route_t *val)
 {
-  lis2duxs12_ctrl1_t ctrl1;
-  lis2duxs12_ctrl2_t ctrl2;
-  lis2duxs12_md1_cfg_t md1_cfg;
+  iis2dulpx_ctrl1_t ctrl1;
+  iis2dulpx_ctrl2_t ctrl2;
+  iis2dulpx_md1_cfg_t md1_cfg;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL1, (uint8_t *)&ctrl1, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL2, (uint8_t *)&ctrl2, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_CTRL1, (uint8_t *)&ctrl1, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_CTRL2, (uint8_t *)&ctrl2, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_MD1_CFG, (uint8_t *)&md1_cfg, 1);
 
   if (ret == 0)
   {
@@ -1605,17 +1604,17 @@ int32_t lis2duxs12_pin_int1_route_get(const stmdev_ctx_t *ctx, lis2duxs12_pin_in
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_emb_pin_int1_route_set(const stmdev_ctx_t *ctx,
-                                          const lis2duxs12_emb_pin_int_route_t *val)
+int32_t iis2dulpx_emb_pin_int1_route_set(const stmdev_ctx_t *ctx,
+                                         const iis2dulpx_emb_pin_int_route_t *val)
 {
-  lis2duxs12_emb_func_int1_t emb_func_int1;
-  lis2duxs12_md1_cfg_t md1_cfg;
+  iis2dulpx_emb_func_int1_t emb_func_int1;
+  iis2dulpx_md1_cfg_t md1_cfg;
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_INT1, (uint8_t *)&emb_func_int1, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_EMB_FUNC_INT1, (uint8_t *)&emb_func_int1, 1);
   }
 
   if (ret == 0)
@@ -1625,15 +1624,15 @@ int32_t lis2duxs12_emb_pin_int1_route_set(const stmdev_ctx_t *ctx,
     emb_func_int1.int1_step_det = val->step_det;
     emb_func_int1.int1_fsm_lc = val->fsm_lc;
 
-    ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_EMB_FUNC_INT1, (uint8_t *)&emb_func_int1, 1);
+    ret = iis2dulpx_write_reg(ctx, IIS2DULPX_EMB_FUNC_INT1, (uint8_t *)&emb_func_int1, 1);
   }
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_MD1_CFG, (uint8_t *)&md1_cfg, 1);
   if (ret == 0)
   {
     md1_cfg.int1_emb_func = 1;
-    ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+    ret = iis2dulpx_write_reg(ctx, IIS2DULPX_MD1_CFG, (uint8_t *)&md1_cfg, 1);
   }
 
   return ret;
@@ -1647,16 +1646,16 @@ int32_t lis2duxs12_emb_pin_int1_route_set(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_emb_pin_int1_route_get(const stmdev_ctx_t *ctx,
-                                          lis2duxs12_emb_pin_int_route_t *val)
+int32_t iis2dulpx_emb_pin_int1_route_get(const stmdev_ctx_t *ctx,
+                                         iis2dulpx_emb_pin_int_route_t *val)
 {
-  lis2duxs12_emb_func_int1_t emb_func_int1;
+  iis2dulpx_emb_func_int1_t emb_func_int1;
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_INT1, (uint8_t *)&emb_func_int1, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_EMB_FUNC_INT1, (uint8_t *)&emb_func_int1, 1);
   }
 
   if (ret == 0)
@@ -1666,7 +1665,7 @@ int32_t lis2duxs12_emb_pin_int1_route_get(const stmdev_ctx_t *ctx,
     val->step_det = emb_func_int1.int1_step_det;
     val->fsm_lc = emb_func_int1.int1_fsm_lc;
   }
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -1679,14 +1678,13 @@ int32_t lis2duxs12_emb_pin_int1_route_get(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_pin_int2_route_set(const stmdev_ctx_t *ctx,
-                                      const lis2duxs12_pin_int_route_t *val)
+int32_t iis2dulpx_pin_int2_route_set(const stmdev_ctx_t *ctx, const iis2dulpx_pin_int_route_t *val)
 {
-  lis2duxs12_ctrl3_t ctrl3;
-  lis2duxs12_md2_cfg_t md2_cfg;
+  iis2dulpx_ctrl3_t ctrl3;
+  iis2dulpx_md2_cfg_t md2_cfg;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL3, (uint8_t *)&ctrl3, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_CTRL3, (uint8_t *)&ctrl3, 1);
 
   if (ret == 0)
   {
@@ -1696,12 +1694,12 @@ int32_t lis2duxs12_pin_int2_route_set(const stmdev_ctx_t *ctx,
     ctrl3.int2_fifo_full = val->fifo_full;
     ctrl3.int2_boot = val->boot;
 
-    ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_CTRL3, (uint8_t *)&ctrl3, 1);
+    ret = iis2dulpx_write_reg(ctx, IIS2DULPX_CTRL3, (uint8_t *)&ctrl3, 1);
   }
 
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_MD2_CFG, (uint8_t *)&md2_cfg, 1);
 
     if (ret == 0)
     {
@@ -1713,7 +1711,7 @@ int32_t lis2duxs12_pin_int2_route_set(const stmdev_ctx_t *ctx,
       md2_cfg.int2_emb_func = val->emb_function;
       md2_cfg.int2_timestamp = val->timestamp;
 
-      ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+      ret = iis2dulpx_write_reg(ctx, IIS2DULPX_MD2_CFG, (uint8_t *)&md2_cfg, 1);
     }
   }
 
@@ -1728,14 +1726,14 @@ int32_t lis2duxs12_pin_int2_route_set(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_pin_int2_route_get(const stmdev_ctx_t *ctx, lis2duxs12_pin_int_route_t *val)
+int32_t iis2dulpx_pin_int2_route_get(const stmdev_ctx_t *ctx, iis2dulpx_pin_int_route_t *val)
 {
-  lis2duxs12_ctrl3_t ctrl3;
-  lis2duxs12_md2_cfg_t md2_cfg;
+  iis2dulpx_ctrl3_t ctrl3;
+  iis2dulpx_md2_cfg_t md2_cfg;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL2, (uint8_t *)&ctrl3, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_MD1_CFG, (uint8_t *)&md2_cfg, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_CTRL2, (uint8_t *)&ctrl3, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_MD1_CFG, (uint8_t *)&md2_cfg, 1);
 
   if (ret == 0)
   {
@@ -1764,17 +1762,17 @@ int32_t lis2duxs12_pin_int2_route_get(const stmdev_ctx_t *ctx, lis2duxs12_pin_in
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_emb_pin_int2_route_set(const stmdev_ctx_t *ctx,
-                                          const lis2duxs12_emb_pin_int_route_t *val)
+int32_t iis2dulpx_emb_pin_int2_route_set(const stmdev_ctx_t *ctx,
+                                         const iis2dulpx_emb_pin_int_route_t *val)
 {
-  lis2duxs12_emb_func_int2_t emb_func_int2;
-  lis2duxs12_md2_cfg_t md2_cfg;
+  iis2dulpx_emb_func_int2_t emb_func_int2;
+  iis2dulpx_md2_cfg_t md2_cfg;
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_INT2, (uint8_t *)&emb_func_int2, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_EMB_FUNC_INT2, (uint8_t *)&emb_func_int2, 1);
   }
 
   if (ret == 0)
@@ -1784,15 +1782,15 @@ int32_t lis2duxs12_emb_pin_int2_route_set(const stmdev_ctx_t *ctx,
     emb_func_int2.int2_step_det = val->step_det;
     emb_func_int2.int2_fsm_lc = val->fsm_lc;
 
-    ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_EMB_FUNC_INT2, (uint8_t *)&emb_func_int2, 1);
+    ret = iis2dulpx_write_reg(ctx, IIS2DULPX_EMB_FUNC_INT2, (uint8_t *)&emb_func_int2, 1);
   }
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_MD2_CFG, (uint8_t *)&md2_cfg, 1);
   if (ret == 0)
   {
     md2_cfg.int2_emb_func = 1;
-    ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+    ret = iis2dulpx_write_reg(ctx, IIS2DULPX_MD2_CFG, (uint8_t *)&md2_cfg, 1);
   }
 
   return ret;
@@ -1806,16 +1804,16 @@ int32_t lis2duxs12_emb_pin_int2_route_set(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_emb_pin_int2_route_get(const stmdev_ctx_t *ctx,
-                                          lis2duxs12_emb_pin_int_route_t *val)
+int32_t iis2dulpx_emb_pin_int2_route_get(const stmdev_ctx_t *ctx,
+                                         iis2dulpx_emb_pin_int_route_t *val)
 {
-  lis2duxs12_emb_func_int2_t emb_func_int2;
+  iis2dulpx_emb_func_int2_t emb_func_int2;
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_INT2, (uint8_t *)&emb_func_int2, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_EMB_FUNC_INT2, (uint8_t *)&emb_func_int2, 1);
   }
 
   if (ret == 0)
@@ -1825,7 +1823,7 @@ int32_t lis2duxs12_emb_pin_int2_route_get(const stmdev_ctx_t *ctx,
     val->step_det = emb_func_int2.int2_step_det;
     val->fsm_lc = emb_func_int2.int2_fsm_lc;
   }
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -1838,27 +1836,27 @@ int32_t lis2duxs12_emb_pin_int2_route_get(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_int_config_set(const stmdev_ctx_t *ctx, const lis2duxs12_int_config_t *val)
+int32_t iis2dulpx_int_config_set(const stmdev_ctx_t *ctx, const iis2dulpx_int_config_t *val)
 {
-  lis2duxs12_interrupt_cfg_t interrupt_cfg;
+  iis2dulpx_interrupt_cfg_t interrupt_cfg;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_INTERRUPT_CFG, (uint8_t *)&interrupt_cfg, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_INTERRUPT_CFG, (uint8_t *)&interrupt_cfg, 1);
 
   if (ret == 0)
   {
     switch (val->int_cfg)
     {
-      case LIS2DUXS12_INT_DISABLED:
+      case IIS2DULPX_INT_DISABLED:
         interrupt_cfg.interrupts_enable = 0;
         break;
 
-      case LIS2DUXS12_INT_LEVEL:
+      case IIS2DULPX_INT_LEVEL:
         interrupt_cfg.interrupts_enable = 1;
         interrupt_cfg.lir = 0;
         break;
 
-      case LIS2DUXS12_INT_LATCHED:
+      case IIS2DULPX_INT_LATCHED:
       default:
         interrupt_cfg.interrupts_enable = 1;
         interrupt_cfg.lir = 1;
@@ -1868,7 +1866,7 @@ int32_t lis2duxs12_int_config_set(const stmdev_ctx_t *ctx, const lis2duxs12_int_
     interrupt_cfg.dis_rst_lir_all_int = val->dis_rst_lir_all_int;
     interrupt_cfg.sleep_status_on_int = val->sleep_status_on_int;
 
-    ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_INTERRUPT_CFG, (uint8_t *)&interrupt_cfg, 1);
+    ret = iis2dulpx_write_reg(ctx, IIS2DULPX_INTERRUPT_CFG, (uint8_t *)&interrupt_cfg, 1);
   }
 
   return ret;
@@ -1882,12 +1880,12 @@ int32_t lis2duxs12_int_config_set(const stmdev_ctx_t *ctx, const lis2duxs12_int_
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_int_config_get(const stmdev_ctx_t *ctx, lis2duxs12_int_config_t *val)
+int32_t iis2dulpx_int_config_get(const stmdev_ctx_t *ctx, iis2dulpx_int_config_t *val)
 {
-  lis2duxs12_interrupt_cfg_t interrupt_cfg;
+  iis2dulpx_interrupt_cfg_t interrupt_cfg;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_INTERRUPT_CFG, (uint8_t *)&interrupt_cfg, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_INTERRUPT_CFG, (uint8_t *)&interrupt_cfg, 1);
 
   if (ret == 0)
   {
@@ -1896,15 +1894,15 @@ int32_t lis2duxs12_int_config_get(const stmdev_ctx_t *ctx, lis2duxs12_int_config
 
     if (interrupt_cfg.interrupts_enable == 0U)
     {
-      val->int_cfg = LIS2DUXS12_INT_DISABLED;
+      val->int_cfg = IIS2DULPX_INT_DISABLED;
     }
     else if (interrupt_cfg.lir == 0U)
     {
-      val->int_cfg = LIS2DUXS12_INT_LEVEL;
+      val->int_cfg = IIS2DULPX_INT_LEVEL;
     }
     else
     {
-      val->int_cfg = LIS2DUXS12_INT_LATCHED;
+      val->int_cfg = IIS2DULPX_INT_LATCHED;
     }
   }
 
@@ -1919,33 +1917,32 @@ int32_t lis2duxs12_int_config_get(const stmdev_ctx_t *ctx, lis2duxs12_int_config
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_embedded_int_cfg_set(const stmdev_ctx_t *ctx,
-                                        lis2duxs12_embedded_int_config_t val)
+int32_t iis2dulpx_embedded_int_cfg_set(const stmdev_ctx_t *ctx, iis2dulpx_embedded_int_config_t val)
 {
-  lis2duxs12_page_rw_t page_rw;
+  iis2dulpx_page_rw_t page_rw;
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_PAGE_RW, (uint8_t *)&page_rw, 1);
 
     switch (val)
     {
-      case LIS2DUXS12_EMBEDDED_INT_LEVEL:
+      case IIS2DULPX_EMBEDDED_INT_LEVEL:
         page_rw.emb_func_lir = 0;
         break;
 
-      case LIS2DUXS12_EMBEDDED_INT_LATCHED:
+      case IIS2DULPX_EMBEDDED_INT_LATCHED:
       default:
         page_rw.emb_func_lir = 1;
         break;
     }
 
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_PAGE_RW, (uint8_t *)&page_rw, 1);
   }
 
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -1958,28 +1955,28 @@ int32_t lis2duxs12_embedded_int_cfg_set(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_embedded_int_cfg_get(const stmdev_ctx_t *ctx,
-                                        lis2duxs12_embedded_int_config_t *val)
+int32_t iis2dulpx_embedded_int_cfg_get(const stmdev_ctx_t *ctx,
+                                       iis2dulpx_embedded_int_config_t *val)
 {
-  lis2duxs12_page_rw_t page_rw;
+  iis2dulpx_page_rw_t page_rw;
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_PAGE_RW, (uint8_t *)&page_rw, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_PAGE_RW, (uint8_t *)&page_rw, 1);
 
     if (page_rw.emb_func_lir == 0U)
     {
-      *val = LIS2DUXS12_EMBEDDED_INT_LEVEL;
+      *val = IIS2DULPX_EMBEDDED_INT_LEVEL;
     }
     else
     {
-      *val = LIS2DUXS12_EMBEDDED_INT_LATCHED;
+      *val = IIS2DULPX_EMBEDDED_INT_LATCHED;
     }
   }
 
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -2004,23 +2001,23 @@ int32_t lis2duxs12_embedded_int_cfg_get(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_fifo_mode_set(const stmdev_ctx_t *ctx, lis2duxs12_fifo_mode_t val)
+int32_t iis2dulpx_fifo_mode_set(const stmdev_ctx_t *ctx, iis2dulpx_fifo_mode_t val)
 {
-  lis2duxs12_ctrl4_t ctrl4;
-  lis2duxs12_fifo_ctrl_t fifo_ctrl;
-  lis2duxs12_fifo_wtm_t fifo_wtm;
-  lis2duxs12_fifo_batch_dec_t fifo_batch;
+  iis2dulpx_ctrl4_t ctrl4;
+  iis2dulpx_fifo_ctrl_t fifo_ctrl;
+  iis2dulpx_fifo_wtm_t fifo_wtm;
+  iis2dulpx_fifo_batch_dec_t fifo_batch;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL4, (uint8_t *)&ctrl4, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_FIFO_CTRL, (uint8_t *)&fifo_ctrl, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_FIFO_BATCH_DEC, (uint8_t *)&fifo_batch, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_FIFO_WTM, (uint8_t *)&fifo_wtm, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_CTRL4, (uint8_t *)&ctrl4, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_FIFO_CTRL, (uint8_t *)&fifo_ctrl, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_FIFO_BATCH_DEC, (uint8_t *)&fifo_batch, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_FIFO_WTM, (uint8_t *)&fifo_wtm, 1);
 
   if (ret == 0)
   {
     /* set FIFO mode */
-    if (val.operation != LIS2DUXS12_FIFO_OFF)
+    if (val.operation != IIS2DULPX_FIFO_OFF)
     {
       ctrl4.fifo_en = 1;
       fifo_ctrl.fifo_mode = ((uint8_t)val.operation & 0x7U);
@@ -2045,14 +2042,14 @@ int32_t lis2duxs12_fifo_mode_set(const stmdev_ctx_t *ctx, lis2duxs12_fifo_mode_t
     /* set watermark */
     if (val.watermark > 0U)
     {
-      fifo_ctrl.stop_on_fth = (val.fifo_event == LIS2DUXS12_FIFO_EV_WTM) ? 1 : 0;
+      fifo_ctrl.stop_on_fth = (val.fifo_event == IIS2DULPX_FIFO_EV_WTM) ? 1 : 0;
       fifo_wtm.fth = val.watermark;
     }
 
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_FIFO_BATCH_DEC, (uint8_t *)&fifo_batch, 1);
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_FIFO_WTM, (uint8_t *)&fifo_wtm, 1);
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_FIFO_CTRL, (uint8_t *)&fifo_ctrl, 1);
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_CTRL4, (uint8_t *)&ctrl4, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_FIFO_BATCH_DEC, (uint8_t *)&fifo_batch, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_FIFO_WTM, (uint8_t *)&fifo_wtm, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_FIFO_CTRL, (uint8_t *)&fifo_ctrl, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_CTRL4, (uint8_t *)&ctrl4, 1);
   }
 
   return ret;
@@ -2066,41 +2063,41 @@ int32_t lis2duxs12_fifo_mode_set(const stmdev_ctx_t *ctx, lis2duxs12_fifo_mode_t
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_fifo_mode_get(const stmdev_ctx_t *ctx, lis2duxs12_fifo_mode_t *val)
+int32_t iis2dulpx_fifo_mode_get(const stmdev_ctx_t *ctx, iis2dulpx_fifo_mode_t *val)
 {
-  lis2duxs12_ctrl4_t ctrl4;
-  lis2duxs12_fifo_ctrl_t fifo_ctrl;
-  lis2duxs12_fifo_wtm_t fifo_wtm;
-  lis2duxs12_fifo_batch_dec_t fifo_batch;
+  iis2dulpx_ctrl4_t ctrl4;
+  iis2dulpx_fifo_ctrl_t fifo_ctrl;
+  iis2dulpx_fifo_wtm_t fifo_wtm;
+  iis2dulpx_fifo_batch_dec_t fifo_batch;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL4, (uint8_t *)&ctrl4, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_FIFO_CTRL, (uint8_t *)&fifo_ctrl, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_FIFO_BATCH_DEC, (uint8_t *)&fifo_batch, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_FIFO_WTM, (uint8_t *)&fifo_wtm, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_CTRL4, (uint8_t *)&ctrl4, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_FIFO_CTRL, (uint8_t *)&fifo_ctrl, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_FIFO_BATCH_DEC, (uint8_t *)&fifo_batch, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_FIFO_WTM, (uint8_t *)&fifo_wtm, 1);
 
   if (ret == 0)
   {
     /* get FIFO mode */
     if (ctrl4.fifo_en == 0U)
     {
-      val->operation = LIS2DUXS12_FIFO_OFF;
+      val->operation = IIS2DULPX_FIFO_OFF;
     }
     else
     {
-      val->operation = (lis2duxs12_operation_t)fifo_ctrl.fifo_mode;
+      val->operation = (iis2dulpx_operation_t)fifo_ctrl.fifo_mode;
     }
     val->cfg_change_in_fifo = fifo_ctrl.cfg_chg_en;
 
     /* get fifo depth (1X/2X) */
-    val->store = (lis2duxs12_store_t)fifo_ctrl.fifo_depth;
+    val->store = (iis2dulpx_store_t)fifo_ctrl.fifo_depth;
 
     /* Get xl_only_fifo */
     val->xl_only = fifo_wtm.xl_only_fifo;
 
     /* get batching info */
-    val->batch.dec_ts = (lis2duxs12_dec_ts_t)fifo_batch.dec_ts_batch;
-    val->batch.bdr_xl = (lis2duxs12_bdr_xl_t)fifo_batch.bdr_xl;
+    val->batch.dec_ts = (iis2dulpx_dec_ts_t)fifo_batch.dec_ts_batch;
+    val->batch.bdr_xl = (iis2dulpx_bdr_xl_t)fifo_batch.bdr_xl;
 
     /* get watermark */
     val->watermark = fifo_wtm.fth;
@@ -2117,77 +2114,77 @@ int32_t lis2duxs12_fifo_mode_get(const stmdev_ctx_t *ctx, lis2duxs12_fifo_mode_t
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_fifo_data_level_get(const stmdev_ctx_t *ctx, uint16_t *val)
+int32_t iis2dulpx_fifo_data_level_get(const stmdev_ctx_t *ctx, uint16_t *val)
 {
   uint8_t buff;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_FIFO_STATUS2, &buff, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_FIFO_STATUS2, &buff, 1);
 
   *val = buff;
 
   return ret;
 }
 
-int32_t lis2duxs12_fifo_wtm_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t iis2dulpx_fifo_wtm_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2duxs12_fifo_status1_t fifo_status1;
+  iis2dulpx_fifo_status1_t fifo_status1;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_FIFO_STATUS1, (uint8_t *)&fifo_status1, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_FIFO_STATUS1, (uint8_t *)&fifo_status1, 1);
 
   *val = fifo_status1.fifo_wtm_ia;
 
   return ret;
 }
 
-int32_t lis2duxs12_fifo_sensor_tag_get(const stmdev_ctx_t *ctx, lis2duxs12_fifo_sensor_tag_t *val)
+int32_t iis2dulpx_fifo_sensor_tag_get(const stmdev_ctx_t *ctx, iis2dulpx_fifo_sensor_tag_t *val)
 {
-  lis2duxs12_fifo_data_out_tag_t fifo_tag;
+  iis2dulpx_fifo_data_out_tag_t fifo_tag;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_FIFO_DATA_OUT_TAG, (uint8_t *)&fifo_tag, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_FIFO_DATA_OUT_TAG, (uint8_t *)&fifo_tag, 1);
 
-  *val = (lis2duxs12_fifo_sensor_tag_t) fifo_tag.tag_sensor;
+  *val = (iis2dulpx_fifo_sensor_tag_t) fifo_tag.tag_sensor;
 
   return ret;
 }
 
-int32_t lis2duxs12_fifo_out_raw_get(const stmdev_ctx_t *ctx, uint8_t *buff)
+int32_t iis2dulpx_fifo_out_raw_get(const stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_FIFO_DATA_OUT_X_L, buff, 6);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_FIFO_DATA_OUT_X_L, buff, 6);
 
   return ret;
 }
 
-int32_t lis2duxs12_fifo_data_get(const stmdev_ctx_t *ctx, const lis2duxs12_md_t *md,
-                                 const lis2duxs12_fifo_mode_t *fmd,
-                                 lis2duxs12_fifo_data_t *data)
+int32_t iis2dulpx_fifo_data_get(const stmdev_ctx_t *ctx, const iis2dulpx_md_t *md,
+                                const iis2dulpx_fifo_mode_t *fmd,
+                                iis2dulpx_fifo_data_t *data)
 {
-  lis2duxs12_fifo_data_out_tag_t fifo_tag;
+  iis2dulpx_fifo_data_out_tag_t fifo_tag;
   uint8_t fifo_raw[6];
   int32_t ret, i;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_FIFO_DATA_OUT_TAG, (uint8_t *)&fifo_tag, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_FIFO_DATA_OUT_TAG, (uint8_t *)&fifo_tag, 1);
   data->tag = fifo_tag.tag_sensor;
 
   switch (fifo_tag.tag_sensor)
   {
-    case LIS2DUXS12_XL_ONLY_2X_TAG:
-    case LIS2DUXS12_XL_ONLY_2X_TAG_2ND:
+    case IIS2DULPX_XL_ONLY_2X_TAG:
+    case IIS2DULPX_XL_ONLY_2X_TAG_2ND:
       /* A FIFO sample consists of 2X 8-bits 3-axis XL at ODR/2 */
-      ret = lis2duxs12_fifo_out_raw_get(ctx, fifo_raw);
+      ret = iis2dulpx_fifo_out_raw_get(ctx, fifo_raw);
       for (i = 0; i < 3; i++)
       {
         data->xl[0].raw[i] = (int16_t)fifo_raw[i] * 256;
         data->xl[1].raw[i] = (int16_t)fifo_raw[3 + i] * 256;
       }
       break;
-    case LIS2DUXS12_XL_AND_QVAR:
-    case LIS2DUXS12_XL_TEMP_TAG:
-      ret = lis2duxs12_fifo_out_raw_get(ctx, fifo_raw);
+    case IIS2DULPX_XL_AND_QVAR:
+    case IIS2DULPX_XL_TEMP_TAG:
+      ret = iis2dulpx_fifo_out_raw_get(ctx, fifo_raw);
       if (fmd->xl_only == 0x0U)
       {
         /* A FIFO sample consists of 12-bits 3-axis XL + T at ODR*/
@@ -2199,14 +2196,14 @@ int32_t lis2duxs12_fifo_data_get(const stmdev_ctx_t *ctx, const lis2duxs12_md_t 
         data->xl[0].raw[2] = (data->xl[0].raw[2] + (int16_t)fifo_raw[4] * 256) * 16;
         data->heat.raw = (int16_t)fifo_raw[4] / 16;
         data->heat.raw = (data->heat.raw + ((int16_t)fifo_raw[5] * 16)) * 16;
-        if (fifo_tag.tag_sensor == (uint8_t)LIS2DUXS12_XL_TEMP_TAG)
+        if (fifo_tag.tag_sensor == (uint8_t)IIS2DULPX_XL_TEMP_TAG)
         {
-          data->heat.deg_c = lis2duxs12_from_lsb_to_celsius(data->heat.raw);
+          data->heat.deg_c = iis2dulpx_from_lsb_to_celsius(data->heat.raw);
         }
         else
         {
           data->ah_qvar.raw = data->heat.raw;
-          data->ah_qvar.mv = lis2duxs12_from_lsb_to_mv(data->ah_qvar.raw);
+          data->ah_qvar.mv = iis2dulpx_from_lsb_to_mv(data->ah_qvar.raw);
         }
       }
       else
@@ -2217,8 +2214,8 @@ int32_t lis2duxs12_fifo_data_get(const stmdev_ctx_t *ctx, const lis2duxs12_md_t 
         data->xl[0].raw[2] = (int16_t)fifo_raw[4] + (int16_t)fifo_raw[5] * 256;
       }
       break;
-    case LIS2DUXS12_TIMESTAMP_TAG:
-      ret = lis2duxs12_fifo_out_raw_get(ctx, fifo_raw);
+    case IIS2DULPX_TIMESTAMP_TAG:
+      ret = iis2dulpx_fifo_out_raw_get(ctx, fifo_raw);
 
       data->cfg_chg.cfg_change = fifo_raw[0] >> 7;
       data->cfg_chg.odr = (fifo_raw[0] >> 3) & 0xFU;
@@ -2235,8 +2232,8 @@ int32_t lis2duxs12_fifo_data_get(const stmdev_ctx_t *ctx, const lis2duxs12_md_t 
       data->cfg_chg.timestamp = (data->cfg_chg.timestamp * 256U) +  fifo_raw[2];
       break;
 
-    case LIS2DUXS12_STEP_COUNTER_TAG:
-      ret = lis2duxs12_fifo_out_raw_get(ctx, fifo_raw);
+    case IIS2DULPX_STEP_COUNTER_TAG:
+      ret = iis2dulpx_fifo_out_raw_get(ctx, fifo_raw);
 
       data->pedo.steps = fifo_raw[1];
       data->pedo.steps = (data->pedo.steps * 256U) +  fifo_raw[0];
@@ -2248,7 +2245,7 @@ int32_t lis2duxs12_fifo_data_get(const stmdev_ctx_t *ctx, const lis2duxs12_md_t 
 
       break;
 
-    case LIS2DUXS12_FIFO_EMPTY:
+    case IIS2DULPX_FIFO_EMPTY:
     default:
       /* do nothing */
       break;
@@ -2258,21 +2255,21 @@ int32_t lis2duxs12_fifo_data_get(const stmdev_ctx_t *ctx, const lis2duxs12_md_t 
   {
     switch (md->fs)
     {
-      case LIS2DUXS12_2g:
-        data->xl[0].mg[i] = lis2duxs12_from_fs2g_to_mg(data->xl[0].raw[i]);
-        data->xl[1].mg[i] = lis2duxs12_from_fs2g_to_mg(data->xl[1].raw[i]);
+      case IIS2DULPX_2g:
+        data->xl[0].mg[i] = iis2dulpx_from_fs2g_to_mg(data->xl[0].raw[i]);
+        data->xl[1].mg[i] = iis2dulpx_from_fs2g_to_mg(data->xl[1].raw[i]);
         break;
-      case LIS2DUXS12_4g:
-        data->xl[0].mg[i] = lis2duxs12_from_fs4g_to_mg(data->xl[0].raw[i]);
-        data->xl[1].mg[i] = lis2duxs12_from_fs4g_to_mg(data->xl[1].raw[i]);
+      case IIS2DULPX_4g:
+        data->xl[0].mg[i] = iis2dulpx_from_fs4g_to_mg(data->xl[0].raw[i]);
+        data->xl[1].mg[i] = iis2dulpx_from_fs4g_to_mg(data->xl[1].raw[i]);
         break;
-      case LIS2DUXS12_8g:
-        data->xl[0].mg[i] = lis2duxs12_from_fs8g_to_mg(data->xl[0].raw[i]);
-        data->xl[1].mg[i] = lis2duxs12_from_fs8g_to_mg(data->xl[1].raw[i]);
+      case IIS2DULPX_8g:
+        data->xl[0].mg[i] = iis2dulpx_from_fs8g_to_mg(data->xl[0].raw[i]);
+        data->xl[1].mg[i] = iis2dulpx_from_fs8g_to_mg(data->xl[1].raw[i]);
         break;
-      case LIS2DUXS12_16g:
-        data->xl[0].mg[i] = lis2duxs12_from_fs16g_to_mg(data->xl[0].raw[i]);
-        data->xl[1].mg[i] = lis2duxs12_from_fs16g_to_mg(data->xl[1].raw[i]);
+      case IIS2DULPX_16g:
+        data->xl[0].mg[i] = iis2dulpx_from_fs16g_to_mg(data->xl[0].raw[i]);
+        data->xl[1].mg[i] = iis2dulpx_from_fs16g_to_mg(data->xl[1].raw[i]);
         break;
       default:
         data->xl[0].mg[i] = 0.0f;
@@ -2292,13 +2289,13 @@ int32_t lis2duxs12_fifo_data_get(const stmdev_ctx_t *ctx, const lis2duxs12_md_t 
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_ah_qvar_mode_set(const stmdev_ctx_t *ctx,
-                                    lis2duxs12_ah_qvar_mode_t val)
+int32_t iis2dulpx_ah_qvar_mode_set(const stmdev_ctx_t *ctx,
+                                   iis2dulpx_ah_qvar_mode_t val)
 {
-  lis2duxs12_ah_qvar_cfg_t ah_qvar_cfg;
+  iis2dulpx_ah_qvar_cfg_t ah_qvar_cfg;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_AH_QVAR_CFG, (uint8_t *)&ah_qvar_cfg, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_AH_QVAR_CFG, (uint8_t *)&ah_qvar_cfg, 1);
   if (ret == 0)
   {
     ah_qvar_cfg.ah_qvar_gain = (uint8_t)val.ah_qvar_gain;
@@ -2306,7 +2303,7 @@ int32_t lis2duxs12_ah_qvar_mode_set(const stmdev_ctx_t *ctx,
     ah_qvar_cfg.ah_qvar_notch_cutoff = (uint8_t)val.ah_qvar_notch;
     ah_qvar_cfg.ah_qvar_notch_en = val.ah_qvar_notch_en;
     ah_qvar_cfg.ah_qvar_en = val.ah_qvar_en;
-    ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_AH_QVAR_CFG, (uint8_t *)&ah_qvar_cfg, 1);
+    ret = iis2dulpx_write_reg(ctx, IIS2DULPX_AH_QVAR_CFG, (uint8_t *)&ah_qvar_cfg, 1);
   }
 
   return ret;
@@ -2320,63 +2317,63 @@ int32_t lis2duxs12_ah_qvar_mode_set(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_ah_qvar_mode_get(const stmdev_ctx_t *ctx,
-                                    lis2duxs12_ah_qvar_mode_t *val)
+int32_t iis2dulpx_ah_qvar_mode_get(const stmdev_ctx_t *ctx,
+                                   iis2dulpx_ah_qvar_mode_t *val)
 {
-  lis2duxs12_ah_qvar_cfg_t ah_qvar_cfg;
+  iis2dulpx_ah_qvar_cfg_t ah_qvar_cfg;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_AH_QVAR_CFG, (uint8_t *)&ah_qvar_cfg, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_AH_QVAR_CFG, (uint8_t *)&ah_qvar_cfg, 1);
 
   switch (ah_qvar_cfg.ah_qvar_gain)
   {
     case 0x0:
-      val->ah_qvar_gain = LIS2DUXS12_GAIN_0_5;
+      val->ah_qvar_gain = IIS2DULPX_GAIN_0_5;
       break;
 
     case 0x1:
-      val->ah_qvar_gain = LIS2DUXS12_GAIN_1;
+      val->ah_qvar_gain = IIS2DULPX_GAIN_1;
       break;
 
     case 0x2:
-      val->ah_qvar_gain = LIS2DUXS12_GAIN_2;
+      val->ah_qvar_gain = IIS2DULPX_GAIN_2;
       break;
 
     case 0x3:
     default:
-      val->ah_qvar_gain = LIS2DUXS12_GAIN_4;
+      val->ah_qvar_gain = IIS2DULPX_GAIN_4;
       break;
   }
 
   switch (ah_qvar_cfg.ah_qvar_c_zin)
   {
     case 0x0:
-      val->ah_qvar_zin = LIS2DUXS12_520MOhm;
+      val->ah_qvar_zin = IIS2DULPX_520MOhm;
       break;
 
     case 0x1:
-      val->ah_qvar_zin = LIS2DUXS12_175MOhm;
+      val->ah_qvar_zin = IIS2DULPX_175MOhm;
       break;
 
     case 0x2:
-      val->ah_qvar_zin = LIS2DUXS12_310MOhm;
+      val->ah_qvar_zin = IIS2DULPX_310MOhm;
       break;
 
     case 0x3:
     default:
-      val->ah_qvar_zin = LIS2DUXS12_75MOhm;
+      val->ah_qvar_zin = IIS2DULPX_75MOhm;
       break;
   }
 
   switch (ah_qvar_cfg.ah_qvar_notch_cutoff)
   {
     case 0x0:
-      val->ah_qvar_notch = LIS2DUXS12_NOTCH_50HZ;
+      val->ah_qvar_notch = IIS2DULPX_NOTCH_50HZ;
       break;
 
     case 0x1:
     default:
-      val->ah_qvar_notch = LIS2DUXS12_NOTCH_60HZ;
+      val->ah_qvar_notch = IIS2DULPX_NOTCH_60HZ;
       break;
   }
 
@@ -2400,18 +2397,18 @@ int32_t lis2duxs12_ah_qvar_mode_get(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_stpcnt_mode_set(const stmdev_ctx_t *ctx, lis2duxs12_stpcnt_mode_t val)
+int32_t iis2dulpx_stpcnt_mode_set(const stmdev_ctx_t *ctx, iis2dulpx_stpcnt_mode_t val)
 {
-  lis2duxs12_emb_func_en_a_t emb_func_en_a;
-  lis2duxs12_emb_func_en_b_t emb_func_en_b;
-  lis2duxs12_emb_func_fifo_en_t emb_func_fifo_en;
-  lis2duxs12_pedo_cmd_reg_t pedo_cmd_reg;
+  iis2dulpx_emb_func_en_a_t emb_func_en_a;
+  iis2dulpx_emb_func_en_b_t emb_func_en_b;
+  iis2dulpx_emb_func_fifo_en_t emb_func_fifo_en;
+  iis2dulpx_pedo_cmd_reg_t pedo_cmd_reg;
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_FIFO_EN, (uint8_t *)&emb_func_fifo_en, 1);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_EMB_FUNC_FIFO_EN, (uint8_t *)&emb_func_fifo_en, 1);
 
   if ((val.false_step_rej == PROPERTY_ENABLE)
       && ((emb_func_en_a.mlc_before_fsm_en & emb_func_en_b.mlc_en) == PROPERTY_DISABLE))
@@ -2420,20 +2417,20 @@ int32_t lis2duxs12_stpcnt_mode_set(const stmdev_ctx_t *ctx, lis2duxs12_stpcnt_mo
   }
 
   emb_func_fifo_en.step_counter_fifo_en = val.step_counter_in_fifo;
-  ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_EMB_FUNC_FIFO_EN, (uint8_t *)&emb_func_fifo_en, 1);
+  ret += iis2dulpx_write_reg(ctx, IIS2DULPX_EMB_FUNC_FIFO_EN, (uint8_t *)&emb_func_fifo_en, 1);
 
   emb_func_en_a.pedo_en = val.step_counter_enable;
-  ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  ret += iis2dulpx_write_reg(ctx, IIS2DULPX_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
 
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
-  ret += lis2duxs12_ln_pg_read(ctx, LIS2DUXS12_EMB_ADV_PG_0 + LIS2DUXS12_PEDO_CMD_REG,
-                               (uint8_t *)&pedo_cmd_reg, 1);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
+  ret += iis2dulpx_ln_pg_read(ctx, IIS2DULPX_EMB_ADV_PG_0 + IIS2DULPX_PEDO_CMD_REG,
+                              (uint8_t *)&pedo_cmd_reg, 1);
 
   if (ret == 0)
   {
     pedo_cmd_reg.fp_rejection_en = val.false_step_rej;
-    ret += lis2duxs12_ln_pg_write(ctx, LIS2DUXS12_EMB_ADV_PG_0 + LIS2DUXS12_PEDO_CMD_REG,
-                                  (uint8_t *)&pedo_cmd_reg, 1);
+    ret += iis2dulpx_ln_pg_write(ctx, IIS2DULPX_EMB_ADV_PG_0 + IIS2DULPX_PEDO_CMD_REG,
+                                 (uint8_t *)&pedo_cmd_reg, 1);
   }
 
   return ret;
@@ -2447,18 +2444,18 @@ int32_t lis2duxs12_stpcnt_mode_set(const stmdev_ctx_t *ctx, lis2duxs12_stpcnt_mo
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_stpcnt_mode_get(const stmdev_ctx_t *ctx, lis2duxs12_stpcnt_mode_t *val)
+int32_t iis2dulpx_stpcnt_mode_get(const stmdev_ctx_t *ctx, iis2dulpx_stpcnt_mode_t *val)
 {
-  lis2duxs12_emb_func_en_a_t emb_func_en_a;
-  lis2duxs12_pedo_cmd_reg_t pedo_cmd_reg;
+  iis2dulpx_emb_func_en_a_t emb_func_en_a;
+  iis2dulpx_pedo_cmd_reg_t pedo_cmd_reg;
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
-  ret += lis2duxs12_ln_pg_read(ctx, LIS2DUXS12_EMB_ADV_PG_0 + LIS2DUXS12_PEDO_CMD_REG,
-                               (uint8_t *)&pedo_cmd_reg, 1);
+  ret += iis2dulpx_ln_pg_read(ctx, IIS2DULPX_EMB_ADV_PG_0 + IIS2DULPX_PEDO_CMD_REG,
+                              (uint8_t *)&pedo_cmd_reg, 1);
   val->false_step_rej = pedo_cmd_reg.fp_rejection_en;
   val->step_counter_enable = emb_func_en_a.pedo_en;
 
@@ -2473,14 +2470,14 @@ int32_t lis2duxs12_stpcnt_mode_get(const stmdev_ctx_t *ctx, lis2duxs12_stpcnt_mo
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_stpcnt_steps_get(const stmdev_ctx_t *ctx, uint16_t *val)
+int32_t iis2dulpx_stpcnt_steps_get(const stmdev_ctx_t *ctx, uint16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_STEP_COUNTER_L, &buff[0], 2);
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_STEP_COUNTER_L, &buff[0], 2);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
@@ -2496,20 +2493,20 @@ int32_t lis2duxs12_stpcnt_steps_get(const stmdev_ctx_t *ctx, uint16_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_stpcnt_rst_step_set(const stmdev_ctx_t *ctx)
+int32_t iis2dulpx_stpcnt_rst_step_set(const stmdev_ctx_t *ctx)
 {
-  lis2duxs12_emb_func_src_t emb_func_src;
+  iis2dulpx_emb_func_src_t emb_func_src;
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
     emb_func_src.pedo_rst_step = 1;
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
   }
 
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -2522,14 +2519,14 @@ int32_t lis2duxs12_stpcnt_rst_step_set(const stmdev_ctx_t *ctx)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_stpcnt_debounce_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t iis2dulpx_stpcnt_debounce_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2duxs12_pedo_deb_steps_conf_t pedo_deb_steps_conf;
+  iis2dulpx_pedo_deb_steps_conf_t pedo_deb_steps_conf;
   int32_t ret;
 
   pedo_deb_steps_conf.deb_step = val;
-  ret = lis2duxs12_ln_pg_write(ctx, LIS2DUXS12_EMB_ADV_PG_0 + LIS2DUXS12_PEDO_DEB_STEPS_CONF,
-                               (uint8_t *)&pedo_deb_steps_conf, 1);
+  ret = iis2dulpx_ln_pg_write(ctx, IIS2DULPX_EMB_ADV_PG_0 + IIS2DULPX_PEDO_DEB_STEPS_CONF,
+                              (uint8_t *)&pedo_deb_steps_conf, 1);
 
   return ret;
 }
@@ -2542,13 +2539,13 @@ int32_t lis2duxs12_stpcnt_debounce_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_stpcnt_debounce_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t iis2dulpx_stpcnt_debounce_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2duxs12_pedo_deb_steps_conf_t pedo_deb_steps_conf;
+  iis2dulpx_pedo_deb_steps_conf_t pedo_deb_steps_conf;
   int32_t ret;
 
-  ret = lis2duxs12_ln_pg_read(ctx, LIS2DUXS12_EMB_ADV_PG_0 + LIS2DUXS12_PEDO_DEB_STEPS_CONF,
-                              (uint8_t *)&pedo_deb_steps_conf, 1);
+  ret = iis2dulpx_ln_pg_read(ctx, IIS2DULPX_EMB_ADV_PG_0 + IIS2DULPX_PEDO_DEB_STEPS_CONF,
+                             (uint8_t *)&pedo_deb_steps_conf, 1);
   *val = pedo_deb_steps_conf.deb_step;
 
   return ret;
@@ -2562,7 +2559,7 @@ int32_t lis2duxs12_stpcnt_debounce_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_stpcnt_period_set(const stmdev_ctx_t *ctx, uint16_t val)
+int32_t iis2dulpx_stpcnt_period_set(const stmdev_ctx_t *ctx, uint16_t val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -2570,8 +2567,8 @@ int32_t lis2duxs12_stpcnt_period_set(const stmdev_ctx_t *ctx, uint16_t val)
   buff[1] = (uint8_t)(val / 256U);
   buff[0] = (uint8_t)(val - (buff[1] * 256U));
 
-  ret = lis2duxs12_ln_pg_write(ctx, LIS2DUXS12_EMB_ADV_PG_0 + LIS2DUXS12_PEDO_SC_DELTAT_L,
-                               (uint8_t *)buff, 2);
+  ret = iis2dulpx_ln_pg_write(ctx, IIS2DULPX_EMB_ADV_PG_0 + IIS2DULPX_PEDO_SC_DELTAT_L,
+                              (uint8_t *)buff, 2);
 
   return ret;
 }
@@ -2584,13 +2581,13 @@ int32_t lis2duxs12_stpcnt_period_set(const stmdev_ctx_t *ctx, uint16_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_stpcnt_period_get(const stmdev_ctx_t *ctx, uint16_t *val)
+int32_t iis2dulpx_stpcnt_period_get(const stmdev_ctx_t *ctx, uint16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
 
-  ret = lis2duxs12_ln_pg_read(ctx, LIS2DUXS12_EMB_ADV_PG_0 + LIS2DUXS12_PEDO_SC_DELTAT_L,
-                              (uint8_t *)buff, 2);
+  ret = iis2dulpx_ln_pg_read(ctx, IIS2DULPX_EMB_ADV_PG_0 + IIS2DULPX_PEDO_SC_DELTAT_L,
+                             (uint8_t *)buff, 2);
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
 
@@ -2601,18 +2598,18 @@ int32_t lis2duxs12_stpcnt_period_get(const stmdev_ctx_t *ctx, uint16_t *val)
   * @brief  smart_power functionality configuration.[set]
   *
   * @param  ctx      read / write interface definitions
-  * @param  val      lis2duxs12_smart_power_cfg_t structure.
+  * @param  val      iis2dulpx_smart_power_cfg_t structure.
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   */
-int32_t lis2duxs12_smart_power_set(const stmdev_ctx_t *ctx, lis2duxs12_smart_power_cfg_t val)
+int32_t iis2dulpx_smart_power_set(const stmdev_ctx_t *ctx, iis2dulpx_smart_power_cfg_t val)
 {
-  lis2duxs12_ctrl1_t ctrl1;
-  lis2duxs12_smart_power_ctrl_t smart_power_ctrl;
+  iis2dulpx_ctrl1_t ctrl1;
+  iis2dulpx_smart_power_ctrl_t smart_power_ctrl;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL1, (uint8_t *)&ctrl1, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_CTRL1, (uint8_t *)&ctrl1, 1);
   ctrl1.smart_power_en = val.enable;
-  ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_CTRL1, (uint8_t *)&ctrl1, 1);
+  ret += iis2dulpx_write_reg(ctx, IIS2DULPX_CTRL1, (uint8_t *)&ctrl1, 1);
 
   if (val.enable == 0)
   {
@@ -2622,8 +2619,8 @@ int32_t lis2duxs12_smart_power_set(const stmdev_ctx_t *ctx, lis2duxs12_smart_pow
 
   smart_power_ctrl.smart_power_ctrl_win = val.window;
   smart_power_ctrl.smart_power_ctrl_dur = val.duration;
-  ret += lis2duxs12_ln_pg_write(ctx, LIS2DUXS12_EMB_ADV_PG_0 + LIS2DUXS12_SMART_POWER_CTRL,
-                                (uint8_t *)&smart_power_ctrl, 1);
+  ret += iis2dulpx_ln_pg_write(ctx, IIS2DULPX_EMB_ADV_PG_0 + IIS2DULPX_SMART_POWER_CTRL,
+                               (uint8_t *)&smart_power_ctrl, 1);
 
   return ret;
 }
@@ -2632,20 +2629,20 @@ int32_t lis2duxs12_smart_power_set(const stmdev_ctx_t *ctx, lis2duxs12_smart_pow
   * @brief  smart_power functionality configuration.[get]
   *
   * @param  ctx      read / write interface definitions
-  * @param  val      lis2duxs12_smart_power_cfg_t structure.
+  * @param  val      iis2dulpx_smart_power_cfg_t structure.
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   */
-int32_t lis2duxs12_smart_power_get(const stmdev_ctx_t *ctx, lis2duxs12_smart_power_cfg_t *val)
+int32_t iis2dulpx_smart_power_get(const stmdev_ctx_t *ctx, iis2dulpx_smart_power_cfg_t *val)
 {
-  lis2duxs12_ctrl1_t ctrl1;
-  lis2duxs12_smart_power_ctrl_t smart_power_ctrl;
+  iis2dulpx_ctrl1_t ctrl1;
+  iis2dulpx_smart_power_ctrl_t smart_power_ctrl;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL1, (uint8_t *)&ctrl1, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_CTRL1, (uint8_t *)&ctrl1, 1);
   val->enable = ctrl1.smart_power_en;
 
-  ret += lis2duxs12_ln_pg_read(ctx, LIS2DUXS12_EMB_ADV_PG_0 + LIS2DUXS12_SMART_POWER_CTRL,
-                               (uint8_t *)&smart_power_ctrl, 1);
+  ret += iis2dulpx_ln_pg_read(ctx, IIS2DULPX_EMB_ADV_PG_0 + IIS2DULPX_SMART_POWER_CTRL,
+                              (uint8_t *)&smart_power_ctrl, 1);
   val->window = smart_power_ctrl.smart_power_ctrl_win;
   val->duration = smart_power_ctrl.smart_power_ctrl_dur;
 
@@ -2671,20 +2668,20 @@ int32_t lis2duxs12_smart_power_get(const stmdev_ctx_t *ctx, lis2duxs12_smart_pow
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_tilt_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t iis2dulpx_tilt_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2duxs12_emb_func_en_a_t emb_func_en_a;
+  iis2dulpx_emb_func_en_a_t emb_func_en_a;
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
     emb_func_en_a.tilt_en = val;
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
   }
 
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -2697,19 +2694,19 @@ int32_t lis2duxs12_tilt_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_tilt_mode_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t iis2dulpx_tilt_mode_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2duxs12_emb_func_en_a_t emb_func_en_a;
+  iis2dulpx_emb_func_en_a_t emb_func_en_a;
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
     *val = emb_func_en_a.tilt_en;
   }
 
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -2733,20 +2730,20 @@ int32_t lis2duxs12_tilt_mode_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_sigmot_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t iis2dulpx_sigmot_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2duxs12_emb_func_en_a_t emb_func_en_a;
+  iis2dulpx_emb_func_en_a_t emb_func_en_a;
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
     emb_func_en_a.sign_motion_en = val;
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
   }
 
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -2759,19 +2756,19 @@ int32_t lis2duxs12_sigmot_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_sigmot_mode_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t iis2dulpx_sigmot_mode_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2duxs12_emb_func_en_a_t emb_func_en_a;
+  iis2dulpx_emb_func_en_a_t emb_func_en_a;
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
     *val = emb_func_en_a.sign_motion_en;
   }
 
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -2796,25 +2793,25 @@ int32_t lis2duxs12_sigmot_mode_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_ff_duration_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t iis2dulpx_ff_duration_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2duxs12_wake_up_dur_t wake_up_dur;
-  lis2duxs12_free_fall_t free_fall;
+  iis2dulpx_wake_up_dur_t wake_up_dur;
+  iis2dulpx_free_fall_t free_fall;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
 
   if (ret == 0)
   {
     wake_up_dur.ff_dur = (val >> 5) & 0x1U;
-    ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+    ret = iis2dulpx_write_reg(ctx, IIS2DULPX_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
   }
 
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_FREE_FALL, (uint8_t *)&free_fall, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_FREE_FALL, (uint8_t *)&free_fall, 1);
     free_fall.ff_dur = val & 0x1FU;
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_FREE_FALL, (uint8_t *)&free_fall, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_FREE_FALL, (uint8_t *)&free_fall, 1);
   }
 
   return ret;
@@ -2828,14 +2825,14 @@ int32_t lis2duxs12_ff_duration_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_ff_duration_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t iis2dulpx_ff_duration_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2duxs12_wake_up_dur_t wake_up_dur;
-  lis2duxs12_free_fall_t free_fall;
+  iis2dulpx_wake_up_dur_t wake_up_dur;
+  iis2dulpx_free_fall_t free_fall;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_FREE_FALL, (uint8_t *)&free_fall, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_FREE_FALL, (uint8_t *)&free_fall, 1);
 
   *val = (wake_up_dur.ff_dur << 5) | free_fall.ff_dur;
 
@@ -2850,14 +2847,14 @@ int32_t lis2duxs12_ff_duration_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_ff_thresholds_set(const stmdev_ctx_t *ctx, lis2duxs12_ff_thresholds_t val)
+int32_t iis2dulpx_ff_thresholds_set(const stmdev_ctx_t *ctx, iis2dulpx_ff_thresholds_t val)
 {
-  lis2duxs12_free_fall_t free_fall;
+  iis2dulpx_free_fall_t free_fall;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_FREE_FALL, (uint8_t *)&free_fall, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_FREE_FALL, (uint8_t *)&free_fall, 1);
   free_fall.ff_ths = ((uint8_t)val & 0x7U);
-  ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_FREE_FALL, (uint8_t *)&free_fall, 1);
+  ret += iis2dulpx_write_reg(ctx, IIS2DULPX_FREE_FALL, (uint8_t *)&free_fall, 1);
 
   return ret;
 }
@@ -2870,49 +2867,49 @@ int32_t lis2duxs12_ff_thresholds_set(const stmdev_ctx_t *ctx, lis2duxs12_ff_thre
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_ff_thresholds_get(const stmdev_ctx_t *ctx, lis2duxs12_ff_thresholds_t *val)
+int32_t iis2dulpx_ff_thresholds_get(const stmdev_ctx_t *ctx, iis2dulpx_ff_thresholds_t *val)
 {
-  lis2duxs12_free_fall_t free_fall;
+  iis2dulpx_free_fall_t free_fall;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_FREE_FALL, (uint8_t *)&free_fall, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_FREE_FALL, (uint8_t *)&free_fall, 1);
 
   switch (free_fall.ff_ths)
   {
     case 0x0:
-      *val = LIS2DUXS12_156_mg;
+      *val = IIS2DULPX_156_mg;
       break;
 
     case 0x1:
-      *val = LIS2DUXS12_219_mg;
+      *val = IIS2DULPX_219_mg;
       break;
 
     case 0x2:
-      *val = LIS2DUXS12_250_mg;
+      *val = IIS2DULPX_250_mg;
       break;
 
     case 0x3:
-      *val = LIS2DUXS12_312_mg;
+      *val = IIS2DULPX_312_mg;
       break;
 
     case 0x4:
-      *val = LIS2DUXS12_344_mg;
+      *val = IIS2DULPX_344_mg;
       break;
 
     case 0x5:
-      *val = LIS2DUXS12_406_mg;
+      *val = IIS2DULPX_406_mg;
       break;
 
     case 0x6:
-      *val = LIS2DUXS12_469_mg;
+      *val = IIS2DULPX_469_mg;
       break;
 
     case 0x7:
-      *val = LIS2DUXS12_500_mg;
+      *val = IIS2DULPX_500_mg;
       break;
 
     default:
-      *val = LIS2DUXS12_156_mg;
+      *val = IIS2DULPX_156_mg;
       break;
   }
   return ret;
@@ -2938,18 +2935,18 @@ int32_t lis2duxs12_ff_thresholds_get(const stmdev_ctx_t *ctx, lis2duxs12_ff_thre
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_sixd_config_set(const stmdev_ctx_t *ctx, lis2duxs12_sixd_config_t val)
+int32_t iis2dulpx_sixd_config_set(const stmdev_ctx_t *ctx, iis2dulpx_sixd_config_t val)
 {
-  lis2duxs12_sixd_t sixd;
+  iis2dulpx_sixd_t sixd;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_SIXD, (uint8_t *)&sixd, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_SIXD, (uint8_t *)&sixd, 1);
 
   if (ret == 0)
   {
     sixd.d4d_en = ((uint8_t)val.mode);
     sixd.d6d_ths = ((uint8_t)val.threshold);
-    ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_SIXD, (uint8_t *)&sixd, 1);
+    ret = iis2dulpx_write_reg(ctx, IIS2DULPX_SIXD, (uint8_t *)&sixd, 1);
   }
 
   return ret;
@@ -2963,35 +2960,35 @@ int32_t lis2duxs12_sixd_config_set(const stmdev_ctx_t *ctx, lis2duxs12_sixd_conf
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_sixd_config_get(const stmdev_ctx_t *ctx, lis2duxs12_sixd_config_t *val)
+int32_t iis2dulpx_sixd_config_get(const stmdev_ctx_t *ctx, iis2dulpx_sixd_config_t *val)
 {
-  lis2duxs12_sixd_t sixd;
+  iis2dulpx_sixd_t sixd;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_SIXD, (uint8_t *)&sixd, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_SIXD, (uint8_t *)&sixd, 1);
 
-  val->mode = (lis2duxs12_mode_t)sixd.d4d_en;
+  val->mode = (iis2dulpx_mode_t)sixd.d4d_en;
 
   switch ((sixd.d6d_ths))
   {
     case 0x0:
-      val->threshold = LIS2DUXS12_DEG_80;
+      val->threshold = IIS2DULPX_DEG_80;
       break;
 
     case 0x1:
-      val->threshold = LIS2DUXS12_DEG_70;
+      val->threshold = IIS2DULPX_DEG_70;
       break;
 
     case 0x2:
-      val->threshold = LIS2DUXS12_DEG_60;
+      val->threshold = IIS2DULPX_DEG_60;
       break;
 
     case 0x3:
-      val->threshold = LIS2DUXS12_DEG_50;
+      val->threshold = IIS2DULPX_DEG_50;
       break;
 
     default:
-      val->threshold = LIS2DUXS12_DEG_80;
+      val->threshold = IIS2DULPX_DEG_80;
       break;
   }
 
@@ -3018,22 +3015,22 @@ int32_t lis2duxs12_sixd_config_get(const stmdev_ctx_t *ctx, lis2duxs12_sixd_conf
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_wakeup_config_set(const stmdev_ctx_t *ctx, lis2duxs12_wakeup_config_t val)
+int32_t iis2dulpx_wakeup_config_set(const stmdev_ctx_t *ctx, iis2dulpx_wakeup_config_t val)
 {
-  lis2duxs12_wake_up_ths_t wup_ths;
-  lis2duxs12_wake_up_dur_t wup_dur;
-  lis2duxs12_wake_up_dur_ext_t wup_dur_ext;
-  lis2duxs12_interrupt_cfg_t int_cfg;
-  lis2duxs12_ctrl1_t ctrl1;
-  lis2duxs12_ctrl4_t ctrl4;
+  iis2dulpx_wake_up_ths_t wup_ths;
+  iis2dulpx_wake_up_dur_t wup_dur;
+  iis2dulpx_wake_up_dur_ext_t wup_dur_ext;
+  iis2dulpx_interrupt_cfg_t int_cfg;
+  iis2dulpx_ctrl1_t ctrl1;
+  iis2dulpx_ctrl4_t ctrl4;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_WAKE_UP_THS, (uint8_t *)&wup_ths, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_WAKE_UP_DUR, (uint8_t *)&wup_dur, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_WAKE_UP_DUR_EXT, (uint8_t *)&wup_dur_ext, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_INTERRUPT_CFG, (uint8_t *)&int_cfg, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL1, (uint8_t *)&ctrl1, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_CTRL4, (uint8_t *)&ctrl4, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_WAKE_UP_THS, (uint8_t *)&wup_ths, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_WAKE_UP_DUR, (uint8_t *)&wup_dur, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_WAKE_UP_DUR_EXT, (uint8_t *)&wup_dur_ext, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_INTERRUPT_CFG, (uint8_t *)&int_cfg, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_CTRL1, (uint8_t *)&ctrl1, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_CTRL4, (uint8_t *)&ctrl4, 1);
 
   if (ret == 0)
   {
@@ -3046,7 +3043,7 @@ int32_t lis2duxs12_wakeup_config_set(const stmdev_ctx_t *ctx, lis2duxs12_wakeup_
     wup_ths.sleep_on = (uint8_t)val.wake_enable;
     ctrl4.inact_odr = (uint8_t)val.inact_odr;
 
-    if (val.wake_enable == LIS2DUXS12_SLEEP_ON)
+    if (val.wake_enable == IIS2DULPX_SLEEP_ON)
     {
       ctrl1.wu_x_en = 1;
       ctrl1.wu_y_en = 1;
@@ -3059,12 +3056,12 @@ int32_t lis2duxs12_wakeup_config_set(const stmdev_ctx_t *ctx, lis2duxs12_wakeup_
       ctrl1.wu_z_en = 0;
     }
 
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_WAKE_UP_THS, (uint8_t *)&wup_ths, 1);
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_WAKE_UP_DUR, (uint8_t *)&wup_dur, 1);
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_WAKE_UP_DUR_EXT, (uint8_t *)&wup_dur_ext, 1);
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_INTERRUPT_CFG, (uint8_t *)&int_cfg, 1);
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_CTRL1, (uint8_t *)&ctrl1, 1);
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_CTRL4, (uint8_t *)&ctrl4, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_WAKE_UP_THS, (uint8_t *)&wup_ths, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_WAKE_UP_DUR, (uint8_t *)&wup_dur, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_WAKE_UP_DUR_EXT, (uint8_t *)&wup_dur_ext, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_INTERRUPT_CFG, (uint8_t *)&int_cfg, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_CTRL1, (uint8_t *)&ctrl1, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_CTRL4, (uint8_t *)&ctrl4, 1);
   }
 
   return ret;
@@ -3078,20 +3075,20 @@ int32_t lis2duxs12_wakeup_config_set(const stmdev_ctx_t *ctx, lis2duxs12_wakeup_
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2duxs12_wakeup_config_get(const stmdev_ctx_t *ctx, lis2duxs12_wakeup_config_t *val)
+int32_t iis2dulpx_wakeup_config_get(const stmdev_ctx_t *ctx, iis2dulpx_wakeup_config_t *val)
 {
-  lis2duxs12_wake_up_ths_t wup_ths;
-  lis2duxs12_wake_up_dur_t wup_dur;
-  lis2duxs12_wake_up_dur_ext_t wup_dur_ext;
-  lis2duxs12_interrupt_cfg_t int_cfg;
-  lis2duxs12_ctrl4_t ctrl4;
+  iis2dulpx_wake_up_ths_t wup_ths;
+  iis2dulpx_wake_up_dur_t wup_dur;
+  iis2dulpx_wake_up_dur_ext_t wup_dur_ext;
+  iis2dulpx_interrupt_cfg_t int_cfg;
+  iis2dulpx_ctrl4_t ctrl4;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_WAKE_UP_THS, (uint8_t *)&wup_ths, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_WAKE_UP_DUR, (uint8_t *)&wup_dur, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_WAKE_UP_DUR_EXT, (uint8_t *)&wup_dur_ext, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_INTERRUPT_CFG, (uint8_t *)&int_cfg, 1);
-  ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_CTRL4, (uint8_t *)&ctrl4, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_WAKE_UP_THS, (uint8_t *)&wup_ths, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_WAKE_UP_DUR, (uint8_t *)&wup_dur, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_WAKE_UP_DUR_EXT, (uint8_t *)&wup_dur_ext, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_INTERRUPT_CFG, (uint8_t *)&int_cfg, 1);
+  ret += iis2dulpx_write_reg(ctx, IIS2DULPX_CTRL4, (uint8_t *)&ctrl4, 1);
 
   if (ret == 0)
   {
@@ -3099,22 +3096,22 @@ int32_t lis2duxs12_wakeup_config_get(const stmdev_ctx_t *ctx, lis2duxs12_wakeup_
     {
       case 0x0:
         val->wake_dur = (wup_dur_ext.wu_dur_extended == 1U) ?
-                        LIS2DUXS12_3_ODR : LIS2DUXS12_0_ODR;
+                        IIS2DULPX_3_ODR : IIS2DULPX_0_ODR;
         break;
 
       case 0x1:
         val->wake_dur = (wup_dur_ext.wu_dur_extended == 1U) ?
-                        LIS2DUXS12_7_ODR : LIS2DUXS12_1_ODR;
+                        IIS2DULPX_7_ODR : IIS2DULPX_1_ODR;
         break;
 
       case 0x2:
         val->wake_dur = (wup_dur_ext.wu_dur_extended == 1U) ?
-                        LIS2DUXS12_11_ODR : LIS2DUXS12_2_ODR;
+                        IIS2DULPX_11_ODR : IIS2DULPX_2_ODR;
         break;
 
       case 0x3:
       default:
-        val->wake_dur = LIS2DUXS12_15_ODR;
+        val->wake_dur = IIS2DULPX_15_ODR;
         break;
     }
 
@@ -3122,8 +3119,8 @@ int32_t lis2duxs12_wakeup_config_get(const stmdev_ctx_t *ctx, lis2duxs12_wakeup_
 
     val->wake_ths_weight = int_cfg.wake_ths_w;
     val->wake_ths = wup_ths.wk_ths;
-    val->wake_enable = (lis2duxs12_wake_enable_t)wup_ths.sleep_on;
-    val->inact_odr = (lis2duxs12_inact_odr_t)ctrl4.inact_odr;
+    val->wake_enable = (iis2dulpx_wake_enable_t)wup_ths.sleep_on;
+    val->inact_odr = (iis2dulpx_inact_odr_t)ctrl4.inact_odr;
   }
 
   return ret;
@@ -3134,24 +3131,24 @@ int32_t lis2duxs12_wakeup_config_get(const stmdev_ctx_t *ctx, lis2duxs12_wakeup_
   *
   */
 
-int32_t lis2duxs12_tap_config_set(const stmdev_ctx_t *ctx, lis2duxs12_tap_config_t val)
+int32_t iis2dulpx_tap_config_set(const stmdev_ctx_t *ctx, iis2dulpx_tap_config_t val)
 {
-  lis2duxs12_tap_cfg0_t tap_cfg0;
-  lis2duxs12_tap_cfg1_t tap_cfg1;
-  lis2duxs12_tap_cfg2_t tap_cfg2;
-  lis2duxs12_tap_cfg3_t tap_cfg3;
-  lis2duxs12_tap_cfg4_t tap_cfg4;
-  lis2duxs12_tap_cfg5_t tap_cfg5;
-  lis2duxs12_tap_cfg6_t tap_cfg6;
+  iis2dulpx_tap_cfg0_t tap_cfg0;
+  iis2dulpx_tap_cfg1_t tap_cfg1;
+  iis2dulpx_tap_cfg2_t tap_cfg2;
+  iis2dulpx_tap_cfg3_t tap_cfg3;
+  iis2dulpx_tap_cfg4_t tap_cfg4;
+  iis2dulpx_tap_cfg5_t tap_cfg5;
+  iis2dulpx_tap_cfg6_t tap_cfg6;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_TAP_CFG3, (uint8_t *)&tap_cfg3, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_TAP_CFG4, (uint8_t *)&tap_cfg4, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_TAP_CFG5, (uint8_t *)&tap_cfg5, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_TAP_CFG6, (uint8_t *)&tap_cfg6, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_TAP_CFG3, (uint8_t *)&tap_cfg3, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_TAP_CFG4, (uint8_t *)&tap_cfg4, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_TAP_CFG5, (uint8_t *)&tap_cfg5, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_TAP_CFG6, (uint8_t *)&tap_cfg6, 1);
 
   if (ret == 0)
   {
@@ -3172,40 +3169,40 @@ int32_t lis2duxs12_tap_config_set(const stmdev_ctx_t *ctx, lis2duxs12_tap_config
     tap_cfg6.pre_still_st = val.pre_still_start;
     tap_cfg6.pre_still_n = val.pre_still_n;
 
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_TAP_CFG3, (uint8_t *)&tap_cfg3, 1);
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_TAP_CFG4, (uint8_t *)&tap_cfg4, 1);
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_TAP_CFG5, (uint8_t *)&tap_cfg5, 1);
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_TAP_CFG6, (uint8_t *)&tap_cfg6, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_TAP_CFG3, (uint8_t *)&tap_cfg3, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_TAP_CFG4, (uint8_t *)&tap_cfg4, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_TAP_CFG5, (uint8_t *)&tap_cfg5, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_TAP_CFG6, (uint8_t *)&tap_cfg6, 1);
   }
 
   return ret;
 }
 
-int32_t lis2duxs12_tap_config_get(const stmdev_ctx_t *ctx, lis2duxs12_tap_config_t *val)
+int32_t iis2dulpx_tap_config_get(const stmdev_ctx_t *ctx, iis2dulpx_tap_config_t *val)
 {
-  lis2duxs12_tap_cfg0_t tap_cfg0;
-  lis2duxs12_tap_cfg1_t tap_cfg1;
-  lis2duxs12_tap_cfg2_t tap_cfg2;
-  lis2duxs12_tap_cfg3_t tap_cfg3;
-  lis2duxs12_tap_cfg4_t tap_cfg4;
-  lis2duxs12_tap_cfg5_t tap_cfg5;
-  lis2duxs12_tap_cfg6_t tap_cfg6;
+  iis2dulpx_tap_cfg0_t tap_cfg0;
+  iis2dulpx_tap_cfg1_t tap_cfg1;
+  iis2dulpx_tap_cfg2_t tap_cfg2;
+  iis2dulpx_tap_cfg3_t tap_cfg3;
+  iis2dulpx_tap_cfg4_t tap_cfg4;
+  iis2dulpx_tap_cfg5_t tap_cfg5;
+  iis2dulpx_tap_cfg6_t tap_cfg6;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_TAP_CFG3, (uint8_t *)&tap_cfg3, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_TAP_CFG4, (uint8_t *)&tap_cfg4, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_TAP_CFG5, (uint8_t *)&tap_cfg5, 1);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_TAP_CFG6, (uint8_t *)&tap_cfg6, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_TAP_CFG3, (uint8_t *)&tap_cfg3, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_TAP_CFG4, (uint8_t *)&tap_cfg4, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_TAP_CFG5, (uint8_t *)&tap_cfg5, 1);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_TAP_CFG6, (uint8_t *)&tap_cfg6, 1);
 
   if (ret == 0)
   {
-    val->axis = (lis2duxs12_axis_t)tap_cfg0.axis;
+    val->axis = (iis2dulpx_axis_t)tap_cfg0.axis;
     val->inverted_peak_time = tap_cfg0.invert_t;
     val->pre_still_ths = tap_cfg1.pre_still_ths;
     val->post_still_ths = tap_cfg3.post_still_ths;
@@ -3231,7 +3228,7 @@ int32_t lis2duxs12_tap_config_get(const stmdev_ctx_t *ctx, lis2duxs12_tap_config
   */
 
 /**
-  * @defgroup   lis2duxs12_Timestamp
+  * @defgroup   iis2dulpx_Timestamp
   * @brief      This section groups all the functions that manage the
   *             timestamp generation.
   * @{
@@ -3246,17 +3243,17 @@ int32_t lis2duxs12_tap_config_get(const stmdev_ctx_t *ctx, lis2duxs12_tap_config
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2duxs12_timestamp_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t iis2dulpx_timestamp_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2duxs12_interrupt_cfg_t int_cfg;
+  iis2dulpx_interrupt_cfg_t int_cfg;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_INTERRUPT_CFG, (uint8_t *)&int_cfg, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_INTERRUPT_CFG, (uint8_t *)&int_cfg, 1);
 
   if (ret == 0)
   {
     int_cfg.timestamp_en = (uint8_t)val;
-    ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_INTERRUPT_CFG, (uint8_t *)&int_cfg, 1);
+    ret = iis2dulpx_write_reg(ctx, IIS2DULPX_INTERRUPT_CFG, (uint8_t *)&int_cfg, 1);
   }
 
   return ret;
@@ -3270,12 +3267,12 @@ int32_t lis2duxs12_timestamp_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2duxs12_timestamp_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t iis2dulpx_timestamp_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2duxs12_interrupt_cfg_t int_cfg;
+  iis2dulpx_interrupt_cfg_t int_cfg;
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_INTERRUPT_CFG, (uint8_t *)&int_cfg, 1);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_INTERRUPT_CFG, (uint8_t *)&int_cfg, 1);
   *val = int_cfg.timestamp_en;
 
   return ret;
@@ -3291,12 +3288,12 @@ int32_t lis2duxs12_timestamp_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2duxs12_timestamp_raw_get(const stmdev_ctx_t *ctx, uint32_t *val)
+int32_t iis2dulpx_timestamp_raw_get(const stmdev_ctx_t *ctx, uint32_t *val)
 {
   uint8_t buff[4];
   int32_t ret;
 
-  ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_TIMESTAMP0, buff, 4);
+  ret = iis2dulpx_read_reg(ctx, IIS2DULPX_TIMESTAMP0, buff, 4);
   *val = buff[3];
   *val = (*val * 256U) +  buff[2];
   *val = (*val * 256U) +  buff[1];
@@ -3311,7 +3308,7 @@ int32_t lis2duxs12_timestamp_raw_get(const stmdev_ctx_t *ctx, uint32_t *val)
   */
 
 /**
-  * @defgroup   LIS2DUXS12_finite_state_machine
+  * @defgroup   IIS2DULPX_finite_state_machine
   * @brief      This section groups all the functions that manage the
   *             state_machine.
   * @{
@@ -3327,23 +3324,23 @@ int32_t lis2duxs12_timestamp_raw_get(const stmdev_ctx_t *ctx, uint32_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2duxs12_long_cnt_flag_data_ready_get(const stmdev_ctx_t *ctx,
-                                                uint8_t *val)
+int32_t iis2dulpx_long_cnt_flag_data_ready_get(const stmdev_ctx_t *ctx,
+                                               uint8_t *val)
 {
-  lis2duxs12_emb_func_status_t emb_func_status;
+  iis2dulpx_emb_func_status_t emb_func_status;
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
 
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_STATUS,
-                              (uint8_t *)&emb_func_status, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_EMB_FUNC_STATUS,
+                             (uint8_t *)&emb_func_status, 1);
 
     *val = emb_func_status.is_fsm_lc;
   }
 
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -3356,25 +3353,25 @@ int32_t lis2duxs12_long_cnt_flag_data_ready_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2duxs12_emb_fsm_en_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t iis2dulpx_emb_fsm_en_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   int32_t ret;
 
-  lis2duxs12_emb_func_en_b_t emb_func_en_b;
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  iis2dulpx_emb_func_en_b_t emb_func_en_b;
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
 
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_EN_B,
-                              (uint8_t *)&emb_func_en_b, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_EMB_FUNC_EN_B,
+                             (uint8_t *)&emb_func_en_b, 1);
 
     emb_func_en_b.fsm_en = (uint8_t)val;
 
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_EMB_FUNC_EN_B,
-                                (uint8_t *)&emb_func_en_b, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_EMB_FUNC_EN_B,
+                               (uint8_t *)&emb_func_en_b, 1);
   }
 
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -3387,25 +3384,25 @@ int32_t lis2duxs12_emb_fsm_en_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2duxs12_emb_fsm_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t iis2dulpx_emb_fsm_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   int32_t ret;
 
-  lis2duxs12_emb_func_en_b_t emb_func_en_b;
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  iis2dulpx_emb_func_en_b_t emb_func_en_b;
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
 
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_EN_B,
-                              (uint8_t *)&emb_func_en_b, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_EMB_FUNC_EN_B,
+                             (uint8_t *)&emb_func_en_b, 1);
 
     *val = emb_func_en_b.fsm_en;
 
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_EMB_FUNC_EN_B,
-                                (uint8_t *)&emb_func_en_b, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_EMB_FUNC_EN_B,
+                               (uint8_t *)&emb_func_en_b, 1);
   }
 
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -3418,24 +3415,24 @@ int32_t lis2duxs12_emb_fsm_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2duxs12_fsm_enable_set(const stmdev_ctx_t *ctx,
-                                  lis2duxs12_emb_fsm_enable_t *val)
+int32_t iis2dulpx_fsm_enable_set(const stmdev_ctx_t *ctx,
+                                 iis2dulpx_emb_fsm_enable_t *val)
 {
-  lis2duxs12_emb_func_en_b_t emb_func_en_b;
+  iis2dulpx_emb_func_en_b_t emb_func_en_b;
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
 
   if (ret == 0)
   {
-    ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_FSM_ENABLE,
-                               (uint8_t *)&val->fsm_enable, 1);
+    ret = iis2dulpx_write_reg(ctx, IIS2DULPX_FSM_ENABLE,
+                              (uint8_t *)&val->fsm_enable, 1);
   }
 
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_EN_B,
-                              (uint8_t *)&emb_func_en_b, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_EMB_FUNC_EN_B,
+                             (uint8_t *)&emb_func_en_b, 1);
 
     if ((val->fsm_enable.fsm1_en |
          val->fsm_enable.fsm2_en |
@@ -3453,11 +3450,11 @@ int32_t lis2duxs12_fsm_enable_set(const stmdev_ctx_t *ctx,
       emb_func_en_b.fsm_en = PROPERTY_DISABLE;
     }
 
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_EMB_FUNC_EN_B,
-                                (uint8_t *)&emb_func_en_b, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_EMB_FUNC_EN_B,
+                               (uint8_t *)&emb_func_en_b, 1);
   }
 
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -3470,20 +3467,20 @@ int32_t lis2duxs12_fsm_enable_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2duxs12_fsm_enable_get(const stmdev_ctx_t *ctx,
-                                  lis2duxs12_emb_fsm_enable_t *val)
+int32_t iis2dulpx_fsm_enable_get(const stmdev_ctx_t *ctx,
+                                 iis2dulpx_emb_fsm_enable_t *val)
 {
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
 
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_FSM_ENABLE,
-                              (uint8_t *)&val->fsm_enable, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_FSM_ENABLE,
+                             (uint8_t *)&val->fsm_enable, 1);
   }
 
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -3497,21 +3494,21 @@ int32_t lis2duxs12_fsm_enable_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2duxs12_long_cnt_set(const stmdev_ctx_t *ctx, uint16_t val)
+int32_t iis2dulpx_long_cnt_set(const stmdev_ctx_t *ctx, uint16_t val)
 {
   uint8_t buff[2];
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
 
   if (ret == 0)
   {
     buff[1] = (uint8_t)(val / 256U);
     buff[0] = (uint8_t)(val - (buff[1] * 256U));
-    ret = lis2duxs12_write_reg(ctx, LIS2DUXS12_FSM_LONG_COUNTER_L, buff, 2);
+    ret = iis2dulpx_write_reg(ctx, IIS2DULPX_FSM_LONG_COUNTER_L, buff, 2);
   }
 
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -3525,21 +3522,21 @@ int32_t lis2duxs12_long_cnt_set(const stmdev_ctx_t *ctx, uint16_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2duxs12_long_cnt_get(const stmdev_ctx_t *ctx, uint16_t *val)
+int32_t iis2dulpx_long_cnt_get(const stmdev_ctx_t *ctx, uint16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
 
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_FSM_LONG_COUNTER_L, buff, 2);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_FSM_LONG_COUNTER_L, buff, 2);
     *val = buff[1];
     *val = (*val * 256U) + buff[0];
   }
 
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -3551,11 +3548,11 @@ int32_t lis2duxs12_long_cnt_get(const stmdev_ctx_t *ctx, uint16_t *val)
   * @param  val      register FSM_STATUS_MAINPAGE
   *
   */
-int32_t lis2duxs12_fsm_status_get(const stmdev_ctx_t *ctx,
-                                  lis2duxs12_fsm_status_mainpage_t *val)
+int32_t iis2dulpx_fsm_status_get(const stmdev_ctx_t *ctx,
+                                 iis2dulpx_fsm_status_mainpage_t *val)
 {
-  return lis2duxs12_read_reg(ctx, LIS2DUXS12_FSM_STATUS_MAINPAGE,
-                             (uint8_t *) val, 1);
+  return iis2dulpx_read_reg(ctx, IIS2DULPX_FSM_STATUS_MAINPAGE,
+                            (uint8_t *) val, 1);
 }
 
 /**
@@ -3566,18 +3563,18 @@ int32_t lis2duxs12_fsm_status_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2duxs12_fsm_out_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t iis2dulpx_fsm_out_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
 
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_FSM_OUTS1, val, 8);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_FSM_OUTS1, val, 8);
   }
 
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -3590,25 +3587,25 @@ int32_t lis2duxs12_fsm_out_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2duxs12_fsm_data_rate_set(const stmdev_ctx_t *ctx,
-                                     lis2duxs12_fsm_val_odr_t val)
+int32_t iis2dulpx_fsm_data_rate_set(const stmdev_ctx_t *ctx,
+                                    iis2dulpx_fsm_val_odr_t val)
 {
-  lis2duxs12_fsm_odr_t fsm_odr_reg;
+  iis2dulpx_fsm_odr_t fsm_odr_reg;
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
 
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_FSM_ODR,
-                              (uint8_t *)&fsm_odr_reg, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_FSM_ODR,
+                             (uint8_t *)&fsm_odr_reg, 1);
 
     fsm_odr_reg.fsm_odr = (uint8_t)val;
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_FSM_ODR,
-                                (uint8_t *)&fsm_odr_reg, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_FSM_ODR,
+                               (uint8_t *)&fsm_odr_reg, 1);
   }
 
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -3621,48 +3618,48 @@ int32_t lis2duxs12_fsm_data_rate_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2duxs12_fsm_data_rate_get(const stmdev_ctx_t *ctx,
-                                     lis2duxs12_fsm_val_odr_t *val)
+int32_t iis2dulpx_fsm_data_rate_get(const stmdev_ctx_t *ctx,
+                                    iis2dulpx_fsm_val_odr_t *val)
 {
-  lis2duxs12_fsm_odr_t fsm_odr_reg;
+  iis2dulpx_fsm_odr_t fsm_odr_reg;
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
-  ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_FSM_ODR, (uint8_t *)&fsm_odr_reg, 1);
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
+  ret += iis2dulpx_read_reg(ctx, IIS2DULPX_FSM_ODR, (uint8_t *)&fsm_odr_reg, 1);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   switch (fsm_odr_reg.fsm_odr)
   {
     case 0:
-      *val = LIS2DUXS12_ODR_FSM_12Hz5;
+      *val = IIS2DULPX_ODR_FSM_12Hz5;
       break;
 
     case 1:
-      *val = LIS2DUXS12_ODR_FSM_25Hz;
+      *val = IIS2DULPX_ODR_FSM_25Hz;
       break;
 
     case 2:
-      *val = LIS2DUXS12_ODR_FSM_50Hz;
+      *val = IIS2DULPX_ODR_FSM_50Hz;
       break;
 
     case 3:
-      *val = LIS2DUXS12_ODR_FSM_100Hz;
+      *val = IIS2DULPX_ODR_FSM_100Hz;
       break;
 
     case 4:
-      *val = LIS2DUXS12_ODR_FSM_200Hz;
+      *val = IIS2DULPX_ODR_FSM_200Hz;
       break;
 
     case 5:
-      *val = LIS2DUXS12_ODR_FSM_400Hz;
+      *val = IIS2DULPX_ODR_FSM_400Hz;
       break;
 
     case 6:
-      *val = LIS2DUXS12_ODR_FSM_800Hz;
+      *val = IIS2DULPX_ODR_FSM_800Hz;
       break;
 
     default:
-      *val = LIS2DUXS12_ODR_FSM_12Hz5;
+      *val = IIS2DULPX_ODR_FSM_12Hz5;
       break;
   }
 
@@ -3677,25 +3674,25 @@ int32_t lis2duxs12_fsm_data_rate_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2duxs12_fsm_init_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t iis2dulpx_fsm_init_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2duxs12_emb_func_init_b_t emb_func_init_b;
+  iis2dulpx_emb_func_init_b_t emb_func_init_b;
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
 
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_INIT_B,
-                              (uint8_t *)&emb_func_init_b, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_EMB_FUNC_INIT_B,
+                             (uint8_t *)&emb_func_init_b, 1);
 
     emb_func_init_b.fsm_init = (uint8_t)val;
 
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_EMB_FUNC_INIT_B,
-                                (uint8_t *)&emb_func_init_b, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_EMB_FUNC_INIT_B,
+                               (uint8_t *)&emb_func_init_b, 1);
   }
 
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -3708,22 +3705,22 @@ int32_t lis2duxs12_fsm_init_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2duxs12_fsm_init_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t iis2dulpx_fsm_init_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2duxs12_emb_func_init_b_t emb_func_init_b;
+  iis2dulpx_emb_func_init_b_t emb_func_init_b;
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
 
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_INIT_B,
-                              (uint8_t *)&emb_func_init_b, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_EMB_FUNC_INIT_B,
+                             (uint8_t *)&emb_func_init_b, 1);
 
     *val = emb_func_init_b.fsm_init;
   }
 
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -3732,25 +3729,25 @@ int32_t lis2duxs12_fsm_init_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @brief  FSM FIFO en bit.[set]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the value of fsm_fifo_en in reg LIS2DUXS12_EMB_FUNC_FIFO_EN
+  * @param  val    Change the value of fsm_fifo_en in reg IIS2DULPX_EMB_FUNC_FIFO_EN
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2duxs12_fsm_fifo_en_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t iis2dulpx_fsm_fifo_en_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2duxs12_emb_func_fifo_en_t fifo_reg;
+  iis2dulpx_emb_func_fifo_en_t fifo_reg;
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
 
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_FIFO_EN, (uint8_t *)&fifo_reg, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_EMB_FUNC_FIFO_EN, (uint8_t *)&fifo_reg, 1);
     fifo_reg.fsm_fifo_en = val;
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_EMB_FUNC_FIFO_EN, (uint8_t *)&fifo_reg, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_EMB_FUNC_FIFO_EN, (uint8_t *)&fifo_reg, 1);
   }
 
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -3759,24 +3756,24 @@ int32_t lis2duxs12_fsm_fifo_en_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @brief  FSM FIFO en bit.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Get the value of fsm_fifo_en in reg LIS2DUXS12_EMB_FUNC_FIFO_EN
+  * @param  val    Get the value of fsm_fifo_en in reg IIS2DULPX_EMB_FUNC_FIFO_EN
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2duxs12_fsm_fifo_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t iis2dulpx_fsm_fifo_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2duxs12_emb_func_fifo_en_t fifo_reg;
+  iis2dulpx_emb_func_fifo_en_t fifo_reg;
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
 
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_FIFO_EN, (uint8_t *)&fifo_reg, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_EMB_FUNC_FIFO_EN, (uint8_t *)&fifo_reg, 1);
     *val = fifo_reg.fsm_fifo_en;
   }
 
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -3792,15 +3789,15 @@ int32_t lis2duxs12_fsm_fifo_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2duxs12_long_cnt_int_value_set(const stmdev_ctx_t *ctx,
-                                          uint16_t val)
+int32_t iis2dulpx_long_cnt_int_value_set(const stmdev_ctx_t *ctx,
+                                         uint16_t val)
 {
   uint8_t buff[2];
   int32_t ret;
 
   buff[1] = (uint8_t)(val / 256U);
   buff[0] = (uint8_t)(val - (buff[1] * 256U));
-  ret = lis2duxs12_ln_pg_write(ctx, LIS2DUXS12_FSM_LC_TIMEOUT_L, buff, 2);
+  ret = iis2dulpx_ln_pg_write(ctx, IIS2DULPX_FSM_LC_TIMEOUT_L, buff, 2);
 
   return ret;
 }
@@ -3816,13 +3813,13 @@ int32_t lis2duxs12_long_cnt_int_value_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2duxs12_long_cnt_int_value_get(const stmdev_ctx_t *ctx,
-                                          uint16_t *val)
+int32_t iis2dulpx_long_cnt_int_value_get(const stmdev_ctx_t *ctx,
+                                         uint16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
 
-  ret = lis2duxs12_ln_pg_read(ctx, LIS2DUXS12_FSM_LC_TIMEOUT_L, buff, 2);
+  ret = iis2dulpx_ln_pg_read(ctx, IIS2DULPX_FSM_LC_TIMEOUT_L, buff, 2);
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
 
@@ -3837,11 +3834,11 @@ int32_t lis2duxs12_long_cnt_int_value_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2duxs12_fsm_programs_num_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t iis2dulpx_fsm_programs_num_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   int32_t ret;
 
-  ret = lis2duxs12_ln_pg_write(ctx, LIS2DUXS12_FSM_PROGRAMS, &val, 1);
+  ret = iis2dulpx_ln_pg_write(ctx, IIS2DULPX_FSM_PROGRAMS, &val, 1);
 
   return ret;
 }
@@ -3854,11 +3851,11 @@ int32_t lis2duxs12_fsm_programs_num_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2duxs12_fsm_programs_num_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t iis2dulpx_fsm_programs_num_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   int32_t ret;
 
-  ret = lis2duxs12_ln_pg_read(ctx, LIS2DUXS12_FSM_PROGRAMS, val, 1);
+  ret = iis2dulpx_ln_pg_read(ctx, IIS2DULPX_FSM_PROGRAMS, val, 1);
 
   return ret;
 }
@@ -3872,15 +3869,15 @@ int32_t lis2duxs12_fsm_programs_num_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2duxs12_fsm_start_address_set(const stmdev_ctx_t *ctx,
-                                         uint16_t val)
+int32_t iis2dulpx_fsm_start_address_set(const stmdev_ctx_t *ctx,
+                                        uint16_t val)
 {
   uint8_t buff[2];
   int32_t ret;
 
   buff[1] = (uint8_t)(val / 256U);
   buff[0] = (uint8_t)(val - (buff[1] * 256U));
-  ret = lis2duxs12_ln_pg_write(ctx, LIS2DUXS12_FSM_START_ADD_L, buff, 2);
+  ret = iis2dulpx_ln_pg_write(ctx, IIS2DULPX_FSM_START_ADD_L, buff, 2);
 
   return ret;
 }
@@ -3894,13 +3891,13 @@ int32_t lis2duxs12_fsm_start_address_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2duxs12_fsm_start_address_get(const stmdev_ctx_t *ctx,
-                                         uint16_t *val)
+int32_t iis2dulpx_fsm_start_address_get(const stmdev_ctx_t *ctx,
+                                        uint16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
 
-  ret = lis2duxs12_ln_pg_read(ctx, LIS2DUXS12_FSM_START_ADD_L, buff, 2);
+  ret = iis2dulpx_ln_pg_read(ctx, IIS2DULPX_FSM_START_ADD_L, buff, 2);
   *val = buff[1];
   *val = (*val * 256U) +  buff[0];
 
@@ -3929,30 +3926,30 @@ int32_t lis2duxs12_fsm_start_address_get(const stmdev_ctx_t *ctx,
   *                  in EMB_FUNC_INIT_A
   *
   */
-int32_t lis2duxs12_mlc_set(const stmdev_ctx_t *ctx, lis2duxs12_mlc_mode_t val)
+int32_t iis2dulpx_mlc_set(const stmdev_ctx_t *ctx, iis2dulpx_mlc_mode_t val)
 {
-  lis2duxs12_emb_func_en_a_t emb_en_a;
-  lis2duxs12_emb_func_en_b_t emb_en_b;
+  iis2dulpx_emb_func_en_a_t emb_en_a;
+  iis2dulpx_emb_func_en_b_t emb_en_b;
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
 
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_EN_A, (uint8_t *)&emb_en_a, 1);
-    ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_EN_B, (uint8_t *)&emb_en_b, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_EMB_FUNC_EN_A, (uint8_t *)&emb_en_a, 1);
+    ret += iis2dulpx_read_reg(ctx, IIS2DULPX_EMB_FUNC_EN_B, (uint8_t *)&emb_en_b, 1);
 
     switch (val)
     {
-      case LIS2DUXS12_MLC_OFF:
+      case IIS2DULPX_MLC_OFF:
         emb_en_a.mlc_before_fsm_en = 0;
         emb_en_b.mlc_en = 0;
         break;
-      case LIS2DUXS12_MLC_ON:
+      case IIS2DULPX_MLC_ON:
         emb_en_a.mlc_before_fsm_en = 0;
         emb_en_b.mlc_en = 1;
         break;
-      case LIS2DUXS12_MLC_ON_BEFORE_FSM:
+      case IIS2DULPX_MLC_ON_BEFORE_FSM:
         emb_en_a.mlc_before_fsm_en = 1;
         emb_en_b.mlc_en = 0;
         break;
@@ -3961,11 +3958,11 @@ int32_t lis2duxs12_mlc_set(const stmdev_ctx_t *ctx, lis2duxs12_mlc_mode_t val)
         break;
     }
 
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_EMB_FUNC_EN_A, (uint8_t *)&emb_en_a, 1);
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_EMB_FUNC_EN_B, (uint8_t *)&emb_en_b, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_EMB_FUNC_EN_A, (uint8_t *)&emb_en_a, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_EMB_FUNC_EN_B, (uint8_t *)&emb_en_b, 1);
   }
 
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -3979,30 +3976,30 @@ int32_t lis2duxs12_mlc_set(const stmdev_ctx_t *ctx, lis2duxs12_mlc_mode_t val)
   *                  in EMB_FUNC_INIT_A
   *
   */
-int32_t lis2duxs12_mlc_get(const stmdev_ctx_t *ctx, lis2duxs12_mlc_mode_t *val)
+int32_t iis2dulpx_mlc_get(const stmdev_ctx_t *ctx, iis2dulpx_mlc_mode_t *val)
 {
-  lis2duxs12_emb_func_en_a_t emb_en_a;
-  lis2duxs12_emb_func_en_b_t emb_en_b;
+  iis2dulpx_emb_func_en_a_t emb_en_a;
+  iis2dulpx_emb_func_en_b_t emb_en_b;
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
 
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_EN_A, (uint8_t *)&emb_en_a, 1);
-    ret += lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_EN_B, (uint8_t *)&emb_en_b, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_EMB_FUNC_EN_A, (uint8_t *)&emb_en_a, 1);
+    ret += iis2dulpx_read_reg(ctx, IIS2DULPX_EMB_FUNC_EN_B, (uint8_t *)&emb_en_b, 1);
 
     if (emb_en_a.mlc_before_fsm_en == 0U && emb_en_b.mlc_en == 0U)
     {
-      *val = LIS2DUXS12_MLC_OFF;
+      *val = IIS2DULPX_MLC_OFF;
     }
     else if (emb_en_a.mlc_before_fsm_en == 0U && emb_en_b.mlc_en == 1U)
     {
-      *val = LIS2DUXS12_MLC_ON;
+      *val = IIS2DULPX_MLC_ON;
     }
     else if (emb_en_a.mlc_before_fsm_en == 1U)
     {
-      *val = LIS2DUXS12_MLC_ON_BEFORE_FSM;
+      *val = IIS2DULPX_MLC_ON_BEFORE_FSM;
     }
     else
     {
@@ -4010,7 +4007,7 @@ int32_t lis2duxs12_mlc_get(const stmdev_ctx_t *ctx, lis2duxs12_mlc_mode_t *val)
     }
   }
 
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -4022,11 +4019,11 @@ int32_t lis2duxs12_mlc_get(const stmdev_ctx_t *ctx, lis2duxs12_mlc_mode_t *val)
   * @param  val      register MLC_STATUS_MAINPAGE
   *
   */
-int32_t lis2duxs12_mlc_status_get(const stmdev_ctx_t *ctx,
-                                  lis2duxs12_mlc_status_mainpage_t *val)
+int32_t iis2dulpx_mlc_status_get(const stmdev_ctx_t *ctx,
+                                 iis2dulpx_mlc_status_mainpage_t *val)
 {
-  return lis2duxs12_read_reg(ctx, LIS2DUXS12_MLC_STATUS_MAINPAGE,
-                             (uint8_t *) val, 1);
+  return iis2dulpx_read_reg(ctx, IIS2DULPX_MLC_STATUS_MAINPAGE,
+                            (uint8_t *) val, 1);
 }
 
 /**
@@ -4036,18 +4033,18 @@ int32_t lis2duxs12_mlc_status_get(const stmdev_ctx_t *ctx,
   * @param  uint8_t * : buffer that stores data read
   *
   */
-int32_t lis2duxs12_mlc_out_get(const stmdev_ctx_t *ctx, uint8_t *buff)
+int32_t iis2dulpx_mlc_out_get(const stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
 
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_MLC1_SRC, buff, 4);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_MLC1_SRC, buff, 4);
   }
 
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -4060,24 +4057,24 @@ int32_t lis2duxs12_mlc_out_get(const stmdev_ctx_t *ctx, uint8_t *buff)
   *                  reg EMB_FUNC_ODR_CFG_C
   *
   */
-int32_t lis2duxs12_mlc_data_rate_set(const stmdev_ctx_t *ctx,
-                                     lis2duxs12_mlc_odr_val_t val)
+int32_t iis2dulpx_mlc_data_rate_set(const stmdev_ctx_t *ctx,
+                                    iis2dulpx_mlc_odr_val_t val)
 {
-  lis2duxs12_mlc_odr_t reg;
+  iis2dulpx_mlc_odr_t reg;
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
 
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_MLC_ODR, (uint8_t *)&reg, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_MLC_ODR, (uint8_t *)&reg, 1);
     reg.mlc_odr = (uint8_t)val;
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_MLC_ODR, (uint8_t *)&reg, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_MLC_ODR, (uint8_t *)&reg, 1);
   }
 
   if (ret == 0)
   {
-    ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+    ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
   }
 
   return ret;
@@ -4091,47 +4088,47 @@ int32_t lis2duxs12_mlc_data_rate_set(const stmdev_ctx_t *ctx,
   *                  reg EMB_FUNC_ODR_CFG_C
   *
   */
-int32_t lis2duxs12_mlc_data_rate_get(const stmdev_ctx_t *ctx,
-                                     lis2duxs12_mlc_odr_val_t *val)
+int32_t iis2dulpx_mlc_data_rate_get(const stmdev_ctx_t *ctx,
+                                    iis2dulpx_mlc_odr_val_t *val)
 {
-  lis2duxs12_mlc_odr_t reg;
+  iis2dulpx_mlc_odr_t reg;
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
 
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_MLC_ODR, (uint8_t *)&reg, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_MLC_ODR, (uint8_t *)&reg, 1);
 
     switch (reg.mlc_odr)
     {
       case 0:
-        *val = LIS2DUXS12_ODR_PRGS_12Hz5;
+        *val = IIS2DULPX_ODR_PRGS_12Hz5;
         break;
 
       case 1:
-        *val = LIS2DUXS12_ODR_PRGS_25Hz;
+        *val = IIS2DULPX_ODR_PRGS_25Hz;
         break;
 
       case 2:
-        *val = LIS2DUXS12_ODR_PRGS_50Hz;
+        *val = IIS2DULPX_ODR_PRGS_50Hz;
         break;
 
       case 3:
-        *val = LIS2DUXS12_ODR_PRGS_100Hz;
+        *val = IIS2DULPX_ODR_PRGS_100Hz;
         break;
 
       case 4:
-        *val = LIS2DUXS12_ODR_PRGS_200Hz;
+        *val = IIS2DULPX_ODR_PRGS_200Hz;
         break;
 
       default:
-        *val = LIS2DUXS12_ODR_PRGS_12Hz5;
+        *val = IIS2DULPX_ODR_PRGS_12Hz5;
         break;
     }
   }
 
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -4140,25 +4137,25 @@ int32_t lis2duxs12_mlc_data_rate_get(const stmdev_ctx_t *ctx,
   * @brief  MLC FIFO en bit.[set]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the value of mlc_fifo_en in reg LIS2DUXS12_EMB_FUNC_FIFO_EN
+  * @param  val    Change the value of mlc_fifo_en in reg IIS2DULPX_EMB_FUNC_FIFO_EN
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2duxs12_mlc_fifo_en_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t iis2dulpx_mlc_fifo_en_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2duxs12_emb_func_fifo_en_t fifo_reg;
+  iis2dulpx_emb_func_fifo_en_t fifo_reg;
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
 
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_FIFO_EN, (uint8_t *)&fifo_reg, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_EMB_FUNC_FIFO_EN, (uint8_t *)&fifo_reg, 1);
     fifo_reg.mlc_fifo_en = val;
-    ret += lis2duxs12_write_reg(ctx, LIS2DUXS12_EMB_FUNC_FIFO_EN, (uint8_t *)&fifo_reg, 1);
+    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_EMB_FUNC_FIFO_EN, (uint8_t *)&fifo_reg, 1);
   }
 
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }
@@ -4167,24 +4164,24 @@ int32_t lis2duxs12_mlc_fifo_en_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @brief  MLC FIFO en bit.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Get the value of mlc_fifo_en in reg LIS2DUXS12_EMB_FUNC_FIFO_EN
+  * @param  val    Get the value of mlc_fifo_en in reg IIS2DULPX_EMB_FUNC_FIFO_EN
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2duxs12_mlc_fifo_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t iis2dulpx_mlc_fifo_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2duxs12_emb_func_fifo_en_t fifo_reg;
+  iis2dulpx_emb_func_fifo_en_t fifo_reg;
   int32_t ret;
 
-  ret = lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_EMBED_FUNC_MEM_BANK);
+  ret = iis2dulpx_mem_bank_set(ctx, IIS2DULPX_EMBED_FUNC_MEM_BANK);
 
   if (ret == 0)
   {
-    ret = lis2duxs12_read_reg(ctx, LIS2DUXS12_EMB_FUNC_FIFO_EN, (uint8_t *)&fifo_reg, 1);
+    ret = iis2dulpx_read_reg(ctx, IIS2DULPX_EMB_FUNC_FIFO_EN, (uint8_t *)&fifo_reg, 1);
     *val = fifo_reg.mlc_fifo_en;
   }
 
-  ret += lis2duxs12_mem_bank_set(ctx, LIS2DUXS12_MAIN_MEM_BANK);
+  ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);
 
   return ret;
 }

--- a/sensor/stmemsc/iis2dulpx_STdC/driver/iis2dulpx_reg.h
+++ b/sensor/stmemsc/iis2dulpx_STdC/driver/iis2dulpx_reg.h
@@ -1,13 +1,13 @@
 /*
  ******************************************************************************
- * @file    st1vafe3bx_reg.h
+ * @file    iis2dulpx_reg.h
  * @author  Sensors Software Solution Team
  * @brief   This file contains all the functions prototypes for the
- *          st1vafe3bx_reg.c driver.
+ *          iis2dulpx_reg.c driver.
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; Copyright (c) 2024 STMicroelectronics.
+ * <h2><center>&copy; Copyright (c) 2022 STMicroelectronics.
  * All rights reserved.</center></h2>
  *
  * This software component is licensed by ST under BSD 3-Clause license,
@@ -19,8 +19,8 @@
  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
-#ifndef ST1VAFE3BX_REGS_H
-#define ST1VAFE3BX_REGS_H
+#ifndef IIS2DULPX_REGS_H
+#define IIS2DULPX_REGS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -31,7 +31,7 @@ extern "C" {
 #include <stddef.h>
 #include <math.h>
 
-/** @addtogroup ST1VAFE3BX
+/** @addtogroup IIS2DULPX
   * @{
   *
   */
@@ -109,22 +109,10 @@ typedef struct
   *
   */
 
-typedef int32_t (*stmdev_write_ptr)(void *ctx, uint8_t reg,
-                                    const uint8_t *data, uint16_t len);
-typedef int32_t (*stmdev_read_ptr)(void *ctx, uint8_t reg,
-                                   uint8_t *data, uint16_t len);
+typedef int32_t (*stmdev_write_ptr)(void *ctx, uint8_t reg, const uint8_t *data, uint16_t len);
+typedef int32_t (*stmdev_read_ptr)(void *ctx, uint8_t reg, uint8_t *data, uint16_t len);
 typedef void (*stmdev_mdelay_ptr)(uint32_t millisec);
 
-/**
-  * @}
-  *
-  */
-
-#endif /* MEMS_SHARED_TYPES */
-
-/*
- * Proprietary read/write device context structure
- */
 typedef struct
 {
   /** Component mandatory fields **/
@@ -134,10 +122,14 @@ typedef struct
   stmdev_mdelay_ptr   mdelay;
   /** Customizable optional pointer **/
   void *handle;
+} stmdev_ctx_t;
 
-  /** private data **/
-  uint8_t vafe_only;
-} st1vafe3bx_ctx_t;
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
 
 #ifndef MEMS_UCF_SHARED_TYPES
 #define MEMS_UCF_SHARED_TYPES
@@ -171,24 +163,24 @@ typedef struct
   *
   */
 
-/** @defgroup ST1VAFE3BX_Infos
+/** @defgroup IIS2DULPX_Infos
   * @{
   *
   */
 
 /** I2C Device Address 8 bit format  if SA0=0 -> 0x if SA0=1 -> 0x **/
-#define ST1VAFE3BX_I2C_ADD_L                            0x41U
-#define ST1VAFE3BX_I2C_ADD_H                            0x43U
+#define IIS2DULPX_I2C_ADD_L                            0x31U
+#define IIS2DULPX_I2C_ADD_H                            0x33U
 
 /** Device Identification (Who am I) **/
-#define ST1VAFE3BX_ID                                   0x48U
+#define IIS2DULPX_ID                                   0x47U
 
 /**
   * @}
   *
   */
 
-#define ST1VAFE3BX_EXT_CLK_CFG                          0x08U
+#define IIS2DULPX_EXT_CLK_CFG                          0x08U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -198,9 +190,9 @@ typedef struct
   uint8_t ext_clk_en                   : 1;
   uint8_t not_used0                    : 7;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_ext_clk_cfg_t;
+} iis2dulpx_ext_clk_cfg_t;
 
-#define ST1VAFE3BX_PIN_CTRL                             0x0CU
+#define IIS2DULPX_PIN_CTRL                             0x0CU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -208,21 +200,23 @@ typedef struct
   uint8_t pp_od                        : 1;
   uint8_t cs_pu_dis                    : 1;
   uint8_t h_lactive                    : 1;
-  uint8_t not_used0                    : 2;
+  uint8_t pd_dis_int1                  : 1;
+  uint8_t pd_dis_int2                  : 1;
   uint8_t sda_pu_en                    : 1;
   uint8_t sdo_pu_en                    : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t sdo_pu_en                    : 1;
   uint8_t sda_pu_en                    : 1;
-  uint8_t not_used0                    : 2;
+  uint8_t pd_dis_int2                  : 1;
+  uint8_t pd_dis_int1                  : 1;
   uint8_t h_lactive                    : 1;
   uint8_t cs_pu_dis                    : 1;
   uint8_t pp_od                        : 1;
   uint8_t sim                          : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_pin_ctrl_t;
+} iis2dulpx_pin_ctrl_t;
 
-#define ST1VAFE3BX_WAKE_UP_DUR_EXT                      0x0EU
+#define IIS2DULPX_WAKE_UP_DUR_EXT                      0x0EU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -234,9 +228,9 @@ typedef struct
   uint8_t wu_dur_extended              : 1;
   uint8_t not_used0                    : 4;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_wake_up_dur_ext_t;
+} iis2dulpx_wake_up_dur_ext_t;
 
-#define ST1VAFE3BX_WHO_AM_I                             0x0FU
+#define IIS2DULPX_WHO_AM_I                             0x0FU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -244,9 +238,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t id                           : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_who_am_i_t;
+} iis2dulpx_who_am_i_t;
 
-#define ST1VAFE3BX_CTRL1                                0x10U
+#define IIS2DULPX_CTRL1                                0x10U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -256,11 +250,11 @@ typedef struct
   uint8_t drdy_pulsed                  : 1;
   uint8_t if_add_inc                   : 1;
   uint8_t sw_reset                     : 1;
-  uint8_t int_pin_en                   : 1;
+  uint8_t int1_on_res                  : 1;
   uint8_t smart_power_en               : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t smart_power_en               : 1;
-  uint8_t int_pin_en                   : 1;
+  uint8_t int1_on_res                  : 1;
   uint8_t sw_reset                     : 1;
   uint8_t if_add_inc                   : 1;
   uint8_t drdy_pulsed                  : 1;
@@ -268,45 +262,53 @@ typedef struct
   uint8_t wu_y_en                      : 1;
   uint8_t wu_z_en                      : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_ctrl1_t;
+} iis2dulpx_ctrl1_t;
 
-#define ST1VAFE3BX_CTRL2                                0x11U
+#define IIS2DULPX_CTRL2                                0x11U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0                    : 3;
-  uint8_t int_drdy                     : 1;
-  uint8_t int_fifo_ovr                 : 1;
-  uint8_t int_fifo_th                  : 1;
-  uint8_t int_fifo_full                : 1;
-  uint8_t int_boot                     : 1;
+  uint8_t int1_drdy                    : 1;
+  uint8_t int1_fifo_ovr                : 1;
+  uint8_t int1_fifo_th                 : 1;
+  uint8_t int1_fifo_full               : 1;
+  uint8_t int1_boot                    : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t int_boot                     : 1;
-  uint8_t int_fifo_full                : 1;
-  uint8_t int_fifo_th                  : 1;
-  uint8_t int_fifo_ovr                 : 1;
-  uint8_t int_drdy                     : 1;
+  uint8_t int1_boot                    : 1;
+  uint8_t int1_fifo_full               : 1;
+  uint8_t int1_fifo_th                 : 1;
+  uint8_t int1_fifo_ovr                : 1;
+  uint8_t int1_drdy                    : 1;
   uint8_t not_used0                    : 3;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_ctrl2_t;
+} iis2dulpx_ctrl2_t;
 
-#define ST1VAFE3BX_CTRL3                                0x12U
+#define IIS2DULPX_CTRL3                                0x12U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t st_sign_x                    : 1;
   uint8_t st_sign_y                    : 1;
   uint8_t hp_en                        : 1;
-  uint8_t not_used0                    : 5;
+  uint8_t int2_drdy                    : 1;
+  uint8_t int2_fifo_ovr                : 1;
+  uint8_t int2_fifo_th                 : 1;
+  uint8_t int2_fifo_full               : 1;
+  uint8_t int2_boot                    : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t not_used0                    : 5;
+  uint8_t int2_boot                    : 1;
+  uint8_t int2_fifo_full               : 1;
+  uint8_t int2_fifo_th                 : 1;
+  uint8_t int2_fifo_ovr                : 1;
+  uint8_t int2_drdy                    : 1;
   uint8_t hp_en                        : 1;
   uint8_t st_sign_y                    : 1;
   uint8_t st_sign_x                    : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_ctrl3_t;
+} iis2dulpx_ctrl3_t;
 
-#define ST1VAFE3BX_CTRL4                                0x13U
+#define IIS2DULPX_CTRL4                                0x13U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -326,9 +328,9 @@ typedef struct
   uint8_t soc                          : 1;
   uint8_t boot                         : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_ctrl4_t;
+} iis2dulpx_ctrl4_t;
 
-#define ST1VAFE3BX_CTRL5                                0x14U
+#define IIS2DULPX_CTRL5                                0x14U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -340,29 +342,29 @@ typedef struct
   uint8_t bw                           : 2;
   uint8_t fs                           : 2;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_ctrl5_t;
+} iis2dulpx_ctrl5_t;
 
-#define ST1VAFE3BX_FIFO_CTRL                            0x15U
+#define IIS2DULPX_FIFO_CTRL                            0x15U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fifo_mode                    : 3;
   uint8_t stop_on_fth                  : 1;
-  uint8_t fifo_en_adv                  : 1;
   uint8_t not_used0                    : 1;
+  uint8_t dis_hard_rst_cs              : 1;
   uint8_t fifo_depth                   : 1;
   uint8_t cfg_chg_en                   : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t cfg_chg_en                   : 1;
   uint8_t fifo_depth                   : 1;
+  uint8_t dis_hard_rst_cs              : 1;
   uint8_t not_used0                    : 1;
-  uint8_t fifo_en_adv                  : 1;
   uint8_t stop_on_fth                  : 1;
   uint8_t fifo_mode                    : 3;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fifo_ctrl_t;
+} iis2dulpx_fifo_ctrl_t;
 
-#define ST1VAFE3BX_FIFO_WTM                             0x16U
+#define IIS2DULPX_FIFO_WTM                             0x16U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -372,9 +374,9 @@ typedef struct
   uint8_t xl_only_fifo                 : 1;
   uint8_t fth                          : 7;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fifo_wtm_t;
+} iis2dulpx_fifo_wtm_t;
 
-#define ST1VAFE3BX_INTERRUPT_CFG                        0x17U
+#define IIS2DULPX_INTERRUPT_CFG                        0x17U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -396,9 +398,9 @@ typedef struct
   uint8_t lir                          : 1;
   uint8_t interrupts_enable            : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_interrupt_cfg_t;
+} iis2dulpx_interrupt_cfg_t;
 
-#define ST1VAFE3BX_SIXD                                 0x18U
+#define IIS2DULPX_SIXD                                 0x18U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -410,9 +412,9 @@ typedef struct
   uint8_t d6d_ths                      : 2;
   uint8_t not_used0                    : 5;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_sixd_t;
+} iis2dulpx_sixd_t;
 
-#define ST1VAFE3BX_WAKE_UP_THS                          0x1CU
+#define IIS2DULPX_WAKE_UP_THS                          0x1CU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -424,9 +426,9 @@ typedef struct
   uint8_t sleep_on                     : 1;
   uint8_t wk_ths                       : 6;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_wake_up_ths_t;
+} iis2dulpx_wake_up_ths_t;
 
-#define ST1VAFE3BX_WAKE_UP_DUR                          0x1DU
+#define IIS2DULPX_WAKE_UP_DUR                          0x1DU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -440,9 +442,9 @@ typedef struct
   uint8_t st_sign_z                    : 1;
   uint8_t sleep_dur                    : 4;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_wake_up_dur_t;
+} iis2dulpx_wake_up_dur_t;
 
-#define ST1VAFE3BX_FREE_FALL                            0x1EU
+#define IIS2DULPX_FREE_FALL                            0x1EU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -452,33 +454,57 @@ typedef struct
   uint8_t ff_dur                       : 5;
   uint8_t ff_ths                       : 3;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_free_fall_t;
+} iis2dulpx_free_fall_t;
 
-#define ST1VAFE3BX_MD1_CFG                              0x1FU
+#define IIS2DULPX_MD1_CFG                              0x1FU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t int_emb_func                 : 1;
-  uint8_t int_timestamp                : 1;
-  uint8_t int_6d                       : 1;
-  uint8_t int_tap                      : 1;
-  uint8_t int_ff                       : 1;
-  uint8_t int_wu                       : 1;
+  uint8_t int1_emb_func                : 1;
+  uint8_t int1_timestamp               : 1;
+  uint8_t int1_6d                      : 1;
+  uint8_t int1_tap                     : 1;
+  uint8_t int1_ff                      : 1;
+  uint8_t int1_wu                      : 1;
   uint8_t not_used0                    : 1;
-  uint8_t int_sleep_change             : 1;
+  uint8_t int1_sleep_change            : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t int_sleep_change             : 1;
+  uint8_t int1_sleep_change            : 1;
   uint8_t not_used0                    : 1;
-  uint8_t int_wu                       : 1;
-  uint8_t int_ff                       : 1;
-  uint8_t int_tap                      : 1;
-  uint8_t int_6d                       : 1;
-  uint8_t int_timestamp                : 1;
-  uint8_t int_emb_func                 : 1;
+  uint8_t int1_wu                      : 1;
+  uint8_t int1_ff                      : 1;
+  uint8_t int1_tap                     : 1;
+  uint8_t int1_6d                      : 1;
+  uint8_t int1_timestamp               : 1;
+  uint8_t int1_emb_func                : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_md1_cfg_t;
+} iis2dulpx_md1_cfg_t;
 
-#define ST1VAFE3BX_WAKE_UP_SRC                          0x21U
+#define IIS2DULPX_MD2_CFG                              0x20U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t int2_emb_func                : 1;
+  uint8_t int2_timestamp               : 1;
+  uint8_t int2_6d                      : 1;
+  uint8_t int2_tap                     : 1;
+  uint8_t int2_ff                      : 1;
+  uint8_t int2_wu                      : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t int2_sleep_change            : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t int2_sleep_change            : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t int2_wu                      : 1;
+  uint8_t int2_ff                      : 1;
+  uint8_t int2_tap                     : 1;
+  uint8_t int2_6d                      : 1;
+  uint8_t int2_timestamp               : 1;
+  uint8_t int2_emb_func                : 1;
+#endif /* DRV_BYTE_ORDER */
+} iis2dulpx_md2_cfg_t;
+
+#define IIS2DULPX_WAKE_UP_SRC                          0x21U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -500,9 +526,9 @@ typedef struct
   uint8_t y_wu                         : 1;
   uint8_t z_wu                         : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_wake_up_src_t;
+} iis2dulpx_wake_up_src_t;
 
-#define ST1VAFE3BX_TAP_SRC                              0x22U
+#define IIS2DULPX_TAP_SRC                              0x22U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -518,9 +544,9 @@ typedef struct
   uint8_t triple_tap_ia                : 1;
   uint8_t not_used0                    : 4;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_tap_src_t;
+} iis2dulpx_tap_src_t;
 
-#define ST1VAFE3BX_SIXD_SRC                             0x23U
+#define IIS2DULPX_SIXD_SRC                             0x23U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -542,9 +568,9 @@ typedef struct
   uint8_t xh                           : 1;
   uint8_t xl                           : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_sixd_src_t;
+} iis2dulpx_sixd_src_t;
 
-#define ST1VAFE3BX_ALL_INT_SRC                          0x24U
+#define IIS2DULPX_ALL_INT_SRC                          0x24U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -566,9 +592,9 @@ typedef struct
   uint8_t wu_ia_all                    : 1;
   uint8_t ff_ia_all                    : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_all_int_src_t;
+} iis2dulpx_all_int_src_t;
 
-#define ST1VAFE3BX_STATUS                               0x25U
+#define IIS2DULPX_STATUS                               0x25U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -582,9 +608,9 @@ typedef struct
   uint8_t not_used0                    : 4;
   uint8_t drdy                         : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_status_register_t;
+} iis2dulpx_status_register_t;
 
-#define ST1VAFE3BX_FIFO_STATUS1                         0x26U
+#define IIS2DULPX_FIFO_STATUS1                         0x26U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -596,9 +622,9 @@ typedef struct
   uint8_t fifo_ovr_ia                  : 1;
   uint8_t not_used0                    : 6;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fifo_status1_t;
+} iis2dulpx_fifo_status1_t;
 
-#define ST1VAFE3BX_FIFO_STATUS2                         0x27U
+#define IIS2DULPX_FIFO_STATUS2                         0x27U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -606,9 +632,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fss                          : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fifo_status2_t;
+} iis2dulpx_fifo_status2_t;
 
-#define ST1VAFE3BX_OUT_X_L                              0x28U
+#define IIS2DULPX_OUT_X_L                              0x28U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -616,9 +642,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t outx                         : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_out_x_l_t;
+} iis2dulpx_out_x_l_t;
 
-#define ST1VAFE3BX_OUT_X_H                              0x29U
+#define IIS2DULPX_OUT_X_H                              0x29U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -626,9 +652,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t outx                         : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_out_x_h_t;
+} iis2dulpx_out_x_h_t;
 
-#define ST1VAFE3BX_OUT_Y_L                              0x2AU
+#define IIS2DULPX_OUT_Y_L                              0x2AU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -636,9 +662,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t outy                         : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_out_y_l_t;
+} iis2dulpx_out_y_l_t;
 
-#define ST1VAFE3BX_OUT_Y_H                              0x2BU
+#define IIS2DULPX_OUT_Y_H                              0x2BU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -646,9 +672,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t outy                         : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_out_y_h_t;
+} iis2dulpx_out_y_h_t;
 
-#define ST1VAFE3BX_OUT_Z_L                              0x2CU
+#define IIS2DULPX_OUT_Z_L                              0x2CU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -656,9 +682,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t outz                         : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_out_z_l_t;
+} iis2dulpx_out_z_l_t;
 
-#define ST1VAFE3BX_OUT_Z_H                              0x2DU
+#define IIS2DULPX_OUT_Z_H                              0x2DU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -666,67 +692,53 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t outz                         : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_out_z_h_t;
+} iis2dulpx_out_z_h_t;
 
-#define ST1VAFE3BX_OUT_AH_BIO_L                         0x2EU
+#define IIS2DULPX_OUT_T_AH_QVAR_L                      0x2EU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t out_ah_bio                   : 8;
+  uint8_t outt                         : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t out_ah_bio                   : 8;
+  uint8_t outt                         : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_out_ah_bio_l_t;
+} iis2dulpx_out_t_ah_qvar_l_t;
 
-#define ST1VAFE3BX_OUT_AH_BIO_H                         0x2FU
+#define IIS2DULPX_OUT_T_AH_QVAR_H                      0x2FU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t out_ah_bio                   : 8;
+  uint8_t outt                         : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t out_ah_bio                   : 8;
+  uint8_t outt                         : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_out_ah_bio_h_t;
+} iis2dulpx_out_t_ah_qvar_h_t;
 
-#define ST1VAFE3BX_AH_BIO_CFG1                          0x30U
+#define IIS2DULPX_AH_QVAR_CFG                          0x31U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t not_used0                    : 3;
-  uint8_t ah_bio_zin_dis_ah2_bio1      : 1;
-  uint8_t ah_bio_zin_dis_ah2_bio2      : 1;
-  uint8_t not_used1                    : 3;
-#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t not_used1                    : 3;
-  uint8_t ah_bio_zin_dis_ah2_bio2      : 1;
-  uint8_t ah_bio_zin_dis_ah2_bio1      : 1;
-  uint8_t not_used0                    : 3;
-#endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_ah_bio_cfg1_t;
-
-#define ST1VAFE3BX_AH_BIO_CFG2                          0x31U
-typedef struct
-{
-#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t ah_bio_en                    : 1;
-  uint8_t ah_bio_gain                  : 2;
-  uint8_t ah_bio_c_zin                 : 2;
-  uint8_t ah_bio_mode                  : 2;
   uint8_t not_used0                    : 1;
+  uint8_t ah_qvar_gain                 : 2;
+  uint8_t ah_qvar_c_zin                : 2;
+  uint8_t ah_qvar_notch_cutoff         : 1;
+  uint8_t ah_qvar_notch_en             : 1;
+  uint8_t ah_qvar_en                   : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ah_qvar_en                   : 1;
+  uint8_t ah_qvar_notch_en             : 1;
+  uint8_t ah_qvar_notch_cutoff         : 1;
+  uint8_t ah_qvar_c_zin                : 2;
+  uint8_t ah_qvar_gain                 : 2;
   uint8_t not_used0                    : 1;
-  uint8_t ah_bio_mode                  : 2;
-  uint8_t ah_bio_c_zin                 : 2;
-  uint8_t ah_bio_gain                  : 2;
-  uint8_t ah_bio_en                    : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_ah_bio_cfg2_t;
+} iis2dulpx_ah_qvar_cfg_t;
 
-#define ST1VAFE3BX_AH_BIO_CFG3                          0x32U
+#define IIS2DULPX_SELF_TEST                            0x32U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t ah_bio_active                : 1;
+  uint8_t t_ah_qvar_dis                : 1;
   uint8_t not_used0                    : 3;
   uint8_t st                           : 2;
   uint8_t not_used1                    : 2;
@@ -734,29 +746,29 @@ typedef struct
   uint8_t not_used1                    : 2;
   uint8_t st                           : 2;
   uint8_t not_used0                    : 3;
-  uint8_t ah_bio_active                : 1;
+  uint8_t t_ah_qvar_dis                : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_ah_bio_cfg3_t;
+} iis2dulpx_self_test_t;
 
-#define ST1VAFE3BX_I3C_IF_CTRL                          0x33U
+#define IIS2DULPX_I3C_IF_CTRL                          0x33U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t bus_act_sel                  : 2;
   uint8_t not_used0                    : 3;
   uint8_t asf_on                       : 1;
-  uint8_t not_used1                    : 1;
   uint8_t dis_drstdaa                  : 1;
+  uint8_t not_used1                    : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t dis_drstdaa                  : 1;
   uint8_t not_used1                    : 1;
+  uint8_t dis_drstdaa                  : 1;
   uint8_t asf_on                       : 1;
   uint8_t not_used0                    : 3;
   uint8_t bus_act_sel                  : 2;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_i3c_if_ctrl_t;
+} iis2dulpx_i3c_if_ctrl_t;
 
-#define ST1VAFE3BX_EMB_FUNC_STATUS_MAINPAGE             0x34U
+#define IIS2DULPX_EMB_FUNC_STATUS_MAINPAGE             0x34U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -774,9 +786,9 @@ typedef struct
   uint8_t is_step_det                  : 1;
   uint8_t not_used0                    : 3;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_emb_func_status_mainpage_t;
+} iis2dulpx_emb_func_status_mainpage_t;
 
-#define ST1VAFE3BX_FSM_STATUS_MAINPAGE                  0x35U
+#define IIS2DULPX_FSM_STATUS_MAINPAGE                  0x35U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -798,9 +810,9 @@ typedef struct
   uint8_t is_fsm2                      : 1;
   uint8_t is_fsm1                      : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fsm_status_mainpage_t;
+} iis2dulpx_fsm_status_mainpage_t;
 
-#define ST1VAFE3BX_MLC_STATUS_MAINPAGE                  0x36U
+#define IIS2DULPX_MLC_STATUS_MAINPAGE                  0x36U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -816,21 +828,33 @@ typedef struct
   uint8_t is_mlc2                      : 1;
   uint8_t is_mlc1                      : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_mlc_status_mainpage_t;
+} iis2dulpx_mlc_status_mainpage_t;
 
-#define ST1VAFE3BX_EN_DEVICE_CONFIG                     0x3EU
+#define IIS2DULPX_SLEEP                                0x3DU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t en_dev_conf                  : 1;
+  uint8_t deep_pd                      : 1;
   uint8_t not_used0                    : 7;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t not_used0                    : 7;
-  uint8_t en_dev_conf                  : 1;
+  uint8_t deep_pd                      : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_en_device_config_t;
+} iis2dulpx_sleep_t;
 
-#define ST1VAFE3BX_FUNC_CFG_ACCESS                      0x3FU
+#define IIS2DULPX_EN_DEVICE_CONFIG                     0x3EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t soft_pd                      : 1;
+  uint8_t not_used0                    : 7;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 7;
+  uint8_t soft_pd                      : 1;
+#endif /* DRV_BYTE_ORDER */
+} iis2dulpx_en_device_config_t;
+
+#define IIS2DULPX_FUNC_CFG_ACCESS                      0x3FU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -842,9 +866,9 @@ typedef struct
   uint8_t not_used0                    : 6;
   uint8_t fsm_wr_ctrl_en               : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_func_cfg_access_t;
+} iis2dulpx_func_cfg_access_t;
 
-#define ST1VAFE3BX_FIFO_DATA_OUT_TAG                    0x40U
+#define IIS2DULPX_FIFO_DATA_OUT_TAG                    0x40U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -854,9 +878,9 @@ typedef struct
   uint8_t tag_sensor                   : 5;
   uint8_t not_used0                    : 3;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fifo_data_out_tag_t;
+} iis2dulpx_fifo_data_out_tag_t;
 
-#define ST1VAFE3BX_FIFO_DATA_OUT_X_L                    0x41U
+#define IIS2DULPX_FIFO_DATA_OUT_X_L                    0x41U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -864,9 +888,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fifo_data_out                : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fifo_data_out_x_l_t;
+} iis2dulpx_fifo_data_out_x_l_t;
 
-#define ST1VAFE3BX_FIFO_DATA_OUT_X_H                    0x42U
+#define IIS2DULPX_FIFO_DATA_OUT_X_H                    0x42U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -874,9 +898,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fifo_data_out                : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fifo_data_out_x_h_t;
+} iis2dulpx_fifo_data_out_x_h_t;
 
-#define ST1VAFE3BX_FIFO_DATA_OUT_Y_L                    0x43U
+#define IIS2DULPX_FIFO_DATA_OUT_Y_L                    0x43U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -884,9 +908,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fifo_data_out                : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fifo_data_out_y_l_t;
+} iis2dulpx_fifo_data_out_y_l_t;
 
-#define ST1VAFE3BX_FIFO_DATA_OUT_Y_H                    0x44U
+#define IIS2DULPX_FIFO_DATA_OUT_Y_H                    0x44U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -894,9 +918,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fifo_data_out                : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fifo_data_out_y_h_t;
+} iis2dulpx_fifo_data_out_y_h_t;
 
-#define ST1VAFE3BX_FIFO_DATA_OUT_Z_L                    0x45U
+#define IIS2DULPX_FIFO_DATA_OUT_Z_L                    0x45U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -904,9 +928,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fifo_data_out                : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fifo_data_out_z_l_t;
+} iis2dulpx_fifo_data_out_z_l_t;
 
-#define ST1VAFE3BX_FIFO_DATA_OUT_Z_H                    0x46U
+#define IIS2DULPX_FIFO_DATA_OUT_Z_H                    0x46U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -914,9 +938,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fifo_data_out                : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fifo_data_out_z_h_t;
+} iis2dulpx_fifo_data_out_z_h_t;
 
-#define ST1VAFE3BX_FIFO_BATCH_DEC                       0x47U
+#define IIS2DULPX_FIFO_BATCH_DEC                       0x47U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -928,9 +952,9 @@ typedef struct
   uint8_t dec_ts_batch                 : 2;
   uint8_t bdr_xl                       : 3;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fifo_batch_dec_t;
+} iis2dulpx_fifo_batch_dec_t;
 
-#define ST1VAFE3BX_TAP_CFG0                             0x6FU
+#define IIS2DULPX_TAP_CFG0                             0x6FU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -942,9 +966,9 @@ typedef struct
   uint8_t invert_t                     : 5;
   uint8_t not_used0                    : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_tap_cfg0_t;
+} iis2dulpx_tap_cfg0_t;
 
-#define ST1VAFE3BX_TAP_CFG1                             0x70U
+#define IIS2DULPX_TAP_CFG1                             0x70U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -954,9 +978,9 @@ typedef struct
   uint8_t pre_still_ths                : 4;
   uint8_t post_still_t                 : 4;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_tap_cfg1_t;
+} iis2dulpx_tap_cfg1_t;
 
-#define ST1VAFE3BX_TAP_CFG2                             0x71U
+#define IIS2DULPX_TAP_CFG2                             0x71U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -966,9 +990,9 @@ typedef struct
   uint8_t post_still_t                 : 2;
   uint8_t wait_t                       : 6;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_tap_cfg2_t;
+} iis2dulpx_tap_cfg2_t;
 
-#define ST1VAFE3BX_TAP_CFG3                             0x72U
+#define IIS2DULPX_TAP_CFG3                             0x72U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -978,9 +1002,9 @@ typedef struct
   uint8_t post_still_ths               : 4;
   uint8_t latency_t                    : 4;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_tap_cfg3_t;
+} iis2dulpx_tap_cfg3_t;
 
-#define ST1VAFE3BX_TAP_CFG4                             0x73U
+#define IIS2DULPX_TAP_CFG4                             0x73U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -992,9 +1016,9 @@ typedef struct
   uint8_t not_used0                    : 1;
   uint8_t peak_ths                     : 6;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_tap_cfg4_t;
+} iis2dulpx_tap_cfg4_t;
 
-#define ST1VAFE3BX_TAP_CFG5                             0x74U
+#define IIS2DULPX_TAP_CFG5                             0x74U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1008,9 +1032,9 @@ typedef struct
   uint8_t single_tap_en                : 1;
   uint8_t rebound_t                    : 5;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_tap_cfg5_t;
+} iis2dulpx_tap_cfg5_t;
 
-#define ST1VAFE3BX_TAP_CFG6                             0x75U
+#define IIS2DULPX_TAP_CFG6                             0x75U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1020,9 +1044,9 @@ typedef struct
   uint8_t pre_still_st                 : 4;
   uint8_t pre_still_n                  : 4;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_tap_cfg6_t;
+} iis2dulpx_tap_cfg6_t;
 
-#define ST1VAFE3BX_TIMESTAMP0                           0x7AU
+#define IIS2DULPX_TIMESTAMP0                           0x7AU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1030,9 +1054,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t timestamp                    : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_timestamp0_t;
+} iis2dulpx_timestamp0_t;
 
-#define ST1VAFE3BX_TIMESTAMP1                           0x7BU
+#define IIS2DULPX_TIMESTAMP1                           0x7BU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1040,9 +1064,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t timestamp                    : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_timestamp1_t;
+} iis2dulpx_timestamp1_t;
 
-#define ST1VAFE3BX_TIMESTAMP2                           0x7CU
+#define IIS2DULPX_TIMESTAMP2                           0x7CU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1050,9 +1074,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t timestamp                    : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_timestamp2_t;
+} iis2dulpx_timestamp2_t;
 
-#define ST1VAFE3BX_TIMESTAMP3                           0x7DU
+#define IIS2DULPX_TIMESTAMP3                           0x7DU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1060,7 +1084,7 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t timestamp                    : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_timestamp3_t;
+} iis2dulpx_timestamp3_t;
 
 /**
   * @}
@@ -1072,7 +1096,7 @@ typedef struct
   *
   */
 
-#define ST1VAFE3BX_PAGE_SEL                             0x2U
+#define IIS2DULPX_PAGE_SEL                             0x2U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1082,9 +1106,9 @@ typedef struct
   uint8_t page_sel                     : 4;
   uint8_t not_used0                    : 4;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_page_sel_t;
+} iis2dulpx_page_sel_t;
 
-#define ST1VAFE3BX_EMB_FUNC_EN_A                        0x4U
+#define IIS2DULPX_EMB_FUNC_EN_A                        0x4U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1102,9 +1126,9 @@ typedef struct
   uint8_t pedo_en                      : 1;
   uint8_t not_used0                    : 3;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_emb_func_en_a_t;
+} iis2dulpx_emb_func_en_a_t;
 
-#define ST1VAFE3BX_EMB_FUNC_EN_B                        0x5U
+#define IIS2DULPX_EMB_FUNC_EN_B                        0x5U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1118,9 +1142,9 @@ typedef struct
   uint8_t not_used0                    : 3;
   uint8_t fsm_en                       : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_emb_func_en_b_t;
+} iis2dulpx_emb_func_en_b_t;
 
-#define ST1VAFE3BX_EMB_FUNC_EXEC_STATUS                 0x7U
+#define IIS2DULPX_EMB_FUNC_EXEC_STATUS                 0x7U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1132,9 +1156,9 @@ typedef struct
   uint8_t emb_func_exec_ovr            : 1;
   uint8_t emb_func_endop               : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_emb_func_exec_status_t;
+} iis2dulpx_emb_func_exec_status_t;
 
-#define ST1VAFE3BX_PAGE_ADDRESS                         0x8U
+#define IIS2DULPX_PAGE_ADDRESS                         0x8U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1142,9 +1166,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t page_addr                    : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_page_address_t;
+} iis2dulpx_page_address_t;
 
-#define ST1VAFE3BX_PAGE_VALUE                           0x9U
+#define IIS2DULPX_PAGE_VALUE                           0x9U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1152,71 +1176,133 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t page_value                   : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_page_value_t;
+} iis2dulpx_page_value_t;
 
-#define ST1VAFE3BX_EMB_FUNC_INT                         0x0AU
+#define IIS2DULPX_EMB_FUNC_INT1                        0x0AU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0                    : 3;
-  uint8_t int_step_det                 : 1;
-  uint8_t int_tilt                     : 1;
-  uint8_t int_sig_mot                  : 1;
+  uint8_t int1_step_det                : 1;
+  uint8_t int1_tilt                    : 1;
+  uint8_t int1_sig_mot                 : 1;
   uint8_t not_used1                    : 1;
-  uint8_t int_fsm_lc                   : 1;
+  uint8_t int1_fsm_lc                  : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t int_fsm_lc                   : 1;
+  uint8_t int1_fsm_lc                  : 1;
   uint8_t not_used1                    : 1;
-  uint8_t int_sig_mot                  : 1;
-  uint8_t int_tilt                     : 1;
-  uint8_t int_step_det                 : 1;
+  uint8_t int1_sig_mot                 : 1;
+  uint8_t int1_tilt                    : 1;
+  uint8_t int1_step_det                : 1;
   uint8_t not_used0                    : 3;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_emb_func_int_t;
+} iis2dulpx_emb_func_int1_t;
 
-#define ST1VAFE3BX_FSM_INT                              0x0BU
+#define IIS2DULPX_FSM_INT1                             0x0BU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t int_fsm1                     : 1;
-  uint8_t int_fsm2                     : 1;
-  uint8_t int_fsm3                     : 1;
-  uint8_t int_fsm4                     : 1;
-  uint8_t int_fsm5                     : 1;
-  uint8_t int_fsm6                     : 1;
-  uint8_t int_fsm7                     : 1;
-  uint8_t int_fsm8                     : 1;
+  uint8_t int1_fsm1                    : 1;
+  uint8_t int1_fsm2                    : 1;
+  uint8_t int1_fsm3                    : 1;
+  uint8_t int1_fsm4                    : 1;
+  uint8_t int1_fsm5                    : 1;
+  uint8_t int1_fsm6                    : 1;
+  uint8_t int1_fsm7                    : 1;
+  uint8_t int1_fsm8                    : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t int_fsm8                     : 1;
-  uint8_t int_fsm7                     : 1;
-  uint8_t int_fsm6                     : 1;
-  uint8_t int_fsm5                     : 1;
-  uint8_t int_fsm4                     : 1;
-  uint8_t int_fsm3                     : 1;
-  uint8_t int_fsm2                     : 1;
-  uint8_t int_fsm1                     : 1;
+  uint8_t int1_fsm8                    : 1;
+  uint8_t int1_fsm7                    : 1;
+  uint8_t int1_fsm6                    : 1;
+  uint8_t int1_fsm5                    : 1;
+  uint8_t int1_fsm4                    : 1;
+  uint8_t int1_fsm3                    : 1;
+  uint8_t int1_fsm2                    : 1;
+  uint8_t int1_fsm1                    : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fsm_int_t;
+} iis2dulpx_fsm_int1_t;
 
-#define ST1VAFE3BX_MLC_INT                              0x0DU
+#define IIS2DULPX_MLC_INT1                             0x0DU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t int_mlc1                     : 1;
-  uint8_t int_mlc2                     : 1;
-  uint8_t int_mlc3                     : 1;
-  uint8_t int_mlc4                     : 1;
+  uint8_t int1_mlc1                    : 1;
+  uint8_t int1_mlc2                    : 1;
+  uint8_t int1_mlc3                    : 1;
+  uint8_t int1_mlc4                    : 1;
   uint8_t not_used0                    : 4;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t not_used0                    : 4;
-  uint8_t int_mlc4                     : 1;
-  uint8_t int_mlc3                     : 1;
-  uint8_t int_mlc2                     : 1;
-  uint8_t int_mlc1                     : 1;
+  uint8_t int1_mlc4                    : 1;
+  uint8_t int1_mlc3                    : 1;
+  uint8_t int1_mlc2                    : 1;
+  uint8_t int1_mlc1                    : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_mlc_int_t;
+} iis2dulpx_mlc_int1_t;
 
-#define ST1VAFE3BX_EMB_FUNC_STATUS                      0x12U
+#define IIS2DULPX_EMB_FUNC_INT2                        0x0EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 3;
+  uint8_t int2_step_det                : 1;
+  uint8_t int2_tilt                    : 1;
+  uint8_t int2_sig_mot                 : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t int2_fsm_lc                  : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t int2_fsm_lc                  : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t int2_sig_mot                 : 1;
+  uint8_t int2_tilt                    : 1;
+  uint8_t int2_step_det                : 1;
+  uint8_t not_used0                    : 3;
+#endif /* DRV_BYTE_ORDER */
+} iis2dulpx_emb_func_int2_t;
+
+#define IIS2DULPX_FSM_INT2                             0x0FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t int2_fsm1                    : 1;
+  uint8_t int2_fsm2                    : 1;
+  uint8_t int2_fsm3                    : 1;
+  uint8_t int2_fsm4                    : 1;
+  uint8_t int2_fsm5                    : 1;
+  uint8_t int2_fsm6                    : 1;
+  uint8_t int2_fsm7                    : 1;
+  uint8_t int2_fsm8                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t int2_fsm8                    : 1;
+  uint8_t int2_fsm7                    : 1;
+  uint8_t int2_fsm6                    : 1;
+  uint8_t int2_fsm5                    : 1;
+  uint8_t int2_fsm4                    : 1;
+  uint8_t int2_fsm3                    : 1;
+  uint8_t int2_fsm2                    : 1;
+  uint8_t int2_fsm1                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} iis2dulpx_fsm_int2_t;
+
+#define IIS2DULPX_MLC_INT2                             0x11U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t int2_mlc1                    : 1;
+  uint8_t int2_mlc2                    : 1;
+  uint8_t int2_mlc3                    : 1;
+  uint8_t int2_mlc4                    : 1;
+  uint8_t not_used0                    : 4;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 4;
+  uint8_t int2_mlc4                    : 1;
+  uint8_t int2_mlc3                    : 1;
+  uint8_t int2_mlc2                    : 1;
+  uint8_t int2_mlc1                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} iis2dulpx_mlc_int2_t;
+
+#define IIS2DULPX_EMB_FUNC_STATUS                      0x12U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1234,9 +1320,9 @@ typedef struct
   uint8_t is_step_det                  : 1;
   uint8_t not_used0                    : 3;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_emb_func_status_t;
+} iis2dulpx_emb_func_status_t;
 
-#define ST1VAFE3BX_FSM_STATUS                           0x13U
+#define IIS2DULPX_FSM_STATUS                           0x13U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1258,9 +1344,9 @@ typedef struct
   uint8_t is_fsm2                      : 1;
   uint8_t is_fsm1                      : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fsm_status_t;
+} iis2dulpx_fsm_status_t;
 
-#define ST1VAFE3BX_MLC_STATUS                           0x15U
+#define IIS2DULPX_MLC_STATUS                           0x15U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1276,9 +1362,9 @@ typedef struct
   uint8_t is_mlc2                      : 1;
   uint8_t is_mlc1                      : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_mlc_status_t;
+} iis2dulpx_mlc_status_t;
 
-#define ST1VAFE3BX_PAGE_RW                              0x17U
+#define IIS2DULPX_PAGE_RW                              0x17U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1292,9 +1378,9 @@ typedef struct
   uint8_t page_read                    : 1;
   uint8_t not_used0                    : 5;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_page_rw_t;
+} iis2dulpx_page_rw_t;
 
-#define ST1VAFE3BX_EMB_FUNC_FIFO_EN                     0x18U
+#define IIS2DULPX_EMB_FUNC_FIFO_EN                     0x18U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1310,9 +1396,9 @@ typedef struct
   uint8_t mlc_fifo_en                  : 1;
   uint8_t step_counter_fifo_en         : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_emb_func_fifo_en_t;
+} iis2dulpx_emb_func_fifo_en_t;
 
-#define ST1VAFE3BX_FSM_ENABLE                           0x1AU
+#define IIS2DULPX_FSM_ENABLE                           0x1AU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1334,9 +1420,9 @@ typedef struct
   uint8_t fsm2_en                      : 1;
   uint8_t fsm1_en                      : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fsm_enable_t;
+} iis2dulpx_fsm_enable_t;
 
-#define ST1VAFE3BX_FSM_LONG_COUNTER_L                   0x1CU
+#define IIS2DULPX_FSM_LONG_COUNTER_L                   0x1CU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1344,9 +1430,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fsm_lc                       : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fsm_long_counter_l_t;
+} iis2dulpx_fsm_long_counter_l_t;
 
-#define ST1VAFE3BX_FSM_LONG_COUNTER_H                   0x1DU
+#define IIS2DULPX_FSM_LONG_COUNTER_H                   0x1DU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1354,9 +1440,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fsm_lc                       : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fsm_long_counter_h_t;
+} iis2dulpx_fsm_long_counter_h_t;
 
-#define ST1VAFE3BX_INT_ACK_MASK                         0x1FU
+#define IIS2DULPX_INT_ACK_MASK                         0x1FU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1378,9 +1464,9 @@ typedef struct
   uint8_t iack_mask1                   : 1;
   uint8_t iack_mask0                   : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_int_ack_mask_t;
+} iis2dulpx_int_ack_mask_t;
 
-#define ST1VAFE3BX_FSM_OUTS1                            0x20U
+#define IIS2DULPX_FSM_OUTS1                            0x20U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1402,9 +1488,9 @@ typedef struct
   uint8_t p_v                          : 1;
   uint8_t n_v                          : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fsm_outs1_t;
+} iis2dulpx_fsm_outs1_t;
 
-#define ST1VAFE3BX_FSM_OUTS2                            0x21U
+#define IIS2DULPX_FSM_OUTS2                            0x21U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1426,9 +1512,9 @@ typedef struct
   uint8_t p_v                          : 1;
   uint8_t n_v                          : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fsm_outs2_t;
+} iis2dulpx_fsm_outs2_t;
 
-#define ST1VAFE3BX_FSM_OUTS3                            0x22U
+#define IIS2DULPX_FSM_OUTS3                            0x22U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1450,9 +1536,9 @@ typedef struct
   uint8_t p_v                          : 1;
   uint8_t n_v                          : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fsm_outs3_t;
+} iis2dulpx_fsm_outs3_t;
 
-#define ST1VAFE3BX_FSM_OUTS4                            0x23U
+#define IIS2DULPX_FSM_OUTS4                            0x23U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1474,9 +1560,9 @@ typedef struct
   uint8_t p_v                          : 1;
   uint8_t n_v                          : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fsm_outs4_t;
+} iis2dulpx_fsm_outs4_t;
 
-#define ST1VAFE3BX_FSM_OUTS5                            0x24U
+#define IIS2DULPX_FSM_OUTS5                            0x24U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1498,9 +1584,9 @@ typedef struct
   uint8_t p_v                          : 1;
   uint8_t n_v                          : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fsm_outs5_t;
+} iis2dulpx_fsm_outs5_t;
 
-#define ST1VAFE3BX_FSM_OUTS6                            0x25U
+#define IIS2DULPX_FSM_OUTS6                            0x25U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1522,9 +1608,9 @@ typedef struct
   uint8_t p_v                          : 1;
   uint8_t n_v                          : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fsm_outs6_t;
+} iis2dulpx_fsm_outs6_t;
 
-#define ST1VAFE3BX_FSM_OUTS7                            0x26U
+#define IIS2DULPX_FSM_OUTS7                            0x26U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1546,9 +1632,9 @@ typedef struct
   uint8_t p_v                          : 1;
   uint8_t n_v                          : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fsm_outs7_t;
+} iis2dulpx_fsm_outs7_t;
 
-#define ST1VAFE3BX_FSM_OUTS8                            0x27U
+#define IIS2DULPX_FSM_OUTS8                            0x27U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1570,19 +1656,9 @@ typedef struct
   uint8_t p_v                          : 1;
   uint8_t n_v                          : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fsm_outs8_t;
+} iis2dulpx_fsm_outs8_t;
 
-#define ST1VAFE3BX_STEP_COUNTER_L                       0x28U
-typedef struct
-{
-#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t step                         : 8;
-#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t step                         : 8;
-#endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_step_counter_l_t;
-
-#define ST1VAFE3BX_STEP_COUNTER_H                       0x29U
+#define IIS2DULPX_STEP_COUNTER_L                       0x28U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1590,9 +1666,19 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t step                         : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_step_counter_h_t;
+} iis2dulpx_step_counter_l_t;
 
-#define ST1VAFE3BX_EMB_FUNC_SRC                         0x2AU
+#define IIS2DULPX_STEP_COUNTER_H                       0x29U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t step                         : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t step                         : 8;
+#endif /* DRV_BYTE_ORDER */
+} iis2dulpx_step_counter_h_t;
+
+#define IIS2DULPX_EMB_FUNC_SRC                         0x2AU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1612,9 +1698,9 @@ typedef struct
   uint8_t stepcounter_bit_set          : 1;
   uint8_t not_used0                    : 2;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_emb_func_src_t;
+} iis2dulpx_emb_func_src_t;
 
-#define ST1VAFE3BX_EMB_FUNC_INIT_A                      0x2CU
+#define IIS2DULPX_EMB_FUNC_INIT_A                      0x2CU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1632,9 +1718,9 @@ typedef struct
   uint8_t step_det_init                : 1;
   uint8_t not_used0                    : 3;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_emb_func_init_a_t;
+} iis2dulpx_emb_func_init_a_t;
 
-#define ST1VAFE3BX_EMB_FUNC_INIT_B                      0x2DU
+#define IIS2DULPX_EMB_FUNC_INIT_B                      0x2DU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1648,9 +1734,9 @@ typedef struct
   uint8_t not_used0                    : 3;
   uint8_t fsm_init                     : 1;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_emb_func_init_b_t;
+} iis2dulpx_emb_func_init_b_t;
 
-#define ST1VAFE3BX_MLC1_SRC                             0x34U
+#define IIS2DULPX_MLC1_SRC                             0x34U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1658,9 +1744,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t mlc1_src                     : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_mlc1_src_t;
+} iis2dulpx_mlc1_src_t;
 
-#define ST1VAFE3BX_MLC2_SRC                             0x35U
+#define IIS2DULPX_MLC2_SRC                             0x35U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1668,9 +1754,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t mlc2_src                     : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_mlc2_src_t;
+} iis2dulpx_mlc2_src_t;
 
-#define ST1VAFE3BX_MLC3_SRC                             0x36U
+#define IIS2DULPX_MLC3_SRC                             0x36U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1678,9 +1764,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t mlc3_src                     : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_mlc3_src_t;
+} iis2dulpx_mlc3_src_t;
 
-#define ST1VAFE3BX_MLC4_SRC                             0x37U
+#define IIS2DULPX_MLC4_SRC                             0x37U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1688,9 +1774,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t mlc4_src                     : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_mlc4_src_t;
+} iis2dulpx_mlc4_src_t;
 
-#define ST1VAFE3BX_FSM_ODR                              0x39U
+#define IIS2DULPX_FSM_ODR                              0x39U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1702,9 +1788,9 @@ typedef struct
   uint8_t fsm_odr                      : 3;
   uint8_t not_used0                    : 3;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fsm_odr_t;
+} iis2dulpx_fsm_odr_t;
 
-#define ST1VAFE3BX_MLC_ODR                              0x3AU
+#define IIS2DULPX_MLC_ODR                              0x3AU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1716,7 +1802,7 @@ typedef struct
   uint8_t mlc_odr                      : 3;
   uint8_t not_used0                    : 4;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_mlc_odr_t;
+} iis2dulpx_mlc_odr_t;
 
 /**
   * @}
@@ -1727,9 +1813,9 @@ typedef struct
   * @{
   *
   */
-#define ST1VAFE3BX_EMB_ADV_PG_0                         0x000U
+#define IIS2DULPX_EMB_ADV_PG_0                         0x000U
 
-#define ST1VAFE3BX_FSM_LC_TIMEOUT_L                     0x54U
+#define IIS2DULPX_FSM_LC_TIMEOUT_L                     0x54U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1737,9 +1823,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fsm_lc_timeout               : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fsm_lc_timeout_l_t;
+} iis2dulpx_fsm_lc_timeout_l_t;
 
-#define ST1VAFE3BX_FSM_LC_TIMEOUT_H                     0x55U
+#define IIS2DULPX_FSM_LC_TIMEOUT_H                     0x55U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1747,9 +1833,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fsm_lc_timeout               : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fsm_lc_timeout_h_t;
+} iis2dulpx_fsm_lc_timeout_h_t;
 
-#define ST1VAFE3BX_FSM_PROGRAMS                         0x56U
+#define IIS2DULPX_FSM_PROGRAMS                         0x56U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1757,9 +1843,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fsm_n_prog                   : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fsm_programs_t;
+} iis2dulpx_fsm_programs_t;
 
-#define ST1VAFE3BX_FSM_START_ADD_L                      0x58U
+#define IIS2DULPX_FSM_START_ADD_L                      0x58U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1767,9 +1853,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fsm_start                    : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fsm_start_add_l_t;
+} iis2dulpx_fsm_start_add_l_t;
 
-#define ST1VAFE3BX_FSM_START_ADD_H                      0x59U
+#define IIS2DULPX_FSM_START_ADD_H                      0x59U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1777,9 +1863,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fsm_start                    : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_fsm_start_add_h_t;
+} iis2dulpx_fsm_start_add_h_t;
 
-#define ST1VAFE3BX_PEDO_CMD_REG                         0x5DU
+#define IIS2DULPX_PEDO_CMD_REG                         0x5DU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1793,9 +1879,9 @@ typedef struct
   uint8_t fp_rejection_en              : 1;
   uint8_t not_used0                    : 2;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_pedo_cmd_reg_t;
+} iis2dulpx_pedo_cmd_reg_t;
 
-#define ST1VAFE3BX_PEDO_DEB_STEPS_CONF                  0x5EU
+#define IIS2DULPX_PEDO_DEB_STEPS_CONF                  0x5EU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1803,9 +1889,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t deb_step                     : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_pedo_deb_steps_conf_t;
+} iis2dulpx_pedo_deb_steps_conf_t;
 
-#define ST1VAFE3BX_PEDO_SC_DELTAT_L                     0xAAU
+#define IIS2DULPX_PEDO_SC_DELTAT_L                     0xAAU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1813,9 +1899,9 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t pd_sc                        : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_pedo_sc_deltat_l_t;
+} iis2dulpx_pedo_sc_deltat_l_t;
 
-#define ST1VAFE3BX_PEDO_SC_DELTAT_H                     0xABU
+#define IIS2DULPX_PEDO_SC_DELTAT_H                     0xABU
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1823,29 +1909,29 @@ typedef struct
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t pd_sc                        : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_pedo_sc_deltat_h_t;
+} iis2dulpx_pedo_sc_deltat_h_t;
 
-#define ST1VAFE3BX_AH_BIO_SENSITIVITY_L                 0xB6U
+#define IIS2DULPX_T_AH_QVAR_SENSITIVITY_L              0xB6U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t ah_bio_s                     : 8;
+  uint8_t t_ah_qvar_s                  : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t ah_bio_s                     : 8;
+  uint8_t t_ah_qvar_s                  : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_ah_bio_sensitivity_l_t;
+} iis2dulpx_t_ah_qvar_sensitivity_l_t;
 
-#define ST1VAFE3BX_AH_BIO_SENSITIVITY_H                 0xB7U
+#define IIS2DULPX_T_AH_QVAR_SENSITIVITY_H              0xB7U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
-  uint8_t ah_bio_s                     : 8;
+  uint8_t t_ah_qvar_s                  : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
-  uint8_t ah_bio_s                     : 8;
+  uint8_t t_ah_qvar_s                  : 8;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_ah_bio_sensitivity_h_t;
+} iis2dulpx_t_ah_qvar_sensitivity_h_t;
 
-#define ST1VAFE3BX_SMART_POWER_CTRL                     0xD2U
+#define IIS2DULPX_SMART_POWER_CTRL                     0xD2U
 typedef struct
 {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
@@ -1855,7 +1941,7 @@ typedef struct
   uint8_t smart_power_ctrl_dur         : 4;
   uint8_t smart_power_ctrl_win         : 4;
 #endif /* DRV_BYTE_ORDER */
-} st1vafe3bx_smart_power_ctrl_t;
+} iis2dulpx_smart_power_ctrl_t;
 
 /**
   * @}
@@ -1864,118 +1950,121 @@ typedef struct
 
 typedef union
 {
-  st1vafe3bx_ext_clk_cfg_t                 ext_clk_cfg;
-  st1vafe3bx_pin_ctrl_t                    pin_ctrl;
-  st1vafe3bx_wake_up_dur_ext_t             wake_up_dur_ext;
-  st1vafe3bx_who_am_i_t                    who_am_i;
-  st1vafe3bx_ctrl1_t                       ctrl1;
-  st1vafe3bx_ctrl2_t                       ctrl2;
-  st1vafe3bx_ctrl3_t                       ctrl3;
-  st1vafe3bx_ctrl4_t                       ctrl4;
-  st1vafe3bx_ctrl5_t                       ctrl5;
-  st1vafe3bx_fifo_ctrl_t                   fifo_ctrl;
-  st1vafe3bx_fifo_wtm_t                    fifo_wtm;
-  st1vafe3bx_interrupt_cfg_t               interrupt_cfg;
-  st1vafe3bx_sixd_t                        sixd;
-  st1vafe3bx_wake_up_ths_t                 wake_up_ths;
-  st1vafe3bx_wake_up_dur_t                 wake_up_dur;
-  st1vafe3bx_free_fall_t                   free_fall;
-  st1vafe3bx_md1_cfg_t                     md1_cfg;
-  st1vafe3bx_wake_up_src_t                 wake_up_src;
-  st1vafe3bx_tap_src_t                     tap_src;
-  st1vafe3bx_sixd_src_t                    sixd_src;
-  st1vafe3bx_all_int_src_t                 all_int_src;
-  st1vafe3bx_status_register_t             status;
-  st1vafe3bx_fifo_status1_t                fifo_status1;
-  st1vafe3bx_fifo_status2_t                fifo_status2;
-  st1vafe3bx_out_x_l_t                     out_x_l;
-  st1vafe3bx_out_x_h_t                     out_x_h;
-  st1vafe3bx_out_y_l_t                     out_y_l;
-  st1vafe3bx_out_y_h_t                     out_y_h;
-  st1vafe3bx_out_z_l_t                     out_z_l;
-  st1vafe3bx_out_z_h_t                     out_z_h;
-  st1vafe3bx_out_ah_bio_l_t                out_ah_bio_l;
-  st1vafe3bx_out_ah_bio_h_t                out_ah_bio_h;
-  st1vafe3bx_ah_bio_cfg1_t                 ah_bio_cfg1;
-  st1vafe3bx_ah_bio_cfg2_t                 ah_bio_cfg2;
-  st1vafe3bx_ah_bio_cfg3_t                 ah_bio_cfg3;
-  st1vafe3bx_i3c_if_ctrl_t                 i3c_if_ctrl;
-  st1vafe3bx_emb_func_status_mainpage_t    emb_func_status_mainpage;
-  st1vafe3bx_fsm_status_mainpage_t         fsm_status_mainpage;
-  st1vafe3bx_mlc_status_mainpage_t         mlc_status_mainpage;
-  st1vafe3bx_en_device_config_t            en_device_config;
-  st1vafe3bx_func_cfg_access_t             func_cfg_access;
-  st1vafe3bx_fifo_data_out_tag_t           fifo_data_out_tag;
-  st1vafe3bx_fifo_data_out_x_l_t           fifo_data_out_x_l;
-  st1vafe3bx_fifo_data_out_x_h_t           fifo_data_out_x_h;
-  st1vafe3bx_fifo_data_out_y_l_t           fifo_data_out_y_l;
-  st1vafe3bx_fifo_data_out_y_h_t           fifo_data_out_y_h;
-  st1vafe3bx_fifo_data_out_z_l_t           fifo_data_out_z_l;
-  st1vafe3bx_fifo_data_out_z_h_t           fifo_data_out_z_h;
-  st1vafe3bx_fifo_batch_dec_t              fifo_batch_dec;
-  st1vafe3bx_tap_cfg0_t                    tap_cfg0;
-  st1vafe3bx_tap_cfg1_t                    tap_cfg1;
-  st1vafe3bx_tap_cfg2_t                    tap_cfg2;
-  st1vafe3bx_tap_cfg3_t                    tap_cfg3;
-  st1vafe3bx_tap_cfg4_t                    tap_cfg4;
-  st1vafe3bx_tap_cfg5_t                    tap_cfg5;
-  st1vafe3bx_tap_cfg6_t                    tap_cfg6;
-  st1vafe3bx_timestamp0_t                  timestamp0;
-  st1vafe3bx_timestamp1_t                  timestamp1;
-  st1vafe3bx_timestamp2_t                  timestamp2;
-  st1vafe3bx_timestamp3_t                  timestamp3;
-  st1vafe3bx_page_sel_t                    page_sel;
-  st1vafe3bx_emb_func_en_a_t               emb_func_en_a;
-  st1vafe3bx_emb_func_en_b_t               emb_func_en_b;
-  st1vafe3bx_emb_func_exec_status_t        emb_func_exec_status;
-  st1vafe3bx_page_address_t                page_address;
-  st1vafe3bx_page_value_t                  page_value;
-  st1vafe3bx_emb_func_int_t                emb_func_int;
-  st1vafe3bx_fsm_int_t                     fsm_int;
-  st1vafe3bx_mlc_int_t                     mlc_int;
-  st1vafe3bx_emb_func_status_t             emb_func_status;
-  st1vafe3bx_fsm_status_t                  fsm_status;
-  st1vafe3bx_mlc_status_t                  mlc_status;
-  st1vafe3bx_page_rw_t                     page_rw;
-  st1vafe3bx_emb_func_fifo_en_t            emb_func_fifo_en;
-  st1vafe3bx_fsm_enable_t                  fsm_enable;
-  st1vafe3bx_fsm_long_counter_l_t          fsm_long_counter_l;
-  st1vafe3bx_fsm_long_counter_h_t          fsm_long_counter_h;
-  st1vafe3bx_int_ack_mask_t                int_ack_mask;
-  st1vafe3bx_fsm_outs1_t                   fsm_outs1;
-  st1vafe3bx_fsm_outs2_t                   fsm_outs2;
-  st1vafe3bx_fsm_outs3_t                   fsm_outs3;
-  st1vafe3bx_fsm_outs4_t                   fsm_outs4;
-  st1vafe3bx_fsm_outs5_t                   fsm_outs5;
-  st1vafe3bx_fsm_outs6_t                   fsm_outs6;
-  st1vafe3bx_fsm_outs7_t                   fsm_outs7;
-  st1vafe3bx_fsm_outs8_t                   fsm_outs8;
-  st1vafe3bx_step_counter_l_t              step_counter_l;
-  st1vafe3bx_step_counter_h_t              step_counter_h;
-  st1vafe3bx_emb_func_src_t                emb_func_src;
-  st1vafe3bx_emb_func_init_a_t             emb_func_init_a;
-  st1vafe3bx_emb_func_init_b_t             emb_func_init_b;
-  st1vafe3bx_mlc1_src_t                    mlc1_src;
-  st1vafe3bx_mlc2_src_t                    mlc2_src;
-  st1vafe3bx_mlc3_src_t                    mlc3_src;
-  st1vafe3bx_mlc4_src_t                    mlc4_src;
-  st1vafe3bx_fsm_odr_t                     fsm_odr;
-  st1vafe3bx_mlc_odr_t                     mlc_odr;
-  st1vafe3bx_fsm_lc_timeout_l_t            fsm_lc_timeout_l;
-  st1vafe3bx_fsm_lc_timeout_h_t            fsm_lc_timeout_h;
-  st1vafe3bx_fsm_programs_t                fsm_programs;
-  st1vafe3bx_fsm_start_add_l_t             fsm_start_add_l;
-  st1vafe3bx_fsm_start_add_h_t             fsm_start_add_h;
-  st1vafe3bx_pedo_cmd_reg_t                pedo_cmd_reg;
-  st1vafe3bx_pedo_deb_steps_conf_t         pedo_deb_steps_conf;
-  st1vafe3bx_pedo_sc_deltat_l_t            pedo_sc_deltat_l;
-  st1vafe3bx_pedo_sc_deltat_h_t            pedo_sc_deltat_h;
-  st1vafe3bx_ah_bio_sensitivity_l_t        ah_bio_sensitivity_l;
-  st1vafe3bx_ah_bio_sensitivity_h_t        ah_bio_sensitivity_h;
-  st1vafe3bx_smart_power_ctrl_t            smart_power_ctrl;
+  iis2dulpx_pin_ctrl_t    pin_ctrl;
+  iis2dulpx_wake_up_dur_ext_t    wake_up_dur_ext;
+  iis2dulpx_who_am_i_t    who_am_i;
+  iis2dulpx_ctrl1_t    ctrl1;
+  iis2dulpx_ctrl2_t    ctrl2;
+  iis2dulpx_ctrl3_t    ctrl3;
+  iis2dulpx_ctrl4_t    ctrl4;
+  iis2dulpx_ctrl5_t    ctrl5;
+  iis2dulpx_fifo_ctrl_t    fifo_ctrl;
+  iis2dulpx_fifo_wtm_t    fifo_wtm;
+  iis2dulpx_interrupt_cfg_t    interrupt_cfg;
+  iis2dulpx_sixd_t    sixd;
+  iis2dulpx_wake_up_ths_t    wake_up_ths;
+  iis2dulpx_wake_up_dur_t    wake_up_dur;
+  iis2dulpx_free_fall_t    free_fall;
+  iis2dulpx_md1_cfg_t    md1_cfg;
+  iis2dulpx_md2_cfg_t    md2_cfg;
+  iis2dulpx_wake_up_src_t    wake_up_src;
+  iis2dulpx_tap_src_t    tap_src;
+  iis2dulpx_sixd_src_t    sixd_src;
+  iis2dulpx_all_int_src_t    all_int_src;
+  iis2dulpx_status_register_t    status;
+  iis2dulpx_fifo_status1_t    fifo_status1;
+  iis2dulpx_fifo_status2_t    fifo_status2;
+  iis2dulpx_out_x_l_t    out_x_l;
+  iis2dulpx_out_x_h_t    out_x_h;
+  iis2dulpx_out_y_l_t    out_y_l;
+  iis2dulpx_out_y_h_t    out_y_h;
+  iis2dulpx_out_z_l_t    out_z_l;
+  iis2dulpx_out_z_h_t    out_z_h;
+  iis2dulpx_out_t_ah_qvar_l_t    out_t_ah_qvar_l;
+  iis2dulpx_out_t_ah_qvar_h_t    out_t_ah_qvar_h;
+  iis2dulpx_ah_qvar_cfg_t    ah_qvar_cfg;
+  iis2dulpx_self_test_t    self_test;
+  iis2dulpx_i3c_if_ctrl_t    i3c_if_ctrl;
+  iis2dulpx_emb_func_status_mainpage_t    emb_func_status_mainpage;
+  iis2dulpx_fsm_status_mainpage_t    fsm_status_mainpage;
+  iis2dulpx_mlc_status_mainpage_t    mlc_status_mainpage;
+  iis2dulpx_sleep_t    sleep;
+  iis2dulpx_en_device_config_t    en_device_config;
+  iis2dulpx_func_cfg_access_t    func_cfg_access;
+  iis2dulpx_fifo_data_out_tag_t    fifo_data_out_tag;
+  iis2dulpx_fifo_data_out_x_l_t    fifo_data_out_x_l;
+  iis2dulpx_fifo_data_out_x_h_t    fifo_data_out_x_h;
+  iis2dulpx_fifo_data_out_y_l_t    fifo_data_out_y_l;
+  iis2dulpx_fifo_data_out_y_h_t    fifo_data_out_y_h;
+  iis2dulpx_fifo_data_out_z_l_t    fifo_data_out_z_l;
+  iis2dulpx_fifo_data_out_z_h_t    fifo_data_out_z_h;
+  iis2dulpx_fifo_batch_dec_t    fifo_batch_dec;
+  iis2dulpx_tap_cfg0_t    tap_cfg0;
+  iis2dulpx_tap_cfg1_t    tap_cfg1;
+  iis2dulpx_tap_cfg2_t    tap_cfg2;
+  iis2dulpx_tap_cfg3_t    tap_cfg3;
+  iis2dulpx_tap_cfg4_t    tap_cfg4;
+  iis2dulpx_tap_cfg5_t    tap_cfg5;
+  iis2dulpx_tap_cfg6_t    tap_cfg6;
+  iis2dulpx_timestamp0_t    timestamp0;
+  iis2dulpx_timestamp1_t    timestamp1;
+  iis2dulpx_timestamp2_t    timestamp2;
+  iis2dulpx_timestamp3_t    timestamp3;
+  iis2dulpx_page_sel_t    page_sel;
+  iis2dulpx_emb_func_en_a_t    emb_func_en_a;
+  iis2dulpx_emb_func_en_b_t    emb_func_en_b;
+  iis2dulpx_emb_func_exec_status_t    emb_func_exec_status;
+  iis2dulpx_page_address_t    page_address;
+  iis2dulpx_page_value_t    page_value;
+  iis2dulpx_emb_func_int1_t    emb_func_int1;
+  iis2dulpx_fsm_int1_t    fsm_int1;
+  iis2dulpx_mlc_int1_t    mlc_int1;
+  iis2dulpx_emb_func_int2_t    emb_func_int2;
+  iis2dulpx_fsm_int2_t    fsm_int2;
+  iis2dulpx_mlc_int2_t    mlc_int2;
+  iis2dulpx_emb_func_status_t    emb_func_status;
+  iis2dulpx_fsm_status_t    fsm_status;
+  iis2dulpx_mlc_status_t    mlc_status;
+  iis2dulpx_page_rw_t    page_rw;
+  iis2dulpx_emb_func_fifo_en_t    emb_func_fifo_en;
+  iis2dulpx_fsm_enable_t    fsm_enable;
+  iis2dulpx_fsm_long_counter_l_t    fsm_long_counter_l;
+  iis2dulpx_fsm_long_counter_h_t    fsm_long_counter_h;
+  iis2dulpx_int_ack_mask_t    int_ack_mask;
+  iis2dulpx_fsm_outs1_t    fsm_outs1;
+  iis2dulpx_fsm_outs2_t    fsm_outs2;
+  iis2dulpx_fsm_outs3_t    fsm_outs3;
+  iis2dulpx_fsm_outs4_t    fsm_outs4;
+  iis2dulpx_fsm_outs5_t    fsm_outs5;
+  iis2dulpx_fsm_outs6_t    fsm_outs6;
+  iis2dulpx_fsm_outs7_t    fsm_outs7;
+  iis2dulpx_fsm_outs8_t    fsm_outs8;
+  iis2dulpx_step_counter_l_t    step_counter_l;
+  iis2dulpx_step_counter_h_t    step_counter_h;
+  iis2dulpx_emb_func_src_t    emb_func_src;
+  iis2dulpx_emb_func_init_a_t    emb_func_init_a;
+  iis2dulpx_emb_func_init_b_t    emb_func_init_b;
+  iis2dulpx_mlc1_src_t    mlc1_src;
+  iis2dulpx_mlc2_src_t    mlc2_src;
+  iis2dulpx_mlc3_src_t    mlc3_src;
+  iis2dulpx_mlc4_src_t    mlc4_src;
+  iis2dulpx_fsm_odr_t    fsm_odr;
+  iis2dulpx_mlc_odr_t    mlc_odr;
+  iis2dulpx_fsm_lc_timeout_l_t    fsm_lc_timeout_l;
+  iis2dulpx_fsm_lc_timeout_h_t    fsm_lc_timeout_h;
+  iis2dulpx_fsm_programs_t    fsm_programs;
+  iis2dulpx_fsm_start_add_l_t    fsm_start_add_l;
+  iis2dulpx_fsm_start_add_h_t    fsm_start_add_h;
+  iis2dulpx_pedo_cmd_reg_t    pedo_cmd_reg;
+  iis2dulpx_pedo_deb_steps_conf_t    pedo_deb_steps_conf;
+  iis2dulpx_pedo_sc_deltat_l_t    pedo_sc_deltat_l;
+  iis2dulpx_pedo_sc_deltat_h_t    pedo_sc_deltat_h;
+  iis2dulpx_t_ah_qvar_sensitivity_l_t    t_ah_qvar_sensitivity_l;
+  iis2dulpx_t_ah_qvar_sensitivity_h_t    t_ah_qvar_sensitivity_h;
+  iis2dulpx_smart_power_ctrl_t   smart_power_ctrl;
   bitwise_t    bitwise;
   uint8_t    byte;
-} st1vafe3bx_reg_t;
+} iis2dulpx_reg_t;
 
 /**
   * @}
@@ -1995,42 +2084,31 @@ typedef union
  * them with a custom implementation.
  */
 
-int32_t st1vafe3bx_read_reg(const st1vafe3bx_ctx_t *ctx, uint8_t reg,
+int32_t iis2dulpx_read_reg(const stmdev_ctx_t *ctx, uint8_t reg,
+                           uint8_t *data,
+                           uint16_t len);
+int32_t iis2dulpx_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
                             uint8_t *data,
                             uint16_t len);
-int32_t st1vafe3bx_write_reg(const st1vafe3bx_ctx_t *ctx, uint8_t reg,
-                             uint8_t *data,
-                             uint16_t len);
 
-float_t st1vafe3bx_from_fs2g_to_mg(int16_t lsb);
-float_t st1vafe3bx_from_fs4g_to_mg(int16_t lsb);
-float_t st1vafe3bx_from_fs8g_to_mg(int16_t lsb);
-float_t st1vafe3bx_from_fs16g_to_mg(int16_t lsb);
-float_t st1vafe3bx_from_lsb_to_celsius(int16_t lsb);
-float_t st1vafe3bx_from_lsb_to_mv(int16_t lsb);
+float_t iis2dulpx_from_fs2g_to_mg(int16_t lsb);
+float_t iis2dulpx_from_fs4g_to_mg(int16_t lsb);
+float_t iis2dulpx_from_fs8g_to_mg(int16_t lsb);
+float_t iis2dulpx_from_fs16g_to_mg(int16_t lsb);
+float_t iis2dulpx_from_lsb_to_celsius(int16_t lsb);
+float_t iis2dulpx_from_lsb_to_mv(int16_t lsb);
 
-int32_t st1vafe3bx_device_id_get(const st1vafe3bx_ctx_t *ctx, uint8_t *val);
+int32_t iis2dulpx_device_id_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum
 {
-  ST1VAFE3BX_SENSOR_ONLY_ON     = 0x00, /* Initialize the driver for sensor usage */
-  ST1VAFE3BX_BOOT               = 0x01, /* Restore calib. param. (it takes 10ms) */
-  ST1VAFE3BX_RESET              = 0x02, /* Reset configuration registers */
-  ST1VAFE3BX_SENSOR_EMB_FUNC_ON = 0x03, /* Initialize the driver for sensor and/or
+  IIS2DULPX_SENSOR_ONLY_ON     = 0x00, /* Initialize the driver for sensor usage */
+  IIS2DULPX_BOOT               = 0x01, /* Restore calib. param. (it takes 10ms) */
+  IIS2DULPX_RESET              = 0x02, /* Reset configuration registers */
+  IIS2DULPX_SENSOR_EMB_FUNC_ON = 0x03, /* Initialize the driver for sensor and/or
                                            embedded functions usage (it takes 10ms) */
-  ST1VAFE3BX_VAFE_ONLY_LP       = 0x04, /* Enable sensor in vAFE only mode - low performance */
-  ST1VAFE3BX_VAFE_ONLY_HP       = 0x05, /* Enable sensor in vAFE only mode - high performance */
-} st1vafe3bx_init_t;
-int32_t st1vafe3bx_init_set(const st1vafe3bx_ctx_t *ctx, st1vafe3bx_init_t val);
-
-typedef struct
-{
-  uint8_t pwr_en                       : 1; /* Smart power enable */
-  uint8_t pwr_ctrl_win                 : 4; /* Number of consecutive windows */
-  uint8_t pwr_ctrl_dur                 : 4; /* Duration threshold */
-} st1vafe3bx_smart_power_t;
-int32_t st1vafe3bx_smart_power_set(const st1vafe3bx_ctx_t *ctx, st1vafe3bx_smart_power_t val);
-int32_t st1vafe3bx_smart_power_get(const st1vafe3bx_ctx_t *ctx, st1vafe3bx_smart_power_t *val);
+} iis2dulpx_init_t;
+int32_t iis2dulpx_init_set(const stmdev_ctx_t *ctx, iis2dulpx_init_t val);
 
 typedef struct
 {
@@ -2038,97 +2116,80 @@ typedef struct
   uint8_t boot                         : 1; /* Restoring calibration parameters */
   uint8_t drdy                         : 1; /* Accelerometer data ready */
   uint8_t power_down                   : 1; /* Monitors power-down. */
-} st1vafe3bx_status_t;
-int32_t st1vafe3bx_status_get(const st1vafe3bx_ctx_t *ctx, st1vafe3bx_status_t *val);
-int32_t st1vafe3bx_drdy_status_get(const st1vafe3bx_ctx_t *ctx, st1vafe3bx_status_t *val);
+} iis2dulpx_status_t;
+int32_t iis2dulpx_status_get(const stmdev_ctx_t *ctx, iis2dulpx_status_t *val);
 
 typedef struct
 {
   uint8_t is_step_det                  : 1; /* Step detected */
   uint8_t is_tilt                      : 1; /* Tilt detected */
   uint8_t is_sigmot                    : 1; /* Significant motion detected */
-  uint8_t is_fsm_lc                    : 1; /* FSM long counter timeout */
-} st1vafe3bx_embedded_status_t;
-int32_t st1vafe3bx_embedded_status_get(const st1vafe3bx_ctx_t *ctx,
-                                       st1vafe3bx_embedded_status_t *val);
+} iis2dulpx_embedded_status_t;
+int32_t iis2dulpx_embedded_status_get(const stmdev_ctx_t *ctx, iis2dulpx_embedded_status_t *val);
 
 typedef enum
 {
-  ST1VAFE3BX_DRDY_LATCHED = 0x0,
-  ST1VAFE3BX_DRDY_PULSED  = 0x1,
-} st1vafe3bx_data_ready_mode_t;
-int32_t st1vafe3bx_data_ready_mode_set(const st1vafe3bx_ctx_t *ctx,
-                                       st1vafe3bx_data_ready_mode_t val);
-int32_t st1vafe3bx_data_ready_mode_get(const st1vafe3bx_ctx_t *ctx,
-                                       st1vafe3bx_data_ready_mode_t *val);
+  IIS2DULPX_DRDY_LATCHED = 0x0,
+  IIS2DULPX_DRDY_PULSED  = 0x1,
+} iis2dulpx_data_ready_mode_t;
+int32_t iis2dulpx_data_ready_mode_set(const stmdev_ctx_t *ctx, iis2dulpx_data_ready_mode_t val);
+int32_t iis2dulpx_data_ready_mode_get(const stmdev_ctx_t *ctx, iis2dulpx_data_ready_mode_t *val);
 
 typedef enum
 {
-  ST1VAFE3BX_OFF               = 0x00, /* in power down */
-  ST1VAFE3BX_1Hz6_ULP          = 0x01, /* @1Hz6 (ultra low power) */
-  ST1VAFE3BX_3Hz_ULP           = 0x02, /* @3Hz (ultra low power) */
-  ST1VAFE3BX_25Hz_ULP          = 0x03, /* @25Hz (ultra low power) */
-  ST1VAFE3BX_6Hz_LP            = 0x04, /* @6Hz (low power) */
-  ST1VAFE3BX_12Hz5_LP          = 0x05, /* @12Hz5 (low power) */
-  ST1VAFE3BX_25Hz_LP           = 0x06, /* @25Hz  (low power ) */
-  ST1VAFE3BX_50Hz_LP           = 0x07, /* @50Hz  (low power) */
-  ST1VAFE3BX_100Hz_LP          = 0x08, /* @100Hz (low power) */
-  ST1VAFE3BX_200Hz_LP          = 0x09, /* @200Hz (low power) */
-  ST1VAFE3BX_400Hz_LP          = 0x0A, /* @400Hz (low power) */
-  ST1VAFE3BX_800Hz_LP          = 0x0B, /* @800Hz (low power) */
-  ST1VAFE3BX_6Hz_HP            = 0x14, /* @6Hz (high performance) */
-  ST1VAFE3BX_12Hz5_HP          = 0x15, /* @12Hz5 (high performance) */
-  ST1VAFE3BX_25Hz_HP           = 0x16, /* @25Hz  (high performance ) */
-  ST1VAFE3BX_50Hz_HP           = 0x17, /* @50Hz  (high performance) */
-  ST1VAFE3BX_100Hz_HP          = 0x18, /* @100Hz (high performance) */
-  ST1VAFE3BX_200Hz_HP          = 0x19, /* @200Hz (high performance) */
-  ST1VAFE3BX_400Hz_HP          = 0x1A, /* @400Hz (high performance) */
-  ST1VAFE3BX_800Hz_HP          = 0x1B, /* @800Hz (high performance) */
-  ST1VAFE3BX_TRIG_PIN          = 0x2E, /* Single-shot high latency by INT2 */
-  ST1VAFE3BX_TRIG_SW           = 0x2F, /* Single-shot high latency by IF */
-  ST1VAFE3BX_3200Hz_VAFE_LP    = 0x2B, /* @3200Hz (vAFE only low power) */
-  ST1VAFE3BX_800Hz_VAFE_HP     = 0x3B, /* @800Hz (vAFE only high performance) */
-} st1vafe3bx_odr_t;
+  IIS2DULPX_OFF               = 0x00, /* in power down */
+  IIS2DULPX_1Hz6_ULP          = 0x01, /* @1Hz6 (ultra low power) */
+  IIS2DULPX_3Hz_ULP           = 0x02, /* @3Hz (ultra low power) */
+  IIS2DULPX_25Hz_ULP          = 0x03, /* @25Hz (ultra low power) */
+  IIS2DULPX_6Hz_LP            = 0x04, /* @6Hz (low power) */
+  IIS2DULPX_12Hz5_LP          = 0x05, /* @12Hz5 (low power) */
+  IIS2DULPX_25Hz_LP           = 0x06, /* @25Hz  (low power ) */
+  IIS2DULPX_50Hz_LP           = 0x07, /* @50Hz  (low power) */
+  IIS2DULPX_100Hz_LP          = 0x08, /* @100Hz (low power) */
+  IIS2DULPX_200Hz_LP          = 0x09, /* @200Hz (low power) */
+  IIS2DULPX_400Hz_LP          = 0x0A, /* @400Hz (low power) */
+  IIS2DULPX_800Hz_LP          = 0x0B, /* @800Hz (low power) */
+  IIS2DULPX_6Hz_HP            = 0x14, /* @6Hz (high performance) */
+  IIS2DULPX_12Hz5_HP          = 0x15, /* @12Hz5 (high performance) */
+  IIS2DULPX_25Hz_HP           = 0x16, /* @25Hz  (high performance ) */
+  IIS2DULPX_50Hz_HP           = 0x17, /* @50Hz  (high performance) */
+  IIS2DULPX_100Hz_HP          = 0x18, /* @100Hz (high performance) */
+  IIS2DULPX_200Hz_HP          = 0x19, /* @200Hz (high performance) */
+  IIS2DULPX_400Hz_HP          = 0x1A, /* @400Hz (high performance) */
+  IIS2DULPX_800Hz_HP          = 0x1B, /* @800Hz (high performance) */
+  IIS2DULPX_TRIG_PIN          = 0x2E, /* Single-shot high latency by INT2 */
+  IIS2DULPX_TRIG_SW           = 0x2F, /* Single-shot high latency by IF */
+} iis2dulpx_odr_t;
 
 typedef enum
 {
-  ST1VAFE3BX_2g   = 0,
-  ST1VAFE3BX_4g   = 1,
-  ST1VAFE3BX_8g   = 2,
-  ST1VAFE3BX_16g  = 3,
-} st1vafe3bx_fs_t;
+  IIS2DULPX_2g   = 0,
+  IIS2DULPX_4g   = 1,
+  IIS2DULPX_8g   = 2,
+  IIS2DULPX_16g  = 3,
+} iis2dulpx_fs_t;
 
 typedef enum
 {
-  ST1VAFE3BX_BW_VAFE_45Hz      = 0,
-  ST1VAFE3BX_BW_VAFE_90Hz      = 1,
-  ST1VAFE3BX_BW_VAFE_180Hz     = 2,
-  ST1VAFE3BX_BW_VAFE_360Hz     = 3,
-  ST1VAFE3BX_BW_VAFE_700Hz     = 4,
-  ST1VAFE3BX_BW_VAFE_1600Hz    = 5,
-  ST1VAFE3BX_BW_ODR_div_2      = 7,
-  ST1VAFE3BX_BW_ODR_div_4      = 8,
-  ST1VAFE3BX_BW_ODR_div_8      = 9,
-  ST1VAFE3BX_BW_ODR_div_16     = 10,
-  ST1VAFE3BX_BW_LP_3Hz         = 11,
-  ST1VAFE3BX_BW_LP_6Hz         = 12,
-  ST1VAFE3BX_BW_LP_12Hz5       = 13,
-} st1vafe3bx_bw_t;
+  IIS2DULPX_ODR_div_2   = 0,
+  IIS2DULPX_ODR_div_4   = 1,
+  IIS2DULPX_ODR_div_8   = 2,
+  IIS2DULPX_ODR_div_16  = 3,
+} iis2dulpx_bw_t;
 
 typedef struct
 {
-  /* if the hp_en bit is set the AH / vAFE data are in 14-bit format */
-  uint8_t hp_en                        : 1;
-  st1vafe3bx_fs_t fs                 : 2;
-  st1vafe3bx_odr_t odr;
-  st1vafe3bx_bw_t bw;
-} st1vafe3bx_md_t;
-int32_t st1vafe3bx_mode_set(const st1vafe3bx_ctx_t *ctx,
-                            const st1vafe3bx_md_t *val);
-int32_t st1vafe3bx_mode_get(const st1vafe3bx_ctx_t *ctx, st1vafe3bx_md_t *val);
+  iis2dulpx_odr_t odr;
+  iis2dulpx_fs_t fs;
+  iis2dulpx_bw_t bw;
+} iis2dulpx_md_t;
+int32_t iis2dulpx_mode_set(const stmdev_ctx_t *ctx, const iis2dulpx_md_t *val);
+int32_t iis2dulpx_mode_get(const stmdev_ctx_t *ctx, iis2dulpx_md_t *val);
 
-int32_t st1vafe3bx_trigger_sw(const st1vafe3bx_ctx_t *ctx,
-                              const st1vafe3bx_md_t *md);
+int32_t iis2dulpx_t_ah_qvar_dis_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dulpx_t_ah_qvar_dis_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dulpx_trigger_sw(const stmdev_ctx_t *ctx, const iis2dulpx_md_t *md);
 
 typedef struct
 {
@@ -2156,110 +2217,114 @@ typedef struct
   uint8_t fifo_full                    : 1;
   uint8_t fifo_ovr                     : 1;
   uint8_t fifo_th                      : 1;
-} st1vafe3bx_all_sources_t;
-int32_t st1vafe3bx_all_sources_get(const st1vafe3bx_ctx_t *ctx,
-                                   st1vafe3bx_all_sources_t *val);
+} iis2dulpx_all_sources_t;
+int32_t iis2dulpx_all_sources_get(const stmdev_ctx_t *ctx, iis2dulpx_all_sources_t *val);
 
 typedef struct
 {
   float_t mg[3];
   int16_t raw[3];
-} st1vafe3bx_xl_data_t;
-int32_t st1vafe3bx_xl_data_get(const st1vafe3bx_ctx_t *ctx,
-                               const st1vafe3bx_md_t *md,
-                               st1vafe3bx_xl_data_t *data);
+} iis2dulpx_xl_data_t;
+int32_t iis2dulpx_xl_data_get(const stmdev_ctx_t *ctx, const iis2dulpx_md_t *md,
+                              iis2dulpx_xl_data_t *data);
+
+typedef struct
+{
+  struct
+  {
+    float_t deg_c;
+    int16_t raw;
+  } heat;
+} iis2dulpx_outt_data_t;
+int32_t iis2dulpx_outt_data_get(const stmdev_ctx_t *ctx,
+                                iis2dulpx_outt_data_t *data);
 
 typedef struct
 {
   float_t mv;
   int16_t raw;
-} st1vafe3bx_ah_bio_data_t;
-int32_t st1vafe3bx_ah_bio_data_get(const st1vafe3bx_ctx_t *ctx,
-                                   st1vafe3bx_ah_bio_data_t *data);
+} iis2dulpx_ah_qvar_data_t;
+int32_t iis2dulpx_ah_qvar_data_get(const stmdev_ctx_t *ctx,
+                                   iis2dulpx_ah_qvar_data_t *data);
 
 typedef enum
 {
-  ST1VAFE3BX_XL_ST_DISABLE  = 0x0,
-  ST1VAFE3BX_XL_ST_POSITIVE = 0x1,
-  ST1VAFE3BX_XL_ST_NEGATIVE = 0x2,
-} st1vafe3bx_xl_self_test_t;
-int32_t st1vafe3bx_self_test_sign_set(const st1vafe3bx_ctx_t *ctx,
-                                      st1vafe3bx_xl_self_test_t val);
-int32_t st1vafe3bx_self_test_start(const st1vafe3bx_ctx_t *ctx, uint8_t val);
-int32_t st1vafe3bx_self_test_stop(const st1vafe3bx_ctx_t *ctx);
+  IIS2DULPX_XL_ST_DISABLE  = 0x0,
+  IIS2DULPX_XL_ST_POSITIVE = 0x1,
+  IIS2DULPX_XL_ST_NEGATIVE = 0x2,
+} iis2dulpx_xl_self_test_t;
+int32_t iis2dulpx_self_test_sign_set(const stmdev_ctx_t *ctx, iis2dulpx_xl_self_test_t val);
+int32_t iis2dulpx_self_test_start(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dulpx_self_test_stop(const stmdev_ctx_t *ctx);
 
-int32_t st1vafe3bx_enter_deep_power_down(const st1vafe3bx_ctx_t *ctx, uint8_t val);
-int32_t st1vafe3bx_exit_deep_power_down(const st1vafe3bx_ctx_t *ctx);
+int32_t iis2dulpx_enter_deep_power_down(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dulpx_exit_deep_power_down(const stmdev_ctx_t *ctx);
+
+int32_t iis2dulpx_disable_hard_reset_from_cs_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dulpx_disable_hard_reset_from_cs_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  IIS2DULPX_I3C_BUS_AVAIL_TIME_20US = 0x0,
+  IIS2DULPX_I3C_BUS_AVAIL_TIME_50US = 0x1,
+  IIS2DULPX_I3C_BUS_AVAIL_TIME_1MS  = 0x2,
+  IIS2DULPX_I3C_BUS_AVAIL_TIME_25MS = 0x3,
+} iis2dulpx_bus_act_sel_t;
 
 typedef struct
 {
-  enum
-  {
-    ST1VAFE3BX_I3C_BUS_AVAIL_TIME_20US = 0x0,
-    ST1VAFE3BX_I3C_BUS_AVAIL_TIME_50US = 0x1,
-    ST1VAFE3BX_I3C_BUS_AVAIL_TIME_1MS  = 0x2,
-    ST1VAFE3BX_I3C_BUS_AVAIL_TIME_25MS = 0x3,
-  } bus_act_sel;
+  iis2dulpx_bus_act_sel_t bus_act_sel;
   uint8_t asf_on                       : 1;
   uint8_t drstdaa_en                   : 1;
-} st1vafe3bx_i3c_cfg_t;
-int32_t st1vafe3bx_i3c_configure_set(const st1vafe3bx_ctx_t *ctx,
-                                     const st1vafe3bx_i3c_cfg_t *val);
-int32_t st1vafe3bx_i3c_configure_get(const st1vafe3bx_ctx_t *ctx,
-                                     st1vafe3bx_i3c_cfg_t *val);
+} iis2dulpx_i3c_cfg_t;
+int32_t iis2dulpx_i3c_configure_set(const stmdev_ctx_t *ctx, const iis2dulpx_i3c_cfg_t *val);
+int32_t iis2dulpx_i3c_configure_get(const stmdev_ctx_t *ctx, iis2dulpx_i3c_cfg_t *val);
 
 typedef enum
 {
-  ST1VAFE3BX_MAIN_MEM_BANK       = 0x0,
-  ST1VAFE3BX_EMBED_FUNC_MEM_BANK = 0x1,
-} st1vafe3bx_mem_bank_t;
-int32_t st1vafe3bx_mem_bank_set(const st1vafe3bx_ctx_t *ctx,
-                                st1vafe3bx_mem_bank_t val);
-int32_t st1vafe3bx_mem_bank_get(const st1vafe3bx_ctx_t *ctx,
-                                st1vafe3bx_mem_bank_t *val);
+  IIS2DULPX_MAIN_MEM_BANK       = 0x0,
+  IIS2DULPX_EMBED_FUNC_MEM_BANK = 0x1,
+} iis2dulpx_mem_bank_t;
+int32_t iis2dulpx_mem_bank_set(const stmdev_ctx_t *ctx, iis2dulpx_mem_bank_t val);
+int32_t iis2dulpx_mem_bank_get(const stmdev_ctx_t *ctx, iis2dulpx_mem_bank_t *val);
 
-int32_t st1vafe3bx_ln_pg_write(const st1vafe3bx_ctx_t *ctx, uint16_t address,
-                               uint8_t *buf, uint8_t len);
-int32_t st1vafe3bx_ln_pg_read(const st1vafe3bx_ctx_t *ctx, uint16_t address,
-                              uint8_t *buf, uint8_t len);
+int32_t iis2dulpx_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t address, uint8_t *buf, uint8_t len);
+int32_t iis2dulpx_ln_pg_read(const stmdev_ctx_t *ctx, uint16_t address, uint8_t *buf, uint8_t len);
 
-int32_t st1vafe3bx_ext_clk_en_set(const st1vafe3bx_ctx_t *ctx, uint8_t val);
-int32_t st1vafe3bx_ext_clk_en_get(const st1vafe3bx_ctx_t *ctx, uint8_t *val);
+int32_t iis2dulpx_ext_clk_en_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dulpx_ext_clk_en_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef struct
 {
   uint8_t sdo_pull_up                  : 1; /* 1 = pull up enable */
   uint8_t sda_pull_up                  : 1; /* 1 = pull up enable */
   uint8_t cs_pull_up                   : 1; /* 1 = pull up enable */
-  uint8_t int_push_pull                : 1; /* 1 = push-pull / 0 = open-drain*/
-} st1vafe3bx_pin_conf_t;
-int32_t st1vafe3bx_pin_conf_set(const st1vafe3bx_ctx_t *ctx,
-                                const st1vafe3bx_pin_conf_t *val);
-int32_t st1vafe3bx_pin_conf_get(const st1vafe3bx_ctx_t *ctx,
-                                st1vafe3bx_pin_conf_t *val);
+  uint8_t int1_int2_push_pull          : 1; /* 1 = push-pull / 0 = open-drain*/
+  uint8_t int1_pull_down               : 1; /* 1 = pull-down always disabled (0=auto) */
+  uint8_t int2_pull_down               : 1; /* 1 = pull-down always disabled (0=auto) */
+} iis2dulpx_pin_conf_t;
+int32_t iis2dulpx_pin_conf_set(const stmdev_ctx_t *ctx, const iis2dulpx_pin_conf_t *val);
+int32_t iis2dulpx_pin_conf_get(const stmdev_ctx_t *ctx, iis2dulpx_pin_conf_t *val);
 
 typedef enum
 {
-  ST1VAFE3BX_ACTIVE_HIGH = 0x0,
-  ST1VAFE3BX_ACTIVE_LOW  = 0x1,
-} st1vafe3bx_int_pin_polarity_t;
-int32_t st1vafe3bx_int_pin_polarity_set(const st1vafe3bx_ctx_t *ctx,
-                                        st1vafe3bx_int_pin_polarity_t val);
-int32_t st1vafe3bx_int_pin_polarity_get(const st1vafe3bx_ctx_t *ctx,
-                                        st1vafe3bx_int_pin_polarity_t *val);
+  IIS2DULPX_ACTIVE_HIGH = 0x0,
+  IIS2DULPX_ACTIVE_LOW  = 0x1,
+} iis2dulpx_int_pin_polarity_t;
+int32_t iis2dulpx_int_pin_polarity_set(const stmdev_ctx_t *ctx, iis2dulpx_int_pin_polarity_t val);
+int32_t iis2dulpx_int_pin_polarity_get(const stmdev_ctx_t *ctx, iis2dulpx_int_pin_polarity_t *val);
 
 typedef enum
 {
-  ST1VAFE3BX_SPI_4_WIRE  = 0x0, /* SPI 4 wires */
-  ST1VAFE3BX_SPI_3_WIRE  = 0x1, /* SPI 3 wires */
-} st1vafe3bx_spi_mode;
-int32_t st1vafe3bx_spi_mode_set(const st1vafe3bx_ctx_t *ctx,
-                                st1vafe3bx_spi_mode val);
-int32_t st1vafe3bx_spi_mode_get(const st1vafe3bx_ctx_t *ctx,
-                                st1vafe3bx_spi_mode *val);
+  IIS2DULPX_SPI_4_WIRE  = 0x0, /* SPI 4 wires */
+  IIS2DULPX_SPI_3_WIRE  = 0x1, /* SPI 3 wires */
+} iis2dulpx_spi_mode;
+int32_t iis2dulpx_spi_mode_set(const stmdev_ctx_t *ctx, iis2dulpx_spi_mode val);
+int32_t iis2dulpx_spi_mode_get(const stmdev_ctx_t *ctx, iis2dulpx_spi_mode *val);
 
 typedef struct
 {
+  uint8_t int_on_res                   : 1; /* Interrupt on RES pin */
   uint8_t drdy                         : 1; /* Accelerometer data ready */
   uint8_t boot                         : 1; /* Restoring calibration parameters */
   uint8_t fifo_th                      : 1; /* FIFO threshold reached */
@@ -2272,11 +2337,15 @@ typedef struct
   uint8_t sleep_change                 : 1; /* Act/Inact (or Vice-versa) status changed */
   uint8_t emb_function                 : 1; /* Embedded Function */
   uint8_t timestamp                    : 1; /* Timestamp */
-} st1vafe3bx_pin_int_route_t;
-int32_t st1vafe3bx_pin_int_route_set(const st1vafe3bx_ctx_t *ctx,
-                                     const st1vafe3bx_pin_int_route_t *val);
-int32_t st1vafe3bx_pin_int_route_get(const st1vafe3bx_ctx_t *ctx,
-                                     st1vafe3bx_pin_int_route_t *val);
+} iis2dulpx_pin_int_route_t;
+int32_t iis2dulpx_pin_int1_route_set(const stmdev_ctx_t *ctx,
+                                     const iis2dulpx_pin_int_route_t *val);
+int32_t iis2dulpx_pin_int1_route_get(const stmdev_ctx_t *ctx,
+                                     iis2dulpx_pin_int_route_t *val);
+int32_t iis2dulpx_pin_int2_route_set(const stmdev_ctx_t *ctx,
+                                     const iis2dulpx_pin_int_route_t *val);
+int32_t iis2dulpx_pin_int2_route_get(const stmdev_ctx_t *ctx,
+                                     iis2dulpx_pin_int_route_t *val);
 
 typedef struct
 {
@@ -2284,112 +2353,123 @@ typedef struct
   uint8_t tilt                         : 1; /* route tilt event on INT pad */
   uint8_t sig_mot                      : 1; /* route significant motion event on INT pad */
   uint8_t fsm_lc                       : 1; /* route FSM long counter event on INT pad */
-} st1vafe3bx_emb_pin_int_route_t;
-int32_t st1vafe3bx_emb_pin_int_route_set(const st1vafe3bx_ctx_t *ctx,
-                                         const st1vafe3bx_emb_pin_int_route_t *val);
-int32_t st1vafe3bx_emb_pin_int_route_get(const st1vafe3bx_ctx_t *ctx,
-                                         st1vafe3bx_emb_pin_int_route_t *val);
+} iis2dulpx_emb_pin_int_route_t;
+int32_t iis2dulpx_emb_pin_int1_route_set(const stmdev_ctx_t *ctx,
+                                         const iis2dulpx_emb_pin_int_route_t *val);
+int32_t iis2dulpx_emb_pin_int1_route_get(const stmdev_ctx_t *ctx,
+                                         iis2dulpx_emb_pin_int_route_t *val);
+int32_t iis2dulpx_emb_pin_int2_route_set(const stmdev_ctx_t *ctx,
+                                         const iis2dulpx_emb_pin_int_route_t *val);
+int32_t iis2dulpx_emb_pin_int2_route_get(const stmdev_ctx_t *ctx,
+                                         iis2dulpx_emb_pin_int_route_t *val);
 
 typedef enum
 {
-  ST1VAFE3BX_INT_DISABLED             = 0x0,
-  ST1VAFE3BX_INT_LEVEL                = 0x1,
-  ST1VAFE3BX_INT_LATCHED              = 0x2,
-} st1vafe3bx_int_cfg_t;
+  IIS2DULPX_INT_DISABLED             = 0x0,
+  IIS2DULPX_INT_LEVEL                = 0x1,
+  IIS2DULPX_INT_LATCHED              = 0x2,
+} iis2dulpx_int_cfg_t;
 
 typedef struct
 {
-  st1vafe3bx_int_cfg_t int_cfg;
+  iis2dulpx_int_cfg_t int_cfg;
   uint8_t sleep_status_on_int          : 1;  /* route sleep_status on interrupt */
   uint8_t dis_rst_lir_all_int          : 1;  /* disable LIR reset when reading ALL_INT_SRC */
-} st1vafe3bx_int_config_t;
-int32_t st1vafe3bx_int_config_set(const st1vafe3bx_ctx_t *ctx,
-                                  const st1vafe3bx_int_config_t *val);
-int32_t st1vafe3bx_int_config_get(const st1vafe3bx_ctx_t *ctx,
-                                  st1vafe3bx_int_config_t *val);
+} iis2dulpx_int_config_t;
+int32_t iis2dulpx_int_config_set(const stmdev_ctx_t *ctx, const iis2dulpx_int_config_t *val);
+int32_t iis2dulpx_int_config_get(const stmdev_ctx_t *ctx, iis2dulpx_int_config_t *val);
 
 typedef enum
 {
-  ST1VAFE3BX_EMBEDDED_INT_LEVEL     = 0x0,
-  ST1VAFE3BX_EMBEDDED_INT_LATCHED   = 0x1,
-} st1vafe3bx_embedded_int_config_t;
-int32_t st1vafe3bx_embedded_int_cfg_set(const st1vafe3bx_ctx_t *ctx,
-                                        st1vafe3bx_embedded_int_config_t val);
-int32_t st1vafe3bx_embedded_int_cfg_get(const st1vafe3bx_ctx_t *ctx,
-                                        st1vafe3bx_embedded_int_config_t *val);
+  IIS2DULPX_EMBEDDED_INT_LEVEL         = 0x0,
+  IIS2DULPX_EMBEDDED_INT_LATCHED       = 0x1,
+} iis2dulpx_embedded_int_config_t;
+int32_t iis2dulpx_embedded_int_cfg_set(const stmdev_ctx_t *ctx,
+                                       iis2dulpx_embedded_int_config_t val);
+int32_t iis2dulpx_embedded_int_cfg_get(const stmdev_ctx_t *ctx,
+                                       iis2dulpx_embedded_int_config_t *val);
+
+typedef enum
+{
+  IIS2DULPX_BYPASS_MODE              = 0x0,
+  IIS2DULPX_FIFO_MODE                = 0x1,
+  IIS2DULPX_STREAM_TO_FIFO_MODE      = 0x3,
+  IIS2DULPX_BYPASS_TO_STREAM_MODE    = 0x4,
+  IIS2DULPX_STREAM_MODE              = 0x6,
+  IIS2DULPX_BYPASS_TO_FIFO_MODE      = 0x7,
+  IIS2DULPX_FIFO_OFF                 = 0x8,
+} iis2dulpx_operation_t;
+
+typedef enum
+{
+  IIS2DULPX_FIFO_1X                  = 0,
+  IIS2DULPX_FIFO_2X                  = 1,
+} iis2dulpx_store_t;
+
+typedef enum
+{
+  IIS2DULPX_DEC_TS_OFF             = 0x0,
+  IIS2DULPX_DEC_TS_1               = 0x1,
+  IIS2DULPX_DEC_TS_8               = 0x2,
+  IIS2DULPX_DEC_TS_32              = 0x3,
+} iis2dulpx_dec_ts_t;
+
+typedef enum
+{
+  IIS2DULPX_BDR_XL_ODR             = 0x0,
+  IIS2DULPX_BDR_XL_ODR_DIV_2       = 0x1,
+  IIS2DULPX_BDR_XL_ODR_DIV_4       = 0x2,
+  IIS2DULPX_BDR_XL_ODR_DIV_8       = 0x3,
+  IIS2DULPX_BDR_XL_ODR_DIV_16      = 0x4,
+  IIS2DULPX_BDR_XL_ODR_DIV_32      = 0x5,
+  IIS2DULPX_BDR_XL_ODR_DIV_64      = 0x6,
+  IIS2DULPX_BDR_XL_ODR_OFF         = 0x7,
+} iis2dulpx_bdr_xl_t;
+
+typedef enum
+{
+  IIS2DULPX_FIFO_EV_WTM           = 0x0,
+  IIS2DULPX_FIFO_EV_FULL          = 0x1,
+} iis2dulpx_fifo_event_t;
 
 typedef struct
 {
-  enum st1vafe3bx_operation_t
-  {
-    ST1VAFE3BX_BYPASS_MODE            = 0x0,
-    ST1VAFE3BX_FIFO_MODE              = 0x1,
-    ST1VAFE3BX_STREAM_TO_FIFO_MODE    = 0x3,
-    ST1VAFE3BX_BYPASS_TO_STREAM_MODE  = 0x4,
-    ST1VAFE3BX_STREAM_MODE            = 0x6,
-    ST1VAFE3BX_BYPASS_TO_FIFO_MODE    = 0x7,
-    ST1VAFE3BX_FIFO_OFF               = 0x8,
-  } operation;
-
-  enum st1vafe3bx_store_t
-  {
-    ST1VAFE3BX_FIFO_1X                = 0,
-    ST1VAFE3BX_FIFO_2X                = 1,
-  } store;
-
+  iis2dulpx_operation_t operation;
+  iis2dulpx_store_t store;
   uint8_t xl_only                      : 1; /* only XL samples (16-bit) are stored in FIFO */
-
   uint8_t watermark                    : 7; /* (0 disable) max 127 @16bit, even and max 256 @8bit.*/
   uint8_t cfg_change_in_fifo           : 1;
+  iis2dulpx_fifo_event_t fifo_event      : 1; /* 0: FIFO watermark, 1: FIFO full */
   struct
   {
-    enum st1vafe3bx_dec_ts_t
-    {
-      ST1VAFE3BX_DEC_TS_OFF             = 0x0,
-      ST1VAFE3BX_DEC_TS_1               = 0x1,
-      ST1VAFE3BX_DEC_TS_8               = 0x2,
-      ST1VAFE3BX_DEC_TS_32              = 0x3,
-    } dec_ts; /* decimation for timestamp batching*/
-
-    enum st1vafe3bx_bdr_xl_t
-    {
-      ST1VAFE3BX_BDR_ODR               = 0x0,
-      ST1VAFE3BX_BDR_ODR_DIV_2         = 0x1,
-      ST1VAFE3BX_BDR_ODR_DIV_4         = 0x2,
-      ST1VAFE3BX_BDR_ODR_DIV_8         = 0x3,
-      ST1VAFE3BX_BDR_ODR_DIV_16        = 0x4,
-      ST1VAFE3BX_BDR_ODR_DIV_32        = 0x5,
-      ST1VAFE3BX_BDR_ODR_DIV_64        = 0x6,
-      ST1VAFE3BX_BDR_ODR_OFF           = 0x7,
-    } bdr_xl; /* accelerometer batch data rate*/
+    iis2dulpx_dec_ts_t dec_ts; /* decimation for timestamp batching*/
+    iis2dulpx_bdr_xl_t bdr_xl; /* accelerometer batch data rate*/
   } batch;
-} st1vafe3bx_fifo_mode_t;
-int32_t st1vafe3bx_fifo_mode_set(const st1vafe3bx_ctx_t *ctx,
-                                 st1vafe3bx_fifo_mode_t val);
-int32_t st1vafe3bx_fifo_mode_get(const st1vafe3bx_ctx_t *ctx,
-                                 st1vafe3bx_fifo_mode_t *val);
+} iis2dulpx_fifo_mode_t;
+int32_t iis2dulpx_fifo_mode_set(const stmdev_ctx_t *ctx, iis2dulpx_fifo_mode_t val);
+int32_t iis2dulpx_fifo_mode_get(const stmdev_ctx_t *ctx, iis2dulpx_fifo_mode_t *val);
 
-int32_t st1vafe3bx_fifo_data_level_get(const st1vafe3bx_ctx_t *ctx, uint16_t *val);
-int32_t st1vafe3bx_fifo_wtm_flag_get(const st1vafe3bx_ctx_t *ctx, uint8_t *val);
+int32_t iis2dulpx_fifo_data_level_get(const stmdev_ctx_t *ctx, uint16_t *val);
+int32_t iis2dulpx_fifo_wtm_flag_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum
 {
-  ST1VAFE3BX_FIFO_EMPTY_TAG             = 0x0,
-  ST1VAFE3BX_XL_ONLY                    = 0x2,
-  ST1VAFE3BX_XL_ONLY_2X_TAG             = 0x3,
-  ST1VAFE3BX_TIMESTAMP_CFG_CHG_TAG      = 0x4,
-  ST1VAFE3BX_STEP_COUNTER_TAG           = 0x12,
-  ST1VAFE3BX_MLC_RESULT_TAG             = 0x1A,
-  ST1VAFE3BX_MLC_FILTER_TAG             = 0x1B,
-  ST1VAFE3BX_MLC_FEATURE_TAG            = 0x1C,
-  ST1VAFE3BX_FSM_RESULT_TAG             = 0x1D,
-  ST1VAFE3BX_AH_VAFE_ONLY_TAG           = 0x1E,
-  ST1VAFE3BX_XL_AND_AH_VAFE1_TAG        = 0x1F,
-} st1vafe3bx_fifo_sensor_tag_t;
-int32_t st1vafe3bx_fifo_sensor_tag_get(const st1vafe3bx_ctx_t *ctx,
-                                       st1vafe3bx_fifo_sensor_tag_t *val);
+  IIS2DULPX_FIFO_EMPTY                 = 0x0,
+  IIS2DULPX_XL_TEMP_TAG                = 0x2,
+  IIS2DULPX_XL_ONLY_2X_TAG             = 0x3,
+  IIS2DULPX_TIMESTAMP_TAG              = 0x4,
+  IIS2DULPX_STEP_COUNTER_TAG           = 0x12,
+  IIS2DULPX_MLC_RESULT_TAG             = 0x1A,
+  IIS2DULPX_MLC_FILTER_TAG             = 0x1B,
+  IIS2DULPX_MLC_FEATURE                = 0x1C,
+  IIS2DULPX_FSM_RESULT_TAG             = 0x1D,
+  IIS2DULPX_XL_ONLY_2X_TAG_2ND         = 0x1E,
+  IIS2DULPX_XL_AND_QVAR                = 0x1F,
+} iis2dulpx_fifo_sensor_tag_t;
+int32_t iis2dulpx_fifo_sensor_tag_get(const stmdev_ctx_t *ctx,
+                                      iis2dulpx_fifo_sensor_tag_t *val);
 
-int32_t st1vafe3bx_fifo_out_raw_get(const st1vafe3bx_ctx_t *ctx, uint8_t *buff);
+int32_t iis2dulpx_fifo_out_raw_get(const stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef struct
 {
@@ -2403,8 +2483,12 @@ typedef struct
   {
     float_t mv;
     int16_t raw;
-  } ah_bio;
-
+  } ah_qvar;
+  struct
+  {
+    float_t deg_c;
+    int16_t raw;
+  } heat;
   struct
   {
     uint32_t steps;
@@ -2416,179 +2500,175 @@ typedef struct
     uint8_t odr                        : 4; /* ODR */
     uint8_t bw                         : 2; /* BW */
     uint8_t lp_hp                      : 1; /* Power: 0 for LP, 1 for HP */
-    uint8_t ah_en                      : 1; /* AH is enabled */
+    uint8_t qvar_en                    : 1; /* QVAR is enabled */
     uint8_t fs                         : 2; /* FS */
     uint8_t dec_ts                     : 2; /* Timestamp decimator value */
     uint8_t odr_xl_batch               : 1; /* Accelerometer ODR is batched */
     uint32_t timestamp;
   } cfg_chg;
-} st1vafe3bx_fifo_data_t;
-int32_t st1vafe3bx_fifo_data_get(const st1vafe3bx_ctx_t *ctx,
-                                 const st1vafe3bx_md_t *md,
-                                 const st1vafe3bx_fifo_mode_t *fmd,
-                                 st1vafe3bx_fifo_data_t *data);
+} iis2dulpx_fifo_data_t;
+int32_t iis2dulpx_fifo_data_get(const stmdev_ctx_t *ctx, const iis2dulpx_md_t *md,
+                                const iis2dulpx_fifo_mode_t *fmd,
+                                iis2dulpx_fifo_data_t *data);
 
+typedef enum
+{
+  IIS2DULPX_NOTCH_50HZ       = 0x0,
+  IIS2DULPX_NOTCH_60HZ       = 0x1,
+} iis2dulpx_ah_qvar_notch_t;
+
+typedef enum
+{
+  IIS2DULPX_520MOhm          = 0x0,
+  IIS2DULPX_175MOhm          = 0x1,
+  IIS2DULPX_310MOhm          = 0x2,
+  IIS2DULPX_75MOhm           = 0x3,
+} iis2dulpx_ah_qvar_zin_t;
+
+typedef enum
+{
+  IIS2DULPX_GAIN_0_5         = 0x0,
+  IIS2DULPX_GAIN_1           = 0x1,
+  IIS2DULPX_GAIN_2           = 0x2,
+  IIS2DULPX_GAIN_4           = 0x3,
+} iis2dulpx_ah_qvar_gain_t;
 
 typedef struct
 {
-  uint8_t ah_bio_zin_dis_1                    : 1;
-  uint8_t ah_bio_zin_dis_2                    : 1;
-
-  enum
-  {
-    ST1VAFE3BX_DIFFERENTIAL_MODE            = 0x0,
-    ST1VAFE3BX_SINGLE_MODE_01               = 0x1,
-    ST1VAFE3BX_SINGLE_MODE_10               = 0x2,
-    ST1VAFE3BX_FORCED_RESET                 = 0x3,
-  } mode;
-
-  enum
-  {
-    ST1VAFE3BX_100MOhm                      = 0x0,
-    ST1VAFE3BX_200MOhm                      = 0x1,
-    ST1VAFE3BX_500MOhm                      = 0x2,
-    ST1VAFE3BX_1GOhm                        = 0x3,
-  } zin;
-
-  enum
-  {
-    ST1VAFE3BX_GAIN_2                       = 0x0,
-    ST1VAFE3BX_GAIN_4                       = 0x1,
-    ST1VAFE3BX_GAIN_8                       = 0x2,
-    ST1VAFE3BX_GAIN_16                      = 0x3,
-  } gain;
-} st1vafe3bx_ah_bio_config_t;
-int32_t st1vafe3bx_ah_bio_config_set(const st1vafe3bx_ctx_t *ctx,
-                                     st1vafe3bx_ah_bio_config_t val);
-int32_t st1vafe3bx_ah_bio_config_get(const st1vafe3bx_ctx_t *ctx,
-                                     st1vafe3bx_ah_bio_config_t *val);
-
-int32_t st1vafe3bx_enter_vafe_only(st1vafe3bx_ctx_t *ctx);
-int32_t st1vafe3bx_exit_vafe_only(st1vafe3bx_ctx_t *ctx);
-int32_t st1vafe3bx_ah_bio_active(const st1vafe3bx_ctx_t *ctx, uint8_t filter_on);
+  uint8_t ah_qvar_en                   : 1;
+  uint8_t ah_qvar_notch_en             : 1;
+  iis2dulpx_ah_qvar_notch_t ah_qvar_notch;
+  iis2dulpx_ah_qvar_zin_t ah_qvar_zin;
+  iis2dulpx_ah_qvar_gain_t ah_qvar_gain;
+} iis2dulpx_ah_qvar_mode_t;
+int32_t iis2dulpx_ah_qvar_mode_set(const stmdev_ctx_t *ctx,
+                                   iis2dulpx_ah_qvar_mode_t val);
+int32_t iis2dulpx_ah_qvar_mode_get(const stmdev_ctx_t *ctx,
+                                   iis2dulpx_ah_qvar_mode_t *val);
 
 typedef struct
 {
   uint8_t false_step_rej               : 1;
   uint8_t step_counter_enable          : 1;
   uint8_t step_counter_in_fifo         : 1;
-} st1vafe3bx_stpcnt_mode_t;
-int32_t st1vafe3bx_stpcnt_mode_set(const st1vafe3bx_ctx_t *ctx,
-                                   st1vafe3bx_stpcnt_mode_t val);
-int32_t st1vafe3bx_stpcnt_mode_get(const st1vafe3bx_ctx_t *ctx,
-                                   st1vafe3bx_stpcnt_mode_t *val);
+} iis2dulpx_stpcnt_mode_t;
+int32_t iis2dulpx_stpcnt_mode_set(const stmdev_ctx_t *ctx, iis2dulpx_stpcnt_mode_t val);
+int32_t iis2dulpx_stpcnt_mode_get(const stmdev_ctx_t *ctx, iis2dulpx_stpcnt_mode_t *val);
 
-int32_t st1vafe3bx_stpcnt_steps_get(const st1vafe3bx_ctx_t *ctx, uint16_t *val);
+int32_t iis2dulpx_stpcnt_steps_get(const stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t st1vafe3bx_stpcnt_rst_step_set(const st1vafe3bx_ctx_t *ctx);
+int32_t iis2dulpx_stpcnt_rst_step_set(const stmdev_ctx_t *ctx);
 
-int32_t st1vafe3bx_stpcnt_debounce_set(const st1vafe3bx_ctx_t *ctx, uint8_t val);
-int32_t st1vafe3bx_stpcnt_debounce_get(const st1vafe3bx_ctx_t *ctx, uint8_t *val);
+int32_t iis2dulpx_stpcnt_debounce_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dulpx_stpcnt_debounce_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t st1vafe3bx_stpcnt_period_set(const st1vafe3bx_ctx_t *ctx, uint16_t val);
-int32_t st1vafe3bx_stpcnt_period_get(const st1vafe3bx_ctx_t *ctx, uint16_t *val);
-
-int32_t st1vafe3bx_tilt_mode_set(const st1vafe3bx_ctx_t *ctx, uint8_t val);
-int32_t st1vafe3bx_tilt_mode_get(const st1vafe3bx_ctx_t *ctx, uint8_t *val);
-int32_t st1vafe3bx_sigmot_mode_set(const st1vafe3bx_ctx_t *ctx, uint8_t val);
-int32_t st1vafe3bx_sigmot_mode_get(const st1vafe3bx_ctx_t *ctx, uint8_t *val);
-
-
-int32_t st1vafe3bx_ff_duration_set(const st1vafe3bx_ctx_t *ctx, uint8_t val);
-int32_t st1vafe3bx_ff_duration_get(const st1vafe3bx_ctx_t *ctx, uint8_t *val);
-
-typedef enum
-{
-  ST1VAFE3BX_156_mg = 0x0,
-  ST1VAFE3BX_219_mg = 0x1,
-  ST1VAFE3BX_250_mg = 0x2,
-  ST1VAFE3BX_312_mg = 0x3,
-  ST1VAFE3BX_344_mg = 0x4,
-  ST1VAFE3BX_406_mg = 0x5,
-  ST1VAFE3BX_469_mg = 0x6,
-  ST1VAFE3BX_500_mg = 0x7,
-} st1vafe3bx_ff_thresholds_t;
-int32_t st1vafe3bx_ff_thresholds_set(const st1vafe3bx_ctx_t *ctx,
-                                     st1vafe3bx_ff_thresholds_t val);
-int32_t st1vafe3bx_ff_thresholds_get(const st1vafe3bx_ctx_t *ctx,
-                                     st1vafe3bx_ff_thresholds_t *val);
-
-typedef enum
-{
-  ST1VAFE3BX_DEG_80 = 0x0,
-  ST1VAFE3BX_DEG_70 = 0x1,
-  ST1VAFE3BX_DEG_60 = 0x2,
-  ST1VAFE3BX_DEG_50 = 0x3,
-} st1vafe3bx_threshold_t;
-
-typedef enum
-{
-  ST1VAFE3BX_6D = 0x0,
-  ST1VAFE3BX_4D = 0x1,
-} st1vafe3bx_mode_t;
+int32_t iis2dulpx_stpcnt_period_set(const stmdev_ctx_t *ctx, uint16_t val);
+int32_t iis2dulpx_stpcnt_period_get(const stmdev_ctx_t *ctx, uint16_t *val);
 
 typedef struct
 {
-  st1vafe3bx_threshold_t threshold;
-  st1vafe3bx_mode_t mode;
-} st1vafe3bx_sixd_config_t;
+  uint8_t enable                       : 1;
+  uint8_t window                       : 1;
+  uint8_t duration                     : 1;
+} iis2dulpx_smart_power_cfg_t;
+int32_t iis2dulpx_smart_power_set(const stmdev_ctx_t *ctx, iis2dulpx_smart_power_cfg_t val);
+int32_t iis2dulpx_smart_power_get(const stmdev_ctx_t *ctx, iis2dulpx_smart_power_cfg_t *val);
 
-int32_t st1vafe3bx_sixd_config_set(const st1vafe3bx_ctx_t *ctx,
-                                   st1vafe3bx_sixd_config_t val);
-int32_t st1vafe3bx_sixd_config_get(const st1vafe3bx_ctx_t *ctx,
-                                   st1vafe3bx_sixd_config_t *val);
+int32_t iis2dulpx_tilt_mode_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dulpx_tilt_mode_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t iis2dulpx_sigmot_mode_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dulpx_sigmot_mode_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum
-{
-  ST1VAFE3BX_0_ODR  = 0x000, /* 0 ODR time */
-  ST1VAFE3BX_1_ODR  = 0x001, /* 1 ODR time */
-  ST1VAFE3BX_2_ODR  = 0x002, /* 2 ODR time */
-  ST1VAFE3BX_3_ODR  = 0x100, /* 3 ODR time */
-  ST1VAFE3BX_7_ODR  = 0x101, /* 7 ODR time */
-  ST1VAFE3BX_11_ODR = 0x102, /* 11 ODR time */
-  ST1VAFE3BX_15_ODR = 0x103, /* 15 ODR time */
-} st1vafe3bx_wake_dur_t;
+
+int32_t iis2dulpx_ff_duration_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dulpx_ff_duration_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum
 {
-  ST1VAFE3BX_SLEEP_OFF = 0,
-  ST1VAFE3BX_SLEEP_ON  = 1,
-} st1vafe3bx_wake_enable_t;
+  IIS2DULPX_156_mg = 0x0,
+  IIS2DULPX_219_mg = 0x1,
+  IIS2DULPX_250_mg = 0x2,
+  IIS2DULPX_312_mg = 0x3,
+  IIS2DULPX_344_mg = 0x4,
+  IIS2DULPX_406_mg = 0x5,
+  IIS2DULPX_469_mg = 0x6,
+  IIS2DULPX_500_mg = 0x7,
+} iis2dulpx_ff_thresholds_t;
+int32_t iis2dulpx_ff_thresholds_set(const stmdev_ctx_t *ctx, iis2dulpx_ff_thresholds_t val);
+int32_t iis2dulpx_ff_thresholds_get(const stmdev_ctx_t *ctx, iis2dulpx_ff_thresholds_t *val);
 
 typedef enum
 {
-  ST1VAFE3BX_ODR_NO_CHANGE       = 0,  /* no odr change during inactivity state */
-  ST1VAFE3BX_ODR_1_6_HZ          = 1,  /* set odr to 1.6Hz during inactivity state */
-  ST1VAFE3BX_ODR_3_HZ            = 1,  /* set odr to 3Hz during inactivity state */
-  ST1VAFE3BX_ODR_25_HZ           = 1,  /* set odr to 25Hz during inactivity state */
-} st1vafe3bx_inact_odr_t;
+  IIS2DULPX_DEG_80 = 0x0,
+  IIS2DULPX_DEG_70 = 0x1,
+  IIS2DULPX_DEG_60 = 0x2,
+  IIS2DULPX_DEG_50 = 0x3,
+} iis2dulpx_threshold_t;
+
+typedef enum
+{
+  IIS2DULPX_6D = 0x0,
+  IIS2DULPX_4D = 0x1,
+} iis2dulpx_mode_t;
 
 typedef struct
 {
-  st1vafe3bx_wake_dur_t wake_dur;
+  iis2dulpx_threshold_t threshold;
+  iis2dulpx_mode_t mode;
+} iis2dulpx_sixd_config_t;
+
+int32_t iis2dulpx_sixd_config_set(const stmdev_ctx_t *ctx, iis2dulpx_sixd_config_t val);
+int32_t iis2dulpx_sixd_config_get(const stmdev_ctx_t *ctx, iis2dulpx_sixd_config_t *val);
+
+typedef enum
+{
+  IIS2DULPX_0_ODR  = 0x000, /* 0 ODR time */
+  IIS2DULPX_1_ODR  = 0x001, /* 1 ODR time */
+  IIS2DULPX_2_ODR  = 0x002, /* 2 ODR time */
+  IIS2DULPX_3_ODR  = 0x100, /* 3 ODR time */
+  IIS2DULPX_7_ODR  = 0x101, /* 7 ODR time */
+  IIS2DULPX_11_ODR = 0x102, /* 11 ODR time */
+  IIS2DULPX_15_ODR = 0x103, /* 15 ODR time */
+} iis2dulpx_wake_dur_t;
+
+typedef enum
+{
+  IIS2DULPX_SLEEP_OFF = 0,
+  IIS2DULPX_SLEEP_ON  = 1,
+} iis2dulpx_wake_enable_t;
+
+typedef enum
+{
+  IIS2DULPX_ODR_NO_CHANGE       = 0,  /* no odr change during inactivity state */
+  IIS2DULPX_ODR_1_6_HZ          = 1,  /* set odr to 1.6Hz during inactivity state */
+  IIS2DULPX_ODR_3_HZ            = 1,  /* set odr to 3Hz during inactivity state */
+  IIS2DULPX_ODR_25_HZ           = 1,  /* set odr to 25Hz during inactivity state */
+} iis2dulpx_inact_odr_t;
+
+typedef struct
+{
+  iis2dulpx_wake_dur_t wake_dur;
   uint8_t sleep_dur                    : 4;       /* 1 LSB == 512 ODR time */
   uint8_t wake_ths                     : 7;       /* wakeup threshold */
   uint8_t wake_ths_weight              : 1;       /* 0: 1LSB = FS_XL/2^6, 1: 1LSB = FS_XL/2^8 */
-  st1vafe3bx_wake_enable_t wake_enable;
-  st1vafe3bx_inact_odr_t inact_odr;
-} st1vafe3bx_wakeup_config_t;
+  iis2dulpx_wake_enable_t wake_enable;
+  iis2dulpx_inact_odr_t inact_odr;
+} iis2dulpx_wakeup_config_t;
 
-int32_t st1vafe3bx_wakeup_config_set(const st1vafe3bx_ctx_t *ctx,
-                                     st1vafe3bx_wakeup_config_t val);
-int32_t st1vafe3bx_wakeup_config_get(const st1vafe3bx_ctx_t *ctx,
-                                     st1vafe3bx_wakeup_config_t *val);
+int32_t iis2dulpx_wakeup_config_set(const stmdev_ctx_t *ctx, iis2dulpx_wakeup_config_t val);
+int32_t iis2dulpx_wakeup_config_get(const stmdev_ctx_t *ctx, iis2dulpx_wakeup_config_t *val);
 
 typedef enum
 {
-  ST1VAFE3BX_TAP_NONE  = 0x0, /* No axis */
-  ST1VAFE3BX_TAP_ON_X  = 0x1, /* Detect tap on X axis */
-  ST1VAFE3BX_TAP_ON_Y  = 0x2, /* Detect tap on Y axis */
-  ST1VAFE3BX_TAP_ON_Z  = 0x3, /* Detect tap on Z axis */
-} st1vafe3bx_axis_t;
+  IIS2DULPX_TAP_NONE  = 0x0, /* No axis */
+  IIS2DULPX_TAP_ON_X  = 0x1, /* Detect tap on X axis */
+  IIS2DULPX_TAP_ON_Y  = 0x2, /* Detect tap on Y axis */
+  IIS2DULPX_TAP_ON_Z  = 0x3, /* Detect tap on Z axis */
+} iis2dulpx_axis_t;
 
 typedef struct
 {
-  st1vafe3bx_axis_t axis;
+  iis2dulpx_axis_t axis;
   uint8_t inverted_peak_time           : 5; /* 1 LSB == 1 sample */
   uint8_t pre_still_ths                : 4; /* 1 LSB == 62.5 mg */
   uint8_t post_still_ths               : 4; /* 1 LSB == 62.5 mg */
@@ -2603,120 +2683,106 @@ typedef struct
   uint8_t single_tap_on                : 1; /* enable single tap */
   uint8_t double_tap_on                : 1; /* enable double tap */
   uint8_t triple_tap_on                : 1; /* enable triple tap */
-} st1vafe3bx_tap_config_t;
+} iis2dulpx_tap_config_t;
 
-int32_t st1vafe3bx_tap_config_set(const st1vafe3bx_ctx_t *ctx,
-                                  st1vafe3bx_tap_config_t val);
-int32_t st1vafe3bx_tap_config_get(const st1vafe3bx_ctx_t *ctx,
-                                  st1vafe3bx_tap_config_t *val);
+int32_t iis2dulpx_tap_config_set(const stmdev_ctx_t *ctx, iis2dulpx_tap_config_t val);
+int32_t iis2dulpx_tap_config_get(const stmdev_ctx_t *ctx, iis2dulpx_tap_config_t *val);
 
-int32_t st1vafe3bx_timestamp_set(const st1vafe3bx_ctx_t *ctx, uint8_t val);
-int32_t st1vafe3bx_timestamp_get(const st1vafe3bx_ctx_t *ctx, uint8_t *val);
+int32_t iis2dulpx_timestamp_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dulpx_timestamp_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t st1vafe3bx_timestamp_raw_get(const st1vafe3bx_ctx_t *ctx, uint32_t *val);
+int32_t iis2dulpx_timestamp_raw_get(const stmdev_ctx_t *ctx, uint32_t *val);
 
-int32_t st1vafe3bx_long_cnt_flag_data_ready_get(const st1vafe3bx_ctx_t *ctx,
-                                                uint8_t *val);
+int32_t iis2dulpx_long_cnt_flag_data_ready_get(const stmdev_ctx_t *ctx,
+                                               uint8_t *val);
 
-int32_t st1vafe3bx_emb_fsm_en_set(const st1vafe3bx_ctx_t *ctx, uint8_t val);
-int32_t st1vafe3bx_emb_fsm_en_get(const st1vafe3bx_ctx_t *ctx, uint8_t *val);
+int32_t iis2dulpx_emb_fsm_en_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dulpx_emb_fsm_en_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef struct
 {
-  st1vafe3bx_fsm_enable_t fsm_enable;
-} st1vafe3bx_emb_fsm_enable_t;
-int32_t st1vafe3bx_fsm_enable_set(const st1vafe3bx_ctx_t *ctx,
-                                  st1vafe3bx_emb_fsm_enable_t *val);
-int32_t st1vafe3bx_fsm_enable_get(const st1vafe3bx_ctx_t *ctx,
-                                  st1vafe3bx_emb_fsm_enable_t *val);
+  iis2dulpx_fsm_enable_t          fsm_enable;
+} iis2dulpx_emb_fsm_enable_t;
+int32_t iis2dulpx_fsm_enable_set(const stmdev_ctx_t *ctx,
+                                 iis2dulpx_emb_fsm_enable_t *val);
+int32_t iis2dulpx_fsm_enable_get(const stmdev_ctx_t *ctx,
+                                 iis2dulpx_emb_fsm_enable_t *val);
 
-int32_t st1vafe3bx_long_cnt_set(const st1vafe3bx_ctx_t *ctx, uint16_t val);
-int32_t st1vafe3bx_long_cnt_get(const st1vafe3bx_ctx_t *ctx, uint16_t *val);
+int32_t iis2dulpx_long_cnt_set(const stmdev_ctx_t *ctx, uint16_t val);
+int32_t iis2dulpx_long_cnt_get(const stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t st1vafe3bx_fsm_status_get(const st1vafe3bx_ctx_t *ctx,
-                                  st1vafe3bx_fsm_status_mainpage_t *val);
-int32_t st1vafe3bx_fsm_out_get(const st1vafe3bx_ctx_t *ctx, uint8_t *val);
+int32_t iis2dulpx_fsm_status_get(const stmdev_ctx_t *ctx,
+                                 iis2dulpx_fsm_status_mainpage_t *val);
+int32_t iis2dulpx_fsm_out_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum
 {
-  ST1VAFE3BX_ODR_FSM_12Hz5       = 0x00,
-  ST1VAFE3BX_ODR_FSM_25Hz        = 0x01,
-  ST1VAFE3BX_ODR_FSM_50Hz        = 0x02,
-  ST1VAFE3BX_ODR_FSM_100Hz       = 0x03,
-  ST1VAFE3BX_ODR_FSM_200Hz       = 0x04,
-  ST1VAFE3BX_ODR_FSM_400Hz       = 0x05,
-  ST1VAFE3BX_ODR_FSM_800Hz       = 0x06,
-  ST1VAFE3BX_ODR_FSM_VAFE_50Hz   = 0x10,
-  ST1VAFE3BX_ODR_FSM_VAFE_100Hz  = 0x11,
-  ST1VAFE3BX_ODR_FSM_VAFE_200Hz  = 0x12,
-  ST1VAFE3BX_ODR_FSM_VAFE_400Hz  = 0x13,
-  ST1VAFE3BX_ODR_FSM_VAFE_800Hz  = 0x14,
-  ST1VAFE3BX_ODR_FSM_VAFE_1600Hz = 0x15,
-} st1vafe3bx_fsm_val_odr_t;
-int32_t st1vafe3bx_fsm_data_rate_set(const st1vafe3bx_ctx_t *ctx,
-                                     st1vafe3bx_fsm_val_odr_t val);
-int32_t st1vafe3bx_fsm_data_rate_get(const st1vafe3bx_ctx_t *ctx,
-                                     st1vafe3bx_fsm_val_odr_t *val);
+  IIS2DULPX_ODR_FSM_12Hz5 = 0,
+  IIS2DULPX_ODR_FSM_25Hz  = 1,
+  IIS2DULPX_ODR_FSM_50Hz  = 2,
+  IIS2DULPX_ODR_FSM_100Hz = 3,
+  IIS2DULPX_ODR_FSM_200Hz = 4,
+  IIS2DULPX_ODR_FSM_400Hz = 5,
+  IIS2DULPX_ODR_FSM_800Hz = 6,
+} iis2dulpx_fsm_val_odr_t;
+int32_t iis2dulpx_fsm_data_rate_set(const stmdev_ctx_t *ctx,
+                                    iis2dulpx_fsm_val_odr_t val);
+int32_t iis2dulpx_fsm_data_rate_get(const stmdev_ctx_t *ctx,
+                                    iis2dulpx_fsm_val_odr_t *val);
 
-int32_t st1vafe3bx_fsm_init_set(const st1vafe3bx_ctx_t *ctx, uint8_t val);
-int32_t st1vafe3bx_fsm_init_get(const st1vafe3bx_ctx_t *ctx, uint8_t *val);
+int32_t iis2dulpx_fsm_init_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dulpx_fsm_init_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t st1vafe3bx_fsm_fifo_en_set(const st1vafe3bx_ctx_t *ctx, uint8_t val);
-int32_t st1vafe3bx_fsm_fifo_en_get(const st1vafe3bx_ctx_t *ctx, uint8_t *val);
+int32_t iis2dulpx_fsm_fifo_en_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dulpx_fsm_fifo_en_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t st1vafe3bx_long_cnt_int_value_set(const st1vafe3bx_ctx_t *ctx,
-                                          uint16_t val);
-int32_t st1vafe3bx_long_cnt_int_value_get(const st1vafe3bx_ctx_t *ctx,
-                                          uint16_t *val);
-
-int32_t st1vafe3bx_fsm_programs_num_set(const st1vafe3bx_ctx_t *ctx, uint8_t val);
-int32_t st1vafe3bx_fsm_programs_num_get(const st1vafe3bx_ctx_t *ctx, uint8_t *val);
-
-int32_t st1vafe3bx_fsm_start_address_set(const st1vafe3bx_ctx_t *ctx,
+int32_t iis2dulpx_long_cnt_int_value_set(const stmdev_ctx_t *ctx,
                                          uint16_t val);
-int32_t st1vafe3bx_fsm_start_address_get(const st1vafe3bx_ctx_t *ctx,
+int32_t iis2dulpx_long_cnt_int_value_get(const stmdev_ctx_t *ctx,
                                          uint16_t *val);
 
-typedef enum
-{
-  ST1VAFE3BX_MLC_OFF              = 0,
-  ST1VAFE3BX_MLC_ON               = 1,
-  ST1VAFE3BX_MLC_ON_BEFORE_FSM    = 2,
-} st1vafe3bx_mlc_mode_t;
-int32_t st1vafe3bx_mlc_set(const st1vafe3bx_ctx_t *ctx, st1vafe3bx_mlc_mode_t val);
-int32_t st1vafe3bx_mlc_get(const st1vafe3bx_ctx_t *ctx, st1vafe3bx_mlc_mode_t *val);
+int32_t iis2dulpx_fsm_programs_num_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dulpx_fsm_programs_num_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t st1vafe3bx_mlc_status_get(const st1vafe3bx_ctx_t *ctx,
-                                  st1vafe3bx_mlc_status_mainpage_t *val);
-
-int32_t st1vafe3bx_mlc_out_get(const st1vafe3bx_ctx_t *ctx, uint8_t *buff);
+int32_t iis2dulpx_fsm_start_address_set(const stmdev_ctx_t *ctx,
+                                        uint16_t val);
+int32_t iis2dulpx_fsm_start_address_get(const stmdev_ctx_t *ctx,
+                                        uint16_t *val);
 
 typedef enum
 {
-  ST1VAFE3BX_ODR_PRGS_12Hz5       = 0x00,
-  ST1VAFE3BX_ODR_PRGS_25Hz        = 0x01,
-  ST1VAFE3BX_ODR_PRGS_50Hz        = 0x02,
-  ST1VAFE3BX_ODR_PRGS_100Hz       = 0x03,
-  ST1VAFE3BX_ODR_PRGS_200Hz       = 0x04,
-  ST1VAFE3BX_ODR_PRGS_VAFE_50Hz   = 0x10,
-  ST1VAFE3BX_ODR_PRGS_VAFE_100Hz  = 0x11,
-  ST1VAFE3BX_ODR_PRGS_VAFE_200Hz  = 0x12,
-  ST1VAFE3BX_ODR_PRGS_VAFE_400Hz  = 0x13,
-  ST1VAFE3BX_ODR_PRGS_VAFE_800Hz  = 0x14,
-  ST1VAFE3BX_ODR_PRGS_VAFE_1600Hz = 0x15,
-} st1vafe3bx_mlc_odr_val_t;
-int32_t st1vafe3bx_mlc_data_rate_set(const st1vafe3bx_ctx_t *ctx,
-                                     st1vafe3bx_mlc_odr_val_t val);
-int32_t st1vafe3bx_mlc_data_rate_get(const st1vafe3bx_ctx_t *ctx,
-                                     st1vafe3bx_mlc_odr_val_t *val);
+  IIS2DULPX_MLC_OFF                    = 0,
+  IIS2DULPX_MLC_ON                     = 1,
+  IIS2DULPX_MLC_ON_BEFORE_FSM          = 2,
+} iis2dulpx_mlc_mode_t;
+int32_t iis2dulpx_mlc_set(const stmdev_ctx_t *ctx, iis2dulpx_mlc_mode_t val);
+int32_t iis2dulpx_mlc_get(const stmdev_ctx_t *ctx, iis2dulpx_mlc_mode_t *val);
 
-int32_t st1vafe3bx_mlc_fifo_en_set(const st1vafe3bx_ctx_t *ctx, uint8_t val);
-int32_t st1vafe3bx_mlc_fifo_en_get(const st1vafe3bx_ctx_t *ctx, uint8_t *val);
+int32_t iis2dulpx_mlc_status_get(const stmdev_ctx_t *ctx,
+                                 iis2dulpx_mlc_status_mainpage_t *val);
+
+int32_t iis2dulpx_mlc_out_get(const stmdev_ctx_t *ctx, uint8_t *buff);
+
+typedef enum
+{
+  IIS2DULPX_ODR_PRGS_12Hz5 = 0,
+  IIS2DULPX_ODR_PRGS_25Hz  = 1,
+  IIS2DULPX_ODR_PRGS_50Hz  = 2,
+  IIS2DULPX_ODR_PRGS_100Hz = 3,
+  IIS2DULPX_ODR_PRGS_200Hz = 4,
+} iis2dulpx_mlc_odr_val_t;
+int32_t iis2dulpx_mlc_data_rate_set(const stmdev_ctx_t *ctx,
+                                    iis2dulpx_mlc_odr_val_t val);
+int32_t iis2dulpx_mlc_data_rate_get(const stmdev_ctx_t *ctx,
+                                    iis2dulpx_mlc_odr_val_t *val);
+
+int32_t iis2dulpx_mlc_fifo_en_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dulpx_mlc_fifo_en_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* ST1VAFE3BX_REGS_H */
+#endif /* IIS2DULPX_REGS_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/iis2mdc_STdC/driver/iis2mdc_reg.c
+++ b/sensor/stmemsc/iis2mdc_STdC/driver/iis2mdc_reg.c
@@ -51,7 +51,10 @@ int32_t __weak iis2mdc_read_reg(const stmdev_ctx_t *ctx, uint8_t reg,
 {
   int32_t ret;
 
-  if (ctx == NULL) return -1;
+  if (ctx == NULL)
+  {
+    return -1;
+  }
 
   ret = ctx->read_reg(ctx->handle, reg, data, len);
 
@@ -69,12 +72,15 @@ int32_t __weak iis2mdc_read_reg(const stmdev_ctx_t *ctx, uint8_t reg,
   *
   */
 int32_t __weak iis2mdc_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
-                                 uint8_t *data,
+                                 const uint8_t *data,
                                  uint16_t len)
 {
   int32_t ret;
 
-  if (ctx == NULL) return -1;
+  if (ctx == NULL)
+  {
+    return -1;
+  }
 
   ret = ctx->write_reg(ctx->handle, reg, data, len);
 
@@ -538,8 +544,7 @@ int32_t iis2mdc_set_rst_mode_get(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_set_rst_sensor_single_set(const stmdev_ctx_t *ctx,
-                                          uint8_t val)
+int32_t iis2mdc_off_canc_en_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2mdc_cfg_reg_b_t reg;
   int32_t ret;
@@ -567,8 +572,7 @@ int32_t iis2mdc_set_rst_sensor_single_set(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_set_rst_sensor_single_get(const stmdev_ctx_t *ctx,
-                                          uint8_t *val)
+int32_t iis2mdc_off_canc_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2mdc_cfg_reg_b_t reg;
   int32_t ret;

--- a/sensor/stmemsc/iis2mdc_STdC/driver/iis2mdc_reg.h
+++ b/sensor/stmemsc/iis2mdc_STdC/driver/iis2mdc_reg.h
@@ -131,33 +131,6 @@ typedef struct
 
 #endif /* MEMS_SHARED_TYPES */
 
-#ifndef MEMS_UCF_SHARED_TYPES
-#define MEMS_UCF_SHARED_TYPES
-
-/** @defgroup    Generic address-data structure definition
-  * @brief       This structure is useful to load a predefined configuration
-  *              of a sensor.
-  *              You can create a sensor configuration by your own or using
-  *              Unico / Unicleo tools available on STMicroelectronics
-  *              web site.
-  *
-  * @{
-  *
-  */
-
-typedef struct
-{
-  uint8_t address;
-  uint8_t data;
-} ucf_line_t;
-
-/**
-  * @}
-  *
-  */
-
-#endif /* MEMS_UCF_SHARED_TYPES */
-
 /**
   * @}
   *
@@ -330,18 +303,6 @@ typedef struct
 #define IIS2MDC_TEMP_OUT_L_REG          0x6EU
 #define IIS2MDC_TEMP_OUT_H_REG          0x6FU
 
-typedef union
-{
-  iis2mdc_cfg_reg_a_t            cfg_reg_a;
-  iis2mdc_cfg_reg_b_t            cfg_reg_b;
-  iis2mdc_cfg_reg_c_t            cfg_reg_c;
-  iis2mdc_int_crtl_reg_t         int_crtl_reg;
-  iis2mdc_int_source_reg_t       int_source_reg;
-  iis2mdc_status_reg_t           status_reg;
-  bitwise_t                      bitwise;
-  uint8_t                        byte;
-} iis2mdc_reg_t;
-
 #ifndef __weak
 #define __weak __attribute__((weak))
 #endif /* __weak */
@@ -358,7 +319,7 @@ int32_t iis2mdc_read_reg(const stmdev_ctx_t *ctx, uint8_t reg,
                          uint8_t *data,
                          uint16_t len);
 int32_t iis2mdc_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
-                          uint8_t *data,
+                          const uint8_t *data,
                           uint16_t len);
 
 float_t iis2mdc_from_lsb_to_mgauss(int16_t lsb);
@@ -419,10 +380,8 @@ int32_t iis2mdc_set_rst_mode_set(const stmdev_ctx_t *ctx,
 int32_t iis2mdc_set_rst_mode_get(const stmdev_ctx_t *ctx,
                                  iis2mdc_set_rst_t *val);
 
-int32_t iis2mdc_set_rst_sensor_single_set(const stmdev_ctx_t *ctx,
-                                          uint8_t val);
-int32_t iis2mdc_set_rst_sensor_single_get(const stmdev_ctx_t *ctx,
-                                          uint8_t *val);
+int32_t iis2mdc_off_canc_en_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2mdc_off_canc_en_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 int32_t iis2mdc_block_data_update_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t iis2mdc_block_data_update_get(const stmdev_ctx_t *ctx,

--- a/sensor/stmemsc/ism330bx_STdC/driver/ism330bx_reg.h
+++ b/sensor/stmemsc/ism330bx_STdC/driver/ism330bx_reg.h
@@ -3181,9 +3181,9 @@ int32_t ism330bx_tap_detection_get(const stmdev_ctx_t *ctx,
 
 typedef struct
 {
-  uint8_t x                             : 1;
-  uint8_t y                             : 1;
-  uint8_t z                             : 1;
+  uint8_t x                             : 5;
+  uint8_t y                             : 5;
+  uint8_t z                             : 5;
 } ism330bx_tap_thresholds_t;
 int32_t ism330bx_tap_thresholds_set(const stmdev_ctx_t *ctx,
                                     ism330bx_tap_thresholds_t val);
@@ -3207,9 +3207,9 @@ int32_t ism330bx_tap_axis_priority_get(const stmdev_ctx_t *ctx,
 
 typedef struct
 {
-  uint8_t shock                         : 1;
-  uint8_t quiet                         : 1;
-  uint8_t tap_gap                       : 1;
+  uint8_t shock                         : 2;
+  uint8_t quiet                         : 2;
+  uint8_t tap_gap                       : 4;
 } ism330bx_tap_time_windows_t;
 int32_t ism330bx_tap_time_windows_set(const stmdev_ctx_t *ctx,
                                       ism330bx_tap_time_windows_t val);

--- a/sensor/stmemsc/ism330dhcx_STdC/driver/ism330dhcx_reg.c
+++ b/sensor/stmemsc/ism330dhcx_STdC/driver/ism330dhcx_reg.c
@@ -73,7 +73,7 @@ int32_t __weak ism330dhcx_read_reg(const stmdev_ctx_t *ctx, uint8_t reg,
   *
   */
 int32_t __weak ism330dhcx_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
-                                    uint8_t *data,
+                                    const uint8_t *data,
                                     uint16_t len)
 {
   int32_t ret;
@@ -86,6 +86,26 @@ int32_t __weak ism330dhcx_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
   ret = ctx->write_reg(ctx->handle, reg, data, len);
 
   return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DU12_Private_functions
+  * @brief     Section collect all the utility functions needed by APIs.
+  * @{
+  *
+  */
+
+static void bytecpy(uint8_t *target, uint8_t *source)
+{
+  if ((target != NULL) && (source != NULL))
+  {
+    *target = *source;
+  }
 }
 
 /**
@@ -2783,8 +2803,7 @@ int32_t ism330dhcx_gy_filter_lp1_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_filter_settling_mask_set(const stmdev_ctx_t *ctx,
-                                            uint8_t val)
+int32_t ism330dhcx_drdy_mask_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -2811,8 +2830,7 @@ int32_t ism330dhcx_filter_settling_mask_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_filter_settling_mask_get(const stmdev_ctx_t *ctx,
-                                            uint8_t *val)
+int32_t ism330dhcx_drdy_mask_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -3169,8 +3187,8 @@ int32_t ism330dhcx_xl_fast_settling_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_xl_hp_path_internal_set(const stmdev_ctx_t *ctx,
-                                           ism330dhcx_slope_fds_t val)
+int32_t ism330dhcx_xl_hp_slope_filter_set(const stmdev_ctx_t *ctx,
+                                          ism330dhcx_slope_fds_t val)
 {
   ism330dhcx_tap_cfg0_t tap_cfg0;
   int32_t ret;
@@ -3197,8 +3215,8 @@ int32_t ism330dhcx_xl_hp_path_internal_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_xl_hp_path_internal_get(const stmdev_ctx_t *ctx,
-                                           ism330dhcx_slope_fds_t *val)
+int32_t ism330dhcx_xl_hp_slope_filter_get(const stmdev_ctx_t *ctx,
+                                          ism330dhcx_slope_fds_t *val)
 {
   ism330dhcx_tap_cfg0_t tap_cfg0;
   int32_t ret;
@@ -3233,8 +3251,8 @@ int32_t ism330dhcx_xl_hp_path_internal_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_gy_hp_path_internal_set(const stmdev_ctx_t *ctx,
-                                           ism330dhcx_hpm_g_t val)
+int32_t ism330dhcx_gy_hp_filter_set(const stmdev_ctx_t *ctx,
+                                    ism330dhcx_hpm_g_t val)
 {
   ism330dhcx_ctrl7_g_t ctrl7_g;
   int32_t ret;
@@ -3262,8 +3280,8 @@ int32_t ism330dhcx_gy_hp_path_internal_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_gy_hp_path_internal_get(const stmdev_ctx_t *ctx,
-                                           ism330dhcx_hpm_g_t *val)
+int32_t ism330dhcx_gy_hp_filter_get(const stmdev_ctx_t *ctx,
+                                    ism330dhcx_hpm_g_t *val)
 {
   ism330dhcx_ctrl7_g_t ctrl7_g;
   int32_t ret;
@@ -4013,8 +4031,8 @@ int32_t ism330dhcx_aux_spi_mode_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_aux_gy_lp1_bandwidth_set(const stmdev_ctx_t *ctx,
-                                            ism330dhcx_ftype_ois_t val)
+int32_t ism330dhcx_aux_gy_lp1_filter_set(const stmdev_ctx_t *ctx,
+                                         ism330dhcx_ftype_ois_t val)
 {
   ism330dhcx_ctrl2_ois_t ctrl2_ois;
   int32_t ret;
@@ -4040,8 +4058,8 @@ int32_t ism330dhcx_aux_gy_lp1_bandwidth_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_aux_gy_lp1_bandwidth_get(const stmdev_ctx_t *ctx,
-                                            ism330dhcx_ftype_ois_t *val)
+int32_t ism330dhcx_aux_gy_lp1_filter_get(const stmdev_ctx_t *ctx,
+                                         ism330dhcx_ftype_ois_t *val)
 {
   ism330dhcx_ctrl2_ois_t ctrl2_ois;
   int32_t ret;
@@ -4083,8 +4101,8 @@ int32_t ism330dhcx_aux_gy_lp1_bandwidth_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_aux_gy_hp_bandwidth_set(const stmdev_ctx_t *ctx,
-                                           ism330dhcx_hpm_ois_t val)
+int32_t ism330dhcx_aux_gy_hp_filter_set(const stmdev_ctx_t *ctx,
+                                        ism330dhcx_hpm_ois_t val)
 {
   ism330dhcx_ctrl2_ois_t ctrl2_ois;
   int32_t ret;
@@ -4111,8 +4129,8 @@ int32_t ism330dhcx_aux_gy_hp_bandwidth_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_aux_gy_hp_bandwidth_get(const stmdev_ctx_t *ctx,
-                                           ism330dhcx_hpm_ois_t *val)
+int32_t ism330dhcx_aux_gy_hp_filter_get(const stmdev_ctx_t *ctx,
+                                        ism330dhcx_hpm_ois_t *val)
 {
   ism330dhcx_ctrl2_ois_t ctrl2_ois;
   int32_t ret;
@@ -5452,8 +5470,7 @@ int32_t ism330dhcx_wkup_threshold_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_xl_usr_offset_on_wkup_set(const stmdev_ctx_t *ctx,
-                                             uint8_t val)
+int32_t ism330dhcx_xl_usr_off_on_wu_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_wake_up_ths_t wake_up_ths;
   int32_t ret;
@@ -5479,8 +5496,7 @@ int32_t ism330dhcx_xl_usr_offset_on_wkup_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_xl_usr_offset_on_wkup_get(const stmdev_ctx_t *ctx,
-                                             uint8_t *val)
+int32_t ism330dhcx_xl_usr_off_on_wu_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_wake_up_ths_t wake_up_ths;
   int32_t ret;
@@ -5607,8 +5623,8 @@ int32_t ism330dhcx_gy_sleep_mode_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_act_pin_notification_set(const stmdev_ctx_t *ctx,
-                                            ism330dhcx_sleep_status_on_int_t val)
+int32_t ism330dhcx_slp_status_route_set(const stmdev_ctx_t *ctx,
+                                        ism330dhcx_sleep_status_on_int_t val)
 {
   ism330dhcx_tap_cfg0_t tap_cfg0;
   int32_t ret;
@@ -5636,8 +5652,8 @@ int32_t ism330dhcx_act_pin_notification_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_act_pin_notification_get(const stmdev_ctx_t *ctx,
-                                            ism330dhcx_sleep_status_on_int_t *val)
+int32_t ism330dhcx_slp_status_route_get(const stmdev_ctx_t *ctx,
+                                        ism330dhcx_sleep_status_on_int_t *val)
 {
   ism330dhcx_tap_cfg0_t tap_cfg0;
   int32_t ret;
@@ -5800,8 +5816,7 @@ int32_t ism330dhcx_act_sleep_dur_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_tap_detection_on_z_set(const stmdev_ctx_t *ctx,
-                                          uint8_t val)
+int32_t ism330dhcx_tap_detect_on_z_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_tap_cfg0_t tap_cfg0;
   int32_t ret;
@@ -5827,8 +5842,7 @@ int32_t ism330dhcx_tap_detection_on_z_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_tap_detection_on_z_get(const stmdev_ctx_t *ctx,
-                                          uint8_t *val)
+int32_t ism330dhcx_tap_detect_on_z_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_tap_cfg0_t tap_cfg0;
   int32_t ret;
@@ -5848,8 +5862,7 @@ int32_t ism330dhcx_tap_detection_on_z_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_tap_detection_on_y_set(const stmdev_ctx_t *ctx,
-                                          uint8_t val)
+int32_t ism330dhcx_tap_detect_on_y_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_tap_cfg0_t tap_cfg0;
   int32_t ret;
@@ -5875,8 +5888,7 @@ int32_t ism330dhcx_tap_detection_on_y_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_tap_detection_on_y_get(const stmdev_ctx_t *ctx,
-                                          uint8_t *val)
+int32_t ism330dhcx_tap_detect_on_y_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_tap_cfg0_t tap_cfg0;
   int32_t ret;
@@ -5896,8 +5908,7 @@ int32_t ism330dhcx_tap_detection_on_y_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_tap_detection_on_x_set(const stmdev_ctx_t *ctx,
-                                          uint8_t val)
+int32_t ism330dhcx_tap_detect_on_x_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_tap_cfg0_t tap_cfg0;
   int32_t ret;
@@ -5923,8 +5934,7 @@ int32_t ism330dhcx_tap_detection_on_x_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_tap_detection_on_x_get(const stmdev_ctx_t *ctx,
-                                          uint8_t *val)
+int32_t ism330dhcx_tap_detect_on_x_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_tap_cfg0_t tap_cfg0;
   int32_t ret;
@@ -6751,8 +6761,7 @@ int32_t ism330dhcx_fifo_watermark_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_compression_algo_init_set(const stmdev_ctx_t *ctx,
-                                             uint8_t val)
+int32_t ism330dhcx_fifo_compr_init_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_emb_func_init_b_t emb_func_init_b;
   int32_t ret;
@@ -6789,8 +6798,7 @@ int32_t ism330dhcx_compression_algo_init_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_compression_algo_init_get(const stmdev_ctx_t *ctx,
-                                             uint8_t *val)
+int32_t ism330dhcx_fifo_compr_init_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_emb_func_init_b_t emb_func_init_b;
   int32_t ret;
@@ -6924,8 +6932,7 @@ int32_t ism330dhcx_compression_algo_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_fifo_virtual_sens_odr_chg_set(const stmdev_ctx_t *ctx,
-                                                 uint8_t val)
+int32_t ism330dhcx_fifo_odr_chg_batch_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
@@ -6951,8 +6958,7 @@ int32_t ism330dhcx_fifo_virtual_sens_odr_chg_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_fifo_virtual_sens_odr_chg_get(const stmdev_ctx_t *ctx,
-                                                 uint8_t *val)
+int32_t ism330dhcx_fifo_odr_chg_batch_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
@@ -6972,8 +6978,7 @@ int32_t ism330dhcx_fifo_virtual_sens_odr_chg_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_compression_algo_real_time_set(const stmdev_ctx_t *ctx,
-                                                  uint8_t val)
+int32_t ism330dhcx_fifo_compr_rt_en_set(const stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dhcx_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
@@ -6999,8 +7004,7 @@ int32_t ism330dhcx_compression_algo_real_time_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_compression_algo_real_time_get(const stmdev_ctx_t *ctx,
-                                                  uint8_t *val)
+int32_t ism330dhcx_fifo_compr_rt_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dhcx_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
@@ -7430,8 +7434,8 @@ int32_t ism330dhcx_fifo_temp_batch_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_fifo_timestamp_decimation_set(const stmdev_ctx_t *ctx,
-                                                 ism330dhcx_odr_ts_batch_t val)
+int32_t ism330dhcx_fifo_ts_dec_set(const stmdev_ctx_t *ctx,
+                                   ism330dhcx_odr_ts_batch_t val)
 {
   ism330dhcx_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
@@ -7460,8 +7464,8 @@ int32_t ism330dhcx_fifo_timestamp_decimation_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_fifo_timestamp_decimation_get(const stmdev_ctx_t *ctx,
-                                                 ism330dhcx_odr_ts_batch_t *val)
+int32_t ism330dhcx_fifo_ts_dec_get(const stmdev_ctx_t *ctx,
+                                   ism330dhcx_odr_ts_batch_t *val)
 {
   ism330dhcx_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
@@ -7505,8 +7509,8 @@ int32_t ism330dhcx_fifo_timestamp_decimation_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_fifo_cnt_event_batch_set(const stmdev_ctx_t *ctx,
-                                            ism330dhcx_trig_counter_bdr_t val)
+int32_t ism330dhcx_fifo_trig_cnt_bdr_set(const stmdev_ctx_t *ctx,
+                                         ism330dhcx_trig_counter_bdr_t val)
 {
   ism330dhcx_counter_bdr_reg1_t counter_bdr_reg1;
   int32_t ret;
@@ -7534,8 +7538,8 @@ int32_t ism330dhcx_fifo_cnt_event_batch_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_fifo_cnt_event_batch_get(const stmdev_ctx_t *ctx,
-                                            ism330dhcx_trig_counter_bdr_t *val)
+int32_t ism330dhcx_fifo_trig_cnt_bdr_get(const stmdev_ctx_t *ctx,
+                                         ism330dhcx_trig_counter_bdr_t *val)
 {
   ism330dhcx_counter_bdr_reg1_t counter_bdr_reg1;
   int32_t ret;
@@ -7620,8 +7624,7 @@ int32_t ism330dhcx_rst_batch_counter_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_batch_counter_threshold_set(const stmdev_ctx_t *ctx,
-                                               uint16_t val)
+int32_t ism330dhcx_batch_counter_th_set(const stmdev_ctx_t *ctx, uint16_t val)
 {
   ism330dhcx_counter_bdr_reg2_t counter_bdr_reg1;
   ism330dhcx_counter_bdr_reg2_t counter_bdr_reg2;
@@ -7657,8 +7660,7 @@ int32_t ism330dhcx_batch_counter_threshold_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_batch_counter_threshold_get(const stmdev_ctx_t *ctx,
-                                               uint16_t *val)
+int32_t ism330dhcx_batch_counter_th_get(const stmdev_ctx_t *ctx, uint16_t *val)
 {
   ism330dhcx_counter_bdr_reg1_t counter_bdr_reg1;
   ism330dhcx_counter_bdr_reg2_t counter_bdr_reg2;
@@ -7691,16 +7693,18 @@ int32_t ism330dhcx_fifo_data_level_get(const stmdev_ctx_t *ctx,
                                        uint16_t *val)
 {
   uint8_t reg[2];
-  ism330dhcx_fifo_status1_t *fifo_status1 = (ism330dhcx_fifo_status1_t *)&reg[0];
-  ism330dhcx_fifo_status2_t *fifo_status2 = (ism330dhcx_fifo_status2_t *)&reg[1];
+  ism330dhcx_fifo_status1_t fifo_status1;
+  ism330dhcx_fifo_status2_t fifo_status2;
   int32_t ret;
 
   /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_STATUS1, (uint8_t *)reg, 2);
   if (ret == 0)
   {
-    *val = fifo_status2->diff_fifo;
-    *val = (*val * 256U) + fifo_status1->diff_fifo;
+    bytecpy((uint8_t *)&fifo_status1, &reg[0]);
+    bytecpy((uint8_t *)&fifo_status2, &reg[1]);
+    *val = fifo_status2.diff_fifo;
+    *val = (*val * 256U) + fifo_status1.diff_fifo;
   }
 
   return ret;
@@ -7718,14 +7722,15 @@ int32_t ism330dhcx_fifo_status_get(const stmdev_ctx_t *ctx,
                                    ism330dhcx_fifo_status2_t *val)
 {
   uint8_t reg[2];
-  ism330dhcx_fifo_status2_t *fifo_status2 = (ism330dhcx_fifo_status2_t *)&reg[1];
+  ism330dhcx_fifo_status2_t fifo_status2;
   int32_t ret;
 
   /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_STATUS1, (uint8_t *)reg, 2);
   if (ret == 0)
   {
-    *val = *fifo_status2;
+    bytecpy((uint8_t *)&fifo_status2, &reg[1]);
+    *val = fifo_status2;
   }
 
   return ret;
@@ -7742,14 +7747,15 @@ int32_t ism330dhcx_fifo_status_get(const stmdev_ctx_t *ctx,
 int32_t ism330dhcx_fifo_full_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   uint8_t reg[2];
-  ism330dhcx_fifo_status2_t *fifo_status2 = (ism330dhcx_fifo_status2_t *)&reg[1];
+  ism330dhcx_fifo_status2_t fifo_status2;
   int32_t ret;
 
   /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_STATUS1, (uint8_t *)reg, 2);
   if (ret == 0)
   {
-    *val = fifo_status2->fifo_full_ia;
+    bytecpy((uint8_t *)&fifo_status2, &reg[1]);
+    *val = fifo_status2.fifo_full_ia;
   }
 
   return ret;
@@ -7767,14 +7773,15 @@ int32_t ism330dhcx_fifo_full_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 int32_t ism330dhcx_fifo_ovr_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   uint8_t reg[2];
-  ism330dhcx_fifo_status2_t *fifo_status2 = (ism330dhcx_fifo_status2_t *)&reg[1];
+  ism330dhcx_fifo_status2_t fifo_status2;
   int32_t ret;
 
   /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_STATUS1, (uint8_t *)reg, 2);
   if (ret == 0)
   {
-    *val = fifo_status2->fifo_ovr_ia;
+    bytecpy((uint8_t *)&fifo_status2, &reg[1]);
+    *val = fifo_status2.fifo_ovr_ia;
   }
 
   return ret;
@@ -7791,14 +7798,15 @@ int32_t ism330dhcx_fifo_ovr_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 int32_t ism330dhcx_fifo_wtm_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
 {
   uint8_t reg[2];
-  ism330dhcx_fifo_status2_t *fifo_status2 = (ism330dhcx_fifo_status2_t *)&reg[1];
+  ism330dhcx_fifo_status2_t fifo_status2;
   int32_t ret;
 
   /* read both FIFO_STATUS1 + FIFO_STATUS2 regs */
   ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_STATUS1, (uint8_t *)reg, 2);
   if (ret == 0)
   {
-    *val = fifo_status2->fifo_wtm_ia;
+    bytecpy((uint8_t *)&fifo_status2, &reg[1]);
+    *val = fifo_status2.fifo_wtm_ia;
   }
 
   return ret;
@@ -8740,8 +8748,7 @@ int32_t ism330dhcx_pedo_step_detect_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_pedo_debounce_steps_set(const stmdev_ctx_t *ctx,
-                                           uint8_t *buff)
+int32_t ism330dhcx_pedo_deb_steps_set(const stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -8759,8 +8766,7 @@ int32_t ism330dhcx_pedo_debounce_steps_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_pedo_debounce_steps_get(const stmdev_ctx_t *ctx,
-                                           uint8_t *buff)
+int32_t ism330dhcx_pedo_deb_steps_get(const stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -10341,8 +10347,7 @@ int32_t ism330dhcx_fsm_init_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_long_cnt_int_value_set(const stmdev_ctx_t *ctx,
-                                          uint16_t val)
+int32_t ism330dhcx_fsm_lc_int_value_set(const stmdev_ctx_t *ctx, uint16_t val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -10372,8 +10377,7 @@ int32_t ism330dhcx_long_cnt_int_value_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_long_cnt_int_value_get(const stmdev_ctx_t *ctx,
-                                          uint16_t *val)
+int32_t ism330dhcx_fsm_lc_int_value_get(const stmdev_ctx_t *ctx, uint16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -10400,8 +10404,7 @@ int32_t ism330dhcx_long_cnt_int_value_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_fsm_number_of_programs_set(const stmdev_ctx_t *ctx,
-                                              uint8_t *buff)
+int32_t ism330dhcx_fsm_programs_num_set(const stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -10425,8 +10428,7 @@ int32_t ism330dhcx_fsm_number_of_programs_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dhcx_fsm_number_of_programs_get(const stmdev_ctx_t *ctx,
-                                              uint8_t *buff)
+int32_t ism330dhcx_fsm_programs_num_get(const stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 

--- a/sensor/stmemsc/ism330dhcx_STdC/driver/ism330dhcx_reg.h
+++ b/sensor/stmemsc/ism330dhcx_STdC/driver/ism330dhcx_reg.h
@@ -131,33 +131,6 @@ typedef struct
 
 #endif /* MEMS_SHARED_TYPES */
 
-#ifndef MEMS_UCF_SHARED_TYPES
-#define MEMS_UCF_SHARED_TYPES
-
-/** @defgroup    Generic address-data structure definition
-  * @brief       This structure is useful to load a predefined configuration
-  *              of a sensor.
-  *              You can create a sensor configuration by your own or using
-  *              Unico / Unicleo tools available on STMicroelectronics
-  *              web site.
-  *
-  * @{
-  *
-  */
-
-typedef struct
-{
-  uint8_t address;
-  uint8_t data;
-} ucf_line_t;
-
-/**
-  * @}
-  *
-  */
-
-#endif /* MEMS_UCF_SHARED_TYPES */
-
 /**
   * @}
   *
@@ -2694,152 +2667,6 @@ typedef struct
   *
   */
 
-/**
-  * @defgroup ISM330DHCX_Register_Union
-  * @brief    This union group all the registers having a bit-field
-  *           description.
-  *           This union is useful but it's not needed by the driver.
-  *
-  *           REMOVING this union you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-typedef union
-{
-  ism330dhcx_func_cfg_access_t               func_cfg_access;
-  ism330dhcx_pin_ctrl_t                      pin_ctrl;
-  ism330dhcx_fifo_ctrl1_t                    fifo_ctrl1;
-  ism330dhcx_fifo_ctrl2_t                    fifo_ctrl2;
-  ism330dhcx_fifo_ctrl3_t                    fifo_ctrl3;
-  ism330dhcx_fifo_ctrl4_t                    fifo_ctrl4;
-  ism330dhcx_counter_bdr_reg1_t              counter_bdr_reg1;
-  ism330dhcx_counter_bdr_reg2_t              counter_bdr_reg2;
-  ism330dhcx_int1_ctrl_t                     int1_ctrl;
-  ism330dhcx_int2_ctrl_t                     int2_ctrl;
-  ism330dhcx_ctrl1_xl_t                      ctrl1_xl;
-  ism330dhcx_ctrl2_g_t                       ctrl2_g;
-  ism330dhcx_ctrl3_c_t                       ctrl3_c;
-  ism330dhcx_ctrl4_c_t                       ctrl4_c;
-  ism330dhcx_ctrl5_c_t                       ctrl5_c;
-  ism330dhcx_ctrl6_c_t                       ctrl6_c;
-  ism330dhcx_ctrl7_g_t                       ctrl7_g;
-  ism330dhcx_ctrl8_xl_t                      ctrl8_xl;
-  ism330dhcx_ctrl9_xl_t                      ctrl9_xl;
-  ism330dhcx_ctrl10_c_t                      ctrl10_c;
-  ism330dhcx_all_int_src_t                   all_int_src;
-  ism330dhcx_wake_up_src_t                   wake_up_src;
-  ism330dhcx_tap_src_t                       tap_src;
-  ism330dhcx_d6d_src_t                       d6d_src;
-  ism330dhcx_status_reg_t                    status_reg;
-  ism330dhcx_status_spiaux_t                 status_spiaux;
-  ism330dhcx_fifo_status1_t                  fifo_status1;
-  ism330dhcx_fifo_status2_t                  fifo_status2;
-  ism330dhcx_tap_cfg0_t                      tap_cfg0;
-  ism330dhcx_tap_cfg1_t                      tap_cfg1;
-  ism330dhcx_tap_cfg2_t                      tap_cfg2;
-  ism330dhcx_tap_ths_6d_t                    tap_ths_6d;
-  ism330dhcx_int_dur2_t                      int_dur2;
-  ism330dhcx_wake_up_ths_t                   wake_up_ths;
-  ism330dhcx_wake_up_dur_t                   wake_up_dur;
-  ism330dhcx_free_fall_t                     free_fall;
-  ism330dhcx_md1_cfg_t                       md1_cfg;
-  ism330dhcx_md2_cfg_t                       md2_cfg;
-  ism330dhcx_internal_freq_fine_t            internal_freq_fine;
-  ism330dhcx_int_ois_t                       int_ois;
-  ism330dhcx_ctrl1_ois_t                     ctrl1_ois;
-  ism330dhcx_ctrl2_ois_t                     ctrl2_ois;
-  ism330dhcx_ctrl3_ois_t                     ctrl3_ois;
-  ism330dhcx_fifo_data_out_tag_t             fifo_data_out_tag;
-  ism330dhcx_page_sel_t                      page_sel;
-  ism330dhcx_emb_func_en_a_t                 emb_func_en_a;
-  ism330dhcx_emb_func_en_b_t                 emb_func_en_b;
-  ism330dhcx_page_address_t                  page_address;
-  ism330dhcx_page_value_t                    page_value;
-  ism330dhcx_emb_func_int1_t                 emb_func_int1;
-  ism330dhcx_fsm_int1_a_t                    fsm_int1_a;
-  ism330dhcx_fsm_int1_b_t                    fsm_int1_b;
-  ism330dhcx_mlc_int1_t                      mlc_int1;
-  ism330dhcx_emb_func_int2_t                 emb_func_int2;
-  ism330dhcx_fsm_int2_a_t                    fsm_int2_a;
-  ism330dhcx_fsm_int2_b_t                    fsm_int2_b;
-  ism330dhcx_mlc_int2_t                      mlc_int2;
-  ism330dhcx_emb_func_status_t               emb_func_status;
-  ism330dhcx_fsm_status_a_t                  fsm_status_a;
-  ism330dhcx_fsm_status_b_t                  fsm_status_b;
-  ism330dhcx_mlc_status_mainpage_t           mlc_status_mainpage;
-  ism330dhcx_page_rw_t                       page_rw;
-  ism330dhcx_emb_func_fifo_cfg_t             emb_func_fifo_cfg;
-  ism330dhcx_fsm_enable_a_t                  fsm_enable_a;
-  ism330dhcx_fsm_enable_b_t                  fsm_enable_b;
-  ism330dhcx_fsm_long_counter_clear_t        fsm_long_counter_clear;
-  ism330dhcx_fsm_outs1_t                     fsm_outs1;
-  ism330dhcx_fsm_outs2_t                     fsm_outs2;
-  ism330dhcx_fsm_outs3_t                     fsm_outs3;
-  ism330dhcx_fsm_outs4_t                     fsm_outs4;
-  ism330dhcx_fsm_outs5_t                     fsm_outs5;
-  ism330dhcx_fsm_outs6_t                     fsm_outs6;
-  ism330dhcx_fsm_outs7_t                     fsm_outs7;
-  ism330dhcx_fsm_outs8_t                     fsm_outs8;
-  ism330dhcx_fsm_outs9_t                     fsm_outs9;
-  ism330dhcx_fsm_outs10_t                    fsm_outs10;
-  ism330dhcx_fsm_outs11_t                    fsm_outs11;
-  ism330dhcx_fsm_outs12_t                    fsm_outs12;
-  ism330dhcx_fsm_outs13_t                    fsm_outs13;
-  ism330dhcx_fsm_outs14_t                    fsm_outs14;
-  ism330dhcx_fsm_outs15_t                    fsm_outs15;
-  ism330dhcx_fsm_outs16_t                    fsm_outs16;
-  ism330dhcx_emb_func_odr_cfg_b_t            emb_func_odr_cfg_b;
-  ism330dhcx_emb_func_odr_cfg_c_t            emb_func_odr_cfg_c_t;
-  ism330dhcx_emb_func_src_t                  emb_func_src;
-  ism330dhcx_emb_func_init_a_t               emb_func_init_a;
-  ism330dhcx_emb_func_init_b_t               emb_func_init_b;
-  ism330dhcx_mag_cfg_a_t                     mag_cfg_a;
-  ism330dhcx_mag_cfg_b_t                     mag_cfg_b;
-  ism330dhcx_pedo_cmd_reg_t                  pedo_cmd_reg;
-  ism330dhcx_sensor_hub_1_t                  sensor_hub_1;
-  ism330dhcx_sensor_hub_2_t                  sensor_hub_2;
-  ism330dhcx_sensor_hub_3_t                  sensor_hub_3;
-  ism330dhcx_sensor_hub_4_t                  sensor_hub_4;
-  ism330dhcx_sensor_hub_5_t                  sensor_hub_5;
-  ism330dhcx_sensor_hub_6_t                  sensor_hub_6;
-  ism330dhcx_sensor_hub_7_t                  sensor_hub_7;
-  ism330dhcx_sensor_hub_8_t                  sensor_hub_8;
-  ism330dhcx_sensor_hub_9_t                  sensor_hub_9;
-  ism330dhcx_sensor_hub_10_t                 sensor_hub_10;
-  ism330dhcx_sensor_hub_11_t                 sensor_hub_11;
-  ism330dhcx_sensor_hub_12_t                 sensor_hub_12;
-  ism330dhcx_sensor_hub_13_t                 sensor_hub_13;
-  ism330dhcx_sensor_hub_14_t                 sensor_hub_14;
-  ism330dhcx_sensor_hub_15_t                 sensor_hub_15;
-  ism330dhcx_sensor_hub_16_t                 sensor_hub_16;
-  ism330dhcx_sensor_hub_17_t                 sensor_hub_17;
-  ism330dhcx_sensor_hub_18_t                 sensor_hub_18;
-  ism330dhcx_master_config_t                 master_config;
-  ism330dhcx_slv0_add_t                      slv0_add;
-  ism330dhcx_slv0_subadd_t                   slv0_subadd;
-  ism330dhcx_slv0_config_t                   slv0_config;
-  ism330dhcx_slv1_add_t                      slv1_add;
-  ism330dhcx_slv1_subadd_t                   slv1_subadd;
-  ism330dhcx_slv1_config_t                   slv1_config;
-  ism330dhcx_slv2_add_t                      slv2_add;
-  ism330dhcx_slv2_subadd_t                   slv2_subadd;
-  ism330dhcx_slv2_config_t                   slv2_config;
-  ism330dhcx_slv3_add_t                      slv3_add;
-  ism330dhcx_slv3_subadd_t                   slv3_subadd;
-  ism330dhcx_slv3_config_t                   slv3_config;
-  ism330dhcx_datawrite_slv0_t                datawrite_slv0;
-  ism330dhcx_status_master_t                 status_master;
-  bitwise_t                                 bitwise;
-  uint8_t                                   byte;
-} ism330dhcx_reg_t;
-
-/**
-  * @}
-  *
-  */
-
 #ifndef __weak
 #define __weak __attribute__((weak))
 #endif /* __weak */
@@ -2856,7 +2683,7 @@ int32_t ism330dhcx_read_reg(const stmdev_ctx_t *ctx, uint8_t reg,
                             uint8_t *data,
                             uint16_t len);
 int32_t ism330dhcx_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
-                             uint8_t *data,
+                             const uint8_t *data,
                              uint16_t len);
 
 float_t ism330dhcx_from_fs2g_to_mg(int16_t lsb);
@@ -3047,8 +2874,6 @@ int32_t ism330dhcx_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *val);
 
 int32_t ism330dhcx_fifo_out_raw_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dhcx_mlc_out_get(const stmdev_ctx_t *ctx, uint8_t *val);
-
 int32_t ism330dhcx_device_conf_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t ism330dhcx_device_conf_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
@@ -3128,8 +2953,8 @@ int32_t ism330dhcx_xl_filter_lp2_get(const stmdev_ctx_t *ctx, uint8_t *val);
 int32_t ism330dhcx_gy_filter_lp1_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t ism330dhcx_gy_filter_lp1_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dhcx_filter_settling_mask_set(const stmdev_ctx_t *ctx, uint8_t val);
-int32_t ism330dhcx_filter_settling_mask_get(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t ism330dhcx_drdy_mask_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_drdy_mask_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum
 {
@@ -3189,10 +3014,10 @@ typedef enum
   ISM330DHCX_USE_SLOPE = 0,
   ISM330DHCX_USE_HPF   = 1,
 } ism330dhcx_slope_fds_t;
-int32_t ism330dhcx_xl_hp_path_internal_set(const stmdev_ctx_t *ctx,
-                                           ism330dhcx_slope_fds_t val);
-int32_t ism330dhcx_xl_hp_path_internal_get(const stmdev_ctx_t *ctx,
-                                           ism330dhcx_slope_fds_t *val);
+int32_t ism330dhcx_xl_hp_slope_filter_set(const stmdev_ctx_t *ctx,
+                                          ism330dhcx_slope_fds_t val);
+int32_t ism330dhcx_xl_hp_slope_filter_get(const stmdev_ctx_t *ctx,
+                                          ism330dhcx_slope_fds_t *val);
 
 typedef enum
 {
@@ -3202,10 +3027,10 @@ typedef enum
   ISM330DHCX_HP_FILTER_260mHz   = 0x82,
   ISM330DHCX_HP_FILTER_1Hz04    = 0x83,
 } ism330dhcx_hpm_g_t;
-int32_t ism330dhcx_gy_hp_path_internal_set(const stmdev_ctx_t *ctx,
-                                           ism330dhcx_hpm_g_t val);
-int32_t ism330dhcx_gy_hp_path_internal_get(const stmdev_ctx_t *ctx,
-                                           ism330dhcx_hpm_g_t *val);
+int32_t ism330dhcx_gy_hp_filter_set(const stmdev_ctx_t *ctx,
+                                    ism330dhcx_hpm_g_t val);
+int32_t ism330dhcx_gy_hp_filter_get(const stmdev_ctx_t *ctx,
+                                    ism330dhcx_hpm_g_t *val);
 
 typedef enum
 {
@@ -3315,10 +3140,10 @@ typedef enum
   ISM330DHCX_172Hz70 = 2,
   ISM330DHCX_937Hz91 = 3,
 } ism330dhcx_ftype_ois_t;
-int32_t ism330dhcx_aux_gy_lp1_bandwidth_set(const stmdev_ctx_t *ctx,
-                                            ism330dhcx_ftype_ois_t val);
-int32_t ism330dhcx_aux_gy_lp1_bandwidth_get(const stmdev_ctx_t *ctx,
-                                            ism330dhcx_ftype_ois_t *val);
+int32_t ism330dhcx_aux_gy_lp1_filter_set(const stmdev_ctx_t *ctx,
+                                         ism330dhcx_ftype_ois_t val);
+int32_t ism330dhcx_aux_gy_lp1_filter_get(const stmdev_ctx_t *ctx,
+                                         ism330dhcx_ftype_ois_t *val);
 
 typedef enum
 {
@@ -3328,10 +3153,10 @@ typedef enum
   ISM330DHCX_AUX_HP_Hz260   = 0x12,
   ISM330DHCX_AUX_HP_1Hz040  = 0x13,
 } ism330dhcx_hpm_ois_t;
-int32_t ism330dhcx_aux_gy_hp_bandwidth_set(const stmdev_ctx_t *ctx,
-                                           ism330dhcx_hpm_ois_t val);
-int32_t ism330dhcx_aux_gy_hp_bandwidth_get(const stmdev_ctx_t *ctx,
-                                           ism330dhcx_hpm_ois_t *val);
+int32_t ism330dhcx_aux_gy_hp_filter_set(const stmdev_ctx_t *ctx,
+                                        ism330dhcx_hpm_ois_t val);
+int32_t ism330dhcx_aux_gy_hp_filter_get(const stmdev_ctx_t *ctx,
+                                        ism330dhcx_hpm_ois_t *val);
 
 typedef enum
 {
@@ -3489,10 +3314,8 @@ int32_t ism330dhcx_wkup_threshold_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t ism330dhcx_wkup_threshold_get(const stmdev_ctx_t *ctx,
                                       uint8_t *val);
 
-int32_t ism330dhcx_xl_usr_offset_on_wkup_set(const stmdev_ctx_t *ctx,
-                                             uint8_t val);
-int32_t ism330dhcx_xl_usr_offset_on_wkup_get(const stmdev_ctx_t *ctx,
-                                             uint8_t *val);
+int32_t ism330dhcx_xl_usr_off_on_wu_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_xl_usr_off_on_wu_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 int32_t ism330dhcx_wkup_dur_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t ism330dhcx_wkup_dur_get(const stmdev_ctx_t *ctx, uint8_t *val);
@@ -3505,10 +3328,10 @@ typedef enum
   ISM330DHCX_DRIVE_SLEEP_CHG_EVENT = 0,
   ISM330DHCX_DRIVE_SLEEP_STATUS    = 1,
 } ism330dhcx_sleep_status_on_int_t;
-int32_t ism330dhcx_act_pin_notification_set(const stmdev_ctx_t *ctx,
-                                            ism330dhcx_sleep_status_on_int_t val);
-int32_t ism330dhcx_act_pin_notification_get(const stmdev_ctx_t *ctx,
-                                            ism330dhcx_sleep_status_on_int_t *val);
+int32_t ism330dhcx_slp_status_route_set(const stmdev_ctx_t *ctx,
+                                        ism330dhcx_sleep_status_on_int_t val);
+int32_t ism330dhcx_slp_status_route_get(const stmdev_ctx_t *ctx,
+                                        ism330dhcx_sleep_status_on_int_t *val);
 
 typedef enum
 {
@@ -3525,20 +3348,14 @@ int32_t ism330dhcx_act_mode_get(const stmdev_ctx_t *ctx,
 int32_t ism330dhcx_act_sleep_dur_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t ism330dhcx_act_sleep_dur_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dhcx_tap_detection_on_z_set(const stmdev_ctx_t *ctx,
-                                          uint8_t val);
-int32_t ism330dhcx_tap_detection_on_z_get(const stmdev_ctx_t *ctx,
-                                          uint8_t *val);
+int32_t ism330dhcx_tap_detect_on_z_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_tap_detect_on_z_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dhcx_tap_detection_on_y_set(const stmdev_ctx_t *ctx,
-                                          uint8_t val);
-int32_t ism330dhcx_tap_detection_on_y_get(const stmdev_ctx_t *ctx,
-                                          uint8_t *val);
+int32_t ism330dhcx_tap_detect_on_y_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_tap_detect_on_y_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dhcx_tap_detection_on_x_set(const stmdev_ctx_t *ctx,
-                                          uint8_t val);
-int32_t ism330dhcx_tap_detection_on_x_get(const stmdev_ctx_t *ctx,
-                                          uint8_t *val);
+int32_t ism330dhcx_tap_detect_on_x_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_tap_detect_on_x_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 int32_t ism330dhcx_tap_threshold_x_set(const stmdev_ctx_t *ctx,
                                        uint8_t val);
@@ -3627,10 +3444,8 @@ int32_t ism330dhcx_fifo_watermark_set(const stmdev_ctx_t *ctx,
 int32_t ism330dhcx_fifo_watermark_get(const stmdev_ctx_t *ctx,
                                       uint16_t *val);
 
-int32_t ism330dhcx_compression_algo_init_set(const stmdev_ctx_t *ctx,
-                                             uint8_t val);
-int32_t ism330dhcx_compression_algo_init_get(const stmdev_ctx_t *ctx,
-                                             uint8_t *val);
+int32_t ism330dhcx_fifo_compr_init_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_fifo_compr_init_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum
 {
@@ -3645,15 +3460,11 @@ int32_t ism330dhcx_compression_algo_set(const stmdev_ctx_t *ctx,
 int32_t ism330dhcx_compression_algo_get(const stmdev_ctx_t *ctx,
                                         ism330dhcx_uncoptr_rate_t *val);
 
-int32_t ism330dhcx_fifo_virtual_sens_odr_chg_set(const stmdev_ctx_t *ctx,
-                                                 uint8_t val);
-int32_t ism330dhcx_fifo_virtual_sens_odr_chg_get(const stmdev_ctx_t *ctx,
-                                                 uint8_t *val);
+int32_t ism330dhcx_fifo_odr_chg_batch_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_fifo_odr_chg_batch_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dhcx_compression_algo_real_time_set(const stmdev_ctx_t *ctx,
-                                                  uint8_t val);
-int32_t ism330dhcx_compression_algo_real_time_get(const stmdev_ctx_t *ctx,
-                                                  uint8_t *val);
+int32_t ism330dhcx_fifo_compr_rt_en_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_fifo_compr_rt_en_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 int32_t ism330dhcx_fifo_stop_on_wtm_set(const stmdev_ctx_t *ctx,
                                         uint8_t val);
@@ -3733,30 +3544,28 @@ typedef enum
   ISM330DHCX_DEC_8         = 2,
   ISM330DHCX_DEC_32        = 3,
 } ism330dhcx_odr_ts_batch_t;
-int32_t ism330dhcx_fifo_timestamp_decimation_set(const stmdev_ctx_t *ctx,
-                                                 ism330dhcx_odr_ts_batch_t val);
-int32_t ism330dhcx_fifo_timestamp_decimation_get(const stmdev_ctx_t *ctx,
-                                                 ism330dhcx_odr_ts_batch_t *val);
+int32_t ism330dhcx_fifo_ts_dec_set(const stmdev_ctx_t *ctx,
+                                   ism330dhcx_odr_ts_batch_t val);
+int32_t ism330dhcx_fifo_ts_dec_get(const stmdev_ctx_t *ctx,
+                                   ism330dhcx_odr_ts_batch_t *val);
 
 typedef enum
 {
   ISM330DHCX_XL_BATCH_EVENT   = 0,
   ISM330DHCX_GYRO_BATCH_EVENT = 1,
 } ism330dhcx_trig_counter_bdr_t;
-int32_t ism330dhcx_fifo_cnt_event_batch_set(const stmdev_ctx_t *ctx,
-                                            ism330dhcx_trig_counter_bdr_t val);
-int32_t ism330dhcx_fifo_cnt_event_batch_get(const stmdev_ctx_t *ctx,
-                                            ism330dhcx_trig_counter_bdr_t *val);
+int32_t ism330dhcx_fifo_trig_cnt_bdr_set(const stmdev_ctx_t *ctx,
+                                         ism330dhcx_trig_counter_bdr_t val);
+int32_t ism330dhcx_fifo_trig_cnt_bdr_get(const stmdev_ctx_t *ctx,
+                                         ism330dhcx_trig_counter_bdr_t *val);
 
 int32_t ism330dhcx_rst_batch_counter_set(const stmdev_ctx_t *ctx,
                                          uint8_t val);
 int32_t ism330dhcx_rst_batch_counter_get(const stmdev_ctx_t *ctx,
                                          uint8_t *val);
 
-int32_t ism330dhcx_batch_counter_threshold_set(const stmdev_ctx_t *ctx,
-                                               uint16_t val);
-int32_t ism330dhcx_batch_counter_threshold_get(const stmdev_ctx_t *ctx,
-                                               uint16_t *val);
+int32_t ism330dhcx_batch_counter_th_set(const stmdev_ctx_t *ctx, uint16_t val);
+int32_t ism330dhcx_batch_counter_th_get(const stmdev_ctx_t *ctx, uint16_t *val);
 
 int32_t ism330dhcx_fifo_data_level_get(const stmdev_ctx_t *ctx,
                                        uint16_t *val);
@@ -3879,10 +3688,8 @@ int32_t ism330dhcx_pedo_sens_get(const stmdev_ctx_t *ctx, uint8_t *val);
 int32_t ism330dhcx_pedo_step_detect_get(const stmdev_ctx_t *ctx,
                                         uint8_t *val);
 
-int32_t ism330dhcx_pedo_debounce_steps_set(const stmdev_ctx_t *ctx,
-                                           uint8_t *val);
-int32_t ism330dhcx_pedo_debounce_steps_get(const stmdev_ctx_t *ctx,
-                                           uint8_t *val);
+int32_t ism330dhcx_pedo_deb_steps_set(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t ism330dhcx_pedo_deb_steps_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 int32_t ism330dhcx_pedo_steps_period_set(const stmdev_ctx_t *ctx,
                                          uint16_t val);
@@ -4033,15 +3840,11 @@ int32_t ism330dhcx_fsm_data_rate_get(const stmdev_ctx_t *ctx,
 int32_t ism330dhcx_fsm_init_set(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t ism330dhcx_fsm_init_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dhcx_long_cnt_int_value_set(const stmdev_ctx_t *ctx,
-                                          uint16_t val);
-int32_t ism330dhcx_long_cnt_int_value_get(const stmdev_ctx_t *ctx,
-                                          uint16_t *val);
+int32_t ism330dhcx_fsm_lc_int_value_set(const stmdev_ctx_t *ctx, uint16_t val);
+int32_t ism330dhcx_fsm_lc_int_value_get(const stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t ism330dhcx_fsm_number_of_programs_set(const stmdev_ctx_t *ctx,
-                                              uint8_t *val);
-int32_t ism330dhcx_fsm_number_of_programs_get(const stmdev_ctx_t *ctx,
-                                              uint8_t *val);
+int32_t ism330dhcx_fsm_programs_num_set(const stmdev_ctx_t *ctx, uint8_t *val);
+int32_t ism330dhcx_fsm_programs_num_get(const stmdev_ctx_t *ctx, uint8_t *val);
 
 int32_t ism330dhcx_fsm_start_address_set(const stmdev_ctx_t *ctx,
                                          uint16_t val);

--- a/sensor/stmemsc/ism330dlc_STdC/driver/ism330dlc_reg.h
+++ b/sensor/stmemsc/ism330dlc_STdC/driver/ism330dlc_reg.h
@@ -228,11 +228,11 @@ typedef struct
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fth                      : 3;  /* + FIFO_CTRL1(fth) */
   uint8_t fifo_temp_en             : 1;
-  uint8_t not_used_01              : 4;
+  uint8_t not_used_01              : 3;
   uint8_t fifo_timer_en            : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t fifo_timer_en            : 1;
-  uint8_t not_used_01              : 4;
+  uint8_t not_used_01              : 3;
   uint8_t fifo_temp_en             : 1;
   uint8_t fth                      : 3;  /* + FIFO_CTRL1(fth) */
 #endif /* DRV_BYTE_ORDER */

--- a/sensor/stmemsc/lis2dux12_STdC/driver/lis2dux12_reg.h
+++ b/sensor/stmemsc/lis2dux12_STdC/driver/lis2dux12_reg.h
@@ -350,13 +350,15 @@ typedef struct
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fifo_mode                    : 3;
   uint8_t stop_on_fth                  : 1;
-  uint8_t not_used0                    : 2;
+  uint8_t not_used0                    : 1;
+  uint8_t dis_hard_rst_cs              : 1;
   uint8_t fifo_depth                   : 1;
   uint8_t cfg_chg_en                   : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t cfg_chg_en                   : 1;
   uint8_t fifo_depth                   : 1;
-  uint8_t not_used0                    : 2;
+  uint8_t dis_hard_rst_cs              : 1;
+  uint8_t not_used0                    : 1;
   uint8_t stop_on_fth                  : 1;
   uint8_t fifo_mode                    : 3;
 #endif /* DRV_BYTE_ORDER */
@@ -2228,6 +2230,9 @@ int32_t lis2dux12_self_test_stop(const stmdev_ctx_t *ctx);
 int32_t lis2dux12_enter_deep_power_down(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t lis2dux12_exit_deep_power_down(const stmdev_ctx_t *ctx);
 
+int32_t lis2dux12_disable_hard_reset_from_cs_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dux12_disable_hard_reset_from_cs_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
 typedef enum
 {
   LIS2DUX12_I3C_BUS_AVAIL_TIME_20US = 0x0,
@@ -2391,6 +2396,12 @@ typedef enum
   LIS2DUX12_BDR_XL_ODR_OFF         = 0x7,
 } lis2dux12_bdr_xl_t;
 
+typedef enum
+{
+  LIS2DUX12_FIFO_EV_WTM           = 0x0,
+  LIS2DUX12_FIFO_EV_FULL          = 0x1,
+} lis2dux12_fifo_event_t;
+
 typedef struct
 {
   lis2dux12_operation_t operation;
@@ -2398,6 +2409,7 @@ typedef struct
   uint8_t xl_only                      : 1; /* only XL samples (16-bit) are stored in FIFO */
   uint8_t watermark                    : 7; /* (0 disable) max 127 @16bit, even and max 256 @8bit.*/
   uint8_t cfg_change_in_fifo           : 1;
+  lis2dux12_fifo_event_t fifo_event      : 1; /* 0: FIFO watermark, 1: FIFO full */
   struct
   {
     lis2dux12_dec_ts_t dec_ts; /* decimation for timestamp batching*/

--- a/sensor/stmemsc/lis2duxs12_STdC/driver/lis2duxs12_reg.h
+++ b/sensor/stmemsc/lis2duxs12_STdC/driver/lis2duxs12_reg.h
@@ -350,13 +350,15 @@ typedef struct
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fifo_mode                    : 3;
   uint8_t stop_on_fth                  : 1;
-  uint8_t not_used0                    : 2;
+  uint8_t not_used0                    : 1;
+  uint8_t dis_hard_rst_cs              : 1;
   uint8_t fifo_depth                   : 1;
   uint8_t cfg_chg_en                   : 1;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
   uint8_t cfg_chg_en                   : 1;
   uint8_t fifo_depth                   : 1;
-  uint8_t not_used0                    : 2;
+  uint8_t dis_hard_rst_cs              : 1;
+  uint8_t not_used0                    : 1;
   uint8_t stop_on_fth                  : 1;
   uint8_t fifo_mode                    : 3;
 #endif /* DRV_BYTE_ORDER */
@@ -2258,6 +2260,9 @@ int32_t lis2duxs12_self_test_stop(const stmdev_ctx_t *ctx);
 int32_t lis2duxs12_enter_deep_power_down(const stmdev_ctx_t *ctx, uint8_t val);
 int32_t lis2duxs12_exit_deep_power_down(const stmdev_ctx_t *ctx);
 
+int32_t lis2duxs12_disable_hard_reset_from_cs_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2duxs12_disable_hard_reset_from_cs_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
 typedef enum
 {
   LIS2DUXS12_I3C_BUS_AVAIL_TIME_20US = 0x0,
@@ -2423,6 +2428,12 @@ typedef enum
   LIS2DUXS12_BDR_XL_ODR_OFF         = 0x7,
 } lis2duxs12_bdr_xl_t;
 
+typedef enum
+{
+  LIS2DUXS12_FIFO_EV_WTM           = 0x0,
+  LIS2DUXS12_FIFO_EV_FULL          = 0x1,
+} lis2duxs12_fifo_event_t;
+
 typedef struct
 {
   lis2duxs12_operation_t operation;
@@ -2430,6 +2441,7 @@ typedef struct
   uint8_t xl_only                      : 1; /* only XL samples (16-bit) are stored in FIFO */
   uint8_t watermark                    : 7; /* (0 disable) max 127 @16bit, even and max 256 @8bit.*/
   uint8_t cfg_change_in_fifo           : 1;
+  lis2duxs12_fifo_event_t fifo_event      : 1; /* 0: FIFO watermark, 1: FIFO full */
   struct
   {
     lis2duxs12_dec_ts_t dec_ts; /* decimation for timestamp batching*/

--- a/sensor/stmemsc/lis3dhh_STdC/driver/lis3dhh_reg.c
+++ b/sensor/stmemsc/lis3dhh_STdC/driver/lis3dhh_reg.c
@@ -241,6 +241,7 @@ int32_t lis3dhh_temperature_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
   ret = lis3dhh_read_reg(ctx, LIS3DHH_OUT_TEMP_L, buff, 2);
   *val = (int16_t)buff[1];
   *val = (*val * 256) + (int16_t)buff[0];
+  *val = (*val / 16);
 
   return ret;
 }

--- a/sensor/stmemsc/lps22hb_STdC/driver/lps22hb_reg.c
+++ b/sensor/stmemsc/lps22hb_STdC/driver/lps22hb_reg.c
@@ -101,7 +101,7 @@ int32_t __weak lps22hb_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
 
 float_t lps22hb_from_lsb_to_hpa(int32_t lsb)
 {
-  return ((float_t)lsb / 4096.0f);
+  return ((float_t)lsb / 1048576.0f);   /* 4096.0f * 256 */
 }
 
 float_t lps22hb_from_lsb_to_kpa(int32_t lsb)
@@ -120,7 +120,7 @@ float_t lps22hb_from_lsb_to_altitude(int32_t lsb)
   // The altitude in meters can be calculated with the
   // international barometric formula.
   // Average sea level pressure is 1013.25 hPa.
-  return 44330.0 * (1.0 - pow(atmospheric / 1013.25f, (1.0 / 5.255)));
+  return 44330.0f * (1.0f - powf(atmospheric / 1013.25f, (1.0f / 5.255f)));
 }
 
 float_t lps22hb_from_lsb_to_degc(int16_t lsb)

--- a/sensor/stmemsc/lps22hh_STdC/driver/lps22hh_reg.c
+++ b/sensor/stmemsc/lps22hh_STdC/driver/lps22hh_reg.c
@@ -73,7 +73,7 @@ int32_t __weak lps22hh_read_reg(const stmdev_ctx_t *ctx, uint8_t reg,
   *
   */
 int32_t __weak lps22hh_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
-                                 uint8_t *data,
+                                 const uint8_t *data,
                                  uint16_t len)
 {
   int32_t ret;
@@ -1492,7 +1492,7 @@ int32_t lps22hh_pin_polarity_get(const stmdev_ctx_t *ctx,
   *
   */
 int32_t lps22hh_pin_int_route_set(const stmdev_ctx_t *ctx,
-                                  lps22hh_pin_int_route_t *val)
+                                  lps22hh_pin_int_route_t val)
 {
   lps22hh_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1500,10 +1500,10 @@ int32_t lps22hh_pin_int_route_set(const stmdev_ctx_t *ctx,
   ret = lps22hh_read_reg(ctx, LPS22HH_CTRL_REG3, (uint8_t *)&ctrl_reg3, 1);
   if (ret == 0)
   {
-    ctrl_reg3.drdy = val->drdy_pres;
-    ctrl_reg3.int_f_wtm = val->fifo_th;
-    ctrl_reg3.int_f_ovr = val->fifo_ovr;
-    ctrl_reg3.int_f_full = val->fifo_full;
+    ctrl_reg3.drdy = val.drdy_pres;
+    ctrl_reg3.int_f_wtm = val.fifo_th;
+    ctrl_reg3.int_f_ovr = val.fifo_ovr;
+    ctrl_reg3.int_f_full = val.fifo_full;
 
     ret = lps22hh_write_reg(ctx, LPS22HH_CTRL_REG3, (uint8_t *)&ctrl_reg3, 1);
   }

--- a/sensor/stmemsc/lps22hh_STdC/driver/lps22hh_reg.h
+++ b/sensor/stmemsc/lps22hh_STdC/driver/lps22hh_reg.h
@@ -131,38 +131,6 @@ typedef struct
 
 #endif /* MEMS_SHARED_TYPES */
 
-#ifndef MEMS_UCF_SHARED_TYPES
-#define MEMS_UCF_SHARED_TYPES
-
-/** @defgroup    Generic address-data structure definition
-  * @brief       This structure is useful to load a predefined configuration
-  *              of a sensor.
-  *              You can create a sensor configuration by your own or using
-  *              Unico / Unicleo tools available on STMicroelectronics
-  *              web site.
-  *
-  * @{
-  *
-  */
-
-typedef struct
-{
-  uint8_t address;
-  uint8_t data;
-} ucf_line_t;
-
-/**
-  * @}
-  *
-  */
-
-#endif /* MEMS_UCF_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
 /** @defgroup LPS22HH_Infos
   * @{
   *
@@ -402,34 +370,6 @@ typedef struct
 #define LPS22HH_FIFO_DATA_OUT_TEMP_H            0x7CU
 
 /**
-  * @defgroup LPS22HH_Register_Union
-  * @brief    This union group all the registers having a bit-field
-  *           description.
-  *           This union is useful but it's not needed by the driver.
-  *
-  *           REMOVING this union you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-typedef union
-{
-  lps22hh_interrupt_cfg_t        interrupt_cfg;
-  lps22hh_if_ctrl_t              if_ctrl;
-  lps22hh_ctrl_reg1_t            ctrl_reg1;
-  lps22hh_ctrl_reg2_t            ctrl_reg2;
-  lps22hh_ctrl_reg3_t            ctrl_reg3;
-  lps22hh_fifo_ctrl_t            fifo_ctrl;
-  lps22hh_fifo_wtm_t             fifo_wtm;
-  lps22hh_int_source_t           int_source;
-  lps22hh_fifo_status2_t         fifo_status2;
-  lps22hh_status_t               status;
-  bitwise_t                      bitwise;
-  uint8_t                        byte;
-} lps22hh_reg_t;
-
-/**
   * @}
   *
   */
@@ -450,7 +390,7 @@ int32_t lps22hh_read_reg(const stmdev_ctx_t *ctx, uint8_t reg,
                          uint8_t *data,
                          uint16_t len);
 int32_t lps22hh_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
-                          uint8_t *data,
+                          const uint8_t *data,
                           uint16_t len);
 
 float_t lps22hh_from_lsb_to_hpa(uint32_t lsb);
@@ -627,7 +567,7 @@ typedef struct
   uint8_t fifo_full : 1; /* FIFO full */
 } lps22hh_pin_int_route_t;
 int32_t lps22hh_pin_int_route_set(const stmdev_ctx_t *ctx,
-                                  lps22hh_pin_int_route_t *val);
+                                  lps22hh_pin_int_route_t val);
 int32_t lps22hh_pin_int_route_get(const stmdev_ctx_t *ctx,
                                   lps22hh_pin_int_route_t *val);
 

--- a/sensor/stmemsc/lsm6dso_STdC/driver/lsm6dso_reg.h
+++ b/sensor/stmemsc/lsm6dso_STdC/driver/lsm6dso_reg.h
@@ -140,7 +140,7 @@ int32_t lsm6dso_read_reg(const stmdev_ctx_t* ctx, uint8_t reg,
                                 uint8_t* data,
                                 uint16_t len);
 int32_t lsm6dso_write_reg(const stmdev_ctx_t* ctx, uint8_t reg,
-                                 uint8_t* data,
+                                 const uint8_t* data,
                                  uint16_t len);
 
 /**
@@ -2597,149 +2597,6 @@ typedef struct
 
 #define LSM6DSO_START_FSM_ADD                0x0400U
 
-/**
-  * @defgroup LSM6DSO_Register_Union
-  * @brief    This union group all the registers having a bit-field
-  *           description.
-  *           This union is useful but it's not needed by the driver.
-  *
-  *           REMOVING this union you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-typedef union
-{
-  lsm6dso_func_cfg_access_t               func_cfg_access;
-  lsm6dso_pin_ctrl_t                      pin_ctrl;
-  lsm6dso_fifo_ctrl1_t                    fifo_ctrl1;
-  lsm6dso_fifo_ctrl2_t                    fifo_ctrl2;
-  lsm6dso_fifo_ctrl3_t                    fifo_ctrl3;
-  lsm6dso_fifo_ctrl4_t                    fifo_ctrl4;
-  lsm6dso_counter_bdr_reg1_t              counter_bdr_reg1;
-  lsm6dso_counter_bdr_reg2_t              counter_bdr_reg2;
-  lsm6dso_int1_ctrl_t                     int1_ctrl;
-  lsm6dso_int2_ctrl_t                     int2_ctrl;
-  lsm6dso_ctrl1_xl_t                      ctrl1_xl;
-  lsm6dso_ctrl2_g_t                       ctrl2_g;
-  lsm6dso_ctrl3_c_t                       ctrl3_c;
-  lsm6dso_ctrl4_c_t                       ctrl4_c;
-  lsm6dso_ctrl5_c_t                       ctrl5_c;
-  lsm6dso_ctrl6_c_t                       ctrl6_c;
-  lsm6dso_ctrl7_g_t                       ctrl7_g;
-  lsm6dso_ctrl8_xl_t                      ctrl8_xl;
-  lsm6dso_ctrl9_xl_t                      ctrl9_xl;
-  lsm6dso_ctrl10_c_t                      ctrl10_c;
-  lsm6dso_all_int_src_t                   all_int_src;
-  lsm6dso_wake_up_src_t                   wake_up_src;
-  lsm6dso_tap_src_t                       tap_src;
-  lsm6dso_d6d_src_t                       d6d_src;
-  lsm6dso_status_reg_t                    status_reg;
-  lsm6dso_status_spiaux_t                 status_spiaux;
-  lsm6dso_fifo_status1_t                  fifo_status1;
-  lsm6dso_fifo_status2_t                  fifo_status2;
-  lsm6dso_tap_cfg0_t                      tap_cfg0;
-  lsm6dso_tap_cfg1_t                      tap_cfg1;
-  lsm6dso_tap_cfg2_t                      tap_cfg2;
-  lsm6dso_tap_ths_6d_t                    tap_ths_6d;
-  lsm6dso_int_dur2_t                      int_dur2;
-  lsm6dso_wake_up_ths_t                   wake_up_ths;
-  lsm6dso_wake_up_dur_t                   wake_up_dur;
-  lsm6dso_free_fall_t                     free_fall;
-  lsm6dso_md1_cfg_t                       md1_cfg;
-  lsm6dso_md2_cfg_t                       md2_cfg;
-  lsm6dso_i3c_bus_avb_t                   i3c_bus_avb;
-  lsm6dso_internal_freq_fine_t            internal_freq_fine;
-  lsm6dso_int_ois_t                       int_ois;
-  lsm6dso_ctrl1_ois_t                     ctrl1_ois;
-  lsm6dso_ctrl2_ois_t                     ctrl2_ois;
-  lsm6dso_ctrl3_ois_t                     ctrl3_ois;
-  lsm6dso_fifo_data_out_tag_t             fifo_data_out_tag;
-  lsm6dso_page_sel_t                      page_sel;
-  lsm6dso_emb_func_en_a_t                 emb_func_en_a;
-  lsm6dso_emb_func_en_b_t                 emb_func_en_b;
-  lsm6dso_page_address_t                  page_address;
-  lsm6dso_page_value_t                    page_value;
-  lsm6dso_emb_func_int1_t                 emb_func_int1;
-  lsm6dso_fsm_int1_a_t                    fsm_int1_a;
-  lsm6dso_fsm_int1_b_t                    fsm_int1_b;
-  lsm6dso_emb_func_int2_t                 emb_func_int2;
-  lsm6dso_fsm_int2_a_t                    fsm_int2_a;
-  lsm6dso_fsm_int2_b_t                    fsm_int2_b;
-  lsm6dso_emb_func_status_t               emb_func_status;
-  lsm6dso_fsm_status_a_t                  fsm_status_a;
-  lsm6dso_fsm_status_b_t                  fsm_status_b;
-  lsm6dso_page_rw_t                       page_rw;
-  lsm6dso_emb_func_fifo_cfg_t              emb_func_fifo_cfg;
-  lsm6dso_fsm_enable_a_t                  fsm_enable_a;
-  lsm6dso_fsm_enable_b_t                  fsm_enable_b;
-  lsm6dso_fsm_long_counter_clear_t        fsm_long_counter_clear;
-  lsm6dso_fsm_outs1_t                     fsm_outs1;
-  lsm6dso_fsm_outs2_t                     fsm_outs2;
-  lsm6dso_fsm_outs3_t                     fsm_outs3;
-  lsm6dso_fsm_outs4_t                     fsm_outs4;
-  lsm6dso_fsm_outs5_t                     fsm_outs5;
-  lsm6dso_fsm_outs6_t                     fsm_outs6;
-  lsm6dso_fsm_outs7_t                     fsm_outs7;
-  lsm6dso_fsm_outs8_t                     fsm_outs8;
-  lsm6dso_fsm_outs9_t                     fsm_outs9;
-  lsm6dso_fsm_outs10_t                    fsm_outs10;
-  lsm6dso_fsm_outs11_t                    fsm_outs11;
-  lsm6dso_fsm_outs12_t                    fsm_outs12;
-  lsm6dso_fsm_outs13_t                    fsm_outs13;
-  lsm6dso_fsm_outs14_t                    fsm_outs14;
-  lsm6dso_fsm_outs15_t                    fsm_outs15;
-  lsm6dso_fsm_outs16_t                    fsm_outs16;
-  lsm6dso_emb_func_odr_cfg_b_t            emb_func_odr_cfg_b;
-  lsm6dso_emb_func_src_t                  emb_func_src;
-  lsm6dso_emb_func_init_a_t               emb_func_init_a;
-  lsm6dso_emb_func_init_b_t               emb_func_init_b;
-  lsm6dso_mag_cfg_a_t                     mag_cfg_a;
-  lsm6dso_mag_cfg_b_t                     mag_cfg_b;
-  lsm6dso_pedo_cmd_reg_t                  pedo_cmd_reg;
-  lsm6dso_sensor_hub_1_t                  sensor_hub_1;
-  lsm6dso_sensor_hub_2_t                  sensor_hub_2;
-  lsm6dso_sensor_hub_3_t                  sensor_hub_3;
-  lsm6dso_sensor_hub_4_t                  sensor_hub_4;
-  lsm6dso_sensor_hub_5_t                  sensor_hub_5;
-  lsm6dso_sensor_hub_6_t                  sensor_hub_6;
-  lsm6dso_sensor_hub_7_t                  sensor_hub_7;
-  lsm6dso_sensor_hub_8_t                  sensor_hub_8;
-  lsm6dso_sensor_hub_9_t                  sensor_hub_9;
-  lsm6dso_sensor_hub_10_t                 sensor_hub_10;
-  lsm6dso_sensor_hub_11_t                 sensor_hub_11;
-  lsm6dso_sensor_hub_12_t                 sensor_hub_12;
-  lsm6dso_sensor_hub_13_t                 sensor_hub_13;
-  lsm6dso_sensor_hub_14_t                 sensor_hub_14;
-  lsm6dso_sensor_hub_15_t                 sensor_hub_15;
-  lsm6dso_sensor_hub_16_t                 sensor_hub_16;
-  lsm6dso_sensor_hub_17_t                 sensor_hub_17;
-  lsm6dso_sensor_hub_18_t                 sensor_hub_18;
-  lsm6dso_master_config_t                 master_config;
-  lsm6dso_slv0_add_t                      slv0_add;
-  lsm6dso_slv0_subadd_t                   slv0_subadd;
-  lsm6dso_slv0_config_t                   slv0_config;
-  lsm6dso_slv1_add_t                      slv1_add;
-  lsm6dso_slv1_subadd_t                   slv1_subadd;
-  lsm6dso_slv1_config_t                   slv1_config;
-  lsm6dso_slv2_add_t                      slv2_add;
-  lsm6dso_slv2_subadd_t                   slv2_subadd;
-  lsm6dso_slv2_config_t                   slv2_config;
-  lsm6dso_slv3_add_t                      slv3_add;
-  lsm6dso_slv3_subadd_t                   slv3_subadd;
-  lsm6dso_slv3_config_t                   slv3_config;
-  lsm6dso_datawrite_src_mode_sub_slv0_t   datawrite_src_mode_sub_slv0;
-  lsm6dso_status_master_t                 status_master;
-  bitwise_t                               bitwise;
-  uint8_t                                 byte;
-} lsm6dso_reg_t;
-
-/**
-  * @}
-  *
-  */
-
 float_t lsm6dso_from_fs2_to_mg(int16_t lsb);
 float_t lsm6dso_from_fs4_to_mg(int16_t lsb);
 float_t lsm6dso_from_fs8_to_mg(int16_t lsb);
@@ -4443,7 +4300,7 @@ typedef struct
   } ois;
 } lsm6dso_data_t;
 int32_t lsm6dso_data_get(const stmdev_ctx_t *ctx, stmdev_ctx_t *aux_ctx,
-                         lsm6dso_md_t *md, lsm6dso_data_t *data);
+                         const lsm6dso_md_t *md, lsm6dso_data_t *data);
 
 typedef struct
 {
@@ -4455,7 +4312,7 @@ typedef struct
   uint8_t fifo_compr   : 1; /* FIFO compression */
 } lsm6dso_emb_sens_t;
 int32_t lsm6dso_embedded_sens_set(const stmdev_ctx_t *ctx,
-                                  lsm6dso_emb_sens_t *emb_sens);
+                                  const lsm6dso_emb_sens_t *emb_sens);
 int32_t lsm6dso_embedded_sens_get(const stmdev_ctx_t *ctx,
                                   lsm6dso_emb_sens_t *emb_sens);
 int32_t lsm6dso_embedded_sens_off(const stmdev_ctx_t *ctx);

--- a/sensor/stmemsc/lsm6dsv16b_STdC/driver/lsm6dsv16b_reg.h
+++ b/sensor/stmemsc/lsm6dsv16b_STdC/driver/lsm6dsv16b_reg.h
@@ -2924,9 +2924,9 @@ int32_t lsm6dsv16b_tap_detection_get(const stmdev_ctx_t *ctx,
 
 typedef struct
 {
-  uint8_t x                             : 1;
-  uint8_t y                             : 1;
-  uint8_t z                             : 1;
+  uint8_t x                             : 5;
+  uint8_t y                             : 5;
+  uint8_t z                             : 5;
 } lsm6dsv16b_tap_thresholds_t;
 int32_t lsm6dsv16b_tap_thresholds_set(const stmdev_ctx_t *ctx,
                                       lsm6dsv16b_tap_thresholds_t val);
@@ -2950,9 +2950,9 @@ int32_t lsm6dsv16b_tap_axis_priority_get(const stmdev_ctx_t *ctx,
 
 typedef struct
 {
-  uint8_t shock                         : 1;
-  uint8_t quiet                         : 1;
-  uint8_t tap_gap                       : 1;
+  uint8_t shock                         : 2;
+  uint8_t quiet                         : 2;
+  uint8_t tap_gap                       : 4;
 } lsm6dsv16b_tap_time_windows_t;
 int32_t lsm6dsv16b_tap_time_windows_set(const stmdev_ctx_t *ctx,
                                         lsm6dsv16b_tap_time_windows_t val);

--- a/sensor/stmemsc/lsm6dsv16bx_STdC/driver/lsm6dsv16bx_reg.h
+++ b/sensor/stmemsc/lsm6dsv16bx_STdC/driver/lsm6dsv16bx_reg.h
@@ -3184,9 +3184,9 @@ int32_t lsm6dsv16bx_tap_detection_get(const stmdev_ctx_t *ctx,
 
 typedef struct
 {
-  uint8_t x                             : 1;
-  uint8_t y                             : 1;
-  uint8_t z                             : 1;
+  uint8_t x                             : 5;
+  uint8_t y                             : 5;
+  uint8_t z                             : 5;
 } lsm6dsv16bx_tap_thresholds_t;
 int32_t lsm6dsv16bx_tap_thresholds_set(const stmdev_ctx_t *ctx,
                                        lsm6dsv16bx_tap_thresholds_t val);
@@ -3210,9 +3210,9 @@ int32_t lsm6dsv16bx_tap_axis_priority_get(const stmdev_ctx_t *ctx,
 
 typedef struct
 {
-  uint8_t shock                         : 1;
-  uint8_t quiet                         : 1;
-  uint8_t tap_gap                       : 1;
+  uint8_t shock                         : 2;
+  uint8_t quiet                         : 2;
+  uint8_t tap_gap                       : 4;
 } lsm6dsv16bx_tap_time_windows_t;
 int32_t lsm6dsv16bx_tap_time_windows_set(const stmdev_ctx_t *ctx,
                                          lsm6dsv16bx_tap_time_windows_t val);

--- a/sensor/stmemsc/lsm6dsv320x_STdC/driver/lsm6dsv320x_reg.c
+++ b/sensor/stmemsc/lsm6dsv320x_STdC/driver/lsm6dsv320x_reg.c
@@ -1,0 +1,11602 @@
+/**
+  ******************************************************************************
+  * @file    lsm6dsv320x_reg.c
+  * @author  Sensors Software Solution Team
+  * @brief   LSM6DSV320X driver file
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2025 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+#include "lsm6dsv320x_reg.h"
+
+/**
+  * @defgroup  LSM6DSV320X
+  * @brief     This file provides a set of functions needed to drive the
+  *            lsm6dsv320x enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup  Interfaces functions
+  * @brief     This section provide a set of functions used to read and
+  *            write a generic register of the device.
+  *            MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   communication interface handler.(ptr)
+  * @param  reg   first register address to read.
+  * @param  data  buffer for data read.(ptr)
+  * @param  len   number of consecutive register to read.
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t __weak lsm6dsv320x_read_reg(const stmdev_ctx_t *ctx, uint8_t reg,
+                                    uint8_t *data,
+                                    uint16_t len)
+{
+  int32_t ret;
+
+  if (ctx == NULL)
+  {
+    return -1;
+  }
+
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   communication interface handler.(ptr)
+  * @param  reg   first register address to write.
+  * @param  data  the buffer contains data to be written.(ptr)
+  * @param  len   number of consecutive register to write.
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t __weak lsm6dsv320x_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
+                                     uint8_t *data,
+                                     uint16_t len)
+{
+  int32_t ret;
+
+  if (ctx == NULL)
+  {
+    return -1;
+  }
+
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Private functions
+  * @brief     Section collect all the utility functions needed by APIs.
+  * @{
+  *
+  */
+
+static void bytecpy(uint8_t *target, uint8_t *source)
+{
+  if ((target != NULL) && (source != NULL))
+  {
+    *target = *source;
+  }
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Sensitivity
+  * @brief     These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+float_t lsm6dsv320x_from_sflp_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.061f;
+}
+
+float_t lsm6dsv320x_from_fs2_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.061f;
+}
+
+float_t lsm6dsv320x_from_fs4_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.122f;
+}
+
+float_t lsm6dsv320x_from_fs8_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.244f;
+}
+
+float_t lsm6dsv320x_from_fs16_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.488f;
+}
+
+float_t lsm6dsv320x_from_fs32_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.976f;
+}
+
+float_t lsm6dsv320x_from_fs64_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 1.952f;
+}
+
+float_t lsm6dsv320x_from_fs128_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 3.904f;
+}
+
+float_t lsm6dsv320x_from_fs256_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 7.808f;
+}
+
+float_t lsm6dsv320x_from_fs320_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 10.417f;
+}
+
+float_t lsm6dsv320x_from_fs250_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb) * 8.750f;
+}
+
+float_t lsm6dsv320x_from_fs500_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb) * 17.50f;
+}
+
+float_t lsm6dsv320x_from_fs1000_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb) * 35.0f;
+}
+
+float_t lsm6dsv320x_from_fs2000_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb) * 70.0f;
+}
+
+float_t lsm6dsv320x_from_fs4000_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb) * 140.0f;
+}
+
+float_t lsm6dsv320x_from_lsb_to_celsius(int16_t lsb)
+{
+  return (((float_t)lsb / 256.0f) + 25.0f);
+}
+
+uint64_t lsm6dsv320x_from_lsb_to_nsec(uint32_t lsb)
+{
+  return ((uint64_t)lsb * 21700);
+}
+
+float_t lsm6dsv320x_from_lsb_to_mv(int16_t lsb)
+{
+  return ((float_t)lsb) / 78.0f;
+}
+
+float_t lsm6dsv320x_from_gbias_lsb_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb) * 4.375f;
+}
+
+float_t lsm6dsv320x_from_gravity_lsb_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.061f;
+}
+
+static float_t npy_half_to_float(uint16_t h);
+float_t lsm6dsv320x_from_quaternion_lsb_to_float(uint16_t lsb)
+{
+  return npy_half_to_float(lsb);
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Accelerometer user offset correction
+  * @brief      This section groups all the functions concerning the
+  *             usage of Accelerometer user offset correction
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enables accelerometer user offset correction block; it is valid for the low-pass path.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables accelerometer user offset correction block; it is valid for the low-pass path.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_xl_offset_on_out_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_ctrl9_t ctrl9;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL9, (uint8_t *)&ctrl9, 1);
+  if (ret == 0)
+  {
+    ctrl9.usr_off_on_out = val;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL9, (uint8_t *)&ctrl9, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables accelerometer user offset correction block; it is valid for the low-pass path.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables accelerometer user offset correction block; it is valid for the low-pass path.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_xl_offset_on_out_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_ctrl9_t ctrl9;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL9, (uint8_t *)&ctrl9, 1);
+  *val = ctrl9.usr_off_on_out;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer user offset correction values in mg.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Accelerometer user offset correction values in mg.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_xl_offset_mg_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv320x_xl_offset_mg_t val)
+{
+  lsm6dsv320x_z_ofs_usr_t z_ofs_usr;
+  lsm6dsv320x_y_ofs_usr_t y_ofs_usr;
+  lsm6dsv320x_x_ofs_usr_t x_ofs_usr;
+  lsm6dsv320x_ctrl9_t ctrl9;
+  int32_t ret;
+  float_t tmp;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_X_OFS_USR, (uint8_t *)&x_ofs_usr, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+
+  if ((val.x_mg < (0.0078125f * 127.0f)) && (val.x_mg > (0.0078125f * -127.0f)) &&
+      (val.y_mg < (0.0078125f * 127.0f)) && (val.y_mg > (0.0078125f * -127.0f)) &&
+      (val.z_mg < (0.0078125f * 127.0f)) && (val.z_mg > (0.0078125f * -127.0f)))
+  {
+    ctrl9.usr_off_w = 0;
+
+    tmp = val.z_mg / 0.0078125f;
+    z_ofs_usr.z_ofs_usr = (uint8_t)tmp;
+
+    tmp = val.y_mg / 0.0078125f;
+    y_ofs_usr.y_ofs_usr = (uint8_t)tmp;
+
+    tmp = val.x_mg / 0.0078125f;
+    x_ofs_usr.x_ofs_usr = (uint8_t)tmp;
+  }
+  else if ((val.x_mg < (0.125f * 127.0f)) && (val.x_mg > (0.125f * -127.0f)) &&
+           (val.y_mg < (0.125f * 127.0f)) && (val.y_mg > (0.125f * -127.0f)) &&
+           (val.z_mg < (0.125f * 127.0f)) && (val.z_mg > (0.125f * -127.0f)))
+  {
+    ctrl9.usr_off_w = 1;
+
+    tmp = val.z_mg / 0.125f;
+    z_ofs_usr.z_ofs_usr = (uint8_t)tmp;
+
+    tmp = val.y_mg / 0.125f;
+    y_ofs_usr.y_ofs_usr = (uint8_t)tmp;
+
+    tmp = val.x_mg / 0.125f;
+    x_ofs_usr.x_ofs_usr = (uint8_t)tmp;
+  }
+  else // out of limit
+  {
+    ctrl9.usr_off_w = 1;
+    z_ofs_usr.z_ofs_usr = 0xFFU;
+    y_ofs_usr.y_ofs_usr = 0xFFU;
+    x_ofs_usr.x_ofs_usr = 0xFFU;
+  }
+
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_X_OFS_USR, (uint8_t *)&x_ofs_usr, 1);
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL9, (uint8_t *)&ctrl9, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer user offset correction values in mg.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Accelerometer user offset correction values in mg.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_xl_offset_mg_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv320x_xl_offset_mg_t *val)
+{
+  lsm6dsv320x_z_ofs_usr_t z_ofs_usr;
+  lsm6dsv320x_y_ofs_usr_t y_ofs_usr;
+  lsm6dsv320x_x_ofs_usr_t x_ofs_usr;
+  lsm6dsv320x_ctrl9_t ctrl9;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL9, (uint8_t *)&ctrl9, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_X_OFS_USR, (uint8_t *)&x_ofs_usr, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  if (ctrl9.usr_off_w == PROPERTY_DISABLE)
+  {
+    val->z_mg = ((float_t)z_ofs_usr.z_ofs_usr * 0.0078125f);
+    val->y_mg = ((float_t)y_ofs_usr.y_ofs_usr * 0.0078125f);
+    val->x_mg = ((float_t)x_ofs_usr.x_ofs_usr * 0.0078125f);
+  }
+  else
+  {
+    val->z_mg = ((float_t)z_ofs_usr.z_ofs_usr * 0.125f);
+    val->y_mg = ((float_t)y_ofs_usr.y_ofs_usr * 0.125f);
+    val->x_mg = ((float_t)x_ofs_usr.x_ofs_usr * 0.125f);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  HG Accelerometer user offset correction values in mg.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Accelerometer user offset correction values in mg.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_hg_xl_offset_mg_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_xl_offset_mg_t val)
+{
+  lsm6dsv320x_hg_z_ofs_usr_t z_ofs_usr;
+  lsm6dsv320x_hg_y_ofs_usr_t y_ofs_usr;
+  lsm6dsv320x_hg_x_ofs_usr_t x_ofs_usr;
+  lsm6dsv320x_ctrl1_xl_hg_t  ctrl1_xl_hg;
+  int32_t ret;
+  float_t tmp;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL1_XL_HG, (uint8_t *)&ctrl1_xl_hg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  if ((val.x_mg < (0.25f * 127.0f)) && (val.x_mg > (0.25f * -127.0f)) &&
+      (val.y_mg < (0.25f * 127.0f)) && (val.y_mg > (0.25f * -127.0f)) &&
+      (val.z_mg < (0.25f * 127.0f)) && (val.z_mg > (0.25f * -127.0f)))
+  {
+    ctrl1_xl_hg.hg_usr_off_on_out = 1;
+
+    tmp = val.z_mg / 0.25f;
+    z_ofs_usr.xl_hg_z_ofs_usr = (uint8_t)tmp;
+
+    tmp = val.y_mg / 0.25f;
+    y_ofs_usr.xl_hg_y_ofs_usr = (uint8_t)tmp;
+
+    tmp = val.x_mg / 0.25f;
+    x_ofs_usr.xl_hg_x_ofs_usr = (uint8_t)tmp;
+  }
+  else // out of limit
+  {
+    ctrl1_xl_hg.hg_usr_off_on_out = 0;
+    z_ofs_usr.xl_hg_z_ofs_usr = 0xFFU;
+    y_ofs_usr.xl_hg_y_ofs_usr = 0xFFU;
+    x_ofs_usr.xl_hg_x_ofs_usr = 0xFFU;
+  }
+
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_XL_HG_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_XL_HG_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_XL_HG_X_OFS_USR, (uint8_t *)&x_ofs_usr, 1);
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL1_XL_HG, (uint8_t *)&ctrl1_xl_hg, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  HG Accelerometer user offset correction values in mg.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Accelerometer user offset correction values in mg.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_hg_xl_offset_mg_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_xl_offset_mg_t *val)
+{
+  lsm6dsv320x_hg_z_ofs_usr_t z_ofs_usr;
+  lsm6dsv320x_hg_y_ofs_usr_t y_ofs_usr;
+  lsm6dsv320x_hg_x_ofs_usr_t x_ofs_usr;
+  lsm6dsv320x_ctrl1_xl_hg_t  ctrl1_xl_hg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL1_XL_HG, (uint8_t *)&ctrl1_xl_hg, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_XL_HG_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_XL_HG_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_XL_HG_X_OFS_USR, (uint8_t *)&x_ofs_usr, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  if (ctrl1_xl_hg.hg_usr_off_on_out == PROPERTY_DISABLE)
+  {
+    val->z_mg = 0.0f;
+    val->y_mg = 0.0f;
+    val->x_mg = 0.0f;
+  }
+  else
+  {
+    val->z_mg = ((float_t)z_ofs_usr.xl_hg_z_ofs_usr * 0.25f);
+    val->y_mg = ((float_t)y_ofs_usr.xl_hg_y_ofs_usr * 0.25f);
+    val->x_mg = ((float_t)x_ofs_usr.xl_hg_x_ofs_usr * 0.25f);
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @brief  Reset of the device.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Reset of the device.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_reset_set(const stmdev_ctx_t *ctx, lsm6dsv320x_reset_t val)
+{
+  lsm6dsv320x_func_cfg_access_t func_cfg_access;
+  lsm6dsv320x_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL3, (uint8_t *)&ctrl3, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ctrl3.boot = ((uint8_t)val & 0x04U) >> 2;
+  ctrl3.sw_reset = ((uint8_t)val & 0x02U) >> 1;
+  func_cfg_access.sw_por = (uint8_t)val & 0x01U;
+
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL3, (uint8_t *)&ctrl3, 1);
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Global reset of the device.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Global reset of the device.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_reset_get(const stmdev_ctx_t *ctx, lsm6dsv320x_reset_t *val)
+{
+  lsm6dsv320x_func_cfg_access_t func_cfg_access;
+  lsm6dsv320x_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL3, (uint8_t *)&ctrl3, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch ((ctrl3.sw_reset << 2) + (ctrl3.boot << 1) + func_cfg_access.sw_por)
+  {
+    case LSM6DSV320X_READY:
+      *val = LSM6DSV320X_READY;
+      break;
+
+    case LSM6DSV320X_GLOBAL_RST:
+      *val = LSM6DSV320X_GLOBAL_RST;
+      break;
+
+    case LSM6DSV320X_RESTORE_CAL_PARAM:
+      *val = LSM6DSV320X_RESTORE_CAL_PARAM;
+      break;
+
+    case LSM6DSV320X_RESTORE_CTRL_REGS:
+      *val = LSM6DSV320X_RESTORE_CTRL_REGS;
+      break;
+
+    default:
+      *val = LSM6DSV320X_GLOBAL_RST;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Change memory bank.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      MAIN_MEM_BANK, EMBED_FUNC_MEM_BANK,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_mem_bank_set(const stmdev_ctx_t *ctx, lsm6dsv320x_mem_bank_t val)
+{
+  lsm6dsv320x_func_cfg_access_t func_cfg_access;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  func_cfg_access.shub_reg_access = ((uint8_t)val & 0x02U) >> 1;
+  func_cfg_access.emb_func_reg_access = (uint8_t)val & 0x01U;
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Change memory bank.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      MAIN_MEM_BANK, SENSOR_HUB_MEM_BANK, EMBED_FUNC_MEM_BANK,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_mem_bank_get(const stmdev_ctx_t *ctx, lsm6dsv320x_mem_bank_t *val)
+{
+  lsm6dsv320x_func_cfg_access_t func_cfg_access;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch ((func_cfg_access.shub_reg_access << 1) + func_cfg_access.emb_func_reg_access)
+  {
+    case LSM6DSV320X_MAIN_MEM_BANK:
+      *val = LSM6DSV320X_MAIN_MEM_BANK;
+      break;
+
+    case LSM6DSV320X_EMBED_FUNC_MEM_BANK:
+      *val = LSM6DSV320X_EMBED_FUNC_MEM_BANK;
+      break;
+
+    case LSM6DSV320X_SENSOR_HUB_MEM_BANK:
+      *val = LSM6DSV320X_SENSOR_HUB_MEM_BANK;
+      break;
+
+    default:
+      *val = LSM6DSV320X_MAIN_MEM_BANK;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Device ID.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Device ID.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_device_id_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_WHO_AM_I, val, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer output data rate (ODR) selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lsm6dsv320x_data_rate_t enum
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_xl_data_rate_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv320x_data_rate_t val)
+{
+  lsm6dsv320x_ctrl1_t ctrl1;
+  lsm6dsv320x_haodr_cfg_t haodr;
+  uint8_t sel;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL1, (uint8_t *)&ctrl1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ctrl1.odr_xl = (uint8_t)val & 0x0Fu;
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL1, (uint8_t *)&ctrl1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  sel = ((uint8_t)val >> 4) & 0xFU;
+  if (sel != 0U)
+  {
+    ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_HAODR_CFG, (uint8_t *)&haodr, 1);
+    haodr.haodr_sel = sel;
+    ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_HAODR_CFG, (uint8_t *)&haodr, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer output data rate (ODR) selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lsm6dsv320x_data_rate_t enum
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_xl_data_rate_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv320x_data_rate_t *val)
+{
+  lsm6dsv320x_ctrl1_t ctrl1;
+  lsm6dsv320x_haodr_cfg_t haodr;
+  uint8_t sel;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL1, (uint8_t *)&ctrl1, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_HAODR_CFG, (uint8_t *)&haodr, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  sel = haodr.haodr_sel;
+
+  switch (ctrl1.odr_xl)
+  {
+    case LSM6DSV320X_ODR_OFF:
+      *val = LSM6DSV320X_ODR_OFF;
+      break;
+
+    case LSM6DSV320X_ODR_AT_1Hz875:
+      *val = LSM6DSV320X_ODR_AT_1Hz875;
+      break;
+
+    case LSM6DSV320X_ODR_AT_7Hz5:
+      *val = LSM6DSV320X_ODR_AT_7Hz5;
+      break;
+
+    case LSM6DSV320X_ODR_AT_15Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV320X_ODR_AT_15Hz;
+          break;
+        case 1:
+          *val = LSM6DSV320X_ODR_HA01_AT_15Hz625;
+          break;
+        case 2:
+          *val = LSM6DSV320X_ODR_HA02_AT_13Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV320X_ODR_AT_30Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV320X_ODR_AT_30Hz;
+          break;
+        case 1:
+          *val = LSM6DSV320X_ODR_HA01_AT_31Hz25;
+          break;
+        case 2:
+          *val = LSM6DSV320X_ODR_HA02_AT_26Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV320X_ODR_AT_60Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV320X_ODR_AT_60Hz;
+          break;
+        case 1:
+          *val = LSM6DSV320X_ODR_HA01_AT_62Hz5;
+          break;
+        case 2:
+          *val = LSM6DSV320X_ODR_HA02_AT_52Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV320X_ODR_AT_120Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV320X_ODR_AT_120Hz;
+          break;
+        case 1:
+          *val = LSM6DSV320X_ODR_HA01_AT_125Hz;
+          break;
+        case 2:
+          *val = LSM6DSV320X_ODR_HA02_AT_104Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV320X_ODR_AT_240Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV320X_ODR_AT_240Hz;
+          break;
+        case 1:
+          *val = LSM6DSV320X_ODR_HA01_AT_250Hz;
+          break;
+        case 2:
+          *val = LSM6DSV320X_ODR_HA02_AT_208Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV320X_ODR_AT_480Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV320X_ODR_AT_480Hz;
+          break;
+        case 1:
+          *val = LSM6DSV320X_ODR_HA01_AT_500Hz;
+          break;
+        case 2:
+          *val = LSM6DSV320X_ODR_HA02_AT_417Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV320X_ODR_AT_960Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV320X_ODR_AT_960Hz;
+          break;
+        case 1:
+          *val = LSM6DSV320X_ODR_HA01_AT_1000Hz;
+          break;
+        case 2:
+          *val = LSM6DSV320X_ODR_HA02_AT_833Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV320X_ODR_AT_1920Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV320X_ODR_AT_1920Hz;
+          break;
+        case 1:
+          *val = LSM6DSV320X_ODR_HA01_AT_2000Hz;
+          break;
+        case 2:
+          *val = LSM6DSV320X_ODR_HA02_AT_1667Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV320X_ODR_AT_3840Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV320X_ODR_AT_3840Hz;
+          break;
+        case 1:
+          *val = LSM6DSV320X_ODR_HA01_AT_4000Hz;
+          break;
+        case 2:
+          *val = LSM6DSV320X_ODR_HA02_AT_3333Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV320X_ODR_AT_7680Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV320X_ODR_AT_7680Hz;
+          break;
+        case 1:
+          *val = LSM6DSV320X_ODR_HA01_AT_8000Hz;
+          break;
+        case 2:
+          *val = LSM6DSV320X_ODR_HA02_AT_6667Hz;
+          break;
+      }
+      break;
+
+    default:
+      *val = LSM6DSV320X_ODR_OFF;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  HG Accelerometer output data rate (ODR) selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lsm6dsv320x_hg_xl_data_rate_t enum
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_hg_xl_data_rate_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_hg_xl_data_rate_t val,
+                                        uint8_t reg_out_en)
+{
+  lsm6dsv320x_ctrl1_xl_hg_t ctrl1_xl_hg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL1_XL_HG, (uint8_t *)&ctrl1_xl_hg, 1);
+  ctrl1_xl_hg.odr_xl_hg = (uint8_t)val & 0x07U;
+  ctrl1_xl_hg.xl_hg_regout_en = reg_out_en & 0x1U;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL1_XL_HG, (uint8_t *)&ctrl1_xl_hg, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer output data rate (ODR) selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lsm6dsv320x_hg_xl_data_rate_t enum
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_hg_xl_data_rate_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_hg_xl_data_rate_t *val,
+                                        uint8_t *reg_out_en)
+{
+  lsm6dsv320x_ctrl1_xl_hg_t ctrl1_xl_hg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL1_XL_HG, (uint8_t *)&ctrl1_xl_hg, 1);
+
+  *reg_out_en = ctrl1_xl_hg.xl_hg_regout_en;
+
+  switch (ctrl1_xl_hg.odr_xl_hg)
+  {
+    case LSM6DSV320X_HG_XL_ODR_OFF:
+      *val = LSM6DSV320X_HG_XL_ODR_OFF;
+      break;
+
+    case LSM6DSV320X_HG_XL_ODR_AT_480Hz:
+      *val = LSM6DSV320X_HG_XL_ODR_AT_480Hz;
+      break;
+
+    case LSM6DSV320X_HG_XL_ODR_AT_960Hz:
+      *val = LSM6DSV320X_HG_XL_ODR_AT_960Hz;
+      break;
+
+    case LSM6DSV320X_HG_XL_ODR_AT_1920Hz:
+      *val = LSM6DSV320X_HG_XL_ODR_AT_1920Hz;
+      break;
+
+    case LSM6DSV320X_HG_XL_ODR_AT_3840Hz:
+      *val = LSM6DSV320X_HG_XL_ODR_AT_3840Hz;
+      break;
+
+    case LSM6DSV320X_HG_XL_ODR_AT_7680Hz:
+      *val = LSM6DSV320X_HG_XL_ODR_AT_7680Hz;
+      break;
+
+    default:
+      *val = LSM6DSV320X_HG_XL_ODR_OFF;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer operating mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      XL_HIGH_PERFORMANCE_MD, XL_HIGH_ACCURACY_ODR_MD, XL_LOW_POWER_2_AVG_MD, XL_LOW_POWER_4_AVG_MD, XL_LOW_POWER_8_AVG_MD, XL_NORMAL_MD,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_xl_mode_set(const stmdev_ctx_t *ctx, lsm6dsv320x_xl_mode_t val)
+{
+  lsm6dsv320x_ctrl1_t ctrl1;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL1, (uint8_t *)&ctrl1, 1);
+
+  if (ret == 0)
+  {
+    ctrl1.op_mode_xl = (uint8_t)val & 0x07U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL1, (uint8_t *)&ctrl1, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer operating mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      XL_HIGH_PERFORMANCE_MD, XL_HIGH_ACCURACY_ODR_MD, XL_LOW_POWER_2_AVG_MD, XL_LOW_POWER_4_AVG_MD, XL_LOW_POWER_8_AVG_MD, XL_NORMAL_MD,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_xl_mode_get(const stmdev_ctx_t *ctx, lsm6dsv320x_xl_mode_t *val)
+{
+  lsm6dsv320x_ctrl1_t ctrl1;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL1, (uint8_t *)&ctrl1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl1.op_mode_xl)
+  {
+    case LSM6DSV320X_XL_HIGH_PERFORMANCE_MD:
+      *val = LSM6DSV320X_XL_HIGH_PERFORMANCE_MD;
+      break;
+
+    case LSM6DSV320X_XL_HIGH_ACCURACY_ODR_MD:
+      *val = LSM6DSV320X_XL_HIGH_ACCURACY_ODR_MD;
+      break;
+
+    case LSM6DSV320X_XL_ODR_TRIGGERED_MD:
+      *val = LSM6DSV320X_XL_ODR_TRIGGERED_MD;
+      break;
+
+    case LSM6DSV320X_XL_LOW_POWER_2_AVG_MD:
+      *val = LSM6DSV320X_XL_LOW_POWER_2_AVG_MD;
+      break;
+
+    case LSM6DSV320X_XL_LOW_POWER_4_AVG_MD:
+      *val = LSM6DSV320X_XL_LOW_POWER_4_AVG_MD;
+      break;
+
+    case LSM6DSV320X_XL_LOW_POWER_8_AVG_MD:
+      *val = LSM6DSV320X_XL_LOW_POWER_8_AVG_MD;
+      break;
+
+    case LSM6DSV320X_XL_NORMAL_MD:
+      *val = LSM6DSV320X_XL_NORMAL_MD;
+      break;
+
+    default:
+      *val = LSM6DSV320X_XL_HIGH_PERFORMANCE_MD;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope output data rate (ODR) selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lsm6dsv320x_data_rate_t enum
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_gy_data_rate_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv320x_data_rate_t val)
+{
+  lsm6dsv320x_ctrl2_t ctrl2;
+  lsm6dsv320x_haodr_cfg_t haodr;
+  uint8_t sel;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL2, (uint8_t *)&ctrl2, 1);
+  ctrl2.odr_g = (uint8_t)val & 0x0Fu;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL2, (uint8_t *)&ctrl2, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  sel = ((uint8_t)val >> 4) & 0xFU;
+  if (sel != 0U)
+  {
+    ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_HAODR_CFG, (uint8_t *)&haodr, 1);
+    haodr.haodr_sel = sel;
+    ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_HAODR_CFG, (uint8_t *)&haodr, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope output data rate (ODR) selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lsm6dsv320x_data_rate_t enum
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_gy_data_rate_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv320x_data_rate_t *val)
+{
+  lsm6dsv320x_ctrl2_t ctrl2;
+  lsm6dsv320x_haodr_cfg_t haodr;
+  uint8_t sel;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL2, (uint8_t *)&ctrl2, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_HAODR_CFG, (uint8_t *)&haodr, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  sel = haodr.haodr_sel;
+
+  switch (ctrl2.odr_g)
+  {
+    case LSM6DSV320X_ODR_OFF:
+      *val = LSM6DSV320X_ODR_OFF;
+      break;
+
+    case LSM6DSV320X_ODR_AT_1Hz875:
+      *val = LSM6DSV320X_ODR_AT_1Hz875;
+      break;
+
+    case LSM6DSV320X_ODR_AT_7Hz5:
+      *val = LSM6DSV320X_ODR_AT_7Hz5;
+      break;
+
+    case LSM6DSV320X_ODR_AT_15Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV320X_ODR_AT_15Hz;
+          break;
+        case 1:
+          *val = LSM6DSV320X_ODR_HA01_AT_15Hz625;
+          break;
+        case 2:
+          *val = LSM6DSV320X_ODR_HA02_AT_13Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV320X_ODR_AT_30Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV320X_ODR_AT_30Hz;
+          break;
+        case 1:
+          *val = LSM6DSV320X_ODR_HA01_AT_31Hz25;
+          break;
+        case 2:
+          *val = LSM6DSV320X_ODR_HA02_AT_26Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV320X_ODR_AT_60Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV320X_ODR_AT_60Hz;
+          break;
+        case 1:
+          *val = LSM6DSV320X_ODR_HA01_AT_62Hz5;
+          break;
+        case 2:
+          *val = LSM6DSV320X_ODR_HA02_AT_52Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV320X_ODR_AT_120Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV320X_ODR_AT_120Hz;
+          break;
+        case 1:
+          *val = LSM6DSV320X_ODR_HA01_AT_125Hz;
+          break;
+        case 2:
+          *val = LSM6DSV320X_ODR_HA02_AT_104Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV320X_ODR_AT_240Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV320X_ODR_AT_240Hz;
+          break;
+        case 1:
+          *val = LSM6DSV320X_ODR_HA01_AT_250Hz;
+          break;
+        case 2:
+          *val = LSM6DSV320X_ODR_HA02_AT_208Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV320X_ODR_AT_480Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV320X_ODR_AT_480Hz;
+          break;
+        case 1:
+          *val = LSM6DSV320X_ODR_HA01_AT_500Hz;
+          break;
+        case 2:
+          *val = LSM6DSV320X_ODR_HA02_AT_417Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV320X_ODR_AT_960Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV320X_ODR_AT_960Hz;
+          break;
+        case 1:
+          *val = LSM6DSV320X_ODR_HA01_AT_1000Hz;
+          break;
+        case 2:
+          *val = LSM6DSV320X_ODR_HA02_AT_833Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV320X_ODR_AT_1920Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV320X_ODR_AT_1920Hz;
+          break;
+        case 1:
+          *val = LSM6DSV320X_ODR_HA01_AT_2000Hz;
+          break;
+        case 2:
+          *val = LSM6DSV320X_ODR_HA02_AT_1667Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV320X_ODR_AT_3840Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV320X_ODR_AT_3840Hz;
+          break;
+        case 1:
+          *val = LSM6DSV320X_ODR_HA01_AT_4000Hz;
+          break;
+        case 2:
+          *val = LSM6DSV320X_ODR_HA02_AT_3333Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV320X_ODR_AT_7680Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV320X_ODR_AT_7680Hz;
+          break;
+        case 1:
+          *val = LSM6DSV320X_ODR_HA01_AT_8000Hz;
+          break;
+        case 2:
+          *val = LSM6DSV320X_ODR_HA02_AT_6667Hz;
+          break;
+      }
+      break;
+
+    default:
+      *val = LSM6DSV320X_ODR_OFF;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope operating mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      GY_HIGH_PERFORMANCE_MD, GY_HIGH_ACCURACY_ODR_MD, GY_SLEEP_MD, GY_LOW_POWER_MD,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_gy_mode_set(const stmdev_ctx_t *ctx, lsm6dsv320x_gy_mode_t val)
+{
+  lsm6dsv320x_ctrl2_t ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL2, (uint8_t *)&ctrl2, 1);
+  if (ret == 0)
+  {
+    ctrl2.op_mode_g = (uint8_t)val & 0x07U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL2, (uint8_t *)&ctrl2, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope operating mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      GY_HIGH_PERFORMANCE_MD, GY_HIGH_ACCURACY_ODR_MD, GY_SLEEP_MD, GY_LOW_POWER_MD,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_gy_mode_get(const stmdev_ctx_t *ctx, lsm6dsv320x_gy_mode_t *val)
+{
+  lsm6dsv320x_ctrl2_t ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL2, (uint8_t *)&ctrl2, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl2.op_mode_g)
+  {
+    case LSM6DSV320X_GY_HIGH_PERFORMANCE_MD:
+      *val = LSM6DSV320X_GY_HIGH_PERFORMANCE_MD;
+      break;
+
+    case LSM6DSV320X_GY_HIGH_ACCURACY_ODR_MD:
+      *val = LSM6DSV320X_GY_HIGH_ACCURACY_ODR_MD;
+      break;
+
+    case LSM6DSV320X_GY_ODR_TRIGGERED_MD:
+      *val = LSM6DSV320X_GY_ODR_TRIGGERED_MD;
+      break;
+
+    case LSM6DSV320X_GY_SLEEP_MD:
+      *val = LSM6DSV320X_GY_SLEEP_MD;
+      break;
+
+    case LSM6DSV320X_GY_LOW_POWER_MD:
+      *val = LSM6DSV320X_GY_LOW_POWER_MD;
+      break;
+
+    default:
+      *val = LSM6DSV320X_GY_HIGH_PERFORMANCE_MD;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a multiple byte access with a serial interface (enable by default).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Register address automatically incremented during a multiple byte access with a serial interface (enable by default).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_auto_increment_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL3, (uint8_t *)&ctrl3, 1);
+  if (ret == 0)
+  {
+    ctrl3.if_inc = val;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL3, (uint8_t *)&ctrl3, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a multiple byte access with a serial interface (enable by default).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Register address automatically incremented during a multiple byte access with a serial interface (enable by default).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_auto_increment_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL3, (uint8_t *)&ctrl3, 1);
+  *val = ctrl3.if_inc;
+
+  return ret;
+}
+
+/**
+  * @brief  Block Data Update (BDU): output registers are not updated until LSB and MSB have been read). [set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Block Data Update (BDU): output registers are not updated until LSB and MSB have been read).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_block_data_update_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL3, (uint8_t *)&ctrl3, 1);
+
+  if (ret == 0)
+  {
+    ctrl3.bdu = val;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL3, (uint8_t *)&ctrl3, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Block Data Update (BDU): output registers are not updated until LSB and MSB have been read). [get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Block Data Update (BDU): output registers are not updated until LSB and MSB have been read).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_block_data_update_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL3, (uint8_t *)&ctrl3, 1);
+  *val = ctrl3.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Configure ODR trigger. [set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      number of data in the reference period.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_odr_trig_cfg_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_odr_trig_cfg_t odr_trig;
+  int32_t ret;
+
+  if (val >= 1U && val <= 3U)
+  {
+    return -1;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_ODR_TRIG_CFG, (uint8_t *)&odr_trig, 1);
+
+  if (ret == 0)
+  {
+    odr_trig.odr_trig_nodr = val;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_ODR_TRIG_CFG, (uint8_t *)&odr_trig, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Configure ODR trigger. [get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      number of data in the reference period.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_odr_trig_cfg_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_odr_trig_cfg_t odr_trig;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_ODR_TRIG_CFG, (uint8_t *)&odr_trig, 1);
+  *val = odr_trig.odr_trig_nodr;
+
+  return ret;
+}
+
+/**
+  * @brief  Enables pulsed data-ready mode (~75 us).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      DRDY_LATCHED, DRDY_PULSED,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_data_ready_mode_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_data_ready_mode_t val)
+{
+  lsm6dsv320x_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL4, (uint8_t *)&ctrl4, 1);
+
+  if (ret == 0)
+  {
+    ctrl4.drdy_pulsed = (uint8_t)val & 0x1U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL4, (uint8_t *)&ctrl4, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables pulsed data-ready mode (~75 us).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      DRDY_LATCHED, DRDY_PULSED,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_data_ready_mode_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_data_ready_mode_t *val)
+{
+  lsm6dsv320x_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL4, (uint8_t *)&ctrl4, 1);
+
+  switch (ctrl4.drdy_pulsed)
+  {
+    case LSM6DSV320X_DRDY_LATCHED:
+      *val = LSM6DSV320X_DRDY_LATCHED;
+      break;
+
+    case LSM6DSV320X_DRDY_PULSED:
+      *val = LSM6DSV320X_DRDY_PULSED;
+      break;
+
+    default:
+      *val = LSM6DSV320X_DRDY_LATCHED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables interrupt.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      enable/disable, latched/pulsed
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_interrupt_enable_set(const stmdev_ctx_t *ctx,
+                                         lsm6dsv320x_interrupt_mode_t val)
+{
+  lsm6dsv320x_tap_cfg0_t cfg;
+  lsm6dsv320x_functions_enable_t func;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FUNCTIONS_ENABLE, (uint8_t *)&func, 1);
+  func.interrupts_enable = val.enable;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FUNCTIONS_ENABLE, (uint8_t *)&func, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TAP_CFG0, (uint8_t *)&cfg, 1);
+  cfg.lir = val.lir;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TAP_CFG0, (uint8_t *)&cfg, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Enables latched interrupt mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      enable/disable, latched/pulsed
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_interrupt_enable_get(const stmdev_ctx_t *ctx,
+                                         lsm6dsv320x_interrupt_mode_t *val)
+{
+  lsm6dsv320x_tap_cfg0_t cfg;
+  lsm6dsv320x_functions_enable_t func;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FUNCTIONS_ENABLE, (uint8_t *)&func, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TAP_CFG0, (uint8_t *)&cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->enable = func.interrupts_enable;
+  val->lir = cfg.lir;
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope full-scale selection[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      250dps, 500dps, 1000dps, 2000dps, 4000dps,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_gy_full_scale_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_gy_full_scale_t val)
+{
+  lsm6dsv320x_ctrl6_t ctrl6;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL6, (uint8_t *)&ctrl6, 1);
+
+  if (ret == 0)
+  {
+    ctrl6.fs_g = (uint8_t)val & 0xfu;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL6, (uint8_t *)&ctrl6, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope full-scale selection[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      250dps, 500dps, 1000dps, 2000dps, 4000dps,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_gy_full_scale_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_gy_full_scale_t *val)
+{
+  lsm6dsv320x_ctrl6_t ctrl6;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL6, (uint8_t *)&ctrl6, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl6.fs_g)
+  {
+    case LSM6DSV320X_250dps:
+      *val = LSM6DSV320X_250dps;
+      break;
+
+    case LSM6DSV320X_500dps:
+      *val = LSM6DSV320X_500dps;
+      break;
+
+    case LSM6DSV320X_1000dps:
+      *val = LSM6DSV320X_1000dps;
+      break;
+
+    case LSM6DSV320X_2000dps:
+      *val = LSM6DSV320X_2000dps;
+      break;
+
+    case LSM6DSV320X_4000dps:
+      *val = LSM6DSV320X_4000dps;
+      break;
+
+    default:
+      *val = LSM6DSV320X_250dps;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      2g, 4g, 8g, 16g,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_xl_full_scale_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_xl_full_scale_t val)
+{
+  lsm6dsv320x_ctrl8_t ctrl8;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL8, (uint8_t *)&ctrl8, 1);
+
+  if (ret == 0)
+  {
+    ctrl8.fs_xl = (uint8_t)val & 0x3U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL8, (uint8_t *)&ctrl8, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      2g, 4g, 8g, 16g,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_xl_full_scale_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_xl_full_scale_t *val)
+{
+  lsm6dsv320x_ctrl8_t ctrl8;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL8, (uint8_t *)&ctrl8, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl8.fs_xl)
+  {
+    case LSM6DSV320X_2g:
+      *val = LSM6DSV320X_2g;
+      break;
+
+    case LSM6DSV320X_4g:
+      *val = LSM6DSV320X_4g;
+      break;
+
+    case LSM6DSV320X_8g:
+      *val = LSM6DSV320X_8g;
+      break;
+
+    case LSM6DSV320X_16g:
+      *val = LSM6DSV320X_16g;
+      break;
+
+    default:
+      *val = LSM6DSV320X_2g;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer HG full-scale selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lsm6dsv320x_hg_xl_full_scale_t
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_hg_xl_full_scale_set(const stmdev_ctx_t *ctx,
+                                         lsm6dsv320x_hg_xl_full_scale_t val)
+{
+  lsm6dsv320x_ctrl1_xl_hg_t ctrl1;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL1_XL_HG, (uint8_t *)&ctrl1, 1);
+
+  if (ret == 0)
+  {
+    ctrl1.fs_xl_hg = (uint8_t)val & 0x7U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL1_XL_HG, (uint8_t *)&ctrl1, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer HG full-scale selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lsm6dsv320x_hg_xl_full_scale_t
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_hg_xl_full_scale_get(const stmdev_ctx_t *ctx,
+                                         lsm6dsv320x_hg_xl_full_scale_t *val)
+{
+  lsm6dsv320x_ctrl1_xl_hg_t ctrl1;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL1_XL_HG, (uint8_t *)&ctrl1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl1.fs_xl_hg)
+  {
+    case LSM6DSV320X_32g:
+      *val = LSM6DSV320X_32g;
+      break;
+
+    case LSM6DSV320X_64g:
+      *val = LSM6DSV320X_64g;
+      break;
+
+    case LSM6DSV320X_128g:
+      *val = LSM6DSV320X_128g;
+      break;
+
+    case LSM6DSV320X_256g:
+      *val = LSM6DSV320X_256g;
+      break;
+
+    case LSM6DSV320X_320g:
+      *val = LSM6DSV320X_320g;
+      break;
+
+    default:
+      *val = LSM6DSV320X_32g;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer self-test selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      ST_DISABLE, ST_POSITIVE, ST_NEGATIVE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_xl_self_test_set(const stmdev_ctx_t *ctx, lsm6dsv320x_self_test_t val)
+{
+  lsm6dsv320x_ctrl10_t ctrl10;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL10, (uint8_t *)&ctrl10, 1);
+
+  if (ret == 0)
+  {
+    ctrl10.st_xl = (uint8_t)val & 0x3U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL10, (uint8_t *)&ctrl10, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer self-test selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      ST_DISABLE, ST_POSITIVE, ST_NEGATIVE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_xl_self_test_get(const stmdev_ctx_t *ctx, lsm6dsv320x_self_test_t *val)
+{
+  lsm6dsv320x_ctrl10_t ctrl10;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL10, (uint8_t *)&ctrl10, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl10.st_xl)
+  {
+    case LSM6DSV320X_ST_DISABLE:
+      *val = LSM6DSV320X_ST_DISABLE;
+      break;
+
+    case LSM6DSV320X_ST_POSITIVE:
+      *val = LSM6DSV320X_ST_POSITIVE;
+      break;
+
+    case LSM6DSV320X_ST_NEGATIVE:
+      *val = LSM6DSV320X_ST_NEGATIVE;
+      break;
+
+    default:
+      *val = LSM6DSV320X_ST_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope self-test selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      ST_DISABLE, ST_POSITIVE, ST_NEGATIVE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_gy_self_test_set(const stmdev_ctx_t *ctx, lsm6dsv320x_self_test_t val)
+{
+  lsm6dsv320x_ctrl10_t ctrl10;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL10, (uint8_t *)&ctrl10, 1);
+
+  if (ret == 0)
+  {
+    ctrl10.st_g = (uint8_t)val & 0x3U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL10, (uint8_t *)&ctrl10, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope self-test selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      ST_DISABLE, ST_POSITIVE, ST_NEGATIVE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_gy_self_test_get(const stmdev_ctx_t *ctx, lsm6dsv320x_self_test_t *val)
+{
+  lsm6dsv320x_ctrl10_t ctrl10;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL10, (uint8_t *)&ctrl10, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl10.st_g)
+  {
+    case LSM6DSV320X_ST_DISABLE:
+      *val = LSM6DSV320X_ST_DISABLE;
+      break;
+
+    case LSM6DSV320X_ST_POSITIVE:
+      *val = LSM6DSV320X_ST_POSITIVE;
+      break;
+
+    case LSM6DSV320X_ST_NEGATIVE:
+      *val = LSM6DSV320X_ST_NEGATIVE;
+      break;
+
+    default:
+      *val = LSM6DSV320X_ST_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  HG XL self-test selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      ST_DISABLE, ST_POSITIVE, ST_NEGATIVE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_hg_xl_self_test_set(const stmdev_ctx_t *ctx, lsm6dsv320x_self_test_t val)
+{
+  lsm6dsv320x_ctrl2_xl_hg_t ctrl2_xl_hg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL2_XL_HG, (uint8_t *)&ctrl2_xl_hg, 1);
+
+  if (ret == 0)
+  {
+    ctrl2_xl_hg.xl_hg_st = (uint8_t)val & 0x3U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL2_XL_HG, (uint8_t *)&ctrl2_xl_hg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  HG XL self-test selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      ST_DISABLE, ST_POSITIVE, ST_NEGATIVE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_hg_xl_self_test_get(const stmdev_ctx_t *ctx, lsm6dsv320x_self_test_t *val)
+{
+  lsm6dsv320x_ctrl2_xl_hg_t ctrl2_xl_hg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL2_XL_HG, (uint8_t *)&ctrl2_xl_hg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl2_xl_hg.xl_hg_st)
+  {
+    case LSM6DSV320X_ST_DISABLE:
+      *val = LSM6DSV320X_ST_DISABLE;
+      break;
+
+    case LSM6DSV320X_ST_POSITIVE:
+      *val = LSM6DSV320X_ST_POSITIVE;
+      break;
+
+    case LSM6DSV320X_ST_NEGATIVE:
+      *val = LSM6DSV320X_ST_NEGATIVE;
+      break;
+
+    default:
+      *val = LSM6DSV320X_ST_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  IF2 Accelerometer self-test selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      ST_DISABLE, ST_POSITIVE, ST_NEGATIVE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ois_xl_self_test_set(const stmdev_ctx_t *ctx, lsm6dsv320x_self_test_t val)
+{
+  lsm6dsv320x_if2_int_ois_t if2_int_ois;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_IF2_INT_OIS, (uint8_t *)&if2_int_ois, 1);
+
+  if (ret == 0)
+  {
+    if2_int_ois.st_xl_ois = ((uint8_t)val & 0x3U);
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_IF2_INT_OIS, (uint8_t *)&if2_int_ois, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  IF2 Accelerometer self-test selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      ST_DISABLE, ST_POSITIVE, ST_NEGATIVE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ois_xl_self_test_get(const stmdev_ctx_t *ctx, lsm6dsv320x_self_test_t *val)
+{
+  lsm6dsv320x_if2_int_ois_t if2_int_ois;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_IF2_INT_OIS, (uint8_t *)&if2_int_ois, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (if2_int_ois.st_xl_ois)
+  {
+    case LSM6DSV320X_ST_DISABLE:
+      *val = LSM6DSV320X_ST_DISABLE;
+      break;
+
+    case LSM6DSV320X_ST_POSITIVE:
+      *val = LSM6DSV320X_ST_POSITIVE;
+      break;
+
+    case LSM6DSV320X_ST_NEGATIVE:
+      *val = LSM6DSV320X_ST_NEGATIVE;
+      break;
+
+    default:
+      *val = LSM6DSV320X_ST_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  IF2 Accelerometer self-test selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      GY_ST_DISABLE, GY_ST_POSITIVE, GY_ST_NEGATIVE, LSM6DSV320X_OIS_GY_ST_CLAMP_POS, LSM6DSV320X_OIS_GY_ST_CLAMP_NEG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ois_gy_self_test_set(const stmdev_ctx_t *ctx,
+                                         lsm6dsv320x_ois_gy_self_test_t val)
+{
+  lsm6dsv320x_if2_int_ois_t if2_int_ois;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_IF2_INT_OIS, (uint8_t *)&if2_int_ois, 1);
+
+  if (ret == 0)
+  {
+    if2_int_ois.st_g_ois = ((uint8_t)val & 0x3U);
+    if2_int_ois.st_ois_clampdis = ((uint8_t)val & 0x04U) >> 2;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_IF2_INT_OIS, (uint8_t *)&if2_int_ois, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  IF2 Accelerometer self-test selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      GY_ST_DISABLE, GY_ST_POSITIVE, GY_ST_NEGATIVE, LSM6DSV320X_OIS_GY_ST_CLAMP_POS, LSM6DSV320X_OIS_GY_ST_CLAMP_NEG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ois_gy_self_test_get(const stmdev_ctx_t *ctx,
+                                         lsm6dsv320x_ois_gy_self_test_t *val)
+{
+  lsm6dsv320x_if2_int_ois_t if2_int_ois;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_IF2_INT_OIS, (uint8_t *)&if2_int_ois, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (if2_int_ois.st_g_ois)
+  {
+    case LSM6DSV320X_OIS_GY_ST_DISABLE:
+      *val = LSM6DSV320X_OIS_GY_ST_DISABLE;
+      break;
+
+    case LSM6DSV320X_OIS_GY_ST_POSITIVE:
+      *val = (if2_int_ois.st_ois_clampdis == 1U) ? LSM6DSV320X_OIS_GY_ST_CLAMP_POS :
+             LSM6DSV320X_OIS_GY_ST_POSITIVE;
+      break;
+
+    case LSM6DSV320X_OIS_GY_ST_NEGATIVE:
+      *val = (if2_int_ois.st_ois_clampdis == 1U) ? LSM6DSV320X_OIS_GY_ST_CLAMP_NEG :
+             LSM6DSV320X_OIS_GY_ST_NEGATIVE;
+      break;
+
+    default:
+      *val = LSM6DSV320X_OIS_GY_ST_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   High-g
+  * @brief      This section groups all the functions that manage
+  *             High-g
+  * @{
+  *
+  */
+
+/**
+  * @brief  High-g event configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lsm6dsv320x_hg_wake_up_cfg_t structure
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_hg_wake_up_cfg_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_hg_wake_up_cfg_t val)
+{
+  lsm6dsv320x_hg_functions_enable_t hg_func;
+  lsm6dsv320x_hg_wake_up_ths_t hg_wake_up_ths;
+  uint8_t reg[2];
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_HG_FUNCTIONS_ENABLE, (uint8_t *)&hg_func, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  hg_func.hg_shock_dur = val.hg_shock_dur;
+  hg_wake_up_ths.hg_wk_ths = val.hg_wakeup_ths;
+
+  bytecpy(&reg[0], (uint8_t *)&hg_func);
+  bytecpy(&reg[1], (uint8_t *)&hg_wake_up_ths);
+
+  return lsm6dsv320x_write_reg(ctx, LSM6DSV320X_HG_FUNCTIONS_ENABLE, reg, 2);
+}
+
+/**
+  * @brief  High-g event configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lsm6dsv320x_hg_wake_up_cfg_t structure
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_hg_wake_up_cfg_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_hg_wake_up_cfg_t *val)
+{
+  lsm6dsv320x_hg_functions_enable_t hg_func;
+  lsm6dsv320x_hg_wake_up_ths_t hg_wake_up_ths;
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_HG_FUNCTIONS_ENABLE, (uint8_t *)buff, 2);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  bytecpy((uint8_t *)&hg_func, &buff[0]);
+  bytecpy((uint8_t *)&hg_wake_up_ths, &buff[1]);
+
+  val->hg_shock_dur = hg_func.hg_shock_dur;
+  val->hg_wakeup_ths = hg_wake_up_ths.hg_wk_ths;
+
+  return ret;
+}
+
+/**
+ * @brief   High-g wake-up interrupt configuration[set]
+ *
+ * @param  ctx    Read / write interface definitions.(ptr)
+ * @param  val    lsm6dsv320x_hg_wu_interrupt_cfg_t.
+ * @retval        Interface status (MANDATORY: return 0 -> no Error).
+ *
+ */
+int32_t lsm6dsv320x_hg_wu_interrupt_cfg_set(const stmdev_ctx_t *ctx,
+                                            lsm6dsv320x_hg_wu_interrupt_cfg_t val)
+{
+  lsm6dsv320x_hg_functions_enable_t hg_func;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_HG_FUNCTIONS_ENABLE, (uint8_t *)&hg_func, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  hg_func.hg_interrupts_enable        = val.hg_interrupts_enable;
+  hg_func.hg_wu_change_int_sel        = val.hg_wakeup_int_sel;
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_HG_FUNCTIONS_ENABLE, (uint8_t *)&hg_func, 1);
+
+  return ret;
+}
+
+/**
+ * @brief   High-g wake-up interrupt configuration[get]
+ *
+ * @param  ctx    Read / write interface definitions.(ptr)
+ * @param  val    lsm6dsv320x_hg_wu_interrupt_cfg_t.
+ * @retval        Interface status (MANDATORY: return 0 -> no Error).
+ *
+ */
+int32_t lsm6dsv320x_hg_wu_interrupt_cfg_get(const stmdev_ctx_t *ctx,
+                                            lsm6dsv320x_hg_wu_interrupt_cfg_t *val)
+{
+  lsm6dsv320x_hg_functions_enable_t hg_func;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_HG_FUNCTIONS_ENABLE, (uint8_t *)&hg_func, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->hg_interrupts_enable = hg_func.hg_interrupts_enable;
+  val->hg_wakeup_int_sel    = hg_func.hg_wu_change_int_sel;
+
+  return ret;
+}
+
+/**
+ * @brief   Emable/disable user offset data correction driving to hg embedded functions[set]
+ *
+ * @param  ctx    Read / write interface definitions.(ptr)
+ * @param  val    0: disable, 1: enable
+ * @retval        Interface status (MANDATORY: return 0 -> no Error).
+ *
+ */
+int32_t lsm6dsv320x_hg_emb_usr_off_correction_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_emb_func_cfg_t emb_func_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
+
+  if (ret == 0)
+  {
+    emb_func_cfg.hg_usr_off_on_emb_func = (uint8_t)val & 0x1U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief   Emable/disable user offset data correction driving to hg embedded functions[get]
+ *
+ * @param  ctx    Read / write interface definitions.(ptr)
+ * @param  val    0: disable, 1: enable
+ * @retval        Interface status (MANDATORY: return 0 -> no Error).
+ *
+ */
+int32_t lsm6dsv320x_hg_emb_usr_off_correction_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_emb_func_cfg_t emb_func_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  *val = emb_func_cfg.hg_usr_off_on_emb_func;
+
+  return ret;
+}
+
+/**
+ * @brief   Emable/disable user offset data correction driving to hg wake-up[set]
+ *
+ * @param  ctx    Read / write interface definitions.(ptr)
+ * @param  val    0: disable, 1: enable
+ * @retval        Interface status (MANDATORY: return 0 -> no Error).
+ *
+ */
+int32_t lsm6dsv320x_hg_wu_usr_off_correction_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_ctrl2_xl_hg_t ctrl2_xl_hg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL2_XL_HG, (uint8_t *)&ctrl2_xl_hg, 1);
+
+  if (ret == 0)
+  {
+    ctrl2_xl_hg.hg_usr_off_on_wu = (uint8_t)val & 0x1U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL2_XL_HG, (uint8_t *)&ctrl2_xl_hg, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief   Emable/disable user offset data correction driving to hg wake-up[get]
+ *
+ * @param  ctx    Read / write interface definitions.(ptr)
+ * @param  val    0: disable, 1: enable
+ * @retval        Interface status (MANDATORY: return 0 -> no Error).
+ *
+ */
+int32_t lsm6dsv320x_hg_wu_usr_off_correction_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_ctrl2_xl_hg_t ctrl2_xl_hg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL2_XL_HG, (uint8_t *)&ctrl2_xl_hg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  *val = ctrl2_xl_hg.hg_usr_off_on_wu;
+
+  return ret;
+}
+
+/**
+  * @brief   High-g event handling[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    High-g event.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsv320x_hg_event_get(const stmdev_ctx_t *ctx, lsm6dsv320x_hg_event_t *val)
+{
+  lsm6dsv320x_all_int_src_t          int_src;
+  lsm6dsv320x_hg_wake_up_src_t       wup_src;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_ALL_INT_SRC, (uint8_t *)&int_src, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->hg_event = int_src.hg_ia;
+
+  /* no High-g event */
+  if (int_src.hg_ia == 0)
+  {
+    return 0;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_HG_WAKE_UP_SRC, (uint8_t *)&wup_src, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->hg_wakeup_z     = wup_src.hg_z_wu;
+  val->hg_wakeup_y     = wup_src.hg_y_wu;
+  val->hg_wakeup_x     = wup_src.hg_x_wu;
+  val->hg_wakeup       = wup_src.hg_wu_ia;
+  val->hg_wakeup_chg   = wup_src.hg_wu_change_ia;
+  val->hg_shock        = wup_src.hg_shock_state;
+  val->hg_shock_change = wup_src.hg_shock_change_ia;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   interrupt_pins
+  * @brief      This section groups all the functions that manage
+  *             interrupt pins
+  * @{
+  *
+  */
+
+/**
+  * @brief   Select the signals that need to be routed on int1 pad.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    the signals to route on int1 pin.
+  *                (xl/g drdy, fifo, 6d/tap/wu/ff/sleep_change/cnt_bdr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsv320x_pin_int1_route_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_pin_int_route_t *val)
+{
+  lsm6dsv320x_int1_ctrl_t           int1_ctrl;
+  lsm6dsv320x_md1_cfg_t             md1_cfg;
+  int32_t ret;
+
+  /* not available on INT1 */
+  if (val->drdy_temp == 1)
+  {
+    return -1;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_INT1_CTRL, (uint8_t *)&int1_ctrl, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  int1_ctrl.int1_drdy_xl       = val->drdy_xl;
+  int1_ctrl.int1_drdy_g        = val->drdy_g;
+  int1_ctrl.int1_fifo_th       = val->fifo_th;
+  int1_ctrl.int1_fifo_ovr      = val->fifo_ovr;
+  int1_ctrl.int1_fifo_full     = val->fifo_full;
+  int1_ctrl.int1_cnt_bdr       = val->cnt_bdr;
+
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_INT1_CTRL, (uint8_t *)&int1_ctrl, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  md1_cfg.int1_shub            = val->shub;
+  md1_cfg.int1_6d              = val->sixd;
+  md1_cfg.int1_single_tap      = val->single_tap;
+  md1_cfg.int1_double_tap      = val->double_tap;
+  md1_cfg.int1_wu              = val->wakeup;
+  md1_cfg.int1_ff              = val->freefall;
+  md1_cfg.int1_sleep_change    = val->sleep_change;
+
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Report the signals that are routed on int1 pad.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    the signals that are routed on int1 pin.(ptr)
+  *                (xl/g drdy, fifo, 6d/tap/wu/ff/sleep_change/cnt_bdr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsv320x_pin_int1_route_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_pin_int_route_t *val)
+{
+  lsm6dsv320x_int1_ctrl_t           int1_ctrl;
+  lsm6dsv320x_md1_cfg_t             md1_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_INT1_CTRL, (uint8_t *)&int1_ctrl, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->drdy_xl   = int1_ctrl.int1_drdy_xl;
+  val->drdy_g    = int1_ctrl.int1_drdy_g;
+  val->fifo_th   = int1_ctrl.int1_fifo_th;
+  val->fifo_ovr  = int1_ctrl.int1_fifo_ovr;
+  val->fifo_full = int1_ctrl.int1_fifo_full;
+  val->cnt_bdr   = int1_ctrl.int1_cnt_bdr;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->shub         = md1_cfg.int1_shub;
+  val->sixd         = md1_cfg.int1_6d;
+  val->single_tap   = md1_cfg.int1_single_tap;
+  val->double_tap   = md1_cfg.int1_double_tap;
+  val->wakeup       = md1_cfg.int1_wu;
+  val->freefall     = md1_cfg.int1_ff;
+  val->sleep_change = md1_cfg.int1_sleep_change;
+
+  return ret;
+}
+
+/**
+  * @brief   Select the signals that need to be routed on int2 pad.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    the signals to route on int1 pin.
+  *                (xl/g drdy, fifo, 6d/tap/wu/ff/sleep_change/cnt_bdr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsv320x_pin_int2_route_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_pin_int_route_t *val)
+{
+  lsm6dsv320x_int2_ctrl_t           int2_ctrl;
+  lsm6dsv320x_ctrl4_t               ctrl4;
+  lsm6dsv320x_md2_cfg_t             md2_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  int2_ctrl.int2_drdy_xl          = val->drdy_xl;
+  int2_ctrl.int2_drdy_g           = val->drdy_g;
+  int2_ctrl.int2_fifo_th          = val->fifo_th;
+  int2_ctrl.int2_fifo_ovr         = val->fifo_ovr;
+  int2_ctrl.int2_fifo_full        = val->fifo_full;
+  int2_ctrl.int2_cnt_bdr          = val->cnt_bdr;
+  int2_ctrl.int2_drdy_g_eis       = val->drdy_g_eis;
+  int2_ctrl.int2_emb_func_endop   = val->emb_func_endop;
+
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL4, (uint8_t *)&ctrl4, 1);
+  ctrl4.int2_drdy_temp         = val->drdy_temp;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL4, (uint8_t *)&ctrl4, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  md2_cfg.int2_timestamp       = val->timestamp;
+  md2_cfg.int2_6d              = val->sixd;
+  md2_cfg.int2_single_tap      = val->single_tap;
+  md2_cfg.int2_double_tap      = val->double_tap;
+  md2_cfg.int2_wu              = val->wakeup;
+  md2_cfg.int2_ff              = val->freefall;
+  md2_cfg.int2_sleep_change    = val->sleep_change;
+
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Report the signals that are routed on int2 pad.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    the signals that are routed on int1 pin.(ptr)
+  *                (xl/g drdy, fifo, 6d/tap/wu/ff/sleep_change/cnt_bdr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsv320x_pin_int2_route_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_pin_int_route_t *val)
+{
+  lsm6dsv320x_int2_ctrl_t           int2_ctrl;
+  lsm6dsv320x_ctrl4_t               ctrl4;
+  lsm6dsv320x_md2_cfg_t             md2_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->drdy_xl        = int2_ctrl.int2_drdy_xl;
+  val->drdy_g         = int2_ctrl.int2_drdy_g;
+  val->fifo_th        = int2_ctrl.int2_fifo_th;
+  val->fifo_ovr       = int2_ctrl.int2_fifo_ovr;
+  val->fifo_full      = int2_ctrl.int2_fifo_full;
+  val->cnt_bdr        = int2_ctrl.int2_cnt_bdr;
+  val->drdy_g_eis     = int2_ctrl.int2_drdy_g_eis;
+  val->emb_func_endop = int2_ctrl.int2_emb_func_endop;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL4, (uint8_t *)&ctrl4, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->drdy_temp      = ctrl4.int2_drdy_temp;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->timestamp      = md2_cfg.int2_timestamp;
+  val->sixd           = md2_cfg.int2_6d;
+  val->single_tap     = md2_cfg.int2_single_tap;
+  val->double_tap     = md2_cfg.int2_double_tap;
+  val->wakeup         = md2_cfg.int2_wu;
+  val->freefall       = md2_cfg.int2_ff;
+  val->sleep_change   = md2_cfg.int2_sleep_change;
+
+  return ret;
+}
+
+/**
+  * @brief   Select the signals that need to be routed on int1 pad.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    the signals to route on int1 pin.
+  *                (HG events only)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsv320x_pin_int1_route_hg_set(const stmdev_ctx_t *ctx,
+                                          lsm6dsv320x_pin_int_route_t *val)
+{
+  lsm6dsv320x_ctrl7_t               ctrl7;
+  lsm6dsv320x_hg_functions_enable_t hg_func;
+  lsm6dsv320x_inactivity_ths_t      reg_shock;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL7, (uint8_t *)&ctrl7, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ctrl7.int1_drdy_xl_hg        = val->drdy_hg_xl;
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL7, (uint8_t *)&ctrl7, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_HG_FUNCTIONS_ENABLE, (uint8_t *)&hg_func, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  hg_func.int1_hg_wu        = val->hg_wakeup;
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_HG_FUNCTIONS_ENABLE, (uint8_t *)&hg_func, 1);
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_INACTIVITY_THS, (uint8_t *)&reg_shock, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  reg_shock.int1_hg_shock_change        = val->hg_shock_change;
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_INACTIVITY_THS, (uint8_t *)&reg_shock, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Report the signals that are routed on int1 pad.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    the signals that are routed on int1 pin.(ptr)
+  *                (HG events only)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsv320x_pin_int1_route_hg_get(const stmdev_ctx_t *ctx,
+                                          lsm6dsv320x_pin_int_route_t *val)
+{
+  lsm6dsv320x_ctrl7_t               ctrl7;
+  lsm6dsv320x_hg_functions_enable_t hg_func;
+  lsm6dsv320x_inactivity_ths_t      reg_shock;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL7, (uint8_t *)&ctrl7, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->drdy_hg_xl = ctrl7.int1_drdy_xl_hg;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_HG_FUNCTIONS_ENABLE, (uint8_t *)&hg_func, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->hg_wakeup = hg_func.int1_hg_wu;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_INACTIVITY_THS, (uint8_t *)&reg_shock, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->hg_shock_change = reg_shock.int1_hg_shock_change;
+
+  return ret;
+}
+
+/**
+  * @brief   Select the signals that need to be routed on int2 pad.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    the signals to route on int2 pin.
+  *                (HG events only)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsv320x_pin_int2_route_hg_set(const stmdev_ctx_t *ctx,
+                                          lsm6dsv320x_pin_int_route_t *val)
+{
+  lsm6dsv320x_ctrl7_t               ctrl7;
+  lsm6dsv320x_hg_functions_enable_t hg_func;
+  lsm6dsv320x_inactivity_ths_t      reg_shock;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL7, (uint8_t *)&ctrl7, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ctrl7.int2_drdy_xl_hg        = val->drdy_hg_xl;
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL7, (uint8_t *)&ctrl7, 1);
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_HG_FUNCTIONS_ENABLE, (uint8_t *)&hg_func, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  hg_func.int2_hg_wu        = val->hg_wakeup;
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_HG_FUNCTIONS_ENABLE, (uint8_t *)&hg_func, 1);
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_INACTIVITY_THS, (uint8_t *)&reg_shock, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  reg_shock.int2_hg_shock_change        = val->hg_shock_change;
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_INACTIVITY_THS, (uint8_t *)&reg_shock, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Report the signals that are routed on int2 pad.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    the signals that are routed on int2 pin.(ptr)
+  *                (HG events only)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsv320x_pin_int2_route_hg_get(const stmdev_ctx_t *ctx,
+                                          lsm6dsv320x_pin_int_route_t *val)
+{
+  lsm6dsv320x_ctrl7_t               ctrl7;
+  lsm6dsv320x_hg_functions_enable_t hg_func;
+  lsm6dsv320x_inactivity_ths_t      reg_shock;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL7, (uint8_t *)&ctrl7, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->drdy_hg_xl = ctrl7.int2_drdy_xl_hg;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_HG_FUNCTIONS_ENABLE, (uint8_t *)&hg_func, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->hg_wakeup = hg_func.int2_hg_wu;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_INACTIVITY_THS, (uint8_t *)&reg_shock, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->hg_shock_change = reg_shock.int2_hg_shock_change;
+
+  return ret;
+}
+
+/**
+  * @brief   Select the signals that need to be routed on int1 pad.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    the signals to route on int1 pin.
+  *                (embedded events)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsv320x_pin_int1_route_embedded_set(const stmdev_ctx_t *ctx,
+                                                lsm6dsv320x_pin_int_route_t *val)
+{
+  lsm6dsv320x_md1_cfg_t             md1_cfg;
+  lsm6dsv320x_emb_func_int1_t       emb_func_int1;
+  lsm6dsv320x_fsm_int1_t            fsm_int1;
+  lsm6dsv320x_mlc_int1_t            mlc_int1;
+  int32_t ret;
+
+  /* Embedded Functions */
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_INT1, (uint8_t *)&emb_func_int1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  emb_func_int1.int1_step_detector = val->step_detector;
+  emb_func_int1.int1_tilt = val->tilt;
+  emb_func_int1.int1_sig_mot = val->sig_mot;
+
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_INT1, (uint8_t *)&emb_func_int1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  md1_cfg.int1_emb_func = 1;
+
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  /* FSM */
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FSM_INT1, (uint8_t *)&fsm_int1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  fsm_int1.int1_fsm1 = val->fsm1;
+  fsm_int1.int1_fsm2 = val->fsm2;
+  fsm_int1.int1_fsm3 = val->fsm3;
+  fsm_int1.int1_fsm4 = val->fsm4;
+  fsm_int1.int1_fsm5 = val->fsm5;
+  fsm_int1.int1_fsm6 = val->fsm6;
+  fsm_int1.int1_fsm7 = val->fsm7;
+  fsm_int1.int1_fsm8 = val->fsm8;
+
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FSM_INT1, (uint8_t *)&fsm_int1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  /* MLC */
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_MLC_INT1, (uint8_t *)&mlc_int1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  mlc_int1.int1_mlc1 = val->mlc1;
+  mlc_int1.int1_mlc2 = val->mlc2;
+  mlc_int1.int1_mlc3 = val->mlc3;
+  mlc_int1.int1_mlc4 = val->mlc4;
+  mlc_int1.int1_mlc5 = val->mlc5;
+  mlc_int1.int1_mlc6 = val->mlc6;
+  mlc_int1.int1_mlc7 = val->mlc7;
+  mlc_int1.int1_mlc8 = val->mlc8;
+
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_MLC_INT1, (uint8_t *)&mlc_int1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   Report the signals that are routed on int1 pad.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    the signals to route on int1 pin.
+  *                (embedded events)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsv320x_pin_int1_route_embedded_get(const stmdev_ctx_t *ctx,
+                                                lsm6dsv320x_pin_int_route_t *val)
+{
+  lsm6dsv320x_emb_func_int1_t       emb_func_int1;
+  lsm6dsv320x_fsm_int1_t            fsm_int1;
+  lsm6dsv320x_mlc_int1_t            mlc_int1;
+  int32_t ret;
+
+  /* Embedded Functions */
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_INT1, (uint8_t *)&emb_func_int1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->step_detector = emb_func_int1.int1_step_detector;
+  val->sig_mot       = emb_func_int1.int1_sig_mot;
+  val->tilt          = emb_func_int1.int1_tilt;
+
+  /* FSM */
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FSM_INT1, (uint8_t *)&fsm_int1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->fsm1 = fsm_int1.int1_fsm1;
+  val->fsm2 = fsm_int1.int1_fsm2;
+  val->fsm3 = fsm_int1.int1_fsm3;
+  val->fsm4 = fsm_int1.int1_fsm4;
+  val->fsm5 = fsm_int1.int1_fsm5;
+  val->fsm6 = fsm_int1.int1_fsm6;
+  val->fsm7 = fsm_int1.int1_fsm7;
+  val->fsm8 = fsm_int1.int1_fsm8;
+
+  /* MLC */
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_MLC_INT1, (uint8_t *)&mlc_int1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->mlc1 = mlc_int1.int1_mlc1;
+  val->mlc2 = mlc_int1.int1_mlc2;
+  val->mlc3 = mlc_int1.int1_mlc3;
+  val->mlc4 = mlc_int1.int1_mlc4;
+  val->mlc5 = mlc_int1.int1_mlc5;
+  val->mlc6 = mlc_int1.int1_mlc6;
+  val->mlc7 = mlc_int1.int1_mlc7;
+  val->mlc8 = mlc_int1.int1_mlc8;
+
+  return ret;
+}
+
+/**
+  * @brief   Select the signals that need to be routed on int2 pad[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    the signals to route on int2 pin.
+  *                (embedded events)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsv320x_pin_int2_route_embedded_set(const stmdev_ctx_t *ctx,
+                                                lsm6dsv320x_pin_int_route_t *val)
+{
+  lsm6dsv320x_md2_cfg_t             md2_cfg;
+  lsm6dsv320x_emb_func_int2_t       emb_func_int2;
+  lsm6dsv320x_fsm_int2_t            fsm_int2;
+  lsm6dsv320x_mlc_int2_t            mlc_int2;
+  int32_t ret;
+
+  /* Embedded Functions */
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_INT2, (uint8_t *)&emb_func_int2, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  emb_func_int2.int2_step_detector = val->step_detector;
+  emb_func_int2.int2_tilt = val->tilt;
+  emb_func_int2.int2_sig_mot = val->sig_mot;
+
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_INT2, (uint8_t *)&emb_func_int2, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  md2_cfg.int2_emb_func = 1;
+
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  /* FSM */
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FSM_INT2, (uint8_t *)&fsm_int2, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  fsm_int2.int2_fsm1 = val->fsm1;
+  fsm_int2.int2_fsm2 = val->fsm2;
+  fsm_int2.int2_fsm3 = val->fsm3;
+  fsm_int2.int2_fsm4 = val->fsm4;
+  fsm_int2.int2_fsm5 = val->fsm5;
+  fsm_int2.int2_fsm6 = val->fsm6;
+  fsm_int2.int2_fsm7 = val->fsm7;
+  fsm_int2.int2_fsm8 = val->fsm8;
+
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FSM_INT2, (uint8_t *)&fsm_int2, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  /* MLC */
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_MLC_INT2, (uint8_t *)&mlc_int2, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  mlc_int2.int2_mlc1 = val->mlc1;
+  mlc_int2.int2_mlc2 = val->mlc2;
+  mlc_int2.int2_mlc3 = val->mlc3;
+  mlc_int2.int2_mlc4 = val->mlc4;
+  mlc_int2.int2_mlc5 = val->mlc5;
+  mlc_int2.int2_mlc6 = val->mlc6;
+  mlc_int2.int2_mlc7 = val->mlc7;
+  mlc_int2.int2_mlc8 = val->mlc8;
+
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_MLC_INT2, (uint8_t *)&mlc_int2, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   Report the signals that are routed on int2 pad.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    the signals to route on int2 pin.
+  *                (embedded events)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsv320x_pin_int2_route_embedded_get(const stmdev_ctx_t *ctx,
+                                                lsm6dsv320x_pin_int_route_t *val)
+{
+  lsm6dsv320x_emb_func_int2_t       emb_func_int2;
+  lsm6dsv320x_fsm_int2_t            fsm_int2;
+  lsm6dsv320x_mlc_int2_t            mlc_int2;
+  int32_t ret;
+
+  /* Embedded Functions */
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_INT2, (uint8_t *)&emb_func_int2, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->step_detector = emb_func_int2.int2_step_detector;
+  val->sig_mot       = emb_func_int2.int2_sig_mot;
+  val->tilt          = emb_func_int2.int2_tilt;
+
+  /* FSM */
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FSM_INT2, (uint8_t *)&fsm_int2, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->fsm1 = fsm_int2.int2_fsm1;
+  val->fsm2 = fsm_int2.int2_fsm2;
+  val->fsm3 = fsm_int2.int2_fsm3;
+  val->fsm4 = fsm_int2.int2_fsm4;
+  val->fsm5 = fsm_int2.int2_fsm5;
+  val->fsm6 = fsm_int2.int2_fsm6;
+  val->fsm7 = fsm_int2.int2_fsm7;
+  val->fsm8 = fsm_int2.int2_fsm8;
+
+  /* MLC */
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_MLC_INT2, (uint8_t *)&mlc_int2, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->mlc1 = mlc_int2.int2_mlc1;
+  val->mlc2 = mlc_int2.int2_mlc2;
+  val->mlc3 = mlc_int2.int2_mlc3;
+  val->mlc4 = mlc_int2.int2_mlc4;
+  val->mlc5 = mlc_int2.int2_mlc5;
+  val->mlc6 = mlc_int2.int2_mlc6;
+  val->mlc7 = mlc_int2.int2_mlc7;
+  val->mlc8 = mlc_int2.int2_mlc8;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @brief  Get the status of all the interrupt sources.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the status of all the interrupt sources.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_all_sources_get(const stmdev_ctx_t *ctx,
+                                    lsm6dsv320x_all_sources_t *val)
+{
+  lsm6dsv320x_emb_func_status_mainpage_t emb_func_status_mainpage;
+  lsm6dsv320x_emb_func_exec_status_t emb_func_exec_status;
+  lsm6dsv320x_fsm_status_mainpage_t fsm_status_mainpage;
+  lsm6dsv320x_mlc_status_mainpage_t mlc_status_mainpage;
+  lsm6dsv320x_functions_enable_t functions_enable;
+  lsm6dsv320x_emb_func_src_t emb_func_src;
+  lsm6dsv320x_fifo_status2_t fifo_status2;
+  lsm6dsv320x_all_int_src_t all_int_src;
+  lsm6dsv320x_wake_up_src_t wake_up_src;
+  lsm6dsv320x_status_reg_t status_reg;
+  lsm6dsv320x_d6d_src_t d6d_src;
+  lsm6dsv320x_tap_src_t tap_src;
+  lsm6dsv320x_ui_status_reg_ois_t status_reg_ois;
+  lsm6dsv320x_status_controller_t status_shub;
+  uint8_t buff[8];
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
+  functions_enable.dis_rst_lir_all_int = PROPERTY_ENABLE;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FIFO_STATUS1, (uint8_t *)&buff, 4);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  bytecpy((uint8_t *)&fifo_status2, &buff[1]);
+  bytecpy((uint8_t *)&all_int_src, &buff[2]);
+  bytecpy((uint8_t *)&status_reg, &buff[3]);
+
+  val->fifo_ovr = fifo_status2.fifo_ovr_ia;
+  val->fifo_bdr = fifo_status2.counter_bdr_ia;
+  val->fifo_full = fifo_status2.fifo_full_ia;
+  val->fifo_th = fifo_status2.fifo_wtm_ia;
+
+  val->hg = all_int_src.hg_ia;
+  val->free_fall = all_int_src.ff_ia;
+  val->wake_up = all_int_src.wu_ia;
+  val->six_d = all_int_src.d6d_ia;
+
+  val->drdy_xl = status_reg.xlda;
+  val->drdy_gy = status_reg.gda;
+  val->drdy_temp = status_reg.tda;
+  val->drdy_xlhgda = status_reg.xlhgda;
+  val->drdy_eis = status_reg.gda_eis;
+  val->drdy_ois = status_reg.ois_drdy;
+  val->timestamp = status_reg.timestamp_endcount;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
+  functions_enable.dis_rst_lir_all_int = PROPERTY_DISABLE;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_UI_STATUS_REG_OIS, (uint8_t *)&buff, 8);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  bytecpy((uint8_t *)&status_reg_ois, &buff[0]);
+  bytecpy((uint8_t *)&wake_up_src, &buff[1]);
+  bytecpy((uint8_t *)&tap_src, &buff[2]);
+  bytecpy((uint8_t *)&d6d_src, &buff[3]);
+  bytecpy((uint8_t *)&emb_func_status_mainpage, &buff[5]);
+  bytecpy((uint8_t *)&fsm_status_mainpage, &buff[6]);
+  bytecpy((uint8_t *)&mlc_status_mainpage, &buff[7]);
+
+  val->gy_settling = status_reg_ois.gyro_settling;
+  val->sleep_change = wake_up_src.sleep_change_ia;
+  val->wake_up_x = wake_up_src.x_wu;
+  val->wake_up_y = wake_up_src.y_wu;
+  val->wake_up_z = wake_up_src.z_wu;
+  val->sleep_state = wake_up_src.sleep_state;
+
+  val->tap_x = tap_src.x_tap;
+  val->tap_y = tap_src.y_tap;
+  val->tap_z = tap_src.z_tap;
+  val->tap_sign = tap_src.tap_sign;
+  val->double_tap = tap_src.double_tap;
+  val->single_tap = tap_src.single_tap;
+
+  val->six_d_zl = d6d_src.zl;
+  val->six_d_zh = d6d_src.zh;
+  val->six_d_yl = d6d_src.yl;
+  val->six_d_yh = d6d_src.yh;
+  val->six_d_xl = d6d_src.xl;
+  val->six_d_xh = d6d_src.xh;
+
+  val->step_detector = emb_func_status_mainpage.is_step_det;
+  val->tilt = emb_func_status_mainpage.is_tilt;
+  val->sig_mot = emb_func_status_mainpage.is_sigmot;
+  val->fsm_lc = emb_func_status_mainpage.is_fsm_lc;
+
+  val->fsm1 = fsm_status_mainpage.is_fsm1;
+  val->fsm2 = fsm_status_mainpage.is_fsm2;
+  val->fsm3 = fsm_status_mainpage.is_fsm3;
+  val->fsm4 = fsm_status_mainpage.is_fsm4;
+  val->fsm5 = fsm_status_mainpage.is_fsm5;
+  val->fsm6 = fsm_status_mainpage.is_fsm6;
+  val->fsm7 = fsm_status_mainpage.is_fsm7;
+  val->fsm8 = fsm_status_mainpage.is_fsm8;
+
+  val->mlc1 = mlc_status_mainpage.is_mlc1;
+  val->mlc2 = mlc_status_mainpage.is_mlc2;
+  val->mlc3 = mlc_status_mainpage.is_mlc3;
+  val->mlc4 = mlc_status_mainpage.is_mlc4;
+  val->mlc5 = mlc_status_mainpage.is_mlc5;
+  val->mlc6 = mlc_status_mainpage.is_mlc6;
+  val->mlc7 = mlc_status_mainpage.is_mlc7;
+  val->mlc8 = mlc_status_mainpage.is_mlc8;
+
+
+  /* embedded func */
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_EXEC_STATUS, (uint8_t *)&emb_func_exec_status,
+                              1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->emb_func_stand_by = emb_func_exec_status.emb_func_endop;
+  val->emb_func_time_exceed = emb_func_exec_status.emb_func_exec_ovr;
+  val->step_count_inc = emb_func_src.stepcounter_bit_set;
+  val->step_count_overflow = emb_func_src.step_overflow;
+  val->step_on_delta_time = emb_func_src.step_count_delta_ia;
+
+  val->step_detector = emb_func_src.step_detected;
+
+  /* sensor hub */
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_STATUS_CONTROLLER_MAINPAGE, (uint8_t *)&status_shub, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->sh_endop = status_shub.sens_hub_endop;
+  val->sh_wr_once = status_shub.wr_once_done;
+  val->sh_target3_nack = status_shub.target3_nack;
+  val->sh_target2_nack = status_shub.target2_nack;
+  val->sh_target1_nack = status_shub.target1_nack;
+  val->sh_target0_nack = status_shub.target0_nack;
+
+  return ret;
+}
+
+int32_t lsm6dsv320x_flag_data_ready_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_data_ready_t *val)
+{
+  lsm6dsv320x_status_reg_t status;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_STATUS_REG, (uint8_t *)&status, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->drdy_hgxl = status.xlhgda;
+  val->drdy_xl = status.xlda;
+  val->drdy_gy = status.gda;
+  val->drdy_temp = status.tda;
+
+  return ret;
+}
+
+/**
+  * @brief  Mask status bit reset[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Mask to prevent status bit being reset
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_int_ack_mask_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  int32_t ret;
+
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_INT_ACK_MASK, &val, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Mask status bit reset[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Mask to prevent status bit being reset
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_int_ack_mask_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_INT_ACK_MASK, val, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature data output register[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Temperature data output register
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_temperature_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_OUT_TEMP_L, &buff[0], 2);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  *val = (int16_t)buff[1];
+  *val = (*val * 256) + (int16_t)buff[0];
+
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Angular rate sensor.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_angular_rate_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
+{
+  uint8_t buff[6];
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_OUTX_L_G, &buff[0], 6);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val[0] = (int16_t)buff[1];
+  val[0] = (val[0] * 256) + (int16_t)buff[0];
+  val[1] = (int16_t)buff[3];
+  val[1] = (val[1] * 256) + (int16_t)buff[2];
+  val[2] = (int16_t)buff[5];
+  val[2] = (val[2] * 256) + (int16_t)buff[4];
+
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      OIS Angular rate sensor (thru IF2).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ois_angular_rate_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
+{
+  uint8_t buff[6];
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_IF2_OUTX_L_G_OIS, &buff[0], 6);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val[0] = (int16_t)buff[1];
+  val[0] = (*val * 256) + (int16_t)buff[0];
+  val[1] = (int16_t)buff[3];
+  val[1] = (*val * 256) + (int16_t)buff[2];
+  val[2] = (int16_t)buff[5];
+  val[2] = (*val * 256) + (int16_t)buff[4];
+
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor for OIS gyro or the EIS gyro channel.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Angular rate sensor for OIS gyro or the EIS gyro channel.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ois_eis_angular_rate_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
+{
+  uint8_t buff[6];
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_UI_OUTX_L_G_OIS_EIS, &buff[0], 6);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val[0] = (int16_t)buff[1];
+  val[0] = (*val * 256) + (int16_t)buff[0];
+  val[1] = (int16_t)buff[3];
+  val[1] = (*val * 256) + (int16_t)buff[2];
+  val[2] = (int16_t)buff[5];
+  val[2] = (*val * 256) + (int16_t)buff[4];
+
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Linear acceleration sensor.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
+{
+  uint8_t buff[6];
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_OUTX_L_A, &buff[0], 6);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val[0] = (int16_t)buff[1];
+  val[0] = (val[0] * 256) + (int16_t)buff[0];
+  val[1] = (int16_t)buff[3];
+  val[1] = (val[1] * 256) + (int16_t)buff[2];
+  val[2] = (int16_t)buff[5];
+  val[2] = (val[2] * 256) + (int16_t)buff[4];
+
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor for hg channel mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Linear acceleration sensor or High-G channel mode.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_hg_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
+{
+  uint8_t buff[6];
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_UI_OUTX_L_A_OIS_HG, &buff[0], 6);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val[0] = (int16_t)buff[1];
+  val[0] = (val[0] * 256) + (int16_t)buff[0];
+  val[1] = (int16_t)buff[3];
+  val[1] = (val[1] * 256) + (int16_t)buff[2];
+  val[2] = (int16_t)buff[5];
+  val[2] = (val[2] * 256) + (int16_t)buff[4];
+
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor for OIS channel mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Linear acceleration sensor or OIS channel mode.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ois_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
+{
+  uint8_t buff[6];
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_UI_OUTX_L_A_OIS_HG, &buff[0], 6);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val[0] = (int16_t)buff[1];
+  val[0] = (val[0] * 256) + (int16_t)buff[0];
+  val[1] = (int16_t)buff[3];
+  val[1] = (val[1] * 256) + (int16_t)buff[2];
+  val[2] = (int16_t)buff[5];
+  val[2] = (val[2] * 256) + (int16_t)buff[4];
+
+  return ret;
+}
+
+/**
+  * @brief  SFLP gbias.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SFLP gbias raw array.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sflp_gbias_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
+{
+  uint8_t buff[6];
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_SFLP_GBIASX_L, &buff[0], 6);
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val[0] = (int16_t)buff[1];
+  val[0] = (val[0] * 256) + (int16_t)buff[0];
+  val[1] = (int16_t)buff[3];
+  val[1] = (val[1] * 256) + (int16_t)buff[2];
+  val[2] = (int16_t)buff[5];
+  val[2] = (val[2] * 256) + (int16_t)buff[4];
+
+  return ret;
+}
+
+/**
+  * @brief  SFLP gravity.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SFLP gravity raw array.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sflp_gravity_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
+{
+  uint8_t buff[6];
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_SFLP_GRAVX_L, &buff[0], 6);
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val[0] = (int16_t)buff[1];
+  val[0] = (val[0] * 256) + (int16_t)buff[0];
+  val[1] = (int16_t)buff[3];
+  val[1] = (val[1] * 256) + (int16_t)buff[2];
+  val[2] = (int16_t)buff[5];
+  val[2] = (val[2] * 256) + (int16_t)buff[4];
+
+  return ret;
+}
+
+/**
+  * @brief  SFLP raw quaternions.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      pointer to SFLP quaternions raw array.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sflp_quaternion_raw_get(const stmdev_ctx_t *ctx, uint16_t *val)
+{
+  uint8_t buff[8];
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_SFLP_QUATW_L, &buff[0], 8);
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val[0] = (uint16_t)buff[1];
+  val[0] = (val[0] * 256) + (uint16_t)buff[0];
+  val[1] = (uint16_t)buff[3];
+  val[1] = (val[1] * 256) + (uint16_t)buff[2];
+  val[2] = (uint16_t)buff[5];
+  val[2] = (val[2] * 256) + (uint16_t)buff[4];
+  val[3] = (uint16_t)buff[7];
+  val[3] = (val[3] * 256) + (uint16_t)buff[6];
+
+  return ret;
+}
+
+/**
+  * @brief  SFLP quaternions.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      pointer to SFLP quaternions raw array.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sflp_quaternion_get(const stmdev_ctx_t *ctx, lsm6dsv320x_quaternion_t *quat)
+{
+  uint16_t val[4];
+  int32_t ret;
+
+  ret = lsm6dsv320x_sflp_quaternion_raw_get(ctx, val);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  quat->quat_w = lsm6dsv320x_from_quaternion_lsb_to_float(val[0]);
+  quat->quat_x = lsm6dsv320x_from_quaternion_lsb_to_float(val[1]);
+  quat->quat_y = lsm6dsv320x_from_quaternion_lsb_to_float(val[2]);
+  quat->quat_z = lsm6dsv320x_from_quaternion_lsb_to_float(val[3]);
+
+  return ret;
+}
+
+/**
+  * @brief  Difference in percentage of the effective ODR (and timestamp rate) with respect to the typical. Step: 0.13%. 8-bit format, 2's complement.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Difference in percentage of the effective ODR (and timestamp rate) with respect to the typical. Step: 0.13%. 8-bit format, 2's complement.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_odr_cal_reg_get(const stmdev_ctx_t *ctx, int8_t *val)
+{
+  lsm6dsv320x_internal_freq_t internal_freq;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_INTERNAL_FREQ, (uint8_t *)&internal_freq, 1);
+  *val = (int8_t)internal_freq.freq_fine;
+
+  return ret;
+}
+
+/**
+  * @defgroup Common
+  * @brief     This section groups common useful functions.
+  * @{/
+  *
+  */
+
+/**
+  * @brief  Disable Embedded functions.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      1 (disable) or 0 (enable) embedded functions
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_disable_embedded_function_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_emb_func_cfg_t emb_func_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
+  emb_func_cfg.emb_func_disable = val & 0x1U;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Disable Embedded functions.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      1 (disable) or 0 (enable) embedded functions
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_disable_embedded_function_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_emb_func_cfg_t emb_func_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
+  *val = emb_func_cfg.emb_func_disable;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable/Disable embedded function sensor conversion.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      0 (disable) or 1 (enable) embedded functions sensor conversion
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_emb_func_conv_set(const stmdev_ctx_t *ctx, lsm6dsv320x_emb_func_conv_t val)
+{
+  lsm6dsv320x_emb_func_sensor_conv_en_t conv_reg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_SENSOR_CONV_EN, (uint8_t *)&conv_reg, 1);
+  conv_reg.xl_hg_conv_en = val.xl_hg_conv_en;
+  conv_reg.gyro_conv_en = val.gyro_conv_en;
+  conv_reg.temp_conv_en = val.temp_conv_en;
+  conv_reg.ext_sensor_conv_en = val.ext_sensor_conv_en;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_SENSOR_CONV_EN, (uint8_t *)&conv_reg, 1);
+
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Enable/Disable embedded function sensor conversion.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      0 (disable) or 1 (enable) embedded functions sensor conversion
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_emb_func_conv_get(const stmdev_ctx_t *ctx, lsm6dsv320x_emb_func_conv_t *val)
+{
+  lsm6dsv320x_emb_func_sensor_conv_en_t conv_reg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_SENSOR_CONV_EN, (uint8_t *)&conv_reg, 1);
+  val->xl_hg_conv_en  = conv_reg.xl_hg_conv_en;
+  val->gyro_conv_en = conv_reg.gyro_conv_en;
+  val->temp_conv_en = conv_reg.temp_conv_en;
+  val->ext_sensor_conv_en = conv_reg.ext_sensor_conv_en;
+
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Write buffer in a page.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Write buffer in a page.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t address,
+                                uint8_t *buf, uint8_t len)
+{
+  lsm6dsv320x_page_address_t  page_address;
+  lsm6dsv320x_page_sel_t page_sel;
+  lsm6dsv320x_page_rw_t page_rw;
+  uint8_t msb;
+  uint8_t lsb;
+  int32_t ret;
+  uint8_t i ;
+
+  msb = ((uint8_t)(address >> 8) & 0x0FU);
+  lsb = (uint8_t)address & 0xFFU;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  /* set page write */
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_PAGE_RW, (uint8_t *)&page_rw, 1);
+  page_rw.page_read = PROPERTY_DISABLE;
+  page_rw.page_write = PROPERTY_ENABLE;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_PAGE_RW, (uint8_t *)&page_rw, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  /* select page */
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  page_sel.page_sel = msb;
+  page_sel.not_used0 = 1; // Default value
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  /* set page addr */
+  page_address.page_addr = lsb;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_PAGE_ADDRESS,
+                               (uint8_t *)&page_address, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  for (i = 0; ((i < len) && (ret == 0)); i++)
+  {
+    ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_PAGE_VALUE, &buf[i], 1);
+    if (ret != 0)
+    {
+      goto exit;
+    }
+
+    lsb++;
+
+    /* Check if page wrap */
+    if (((lsb & 0xFFU) == 0x00U) && (ret == 0))
+    {
+      msb++;
+      ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_PAGE_SEL, (uint8_t *)&page_sel, 1);
+      if (ret != 0)
+      {
+        goto exit;
+      }
+
+      page_sel.page_sel = msb;
+      page_sel.not_used0 = 1; // Default value
+      ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_PAGE_SEL, (uint8_t *)&page_sel, 1);
+      if (ret != 0)
+      {
+        goto exit;
+      }
+    }
+  }
+
+  page_sel.page_sel = 0;
+  page_sel.not_used0 = 1;// Default value
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  /* unset page write */
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_PAGE_RW, (uint8_t *)&page_rw, 1);
+  page_rw.page_read = PROPERTY_DISABLE;
+  page_rw.page_write = PROPERTY_DISABLE;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_PAGE_RW, (uint8_t *)&page_rw, 1);
+
+exit:
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Read buffer in a page.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Write buffer in a page.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ln_pg_read(const stmdev_ctx_t *ctx, uint16_t address, uint8_t *buf,
+                               uint8_t len)
+{
+  lsm6dsv320x_page_address_t  page_address;
+  lsm6dsv320x_page_sel_t page_sel;
+  lsm6dsv320x_page_rw_t page_rw;
+  uint8_t msb;
+  uint8_t lsb;
+  int32_t ret;
+  uint8_t i ;
+
+  msb = ((uint8_t)(address >> 8) & 0x0FU);
+  lsb = (uint8_t)address & 0xFFU;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  /* set page write */
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_PAGE_RW, (uint8_t *)&page_rw, 1);
+  page_rw.page_read = PROPERTY_ENABLE;
+  page_rw.page_write = PROPERTY_DISABLE;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_PAGE_RW, (uint8_t *)&page_rw, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  /* select page */
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  page_sel.page_sel = msb;
+  page_sel.not_used0 = 1; // Default value
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  /* set page addr */
+  page_address.page_addr = lsb;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_PAGE_ADDRESS,
+                               (uint8_t *)&page_address, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  for (i = 0; ((i < len) && (ret == 0)); i++)
+  {
+    ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_PAGE_VALUE, &buf[i], 1);
+    if (ret != 0)
+    {
+      goto exit;
+    }
+
+    lsb++;
+
+    /* Check if page wrap */
+    if (((lsb & 0xFFU) == 0x00U) && (ret == 0))
+    {
+      msb++;
+      ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_PAGE_SEL, (uint8_t *)&page_sel, 1);
+      if (ret != 0)
+      {
+        goto exit;
+      }
+
+      page_sel.page_sel = msb;
+      page_sel.not_used0 = 1; // Default value
+      ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_PAGE_SEL, (uint8_t *)&page_sel, 1);
+      if (ret != 0)
+      {
+        goto exit;
+      }
+    }
+  }
+
+  page_sel.page_sel = 0;
+  page_sel.not_used0 = 1;// Default value
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  /* unset page write */
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_PAGE_RW, (uint8_t *)&page_rw, 1);
+  page_rw.page_read = PROPERTY_DISABLE;
+  page_rw.page_write = PROPERTY_DISABLE;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_PAGE_RW, (uint8_t *)&page_rw, 1);
+
+exit:
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Enable debug mode for embedded functions [set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      0, 1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_emb_function_dbg_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_ctrl10_t ctrl10;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL10, (uint8_t *)&ctrl10, 1);
+
+  if (ret == 0)
+  {
+    ctrl10.emb_func_debug = val;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL10, (uint8_t *)&ctrl10, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable debug mode for embedded functions [get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      0, 1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_emb_function_dbg_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_ctrl10_t ctrl10;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL10, (uint8_t *)&ctrl10, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  *val = ctrl10.emb_func_debug;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Data ENable (DEN)
+  * @brief     This section groups all the functions concerning
+  *            DEN functionality.
+  * @{
+  *
+  */
+
+/**
+  * @brief  It changes the polarity of INT2 pin input trigger for data enable (DEN) or embedded functions.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      DEN_ACT_LOW, DEN_ACT_HIGH,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_den_polarity_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv320x_den_polarity_t val)
+{
+  lsm6dsv320x_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL4, (uint8_t *)&ctrl4, 1);
+
+  if (ret == 0)
+  {
+    ctrl4.int2_in_lh = (uint8_t)val & 0x1U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL4, (uint8_t *)&ctrl4, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  It changes the polarity of INT2 pin input trigger for data enable (DEN) or embedded functions.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      DEN_ACT_LOW, DEN_ACT_HIGH,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_den_polarity_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv320x_den_polarity_t *val)
+{
+  lsm6dsv320x_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL4, (uint8_t *)&ctrl4, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl4.int2_in_lh)
+  {
+    case LSM6DSV320X_DEN_ACT_LOW:
+      *val = LSM6DSV320X_DEN_ACT_LOW;
+      break;
+
+    case LSM6DSV320X_DEN_ACT_HIGH:
+      *val = LSM6DSV320X_DEN_ACT_HIGH;
+      break;
+
+    default:
+      *val = LSM6DSV320X_DEN_ACT_LOW;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup Electronic Image Stabilization (EIS)
+  * @brief    Electronic Image Stabilization (EIS)
+  * @{/
+  *
+  */
+
+/**
+  * @brief  Gyroscope full-scale selection for EIS channel. WARNING: 4000dps will be available only if also User Interface chain is set to 4000dps[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      250dps, 500dps, 1000dps, 2000dps, 4000dps,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_eis_gy_full_scale_set(const stmdev_ctx_t *ctx,
+                                          lsm6dsv320x_eis_gy_full_scale_t val)
+{
+  lsm6dsv320x_ctrl_eis_t ctrl_eis;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
+
+  if (ret == 0)
+  {
+    ctrl_eis.fs_g_eis = (uint8_t)val & 0x7U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope full-scale selection for EIS channel. WARNING: 4000dps will be available only if also User Interface chain is set to 4000dps[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      250dps, 500dps, 1000dps, 2000dps, 4000dps
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_eis_gy_full_scale_get(const stmdev_ctx_t *ctx,
+                                          lsm6dsv320x_eis_gy_full_scale_t *val)
+{
+  lsm6dsv320x_ctrl_eis_t ctrl_eis;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl_eis.fs_g_eis)
+  {
+    case 1:
+      *val = LSM6DSV320X_EIS_250dps;
+      break;
+
+    case 2:
+      *val = LSM6DSV320X_EIS_500dps;
+      break;
+
+    case 3:
+      *val = LSM6DSV320X_EIS_1000dps;
+      break;
+
+    case 4:
+      *val = LSM6DSV320X_EIS_2000dps;
+      break;
+
+    case 5:
+      *val = LSM6DSV320X_EIS_4000dps;
+      break;
+
+    default:
+      *val = LSM6DSV320X_EIS_250dps;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables routing of gyroscope EIS outputs on IF2 (OIS interface). The gyroscope data on IF2 (OIS interface) cannot be read from User Interface (UI).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables routing of gyroscope EIS outputs on IF2 (OIS interface). The gyroscope data on IF2 (OIS interface) cannot be read from User Interface (UI).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_eis_gy_on_if2_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_ctrl_eis_t ctrl_eis;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
+
+  if (ret == 0)
+  {
+    ctrl_eis.g_eis_on_g_ois_out_reg = val;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables routing of gyroscope EIS outputs on IF2 (OIS interface). The gyroscope data on IF2 (OIS interface) cannot be read from User Interface (UI).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables routing of gyroscope EIS outputs on IF2 (OIS interface). The gyroscope data on IF2 (OIS interface) cannot be read from User Interface (UI).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_eis_gy_on_if2_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_ctrl_eis_t ctrl_eis;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
+  *val = ctrl_eis.g_eis_on_g_ois_out_reg;
+
+  return ret;
+}
+
+/**
+  * @brief  Enables and selects the ODR of the gyroscope EIS channel.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      EIS_1920Hz, EIS_960Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_gy_eis_data_rate_set(const stmdev_ctx_t *ctx,
+                                         lsm6dsv320x_gy_eis_data_rate_t val)
+{
+  lsm6dsv320x_ctrl_eis_t ctrl_eis;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
+
+  if (ret == 0)
+  {
+    ctrl_eis.odr_g_eis = (uint8_t)val & 0x03U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables and selects the ODR of the gyroscope EIS channel.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      EIS_1920Hz, EIS_960Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_gy_eis_data_rate_get(const stmdev_ctx_t *ctx,
+                                         lsm6dsv320x_gy_eis_data_rate_t *val)
+{
+  lsm6dsv320x_ctrl_eis_t ctrl_eis;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl_eis.odr_g_eis)
+  {
+    case LSM6DSV320X_EIS_ODR_OFF:
+      *val = LSM6DSV320X_EIS_ODR_OFF;
+      break;
+
+    case LSM6DSV320X_EIS_1920Hz:
+      *val = LSM6DSV320X_EIS_1920Hz;
+      break;
+
+    case LSM6DSV320X_EIS_960Hz:
+      *val = LSM6DSV320X_EIS_960Hz;
+      break;
+
+    default:
+      *val = LSM6DSV320X_EIS_1920Hz;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  FIFO
+  * @brief     This section group all the functions concerning the FIFO usage
+  * @{
+  *
+  */
+
+/**
+  * @brief  FIFO watermark threshold (1 LSb = TAG (1 Byte) + 1 sensor (6 Bytes) written in FIFO).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      FIFO watermark threshold (1 LSb = TAG (1 Byte) + 1 sensor (6 Bytes) written in FIFO).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_watermark_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_fifo_ctrl1_t fifo_ctrl1;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
+
+  if (ret == 0)
+  {
+    fifo_ctrl1.wtm = val;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark threshold (1 LSb = TAG (1 Byte) + 1 sensor (6 Bytes) written in FIFO).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      FIFO watermark threshold (1 LSb = TAG (1 Byte) + 1 sensor (6 Bytes) written in FIFO).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_watermark_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_fifo_ctrl1_t fifo_ctrl1;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
+  *val = fifo_ctrl1.wtm;
+
+  return ret;
+}
+
+/**
+  * @brief  It configures the compression algorithm to write non-compressed data at each rate.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      CMP_DISABLE, CMP_ALWAYS, CMP_8_TO_1, CMP_16_TO_1, CMP_32_TO_1,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_compress_algo_set(const stmdev_ctx_t *ctx,
+                                           lsm6dsv320x_fifo_compress_algo_t val)
+{
+  lsm6dsv320x_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+  if (ret == 0)
+  {
+    fifo_ctrl2.uncompr_rate = (uint8_t)val & 0x03U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  It configures the compression algorithm to write non-compressed data at each rate.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      CMP_DISABLE, CMP_ALWAYS, CMP_8_TO_1, CMP_16_TO_1, CMP_32_TO_1,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_compress_algo_get(const stmdev_ctx_t *ctx,
+                                           lsm6dsv320x_fifo_compress_algo_t *val)
+{
+  lsm6dsv320x_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (fifo_ctrl2.uncompr_rate)
+  {
+    case LSM6DSV320X_CMP_DISABLE:
+      *val = LSM6DSV320X_CMP_DISABLE;
+      break;
+
+    case LSM6DSV320X_CMP_8_TO_1:
+      *val = LSM6DSV320X_CMP_8_TO_1;
+      break;
+
+    case LSM6DSV320X_CMP_16_TO_1:
+      *val = LSM6DSV320X_CMP_16_TO_1;
+      break;
+
+    case LSM6DSV320X_CMP_32_TO_1:
+      *val = LSM6DSV320X_CMP_32_TO_1;
+      break;
+
+    default:
+      *val = LSM6DSV320X_CMP_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables ODR CHANGE virtual sensor to be batched in FIFO.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables ODR CHANGE virtual sensor to be batched in FIFO.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_virtual_sens_odr_chg_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+  if (ret == 0)
+  {
+    fifo_ctrl2.odr_chg_en = val;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables ODR CHANGE virtual sensor to be batched in FIFO.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables ODR CHANGE virtual sensor to be batched in FIFO.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_virtual_sens_odr_chg_get(const stmdev_ctx_t *ctx,
+                                                  uint8_t *val)
+{
+  lsm6dsv320x_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+  *val = fifo_ctrl2.odr_chg_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enables/Disables compression algorithm runtime.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables/Disables compression algorithm runtime.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_compress_algo_real_time_set(const stmdev_ctx_t *ctx,
+                                                     uint8_t val)
+{
+  lsm6dsv320x_emb_func_en_b_t emb_func_en_b;
+  lsm6dsv320x_fifo_ctrl2_t fifo_ctrl2;
+
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+  fifo_ctrl2.fifo_compr_rt_en = val;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
+  emb_func_en_b.fifo_compr_en = val;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Enables/Disables compression algorithm runtime.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables/Disables compression algorithm runtime.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_compress_algo_real_time_get(const stmdev_ctx_t *ctx,
+                                                     uint8_t *val)
+{
+  lsm6dsv320x_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+
+  *val = fifo_ctrl2.fifo_compr_rt_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at threshold level.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Sensing chain FIFO stop values memorization at threshold level.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_stop_on_wtm_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+  if (ret == 0)
+  {
+    fifo_ctrl2.stop_on_wtm = val;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at threshold level.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Sensing chain FIFO stop values memorization at threshold level.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_stop_on_wtm_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+  *val = fifo_ctrl2.stop_on_wtm;
+
+  return ret;
+}
+
+/**
+  * @brief  Selects Batch Data Rate (write frequency in FIFO) for accelerometer data.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      XL_NOT_BATCHED, XL_BATCHED_AT_1Hz875, XL_BATCHED_AT_7Hz5, XL_BATCHED_AT_15Hz, XL_BATCHED_AT_30Hz, XL_BATCHED_AT_60Hz, XL_BATCHED_AT_120Hz, XL_BATCHED_AT_240Hz, XL_BATCHED_AT_480Hz, XL_BATCHED_AT_960Hz, XL_BATCHED_AT_1920Hz, XL_BATCHED_AT_3840Hz, XL_BATCHED_AT_7680Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_xl_batch_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_fifo_xl_batch_t val)
+{
+  lsm6dsv320x_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FIFO_CTRL3, (uint8_t *)&fifo_ctrl3, 1);
+  if (ret == 0)
+  {
+    fifo_ctrl3.bdr_xl = (uint8_t)val & 0xFu;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FIFO_CTRL3, (uint8_t *)&fifo_ctrl3, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects Batch Data Rate (write frequency in FIFO) for accelerometer data.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      XL_NOT_BATCHED, XL_BATCHED_AT_1Hz875, XL_BATCHED_AT_7Hz5, XL_BATCHED_AT_15Hz, XL_BATCHED_AT_30Hz, XL_BATCHED_AT_60Hz, XL_BATCHED_AT_120Hz, XL_BATCHED_AT_240Hz, XL_BATCHED_AT_480Hz, XL_BATCHED_AT_960Hz, XL_BATCHED_AT_1920Hz, XL_BATCHED_AT_3840Hz, XL_BATCHED_AT_7680Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_xl_batch_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_fifo_xl_batch_t *val)
+{
+  lsm6dsv320x_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FIFO_CTRL3, (uint8_t *)&fifo_ctrl3, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (fifo_ctrl3.bdr_xl)
+  {
+    case LSM6DSV320X_XL_NOT_BATCHED:
+      *val = LSM6DSV320X_XL_NOT_BATCHED;
+      break;
+
+    case LSM6DSV320X_XL_BATCHED_AT_1Hz875:
+      *val = LSM6DSV320X_XL_BATCHED_AT_1Hz875;
+      break;
+
+    case LSM6DSV320X_XL_BATCHED_AT_7Hz5:
+      *val = LSM6DSV320X_XL_BATCHED_AT_7Hz5;
+      break;
+
+    case LSM6DSV320X_XL_BATCHED_AT_15Hz:
+      *val = LSM6DSV320X_XL_BATCHED_AT_15Hz;
+      break;
+
+    case LSM6DSV320X_XL_BATCHED_AT_30Hz:
+      *val = LSM6DSV320X_XL_BATCHED_AT_30Hz;
+      break;
+
+    case LSM6DSV320X_XL_BATCHED_AT_60Hz:
+      *val = LSM6DSV320X_XL_BATCHED_AT_60Hz;
+      break;
+
+    case LSM6DSV320X_XL_BATCHED_AT_120Hz:
+      *val = LSM6DSV320X_XL_BATCHED_AT_120Hz;
+      break;
+
+    case LSM6DSV320X_XL_BATCHED_AT_240Hz:
+      *val = LSM6DSV320X_XL_BATCHED_AT_240Hz;
+      break;
+
+    case LSM6DSV320X_XL_BATCHED_AT_480Hz:
+      *val = LSM6DSV320X_XL_BATCHED_AT_480Hz;
+      break;
+
+    case LSM6DSV320X_XL_BATCHED_AT_960Hz:
+      *val = LSM6DSV320X_XL_BATCHED_AT_960Hz;
+      break;
+
+    case LSM6DSV320X_XL_BATCHED_AT_1920Hz:
+      *val = LSM6DSV320X_XL_BATCHED_AT_1920Hz;
+      break;
+
+    case LSM6DSV320X_XL_BATCHED_AT_3840Hz:
+      *val = LSM6DSV320X_XL_BATCHED_AT_3840Hz;
+      break;
+
+    case LSM6DSV320X_XL_BATCHED_AT_7680Hz:
+      *val = LSM6DSV320X_XL_BATCHED_AT_7680Hz;
+      break;
+
+    default:
+      *val = LSM6DSV320X_XL_NOT_BATCHED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects Batch Data Rate (write frequency in FIFO) for gyroscope data.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      GY_NOT_BATCHED, GY_BATCHED_AT_1Hz875, GY_BATCHED_AT_7Hz5, GY_BATCHED_AT_15Hz, GY_BATCHED_AT_30Hz, GY_BATCHED_AT_60Hz, GY_BATCHED_AT_120Hz, GY_BATCHED_AT_240Hz, GY_BATCHED_AT_480Hz, GY_BATCHED_AT_960Hz, GY_BATCHED_AT_1920Hz, GY_BATCHED_AT_3840Hz, GY_BATCHED_AT_7680Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_gy_batch_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_fifo_gy_batch_t val)
+{
+  lsm6dsv320x_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FIFO_CTRL3, (uint8_t *)&fifo_ctrl3, 1);
+  if (ret == 0)
+  {
+    fifo_ctrl3.bdr_gy = (uint8_t)val & 0x0Fu;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FIFO_CTRL3, (uint8_t *)&fifo_ctrl3, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects Batch Data Rate (write frequency in FIFO) for gyroscope data.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      GY_NOT_BATCHED, GY_BATCHED_AT_1Hz875, GY_BATCHED_AT_7Hz5, GY_BATCHED_AT_15Hz, GY_BATCHED_AT_30Hz, GY_BATCHED_AT_60Hz, GY_BATCHED_AT_120Hz, GY_BATCHED_AT_240Hz, GY_BATCHED_AT_480Hz, GY_BATCHED_AT_960Hz, GY_BATCHED_AT_1920Hz, GY_BATCHED_AT_3840Hz, GY_BATCHED_AT_7680Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_gy_batch_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_fifo_gy_batch_t *val)
+{
+  lsm6dsv320x_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FIFO_CTRL3, (uint8_t *)&fifo_ctrl3, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (fifo_ctrl3.bdr_gy)
+  {
+    case LSM6DSV320X_GY_NOT_BATCHED:
+      *val = LSM6DSV320X_GY_NOT_BATCHED;
+      break;
+
+    case LSM6DSV320X_GY_BATCHED_AT_1Hz875:
+      *val = LSM6DSV320X_GY_BATCHED_AT_1Hz875;
+      break;
+
+    case LSM6DSV320X_GY_BATCHED_AT_7Hz5:
+      *val = LSM6DSV320X_GY_BATCHED_AT_7Hz5;
+      break;
+
+    case LSM6DSV320X_GY_BATCHED_AT_15Hz:
+      *val = LSM6DSV320X_GY_BATCHED_AT_15Hz;
+      break;
+
+    case LSM6DSV320X_GY_BATCHED_AT_30Hz:
+      *val = LSM6DSV320X_GY_BATCHED_AT_30Hz;
+      break;
+
+    case LSM6DSV320X_GY_BATCHED_AT_60Hz:
+      *val = LSM6DSV320X_GY_BATCHED_AT_60Hz;
+      break;
+
+    case LSM6DSV320X_GY_BATCHED_AT_120Hz:
+      *val = LSM6DSV320X_GY_BATCHED_AT_120Hz;
+      break;
+
+    case LSM6DSV320X_GY_BATCHED_AT_240Hz:
+      *val = LSM6DSV320X_GY_BATCHED_AT_240Hz;
+      break;
+
+    case LSM6DSV320X_GY_BATCHED_AT_480Hz:
+      *val = LSM6DSV320X_GY_BATCHED_AT_480Hz;
+      break;
+
+    case LSM6DSV320X_GY_BATCHED_AT_960Hz:
+      *val = LSM6DSV320X_GY_BATCHED_AT_960Hz;
+      break;
+
+    case LSM6DSV320X_GY_BATCHED_AT_1920Hz:
+      *val = LSM6DSV320X_GY_BATCHED_AT_1920Hz;
+      break;
+
+    case LSM6DSV320X_GY_BATCHED_AT_3840Hz:
+      *val = LSM6DSV320X_GY_BATCHED_AT_3840Hz;
+      break;
+
+    case LSM6DSV320X_GY_BATCHED_AT_7680Hz:
+      *val = LSM6DSV320X_GY_BATCHED_AT_7680Hz;
+      break;
+
+    default:
+      *val = LSM6DSV320X_GY_NOT_BATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO Batch for hg XL data.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      0 (disable) / 1 (enabled)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_hg_xl_batch_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_counter_bdr_reg1_t cbdr_reg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_COUNTER_BDR_REG1, (uint8_t *)&cbdr_reg, 1);
+  if (ret == 0)
+  {
+    cbdr_reg.xl_hg_batch_en = (uint8_t)val & 0x01U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_COUNTER_BDR_REG1, (uint8_t *)&cbdr_reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO Batch for hg XL data.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      0 (disable) / 1 (enabled)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_hg_xl_batch_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_counter_bdr_reg1_t cbdr_reg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_COUNTER_BDR_REG1, (uint8_t *)&cbdr_reg, 1);
+  *val = cbdr_reg.xl_hg_batch_en;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      BYPASS_MODE, FIFO_MODE, STREAM_WTM_TO_FULL_MODE, STREAM_TO_FIFO_MODE, BYPASS_TO_STREAM_MODE, STREAM_MODE, BYPASS_TO_FIFO_MODE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_mode_set(const stmdev_ctx_t *ctx, lsm6dsv320x_fifo_mode_t val)
+{
+  lsm6dsv320x_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
+  if (ret == 0)
+  {
+    fifo_ctrl4.fifo_mode = (uint8_t)val & 0x07U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      BYPASS_MODE, FIFO_MODE, STREAM_WTM_TO_FULL_MODE, STREAM_TO_FIFO_MODE, BYPASS_TO_STREAM_MODE, STREAM_MODE, BYPASS_TO_FIFO_MODE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_mode_get(const stmdev_ctx_t *ctx, lsm6dsv320x_fifo_mode_t *val)
+{
+  lsm6dsv320x_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (fifo_ctrl4.fifo_mode)
+  {
+    case LSM6DSV320X_BYPASS_MODE:
+      *val = LSM6DSV320X_BYPASS_MODE;
+      break;
+
+    case LSM6DSV320X_FIFO_MODE:
+      *val = LSM6DSV320X_FIFO_MODE;
+      break;
+
+    case LSM6DSV320X_STREAM_WTM_TO_FULL_MODE:
+      *val = LSM6DSV320X_STREAM_WTM_TO_FULL_MODE;
+      break;
+
+    case LSM6DSV320X_STREAM_TO_FIFO_MODE:
+      *val = LSM6DSV320X_STREAM_TO_FIFO_MODE;
+      break;
+
+    case LSM6DSV320X_BYPASS_TO_STREAM_MODE:
+      *val = LSM6DSV320X_BYPASS_TO_STREAM_MODE;
+      break;
+
+    case LSM6DSV320X_STREAM_MODE:
+      *val = LSM6DSV320X_STREAM_MODE;
+      break;
+
+    case LSM6DSV320X_BYPASS_TO_FIFO_MODE:
+      *val = LSM6DSV320X_BYPASS_TO_FIFO_MODE;
+      break;
+
+    default:
+      *val = LSM6DSV320X_BYPASS_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables FIFO batching of EIS gyroscope output values.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables FIFO batching of EIS gyroscope output values.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_gy_eis_batch_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
+  if (ret == 0)
+  {
+    fifo_ctrl4.g_eis_fifo_en = val;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables FIFO batching of EIS gyroscope output values.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables FIFO batching of EIS gyroscope output values.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_gy_eis_batch_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
+  *val = fifo_ctrl4.g_eis_fifo_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Selects batch data rate (write frequency in FIFO) for temperature data.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      TEMP_NOT_BATCHED, TEMP_BATCHED_AT_1Hz875, TEMP_BATCHED_AT_15Hz, TEMP_BATCHED_AT_60Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_temp_batch_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_fifo_temp_batch_t val)
+{
+  lsm6dsv320x_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
+  if (ret == 0)
+  {
+    fifo_ctrl4.odr_t_batch = (uint8_t)val & 0x03U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects batch data rate (write frequency in FIFO) for temperature data.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      TEMP_NOT_BATCHED, TEMP_BATCHED_AT_1Hz875, TEMP_BATCHED_AT_15Hz, TEMP_BATCHED_AT_60Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_temp_batch_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_fifo_temp_batch_t *val)
+{
+  lsm6dsv320x_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (fifo_ctrl4.odr_t_batch)
+  {
+    case LSM6DSV320X_TEMP_NOT_BATCHED:
+      *val = LSM6DSV320X_TEMP_NOT_BATCHED;
+      break;
+
+    case LSM6DSV320X_TEMP_BATCHED_AT_1Hz875:
+      *val = LSM6DSV320X_TEMP_BATCHED_AT_1Hz875;
+      break;
+
+    case LSM6DSV320X_TEMP_BATCHED_AT_15Hz:
+      *val = LSM6DSV320X_TEMP_BATCHED_AT_15Hz;
+      break;
+
+    case LSM6DSV320X_TEMP_BATCHED_AT_60Hz:
+      *val = LSM6DSV320X_TEMP_BATCHED_AT_60Hz;
+      break;
+
+    default:
+      *val = LSM6DSV320X_TEMP_NOT_BATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects decimation for timestamp batching in FIFO. Write rate will be the maximum rate between XL and GYRO BDR divided by decimation decoder.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      TMSTMP_NOT_BATCHED, TMSTMP_DEC_1, TMSTMP_DEC_8, TMSTMP_DEC_32,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_timestamp_batch_set(const stmdev_ctx_t *ctx,
+                                             lsm6dsv320x_fifo_timestamp_batch_t val)
+{
+  lsm6dsv320x_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
+  if (ret == 0)
+  {
+    fifo_ctrl4.dec_ts_batch = (uint8_t)val & 0x03U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects decimation for timestamp batching in FIFO. Write rate will be the maximum rate between XL and GYRO BDR divided by decimation decoder.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      TMSTMP_NOT_BATCHED, TMSTMP_DEC_1, TMSTMP_DEC_8, TMSTMP_DEC_32,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_timestamp_batch_get(const stmdev_ctx_t *ctx,
+                                             lsm6dsv320x_fifo_timestamp_batch_t *val)
+{
+  lsm6dsv320x_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (fifo_ctrl4.dec_ts_batch)
+  {
+    case LSM6DSV320X_TMSTMP_NOT_BATCHED:
+      *val = LSM6DSV320X_TMSTMP_NOT_BATCHED;
+      break;
+
+    case LSM6DSV320X_TMSTMP_DEC_1:
+      *val = LSM6DSV320X_TMSTMP_DEC_1;
+      break;
+
+    case LSM6DSV320X_TMSTMP_DEC_8:
+      *val = LSM6DSV320X_TMSTMP_DEC_8;
+      break;
+
+    case LSM6DSV320X_TMSTMP_DEC_32:
+      *val = LSM6DSV320X_TMSTMP_DEC_32;
+      break;
+
+    default:
+      *val = LSM6DSV320X_TMSTMP_NOT_BATCHED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  The threshold for the internal counter of batch events. When this counter reaches the threshold, the counter is reset and the interrupt flag is set to 1.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      The threshold for the internal counter of batch events. When this counter reaches the threshold, the counter is reset and the interrupt flag is set to 1.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_batch_counter_threshold_set(const stmdev_ctx_t *ctx,
+                                                     uint16_t val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  buff[1] = (uint8_t)(val / 256U);
+  buff[0] = (uint8_t)(val - (buff[1] * 256U));
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_COUNTER_BDR_REG1, (uint8_t *)&buff[0], 2);
+
+  return ret;
+}
+
+/**
+  * @brief  The threshold for the internal counter of batch events. When this counter reaches the threshold, the counter is reset and the interrupt flag is set to 1.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      The threshold for the internal counter of batch events. When this counter reaches the threshold, the counter is reset and the interrupt flag is set to 1.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_batch_counter_threshold_get(const stmdev_ctx_t *ctx,
+                                                     uint16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_COUNTER_BDR_REG1, &buff[0], 2);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  *val = buff[1];
+  *val = (*val * 256U) + buff[0];
+
+  return ret;
+}
+
+/**
+  * @brief  Selects the trigger for the internal counter of batch events.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lsm6dsv320x_fifo_batch_cnt_event_t struct
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_batch_cnt_event_set(const stmdev_ctx_t *ctx,
+                                             lsm6dsv320x_fifo_batch_cnt_event_t val)
+{
+  lsm6dsv320x_counter_bdr_reg1_t counter_bdr_reg1;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_COUNTER_BDR_REG1, (uint8_t *)&counter_bdr_reg1, 1);
+  if (ret == 0)
+  {
+    counter_bdr_reg1.trig_counter_bdr = (uint8_t)val & 0x03U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_COUNTER_BDR_REG1, (uint8_t *)&counter_bdr_reg1, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects the trigger for the internal counter of batch events.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lsm6dsv320x_fifo_batch_cnt_event_t struct
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_batch_cnt_event_get(const stmdev_ctx_t *ctx,
+                                             lsm6dsv320x_fifo_batch_cnt_event_t *val)
+{
+  lsm6dsv320x_counter_bdr_reg1_t counter_bdr_reg1;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_COUNTER_BDR_REG1, (uint8_t *)&counter_bdr_reg1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (counter_bdr_reg1.trig_counter_bdr)
+  {
+    case 0:
+      *val = LSM6DSV320X_XL_LG_BATCH_EVENT;
+      break;
+
+    case 1:
+      *val = LSM6DSV320X_GY_BATCH_EVENT;
+      break;
+
+    case 2:
+      *val = LSM6DSV320X_GY_EIS_BATCH_EVENT;
+      break;
+
+    case 3:
+      *val = LSM6DSV320X_XL_HG_BATCH_EVENT;
+      break;
+
+    default:
+      *val = LSM6DSV320X_XL_LG_BATCH_EVENT;
+      break;
+  }
+
+  return ret;
+}
+
+int32_t lsm6dsv320x_fifo_status_get(const stmdev_ctx_t *ctx,
+                                    lsm6dsv320x_fifo_status_t *val)
+{
+  uint8_t buff[2];
+  lsm6dsv320x_fifo_status2_t status;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FIFO_STATUS1, (uint8_t *)&buff[0], 2);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  bytecpy((uint8_t *)&status, &buff[1]);
+
+  val->fifo_bdr = status.counter_bdr_ia;
+  val->fifo_ovr = status.fifo_ovr_ia;
+  val->fifo_full = status.fifo_full_ia;
+  val->fifo_th = status.fifo_wtm_ia;
+
+  val->fifo_level = (uint16_t)buff[1] & 0x01U;
+  val->fifo_level = (val->fifo_level * 256U) + buff[0];
+
+  return ret;
+}
+
+
+/**
+  * @brief  FIFO data output[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      FIFO tag
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_out_raw_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv320x_fifo_out_raw_t *val)
+{
+  lsm6dsv320x_fifo_data_out_tag_t fifo_data_out_tag;
+  uint8_t buff[7];
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FIFO_DATA_OUT_TAG, buff, 7);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  bytecpy((uint8_t *)&fifo_data_out_tag, &buff[0]);
+
+  switch (fifo_data_out_tag.tag_sensor)
+  {
+    case 0:
+      val->tag = LSM6DSV320X_FIFO_EMPTY;
+      break;
+
+    case 1:
+      val->tag = LSM6DSV320X_GY_NC_TAG;
+      break;
+
+    case 2:
+      val->tag = LSM6DSV320X_XL_NC_TAG;
+      break;
+
+    case 3:
+      val->tag = LSM6DSV320X_TIMESTAMP_TAG;
+      break;
+
+    case 4:
+      val->tag = LSM6DSV320X_TEMPERATURE_TAG;
+      break;
+
+    case 5:
+      val->tag = LSM6DSV320X_CFG_CHANGE_TAG;
+      break;
+
+    case 6:
+      val->tag = LSM6DSV320X_XL_NC_T_2_TAG;
+      break;
+
+    case 7:
+      val->tag = LSM6DSV320X_XL_NC_T_1_TAG;
+      break;
+
+    case 8:
+      val->tag = LSM6DSV320X_XL_2XC_TAG;
+      break;
+
+    case 9:
+      val->tag = LSM6DSV320X_XL_3XC_TAG;
+      break;
+
+    case 0xA:
+      val->tag = LSM6DSV320X_GY_NC_T_2_TAG;
+      break;
+
+    case 0xB:
+      val->tag = LSM6DSV320X_GY_NC_T_1_TAG;
+      break;
+
+    case 0xC:
+      val->tag = LSM6DSV320X_GY_2XC_TAG;
+      break;
+
+    case 0xD:
+      val->tag = LSM6DSV320X_GY_3XC_TAG;
+      break;
+
+    case 0xE:
+      val->tag = LSM6DSV320X_SENSORHUB_TARGET0_TAG;
+      break;
+
+    case 0xF:
+      val->tag = LSM6DSV320X_SENSORHUB_TARGET1_TAG;
+      break;
+
+    case 0x10:
+      val->tag = LSM6DSV320X_SENSORHUB_TARGET2_TAG;
+      break;
+
+    case 0x11:
+      val->tag = LSM6DSV320X_SENSORHUB_TARGET3_TAG;
+      break;
+
+    case 0x12:
+      val->tag = LSM6DSV320X_STEP_COUNTER_TAG;
+      break;
+
+    case 0x13:
+      val->tag = LSM6DSV320X_SFLP_GAME_ROTATION_VECTOR_TAG;
+      break;
+
+    case 0x16:
+      val->tag = LSM6DSV320X_SFLP_GYROSCOPE_BIAS_TAG;
+      break;
+
+    case 0x17:
+      val->tag = LSM6DSV320X_SFLP_GRAVITY_VECTOR_TAG;
+      break;
+
+    case 0x18:
+      val->tag = LSM6DSV320X_HG_XL_PEAK_TAG;
+      break;
+
+    case 0x19:
+      val->tag = LSM6DSV320X_SENSORHUB_NACK_TAG;
+      break;
+
+    case 0x1A:
+      val->tag = LSM6DSV320X_MLC_RESULT_TAG;
+      break;
+
+    case 0x1B:
+      val->tag = LSM6DSV320X_MLC_FILTER;
+      break;
+
+    case 0x1C:
+      val->tag = LSM6DSV320X_MLC_FEATURE;
+      break;
+
+    case 0x1D:
+      val->tag = LSM6DSV320X_XL_HG_TAG;
+      break;
+
+    case 0x1E:
+      val->tag = LSM6DSV320X_GY_ENHANCED_EIS;
+      break;
+
+    case 0x1F:
+      val->tag = LSM6DSV320X_FSM_RESULT_TAG;
+      break;
+
+    default:
+      val->tag = LSM6DSV320X_FIFO_EMPTY;
+      break;
+  }
+
+  val->cnt = fifo_data_out_tag.tag_cnt;
+
+  val->data[0] = buff[1];
+  val->data[1] = buff[2];
+  val->data[2] = buff[3];
+  val->data[3] = buff[4];
+  val->data[4] = buff[5];
+  val->data[5] = buff[6];
+
+  return ret;
+}
+
+/**
+  * @brief  Batching in FIFO buffer of step counter value.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Batching in FIFO buffer of step counter value.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_stpcnt_batch_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_emb_func_fifo_en_a_t emb_func_fifo_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
+  emb_func_fifo_en_a.step_counter_fifo_en = val;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a,
+                               1);
+
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Batching in FIFO buffer of step counter value.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Batching in FIFO buffer of step counter value.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_stpcnt_batch_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_emb_func_fifo_en_a_t emb_func_fifo_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
+  *val = emb_func_fifo_en_a.step_counter_fifo_en;
+
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Batching in FIFO buffer of finite state machine results.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Batching in FIFO buffer of finite state machine results.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_fsm_batch_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_emb_func_fifo_en_b_t emb_func_fifo_en_b;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_b, 1);
+  emb_func_fifo_en_b.fsm_fifo_en = val;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_b,
+                               1);
+
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Batching in FIFO buffer of finite state machine results.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Batching in FIFO buffer of finite state machine results.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_fsm_batch_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_emb_func_fifo_en_b_t emb_func_fifo_en_b;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_b, 1);
+  *val = emb_func_fifo_en_b.fsm_fifo_en;
+
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Batching in FIFO buffer of machine learning core results.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Batching in FIFO buffer of machine learning core results.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_mlc_batch_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_emb_func_fifo_en_a_t emb_func_fifo_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
+  emb_func_fifo_en_a.mlc_fifo_en = val;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a,
+                               1);
+
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Batching in FIFO buffer of machine learning core results.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Batching in FIFO buffer of machine learning core results.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_mlc_batch_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_emb_func_fifo_en_a_t emb_func_fifo_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
+  *val = emb_func_fifo_en_a.mlc_fifo_en;
+
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Enables batching in FIFO buffer of machine learning core filters and features.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables batching in FIFO buffer of machine learning core filters and features.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_mlc_filt_batch_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_emb_func_fifo_en_b_t emb_func_fifo_en_b;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_FIFO_EN_B, (uint8_t *)&emb_func_fifo_en_b, 1);
+  emb_func_fifo_en_b.mlc_filter_feature_fifo_en = val;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_FIFO_EN_B, (uint8_t *)&emb_func_fifo_en_b,
+                               1);
+
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Enables batching in FIFO buffer of machine learning core filters and features.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables batching in FIFO buffer of machine learning core filters and features.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_mlc_filt_batch_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_emb_func_fifo_en_b_t emb_func_fifo_en_b;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_FIFO_EN_B, (uint8_t *)&emb_func_fifo_en_b, 1);
+  *val = emb_func_fifo_en_b.mlc_filter_feature_fifo_en;
+
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO data batching of target idx.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enable FIFO data batching of target idx.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_sh_batch_target_set(const stmdev_ctx_t *ctx, uint8_t idx, uint8_t val)
+{
+  lsm6dsv320x_tgt0_config_t tgt_config;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_SENSOR_HUB_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TGT0_CONFIG + idx * 3U, (uint8_t *)&tgt_config, 1);
+  tgt_config.batch_ext_sens_0_en = val;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TGT0_CONFIG + idx * 3U, (uint8_t *)&tgt_config, 1);
+
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO data batching of target idx.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enable FIFO data batching of target idx.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_sh_batch_target_get(const stmdev_ctx_t *ctx, uint8_t idx, uint8_t *val)
+{
+  lsm6dsv320x_tgt0_config_t tgt_config;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_SENSOR_HUB_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TGT0_CONFIG + idx * 3U, (uint8_t *)&tgt_config, 1);
+  *val = tgt_config.batch_ext_sens_0_en;
+
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Batching in FIFO buffer of SFLP.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Batching in FIFO buffer of SFLP values.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_sflp_batch_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_fifo_sflp_raw_t val)
+{
+  lsm6dsv320x_emb_func_fifo_en_a_t emb_func_fifo_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
+    emb_func_fifo_en_a.sflp_game_fifo_en = val.game_rotation;
+    emb_func_fifo_en_a.sflp_gravity_fifo_en = val.gravity;
+    emb_func_fifo_en_a.sflp_gbias_fifo_en = val.gbias;
+    ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_FIFO_EN_A,
+                                 (uint8_t *)&emb_func_fifo_en_a, 1);
+  }
+
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Batching in FIFO buffer of SFLP.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Batching in FIFO buffer of SFLP values.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fifo_sflp_batch_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_fifo_sflp_raw_t *val)
+{
+  lsm6dsv320x_emb_func_fifo_en_a_t emb_func_fifo_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
+
+    val->game_rotation = emb_func_fifo_en_a.sflp_game_fifo_en;
+    val->gravity = emb_func_fifo_en_a.sflp_gravity_fifo_en;
+    val->gbias = emb_func_fifo_en_a.sflp_gbias_fifo_en;
+  }
+
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Filters
+  * @brief     This section group all the functions concerning the
+  *            filters configuration
+  * @{
+  *
+  */
+
+/**
+  * @brief  Protocol anti-spike filters.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      AUTO, ALWAYS_ACTIVE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_anti_spike_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_filt_anti_spike_t val)
+{
+  lsm6dsv320x_if_cfg_t if_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_IF_CFG, (uint8_t *)&if_cfg, 1);
+
+  if (ret == 0)
+  {
+    if_cfg.asf_ctrl = (uint8_t)val & 0x01U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Protocol anti-spike filters.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      AUTO, ALWAYS_ACTIVE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_anti_spike_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_filt_anti_spike_t *val)
+{
+  lsm6dsv320x_if_cfg_t if_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (if_cfg.asf_ctrl)
+  {
+    case LSM6DSV320X_AUTO:
+      *val = LSM6DSV320X_AUTO;
+      break;
+
+    case LSM6DSV320X_ALWAYS_ACTIVE:
+      *val = LSM6DSV320X_ALWAYS_ACTIVE;
+      break;
+
+    default:
+      *val = LSM6DSV320X_AUTO;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  It masks DRDY and Interrupts RQ until filter settling ends.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      It masks DRDY and Interrupts RQ until filter settling ends.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_settling_mask_set(const stmdev_ctx_t *ctx,
+                                           lsm6dsv320x_filt_settling_mask_t val)
+{
+  lsm6dsv320x_emb_func_cfg_t emb_func_cfg;
+  lsm6dsv320x_ui_int_ois_t ui_int_ois;
+  lsm6dsv320x_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL4, (uint8_t *)&ctrl4, 1);
+  ctrl4.drdy_mask = val.drdy;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL4, (uint8_t *)&ctrl4, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
+  emb_func_cfg.emb_func_irq_mask_xl_settl = val.irq_xl;
+  emb_func_cfg.emb_func_irq_mask_xl_hg_settl = val.irq_xl_hg;
+  emb_func_cfg.emb_func_irq_mask_g_settl = val.irq_g;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_UI_INT_OIS, (uint8_t *)&ui_int_ois, 1);
+  ui_int_ois.drdy_mask_ois = val.ois_drdy;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_UI_INT_OIS, (uint8_t *)&ui_int_ois, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  It masks DRDY and Interrupts RQ until filter settling ends.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      It masks DRDY and Interrupts RQ until filter settling ends.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_settling_mask_get(const stmdev_ctx_t *ctx,
+                                           lsm6dsv320x_filt_settling_mask_t *val)
+{
+  lsm6dsv320x_emb_func_cfg_t emb_func_cfg;
+  lsm6dsv320x_ui_int_ois_t ui_int_ois;
+  lsm6dsv320x_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL4, (uint8_t *)&ctrl4, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_UI_INT_OIS, (uint8_t *)&ui_int_ois, 1);
+
+  val->irq_xl = emb_func_cfg.emb_func_irq_mask_xl_settl;
+  val->irq_g = emb_func_cfg.emb_func_irq_mask_g_settl;
+  val->drdy = ctrl4.drdy_mask;
+
+  return ret;
+}
+
+/**
+  * @brief  It masks DRDY and Interrupts RQ until filter settling ends.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      It masks DRDY and Interrupts RQ until filter settling ends from OIS interface.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_ois_settling_mask_set(const stmdev_ctx_t *ctx,
+                                               lsm6dsv320x_filt_ois_settling_mask_t val)
+{
+  lsm6dsv320x_if2_int_ois_t if2_int_ois;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_IF2_INT_OIS, (uint8_t *)&if2_int_ois, 1);
+
+  if (ret == 0)
+  {
+    if2_int_ois.drdy_mask_ois = val.ois_drdy;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_IF2_INT_OIS, (uint8_t *)&if2_int_ois, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  It masks DRDY and Interrupts RQ until filter settling ends.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      It masks DRDY and Interrupts RQ until filter settling ends.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_ois_settling_mask_get(const stmdev_ctx_t *ctx,
+                                               lsm6dsv320x_filt_ois_settling_mask_t *val)
+{
+
+  lsm6dsv320x_if2_int_ois_t if2_int_ois;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_IF2_INT_OIS, (uint8_t *)&if2_int_ois, 1);
+  val->ois_drdy = if2_int_ois.drdy_mask_ois;
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope low-pass filter (LPF1) bandwidth selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      GY_ULTRA_LIGHT, GY_VERY_LIGHT, GY_LIGHT, GY_MEDIUM, GY_STRONG, GY_VERY_STRONG, GY_AGGRESSIVE, GY_XTREME,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_gy_lp1_bandwidth_set(const stmdev_ctx_t *ctx,
+                                              lsm6dsv320x_filt_gy_lp1_bandwidth_t val)
+{
+  lsm6dsv320x_ctrl6_t ctrl6;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL6, (uint8_t *)&ctrl6, 1);
+  if (ret == 0)
+  {
+    ctrl6.lpf1_g_bw = (uint8_t)val & 0x0Fu;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL6, (uint8_t *)&ctrl6, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope low-pass filter (LPF1) bandwidth selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      GY_ULTRA_LIGHT, GY_VERY_LIGHT, GY_LIGHT, GY_MEDIUM, GY_STRONG, GY_VERY_STRONG, GY_AGGRESSIVE, GY_XTREME,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_gy_lp1_bandwidth_get(const stmdev_ctx_t *ctx,
+                                              lsm6dsv320x_filt_gy_lp1_bandwidth_t *val)
+{
+  lsm6dsv320x_ctrl6_t ctrl6;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL6, (uint8_t *)&ctrl6, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl6.lpf1_g_bw)
+  {
+    case LSM6DSV320X_GY_ULTRA_LIGHT:
+      *val = LSM6DSV320X_GY_ULTRA_LIGHT;
+      break;
+
+    case LSM6DSV320X_GY_VERY_LIGHT:
+      *val = LSM6DSV320X_GY_VERY_LIGHT;
+      break;
+
+    case LSM6DSV320X_GY_LIGHT:
+      *val = LSM6DSV320X_GY_LIGHT;
+      break;
+
+    case LSM6DSV320X_GY_MEDIUM:
+      *val = LSM6DSV320X_GY_MEDIUM;
+      break;
+
+    case LSM6DSV320X_GY_STRONG:
+      *val = LSM6DSV320X_GY_STRONG;
+      break;
+
+    case LSM6DSV320X_GY_VERY_STRONG:
+      *val = LSM6DSV320X_GY_VERY_STRONG;
+      break;
+
+    case LSM6DSV320X_GY_AGGRESSIVE:
+      *val = LSM6DSV320X_GY_AGGRESSIVE;
+      break;
+
+    case LSM6DSV320X_GY_XTREME:
+      *val = LSM6DSV320X_GY_XTREME;
+      break;
+
+    default:
+      *val = LSM6DSV320X_GY_ULTRA_LIGHT;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  It enables gyroscope digital LPF1 filter.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      It enables gyroscope digital LPF1 filter.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_gy_lp1_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_ctrl7_t ctrl7;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL7, (uint8_t *)&ctrl7, 1);
+  if (ret == 0)
+  {
+    ctrl7.lpf1_g_en = val;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL7, (uint8_t *)&ctrl7, 1);
+  }
+
+  return ret;
+}
+
+
+/**
+  * @brief  It enables gyroscope digital LPF1 filter.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      It enables gyroscope digital LPF1 filter.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_gy_lp1_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_ctrl7_t ctrl7;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL7, (uint8_t *)&ctrl7, 1);
+  *val = ctrl7.lpf1_g_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer LPF2 and high pass filter configuration and cutoff setting.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      XL_ULTRA_LIGHT, XL_VERY_LIGHT, XL_LIGHT, XL_MEDIUM, XL_STRONG, XL_VERY_STRONG, XL_AGGRESSIVE, XL_XTREME,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_xl_lp2_bandwidth_set(const stmdev_ctx_t *ctx,
+                                              lsm6dsv320x_filt_xl_lp2_bandwidth_t val)
+{
+  lsm6dsv320x_ctrl8_t ctrl8;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL8, (uint8_t *)&ctrl8, 1);
+  if (ret == 0)
+  {
+    ctrl8.hp_lpf2_xl_bw = (uint8_t)val & 0x07U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL8, (uint8_t *)&ctrl8, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer LPF2 and high pass filter configuration and cutoff setting.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      XL_ULTRA_LIGHT, XL_VERY_LIGHT, XL_LIGHT, XL_MEDIUM, XL_STRONG, XL_VERY_STRONG, XL_AGGRESSIVE, XL_XTREME,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_xl_lp2_bandwidth_get(const stmdev_ctx_t *ctx,
+                                              lsm6dsv320x_filt_xl_lp2_bandwidth_t *val)
+{
+  lsm6dsv320x_ctrl8_t ctrl8;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL8, (uint8_t *)&ctrl8, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl8.hp_lpf2_xl_bw)
+  {
+    case LSM6DSV320X_XL_ULTRA_LIGHT:
+      *val = LSM6DSV320X_XL_ULTRA_LIGHT;
+      break;
+
+    case LSM6DSV320X_XL_VERY_LIGHT:
+      *val = LSM6DSV320X_XL_VERY_LIGHT;
+      break;
+
+    case LSM6DSV320X_XL_LIGHT:
+      *val = LSM6DSV320X_XL_LIGHT;
+      break;
+
+    case LSM6DSV320X_XL_MEDIUM:
+      *val = LSM6DSV320X_XL_MEDIUM;
+      break;
+
+    case LSM6DSV320X_XL_STRONG:
+      *val = LSM6DSV320X_XL_STRONG;
+      break;
+
+    case LSM6DSV320X_XL_VERY_STRONG:
+      *val = LSM6DSV320X_XL_VERY_STRONG;
+      break;
+
+    case LSM6DSV320X_XL_AGGRESSIVE:
+      *val = LSM6DSV320X_XL_AGGRESSIVE;
+      break;
+
+    case LSM6DSV320X_XL_XTREME:
+      *val = LSM6DSV320X_XL_XTREME;
+      break;
+
+    default:
+      *val = LSM6DSV320X_XL_ULTRA_LIGHT;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable accelerometer LPS2 (Low Pass Filter 2) filtering stage.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enable accelerometer LPS2 (Low Pass Filter 2) filtering stage.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_xl_lp2_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_ctrl9_t ctrl9;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL9, (uint8_t *)&ctrl9, 1);
+  if (ret == 0)
+  {
+    ctrl9.lpf2_xl_en = val;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL9, (uint8_t *)&ctrl9, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable accelerometer LPS2 (Low Pass Filter 2) filtering stage.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enable accelerometer LPS2 (Low Pass Filter 2) filtering stage.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_xl_lp2_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_ctrl9_t ctrl9;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL9, (uint8_t *)&ctrl9, 1);
+  *val = ctrl9.lpf2_xl_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer slope filter / high-pass filter selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Accelerometer slope filter / high-pass filter selection.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_xl_hp_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_ctrl9_t ctrl9;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL9, (uint8_t *)&ctrl9, 1);
+  if (ret == 0)
+  {
+    ctrl9.hp_slope_xl_en = val;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL9, (uint8_t *)&ctrl9, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer slope filter / high-pass filter selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Accelerometer slope filter / high-pass filter selection.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_xl_hp_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_ctrl9_t ctrl9;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL9, (uint8_t *)&ctrl9, 1);
+  *val = ctrl9.hp_slope_xl_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enables accelerometer LPF2 and HPF fast-settling mode. The filter sets the first sample.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables accelerometer LPF2 and HPF fast-settling mode. The filter sets the first sample.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_xl_fast_settling_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_ctrl9_t ctrl9;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL9, (uint8_t *)&ctrl9, 1);
+  if (ret == 0)
+  {
+    ctrl9.xl_fastsettl_mode = val;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL9, (uint8_t *)&ctrl9, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables accelerometer LPF2 and HPF fast-settling mode. The filter sets the first sample.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables accelerometer LPF2 and HPF fast-settling mode. The filter sets the first sample.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_xl_fast_settling_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_ctrl9_t ctrl9;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL9, (uint8_t *)&ctrl9, 1);
+  *val = ctrl9.xl_fastsettl_mode;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer high-pass filter mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      HP_MD_NORMAL, HP_MD_REFERENCE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_xl_hp_mode_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_filt_xl_hp_mode_t val)
+{
+  lsm6dsv320x_ctrl9_t ctrl9;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL9, (uint8_t *)&ctrl9, 1);
+  if (ret == 0)
+  {
+    ctrl9.hp_ref_mode_xl = (uint8_t)val & 0x01U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL9, (uint8_t *)&ctrl9, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer high-pass filter mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      HP_MD_NORMAL, HP_MD_REFERENCE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_xl_hp_mode_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_filt_xl_hp_mode_t *val)
+{
+  lsm6dsv320x_ctrl9_t ctrl9;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL9, (uint8_t *)&ctrl9, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl9.hp_ref_mode_xl)
+  {
+    case LSM6DSV320X_HP_MD_NORMAL:
+      *val = LSM6DSV320X_HP_MD_NORMAL;
+      break;
+
+    case LSM6DSV320X_HP_MD_REFERENCE:
+      *val = LSM6DSV320X_HP_MD_REFERENCE;
+      break;
+
+    default:
+      *val = LSM6DSV320X_HP_MD_NORMAL;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  HPF or SLOPE filter selection on wake-up and Activity/Inactivity functions.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      WK_FEED_SLOPE, WK_FEED_HIGH_PASS, WK_FEED_LP_WITH_OFFSET,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_wkup_act_feed_set(const stmdev_ctx_t *ctx,
+                                           lsm6dsv320x_filt_wkup_act_feed_t val)
+{
+  lsm6dsv320x_wake_up_ths_t wake_up_ths;
+  lsm6dsv320x_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  tap_cfg0.slope_fds = (uint8_t)val & 0x01U;
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  wake_up_ths.usr_off_on_wu = ((uint8_t)val & 0x02U) >> 1;
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  HPF or SLOPE filter selection on wake-up and Activity/Inactivity functions.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      WK_FEED_SLOPE, WK_FEED_HIGH_PASS, WK_FEED_LP_WITH_OFFSET,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_wkup_act_feed_get(const stmdev_ctx_t *ctx,
+                                           lsm6dsv320x_filt_wkup_act_feed_t *val)
+{
+  lsm6dsv320x_wake_up_ths_t wake_up_ths;
+  lsm6dsv320x_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch ((wake_up_ths.usr_off_on_wu << 1) + tap_cfg0.slope_fds)
+  {
+    case LSM6DSV320X_WK_FEED_SLOPE:
+      *val = LSM6DSV320X_WK_FEED_SLOPE;
+      break;
+
+    case LSM6DSV320X_WK_FEED_HIGH_PASS:
+      *val = LSM6DSV320X_WK_FEED_HIGH_PASS;
+      break;
+
+    case LSM6DSV320X_WK_FEED_LP_WITH_OFFSET:
+      *val = LSM6DSV320X_WK_FEED_LP_WITH_OFFSET;
+      break;
+
+    default:
+      *val = LSM6DSV320X_WK_FEED_SLOPE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Mask hw function triggers when xl is settling.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      0 or 1,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_mask_trigger_xl_settl_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+
+  if (ret == 0)
+  {
+    tap_cfg0.hw_func_mask_xl_settl = val & 0x01U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Mask hw function triggers when xl is settling.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      0 or 1,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_mask_trigger_xl_settl_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  *val = tap_cfg0.hw_func_mask_xl_settl;
+
+  return ret;
+}
+
+/**
+  * @brief  LPF2 filter on 6D (sixd) function selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SIXD_FEED_ODR_DIV_2, SIXD_FEED_LOW_PASS,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_sixd_feed_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_filt_sixd_feed_t val)
+{
+  lsm6dsv320x_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+
+  if (ret == 0)
+  {
+    tap_cfg0.low_pass_on_6d = (uint8_t)val & 0x01U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  LPF2 filter on 6D (sixd) function selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SIXD_FEED_ODR_DIV_2, SIXD_FEED_LOW_PASS,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_sixd_feed_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_filt_sixd_feed_t *val)
+{
+  lsm6dsv320x_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (tap_cfg0.low_pass_on_6d)
+  {
+    case LSM6DSV320X_SIXD_FEED_ODR_DIV_2:
+      *val = LSM6DSV320X_SIXD_FEED_ODR_DIV_2;
+      break;
+
+    case LSM6DSV320X_SIXD_FEED_LOW_PASS:
+      *val = LSM6DSV320X_SIXD_FEED_LOW_PASS;
+      break;
+
+    default:
+      *val = LSM6DSV320X_SIXD_FEED_ODR_DIV_2;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope digital LPF_EIS filter bandwidth selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      EIS_LP_NORMAL, EIS_LP_LIGHT,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_gy_eis_lp_bandwidth_set(const stmdev_ctx_t *ctx,
+                                                 lsm6dsv320x_filt_gy_eis_lp_bandwidth_t val)
+{
+  lsm6dsv320x_ctrl_eis_t ctrl_eis;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
+
+  if (ret == 0)
+  {
+    ctrl_eis.lpf_g_eis_bw = (uint8_t)val & 0x01U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope digital LPF_EIS filter bandwidth selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      EIS_LP_NORMAL, EIS_LP_LIGHT,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_gy_eis_lp_bandwidth_get(const stmdev_ctx_t *ctx,
+                                                 lsm6dsv320x_filt_gy_eis_lp_bandwidth_t *val)
+{
+  lsm6dsv320x_ctrl_eis_t ctrl_eis;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl_eis.lpf_g_eis_bw)
+  {
+    case LSM6DSV320X_EIS_LP_NORMAL:
+      *val = LSM6DSV320X_EIS_LP_NORMAL;
+      break;
+
+    case LSM6DSV320X_EIS_LP_LIGHT:
+      *val = LSM6DSV320X_EIS_LP_LIGHT;
+      break;
+
+    default:
+      *val = LSM6DSV320X_EIS_LP_NORMAL;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope OIS digital LPF1 filter bandwidth selection. This function works also on OIS interface (IF2_CTRL2_OIS = UI_CTRL2_OIS).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      OIS_GY_LP_NORMAL, OIS_GY_LP_STRONG, OIS_GY_LP_AGGRESSIVE, OIS_GY_LP_LIGHT,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_gy_ois_lp_bandwidth_set(const stmdev_ctx_t *ctx,
+                                                 lsm6dsv320x_filt_gy_ois_lp_bandwidth_t val)
+{
+  lsm6dsv320x_ui_ctrl2_ois_t ui_ctrl2_ois;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_UI_CTRL2_OIS, (uint8_t *)&ui_ctrl2_ois, 1);
+
+  if (ret == 0)
+  {
+    ui_ctrl2_ois.lpf1_g_ois_bw = (uint8_t)val & 0x03U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_UI_CTRL2_OIS, (uint8_t *)&ui_ctrl2_ois, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope OIS digital LPF1 filter bandwidth selection. This function works also on OIS interface (IF2_CTRL2_OIS = UI_CTRL2_OIS).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      OIS_GY_LP_NORMAL, OIS_GY_LP_STRONG, OIS_GY_LP_AGGRESSIVE, OIS_GY_LP_LIGHT,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_gy_ois_lp_bandwidth_get(const stmdev_ctx_t *ctx,
+                                                 lsm6dsv320x_filt_gy_ois_lp_bandwidth_t *val)
+{
+
+  lsm6dsv320x_ui_ctrl2_ois_t ui_ctrl2_ois;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_UI_CTRL2_OIS, (uint8_t *)&ui_ctrl2_ois, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ui_ctrl2_ois.lpf1_g_ois_bw)
+  {
+    case LSM6DSV320X_OIS_GY_LP_NORMAL:
+      *val = LSM6DSV320X_OIS_GY_LP_NORMAL;
+      break;
+
+    case LSM6DSV320X_OIS_GY_LP_STRONG:
+      *val = LSM6DSV320X_OIS_GY_LP_STRONG;
+      break;
+
+    case LSM6DSV320X_OIS_GY_LP_AGGRESSIVE:
+      *val = LSM6DSV320X_OIS_GY_LP_AGGRESSIVE;
+      break;
+
+    case LSM6DSV320X_OIS_GY_LP_LIGHT:
+      *val = LSM6DSV320X_OIS_GY_LP_LIGHT;
+      break;
+
+    default:
+      *val = LSM6DSV320X_OIS_GY_LP_NORMAL;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer OIS channel bandwidth. This function works also on OIS interface (IF2_CTRL3_OIS = UI_CTRL3_OIS).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      OIS_XL_LP_ULTRA_LIGHT, OIS_XL_LP_VERY_LIGHT, OIS_XL_LP_LIGHT, OIS_XL_LP_NORMAL, OIS_XL_LP_STRONG, OIS_XL_LP_VERY_STRONG, OIS_XL_LP_AGGRESSIVE, OIS_XL_LP_XTREME,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_xl_ois_lp_bandwidth_set(const stmdev_ctx_t *ctx,
+                                                 lsm6dsv320x_filt_xl_ois_lp_bandwidth_t val)
+{
+  lsm6dsv320x_ui_ctrl3_ois_t ui_ctrl3_ois;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_UI_CTRL3_OIS, (uint8_t *)&ui_ctrl3_ois, 1);
+
+  if (ret == 0)
+  {
+    ui_ctrl3_ois.lpf_xl_ois_bw = (uint8_t)val & 0x07U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_UI_CTRL3_OIS, (uint8_t *)&ui_ctrl3_ois, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer OIS channel bandwidth. This function works also on OIS interface (IF2_CTRL3_OIS = UI_CTRL3_OIS).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      OIS_XL_LP_ULTRA_LIGHT, OIS_XL_LP_VERY_LIGHT, OIS_XL_LP_LIGHT, OIS_XL_LP_NORMAL, OIS_XL_LP_STRONG, OIS_XL_LP_VERY_STRONG, OIS_XL_LP_AGGRESSIVE, OIS_XL_LP_XTREME,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_filt_xl_ois_lp_bandwidth_get(const stmdev_ctx_t *ctx,
+                                                 lsm6dsv320x_filt_xl_ois_lp_bandwidth_t *val)
+{
+  lsm6dsv320x_ui_ctrl3_ois_t ui_ctrl3_ois;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_UI_CTRL3_OIS, (uint8_t *)&ui_ctrl3_ois, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ui_ctrl3_ois.lpf_xl_ois_bw)
+  {
+    case LSM6DSV320X_OIS_XL_LP_ULTRA_LIGHT:
+      *val = LSM6DSV320X_OIS_XL_LP_ULTRA_LIGHT;
+      break;
+
+    case LSM6DSV320X_OIS_XL_LP_VERY_LIGHT:
+      *val = LSM6DSV320X_OIS_XL_LP_VERY_LIGHT;
+      break;
+
+    case LSM6DSV320X_OIS_XL_LP_LIGHT:
+      *val = LSM6DSV320X_OIS_XL_LP_LIGHT;
+      break;
+
+    case LSM6DSV320X_OIS_XL_LP_NORMAL:
+      *val = LSM6DSV320X_OIS_XL_LP_NORMAL;
+      break;
+
+    case LSM6DSV320X_OIS_XL_LP_STRONG:
+      *val = LSM6DSV320X_OIS_XL_LP_STRONG;
+      break;
+
+    case LSM6DSV320X_OIS_XL_LP_VERY_STRONG:
+      *val = LSM6DSV320X_OIS_XL_LP_VERY_STRONG;
+      break;
+
+    case LSM6DSV320X_OIS_XL_LP_AGGRESSIVE:
+      *val = LSM6DSV320X_OIS_XL_LP_AGGRESSIVE;
+      break;
+
+    case LSM6DSV320X_OIS_XL_LP_XTREME:
+      *val = LSM6DSV320X_OIS_XL_LP_XTREME;
+      break;
+
+    default:
+      *val = LSM6DSV320X_OIS_XL_LP_ULTRA_LIGHT;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Finite State Machine (FSM)
+  * @brief     This section groups all the functions that manage the
+  *            state_machine.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enables the control of the CTRL registers to FSM (FSM can change some configurations of the device autonomously).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      PROTECT_CTRL_REGS, WRITE_CTRL_REG,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fsm_permission_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_fsm_permission_t val)
+{
+  lsm6dsv320x_func_cfg_access_t func_cfg_access;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+
+  if (ret == 0)
+  {
+    func_cfg_access.fsm_wr_ctrl_en = (uint8_t)val & 0x01U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables the control of the CTRL registers to FSM (FSM can change some configurations of the device autonomously).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      PROTECT_CTRL_REGS, WRITE_CTRL_REG,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fsm_permission_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_fsm_permission_t *val)
+{
+  lsm6dsv320x_func_cfg_access_t func_cfg_access;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (func_cfg_access.fsm_wr_ctrl_en)
+  {
+    case LSM6DSV320X_PROTECT_CTRL_REGS:
+      *val = LSM6DSV320X_PROTECT_CTRL_REGS;
+      break;
+
+    case LSM6DSV320X_WRITE_CTRL_REG:
+      *val = LSM6DSV320X_WRITE_CTRL_REG;
+      break;
+
+    default:
+      *val = LSM6DSV320X_PROTECT_CTRL_REGS;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Get the FSM permission status
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      0: All reg writable from std if - 1: some regs are under FSM control.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fsm_permission_status(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_ctrl_status_t ctrl_status;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL_STATUS, (uint8_t *)&ctrl_status, 1);
+
+  *val = ctrl_status.fsm_wr_ctrl_status;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable Finite State Machine (FSM) feature.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enable Finite State Machine (FSM) feature.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fsm_mode_set(const stmdev_ctx_t *ctx, lsm6dsv320x_fsm_mode_t val)
+{
+  lsm6dsv320x_emb_func_en_b_t emb_func_en_b;
+  lsm6dsv320x_fsm_enable_t fsm_enable;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FSM_ENABLE, (uint8_t *)&fsm_enable, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  if ((val.fsm1_en | val.fsm2_en | val.fsm3_en | val.fsm4_en
+       | val.fsm5_en | val.fsm6_en | val.fsm7_en | val.fsm8_en) == PROPERTY_ENABLE)
+  {
+    emb_func_en_b.fsm_en = PROPERTY_ENABLE;
+  }
+  else
+  {
+    emb_func_en_b.fsm_en = PROPERTY_DISABLE;
+  }
+
+  fsm_enable.fsm1_en = val.fsm1_en;
+  fsm_enable.fsm2_en = val.fsm2_en;
+  fsm_enable.fsm3_en = val.fsm3_en;
+  fsm_enable.fsm4_en = val.fsm4_en;
+  fsm_enable.fsm5_en = val.fsm5_en;
+  fsm_enable.fsm6_en = val.fsm6_en;
+  fsm_enable.fsm7_en = val.fsm7_en;
+  fsm_enable.fsm8_en = val.fsm8_en;
+
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FSM_ENABLE, (uint8_t *)&fsm_enable, 1);
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
+
+exit:
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Enable Finite State Machine (FSM) feature.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enable Finite State Machine (FSM) feature.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fsm_mode_get(const stmdev_ctx_t *ctx, lsm6dsv320x_fsm_mode_t *val)
+{
+  lsm6dsv320x_fsm_enable_t fsm_enable;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FSM_ENABLE, (uint8_t *)&fsm_enable, 1);
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->fsm1_en = fsm_enable.fsm1_en;
+  val->fsm2_en = fsm_enable.fsm2_en;
+  val->fsm3_en = fsm_enable.fsm3_en;
+  val->fsm4_en = fsm_enable.fsm4_en;
+  val->fsm5_en = fsm_enable.fsm5_en;
+  val->fsm6_en = fsm_enable.fsm6_en;
+  val->fsm7_en = fsm_enable.fsm7_en;
+  val->fsm8_en = fsm_enable.fsm8_en;
+
+  return ret;
+}
+
+/**
+  * @brief  FSM long counter status register. Long counter value is an unsigned integer value (16-bit format).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      FSM long counter status register. Long counter value is an unsigned integer value (16-bit format).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fsm_long_cnt_set(const stmdev_ctx_t *ctx, uint16_t val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  buff[1] = (uint8_t)(val / 256U);
+  buff[0] = (uint8_t)(val - (buff[1] * 256U));
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FSM_LONG_COUNTER_L, (uint8_t *)&buff[0], 2);
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  FSM long counter status register. Long counter value is an unsigned integer value (16-bit format).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      FSM long counter status register. Long counter value is an unsigned integer value (16-bit format).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fsm_long_cnt_get(const stmdev_ctx_t *ctx, uint16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FSM_LONG_COUNTER_L, &buff[0], 2);
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  *val = buff[1];
+  *val = (*val * 256U) + buff[0];
+
+  return ret;
+}
+
+/**
+  * @brief  FSM output registers[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      FSM output registers
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fsm_out_get(const stmdev_ctx_t *ctx, lsm6dsv320x_fsm_out_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FSM_OUTS1, (uint8_t *)val, 8);
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Finite State Machine Output Data Rate (ODR) configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      FSM_15Hz, FSM_30Hz, FSM_60Hz, FSM_120Hz, FSM_240Hz, FSM_480Hz, FSM_960Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fsm_data_rate_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_fsm_data_rate_t val)
+{
+  lsm6dsv320x_fsm_odr_t fsm_odr;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FSM_ODR, (uint8_t *)&fsm_odr, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  fsm_odr.fsm_odr = (uint8_t)val & 0x07U;
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FSM_ODR, (uint8_t *)&fsm_odr, 1);
+
+exit:
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Finite State Machine Output Data Rate (ODR) configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      FSM_15Hz, FSM_30Hz, FSM_60Hz, FSM_120Hz, FSM_240Hz, FSM_480Hz, FSM_960Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fsm_data_rate_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_fsm_data_rate_t *val)
+{
+  lsm6dsv320x_fsm_odr_t fsm_odr;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FSM_ODR, (uint8_t *)&fsm_odr, 1);
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (fsm_odr.fsm_odr)
+  {
+    case LSM6DSV320X_FSM_15Hz:
+      *val = LSM6DSV320X_FSM_15Hz;
+      break;
+
+    case LSM6DSV320X_FSM_30Hz:
+      *val = LSM6DSV320X_FSM_30Hz;
+      break;
+
+    case LSM6DSV320X_FSM_60Hz:
+      *val = LSM6DSV320X_FSM_60Hz;
+      break;
+
+    case LSM6DSV320X_FSM_120Hz:
+      *val = LSM6DSV320X_FSM_120Hz;
+      break;
+
+    case LSM6DSV320X_FSM_240Hz:
+      *val = LSM6DSV320X_FSM_240Hz;
+      break;
+
+    case LSM6DSV320X_FSM_480Hz:
+      *val = LSM6DSV320X_FSM_480Hz;
+      break;
+
+    case LSM6DSV320X_FSM_960Hz:
+      *val = LSM6DSV320X_FSM_960Hz;
+      break;
+
+    default:
+      *val = LSM6DSV320X_FSM_15Hz;
+      break;
+  }
+
+  return ret;
+}
+
+/*
+ * Original conversion routines taken from: https://github.com/numpy/numpy
+ *
+ * uint16_t npy_floatbits_to_halfbits(uint32_t f);
+ * uint16_t npy_float_to_half(float_t f);
+ * uint32_t npy_halfbits_to_floatbits(uint16_t h)
+ * float_t  npy_half_to_float(uint16_t h)
+ *
+ * Released under BSD-3-Clause License
+ */
+typedef union
+{
+  float_t f;
+  uint32_t fbits;
+} hf_conv_t;
+
+static uint16_t npy_floatbits_to_halfbits(uint32_t f)
+{
+  uint32_t f_exp, f_sig;
+  uint16_t h_sgn, h_exp, h_sig;
+
+  h_sgn = (uint16_t)((f & 0x80000000u) >> 16);
+  f_exp = (f & 0x7f800000u);
+
+  /* Exponent overflow/NaN converts to signed inf/NaN */
+  if (f_exp >= 0x47800000u)
+  {
+    if (f_exp == 0x7f800000u)
+    {
+      /* Inf or NaN */
+      f_sig = (f & 0x007fffffu);
+      if (f_sig != 0U)
+      {
+        /* NaN - propagate the flag in the significand... */
+        uint16_t ret = (uint16_t)(0x7c00u + (f_sig >> 13));
+        /* ...but make sure it stays a NaN */
+        if (ret == 0x7c00u)
+        {
+          ret++;
+        }
+        return h_sgn + ret;
+      }
+      else
+      {
+        /* signed inf */
+        return (uint16_t)(h_sgn + 0x7c00u);
+      }
+    }
+    else
+    {
+      /* overflow to signed inf */
+#if NPY_HALF_GENERATE_OVERFLOW
+      npy_set_floatstatus_overflow();
+#endif
+      return (uint16_t)(h_sgn + 0x7c00u);
+    }
+  }
+
+  /* Exponent underflow converts to a subnormal half or signed zero */
+  if (f_exp <= 0x38000000u)
+  {
+    /*
+     * Signed zeros, subnormal floats, and floats with small
+     * exponents all convert to signed zero half-floats.
+     */
+    if (f_exp < 0x33000000u)
+    {
+#if NPY_HALF_GENERATE_UNDERFLOW
+      /* If f != 0, it underflowed to 0 */
+      if ((f & 0x7fffffff) != 0)
+      {
+        npy_set_floatstatus_underflow();
+      }
+#endif
+      return h_sgn;
+    }
+    /* Make the subnormal significand */
+    f_exp >>= 23;
+    f_sig = (0x00800000u + (f & 0x007fffffu));
+#if NPY_HALF_GENERATE_UNDERFLOW
+    /* If it's not exactly represented, it underflowed */
+    if ((f_sig & (((uint32_t)1 << (126 - f_exp)) - 1)) != 0)
+    {
+      npy_set_floatstatus_underflow();
+    }
+#endif
+    /*
+     * Usually the significand is shifted by 13. For subnormals an
+     * additional shift needs to occur. This shift is one for the largest
+     * exponent giving a subnormal `f_exp = 0x38000000 >> 23 = 112`, which
+     * offsets the new first bit. At most the shift can be 1+10 bits.
+     */
+    f_sig >>= (113U - f_exp);
+    /* Handle rounding by adding 1 to the bit beyond half precision */
+#if NPY_HALF_ROUND_TIES_TO_EVEN
+    /*
+     * If the last bit in the half significand is 0 (already even), and
+     * the remaining bit pattern is 1000...0, then we do not add one
+     * to the bit after the half significand. However, the (113 - f_exp)
+     * shift can lose up to 11 bits, so the || checks them in the original.
+     * In all other cases, we can just add one.
+     */
+    if (((f_sig & 0x00003fffu) != 0x00001000u) || (f & 0x000007ffu))
+    {
+      f_sig += 0x00001000u;
+    }
+#else
+    f_sig += 0x00001000u;
+#endif
+    h_sig = (uint16_t)(f_sig >> 13);
+    /*
+     * If the rounding causes a bit to spill into h_exp, it will
+     * increment h_exp from zero to one and h_sig will be zero.
+     * This is the correct result.
+     */
+    return (uint16_t)(h_sgn + h_sig);
+  }
+
+  /* Regular case with no overflow or underflow */
+  h_exp = (uint16_t)((f_exp - 0x38000000u) >> 13);
+  /* Handle rounding by adding 1 to the bit beyond half precision */
+  f_sig = (f & 0x007fffffu);
+#if NPY_HALF_ROUND_TIES_TO_EVEN
+  /*
+   * If the last bit in the half significand is 0 (already even), and
+   * the remaining bit pattern is 1000...0, then we do not add one
+   * to the bit after the half significand.  In all other cases, we do.
+   */
+  if ((f_sig & 0x00003fffu) != 0x00001000u)
+  {
+    f_sig += 0x00001000u;
+  }
+#else
+  f_sig += 0x00001000u;
+#endif
+  h_sig = (uint16_t)(f_sig >> 13);
+  /*
+   * If the rounding causes a bit to spill into h_exp, it will
+   * increment h_exp by one and h_sig will be zero.  This is the
+   * correct result.  h_exp may increment to 15, at greatest, in
+   * which case the result overflows to a signed inf.
+   */
+#if NPY_HALF_GENERATE_OVERFLOW
+  h_sig += h_exp;
+  if (h_sig == 0x7c00u)
+  {
+    npy_set_floatstatus_overflow();
+  }
+  return h_sgn + h_sig;
+#else
+  return h_sgn + h_exp + h_sig;
+#endif
+}
+
+static uint16_t npy_float_to_half(float_t f)
+{
+  hf_conv_t conv;
+
+  conv.f = f;
+  return npy_floatbits_to_halfbits(conv.fbits);
+}
+
+static uint32_t npy_halfbits_to_floatbits(uint16_t h)
+{
+  uint16_t h_exp = (h & 0x7c00u);
+  uint32_t f_sgn = ((uint32_t)h & 0x8000u) << 16;
+  switch (h_exp)
+  {
+    case 0x0000u:   // 0 or subnormal
+    {
+      uint16_t h_sig = (h & 0x03ffu);
+      // Signed zero
+      if (h_sig == 0)
+      {
+        return f_sgn;
+      }
+      // Subnormal
+      h_sig <<= 1;
+      while ((h_sig & 0x0400u) == 0)
+      {
+        h_sig <<= 1;
+        h_exp++;
+      }
+      uint32_t f_exp = ((uint32_t)(127 - 15 - h_exp)) << 23;
+      uint32_t f_sig = ((uint32_t)(h_sig & 0x03ffu)) << 13;
+      return f_sgn + f_exp + f_sig;
+    }
+    case 0x7c00u: // inf or NaN
+      // All-ones exponent and a copy of the significand
+      return f_sgn + 0x7f800000u + (((uint32_t)(h & 0x03ffu)) << 13);
+    default: // normalized
+      // Just need to adjust the exponent and shift
+      return f_sgn + (((uint32_t)(h & 0x7fffu) + 0x1c000u) << 13);
+  }
+}
+
+static float_t npy_half_to_float(uint16_t h)
+{
+  hf_conv_t conv;
+
+  conv.fbits = npy_halfbits_to_floatbits(h);
+
+  return conv.f;
+}
+
+/**
+  * @brief  SFLP GBIAS value. The register value is expressed as half-precision
+  *         floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent
+  *          bits; F: 10 fraction bits).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      GBIAS x/y/z val.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sflp_game_gbias_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_sflp_gbias_t *val)
+{
+  lsm6dsv320x_sflp_data_rate_t sflp_odr;
+  uint16_t gbias_hf[3];
+  float_t k = 0.005f;
+  int32_t ret;
+
+  ret = lsm6dsv320x_sflp_data_rate_get(ctx, &sflp_odr);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  /* Calculate k factor */
+  switch (sflp_odr)
+  {
+    default:
+    case LSM6DSV320X_SFLP_15Hz:
+      k = 0.04f;
+      break;
+    case LSM6DSV320X_SFLP_30Hz:
+      k = 0.02f;
+      break;
+    case LSM6DSV320X_SFLP_60Hz:
+      k = 0.01f;
+      break;
+    case LSM6DSV320X_SFLP_120Hz:
+      k = 0.005f;
+      break;
+    case LSM6DSV320X_SFLP_240Hz:
+      k = 0.0025f;
+      break;
+    case LSM6DSV320X_SFLP_480Hz:
+      k = 0.00125f;
+      break;
+  }
+
+  /* compute gbias as half precision float in order to be put in embedded advanced feature register */
+  gbias_hf[0] = npy_float_to_half(val->gbias_x * (3.14159265358979323846f / 180.0f) / k);
+  gbias_hf[1] = npy_float_to_half(val->gbias_y * (3.14159265358979323846f / 180.0f) / k);
+  gbias_hf[2] = npy_float_to_half(val->gbias_z * (3.14159265358979323846f / 180.0f) / k);
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_SFLP_GBIASX_INIT_L, (uint8_t *)&gbias_hf[0], 6);
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  External sensor sensitivity value register for the Finite State Machine (r/w). This register corresponds to the conversion value of the external sensor. The register value is expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits). Default value is 0x1624 (when using an external magnetometer this value corresponds to 0.0015 gauss/LSB).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      External sensor sensitivity value register for the Finite State Machine (r/w). This register corresponds to the conversion value of the external sensor. The register value is expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits). Default value is 0x1624 (when using an external magnetometer this value corresponds to 0.0015 gauss/LSB).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fsm_ext_sens_sensitivity_set(const stmdev_ctx_t *ctx, uint16_t val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  buff[1] = (uint8_t)(val / 256U);
+  buff[0] = (uint8_t)(val - (buff[1] * 256U));
+  ret = lsm6dsv320x_ln_pg_write(ctx, LSM6DSV320X_FSM_EXT_SENSITIVITY_L, (uint8_t *)&buff[0], 2);
+
+  return ret;
+}
+
+/**
+  * @brief  External sensor sensitivity value register for the Finite State Machine (r/w). This register corresponds to the conversion value of the external sensor. The register value is expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits). Default value is 0x1624 (when using an external magnetometer this value corresponds to 0.0015 gauss/LSB).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      External sensor sensitivity value register for the Finite State Machine (r/w). This register corresponds to the conversion value of the external sensor. The register value is expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits). Default value is 0x1624 (when using an external magnetometer this value corresponds to 0.0015 gauss/LSB).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fsm_ext_sens_sensitivity_get(const stmdev_ctx_t *ctx,
+                                                 uint16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = lsm6dsv320x_ln_pg_read(ctx, LSM6DSV320X_FSM_EXT_SENSITIVITY_L, &buff[0], 2);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  *val = buff[1];
+  *val = (*val * 256U) + buff[0];
+
+  return ret;
+}
+
+/**
+  * @brief  External sensor offsets (X,Y,Z). The values are expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      External sensor offsets (X,Y,Z). The values are expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fsm_ext_sens_offset_set(const stmdev_ctx_t *ctx,
+                                            lsm6dsv320x_xl_fsm_ext_sens_offset_t val)
+{
+  uint8_t buff[6];
+  int32_t ret;
+
+  buff[1] = (uint8_t)(val.x / 256U);
+  buff[0] = (uint8_t)(val.x - (buff[1] * 256U));
+  buff[3] = (uint8_t)(val.y / 256U);
+  buff[2] = (uint8_t)(val.y - (buff[3] * 256U));
+  buff[5] = (uint8_t)(val.z / 256U);
+  buff[4] = (uint8_t)(val.z - (buff[5] * 256U));
+  ret = lsm6dsv320x_ln_pg_write(ctx, LSM6DSV320X_FSM_EXT_OFFX_L, (uint8_t *)&buff[0], 6);
+
+  return ret;
+}
+
+/**
+  * @brief  External sensor offsets (X,Y,Z). The values are expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      External sensor offsets (X,Y,Z). The values are expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fsm_ext_sens_offset_get(const stmdev_ctx_t *ctx,
+                                            lsm6dsv320x_xl_fsm_ext_sens_offset_t *val)
+{
+  uint8_t buff[6];
+  int32_t ret;
+
+  ret = lsm6dsv320x_ln_pg_read(ctx, LSM6DSV320X_FSM_EXT_OFFX_L, &buff[0], 6);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->x = buff[1];
+  val->x = (val->x * 256U) + buff[0];
+  val->y = buff[3];
+  val->y = (val->y * 256U) + buff[2];
+  val->z = buff[5];
+  val->z = (val->z * 256U) + buff[4];
+
+  return ret;
+}
+
+/**
+  * @brief  External sensor transformation matrix. The value is expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      External sensor transformation matrix. The value is expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fsm_ext_sens_matrix_set(const stmdev_ctx_t *ctx,
+                                            lsm6dsv320x_xl_fsm_ext_sens_matrix_t val)
+{
+  uint8_t buff[12];
+  int32_t ret;
+
+  buff[1] = (uint8_t)(val.xx / 256U);
+  buff[0] = (uint8_t)(val.xx - (buff[1] * 256U));
+  buff[3] = (uint8_t)(val.xy / 256U);
+  buff[2] = (uint8_t)(val.xy - (buff[3] * 256U));
+  buff[5] = (uint8_t)(val.xz / 256U);
+  buff[4] = (uint8_t)(val.xz - (buff[5] * 256U));
+  buff[7] = (uint8_t)(val.yy / 256U);
+  buff[6] = (uint8_t)(val.yy - (buff[7] * 256U));
+  buff[9] = (uint8_t)(val.yz / 256U);
+  buff[8] = (uint8_t)(val.yz - (buff[9] * 256U));
+  buff[11] = (uint8_t)(val.zz / 256U);
+  buff[10] = (uint8_t)(val.zz - (buff[11] * 256U));
+  ret = lsm6dsv320x_ln_pg_write(ctx, LSM6DSV320X_FSM_EXT_MATRIX_XX_L, (uint8_t *)&buff[0], 12);
+
+  return ret;
+}
+
+/**
+  * @brief  External sensor transformation matrix. The value is expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      External sensor transformation matrix. The value is expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fsm_ext_sens_matrix_get(const stmdev_ctx_t *ctx,
+                                            lsm6dsv320x_xl_fsm_ext_sens_matrix_t *val)
+{
+  uint8_t buff[12];
+  int32_t ret;
+
+  ret = lsm6dsv320x_ln_pg_read(ctx, LSM6DSV320X_FSM_EXT_MATRIX_XX_L, &buff[0], 12);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->xx = buff[1];
+  val->xx = (val->xx * 256U) + buff[0];
+  val->xy = buff[3];
+  val->xy = (val->xy * 256U) + buff[2];
+  val->xz = buff[5];
+  val->xz = (val->xz * 256U) + buff[4];
+  val->yy = buff[7];
+  val->yy = (val->yy * 256U) + buff[6];
+  val->yz = buff[9];
+  val->yz = (val->yz * 256U) + buff[8];
+  val->zz = buff[11];
+  val->zz = (val->zz * 256U) + buff[10];
+
+  return ret;
+}
+
+/**
+  * @brief  External sensor z-axis coordinates rotation.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Z_EQ_Y, Z_EQ_MIN_Y, Z_EQ_X, Z_EQ_MIN_X, Z_EQ_MIN_Z, Z_EQ_Z,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fsm_ext_sens_z_orient_set(const stmdev_ctx_t *ctx,
+                                              lsm6dsv320x_fsm_ext_sens_z_orient_t val)
+{
+  lsm6dsv320x_ext_cfg_a_t ext_cfg_a;
+  int32_t ret;
+
+  ret = lsm6dsv320x_ln_pg_read(ctx, LSM6DSV320X_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
+  ext_cfg_a.ext_z_axis = (uint8_t)val & 0x07U;
+  ret += lsm6dsv320x_ln_pg_write(ctx, LSM6DSV320X_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  External sensor z-axis coordinates rotation.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Z_EQ_Y, Z_EQ_MIN_Y, Z_EQ_X, Z_EQ_MIN_X, Z_EQ_MIN_Z, Z_EQ_Z,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fsm_ext_sens_z_orient_get(const stmdev_ctx_t *ctx,
+                                              lsm6dsv320x_fsm_ext_sens_z_orient_t *val)
+{
+  lsm6dsv320x_ext_cfg_a_t ext_cfg_a;
+  int32_t ret;
+
+  ret = lsm6dsv320x_ln_pg_read(ctx, LSM6DSV320X_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ext_cfg_a.ext_z_axis)
+  {
+    case LSM6DSV320X_Z_EQ_Y:
+      *val = LSM6DSV320X_Z_EQ_Y;
+      break;
+
+    case LSM6DSV320X_Z_EQ_MIN_Y:
+      *val = LSM6DSV320X_Z_EQ_MIN_Y;
+      break;
+
+    case LSM6DSV320X_Z_EQ_X:
+      *val = LSM6DSV320X_Z_EQ_X;
+      break;
+
+    case LSM6DSV320X_Z_EQ_MIN_X:
+      *val = LSM6DSV320X_Z_EQ_MIN_X;
+      break;
+
+    case LSM6DSV320X_Z_EQ_MIN_Z:
+      *val = LSM6DSV320X_Z_EQ_MIN_Z;
+      break;
+
+    case LSM6DSV320X_Z_EQ_Z:
+      *val = LSM6DSV320X_Z_EQ_Z;
+      break;
+
+    default:
+      *val = LSM6DSV320X_Z_EQ_Y;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  External sensor Y-axis coordinates rotation.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Y_EQ_Y, Y_EQ_MIN_Y, Y_EQ_X, Y_EQ_MIN_X, Y_EQ_MIN_Z, Y_EQ_Z,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fsm_ext_sens_y_orient_set(const stmdev_ctx_t *ctx,
+                                              lsm6dsv320x_fsm_ext_sens_y_orient_t val)
+{
+  lsm6dsv320x_ext_cfg_a_t ext_cfg_a;
+  int32_t ret;
+
+  ret = lsm6dsv320x_ln_pg_read(ctx, LSM6DSV320X_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
+  if (ret == 0)
+  {
+    ext_cfg_a.ext_y_axis = (uint8_t)val & 0x7U;
+    ret = lsm6dsv320x_ln_pg_write(ctx, LSM6DSV320X_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  External sensor Y-axis coordinates rotation.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Y_EQ_Y, Y_EQ_MIN_Y, Y_EQ_X, Y_EQ_MIN_X, Y_EQ_MIN_Z, Y_EQ_Z,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fsm_ext_sens_y_orient_get(const stmdev_ctx_t *ctx,
+                                              lsm6dsv320x_fsm_ext_sens_y_orient_t *val)
+{
+  lsm6dsv320x_ext_cfg_a_t ext_cfg_a;
+  int32_t ret;
+
+  ret = lsm6dsv320x_ln_pg_read(ctx, LSM6DSV320X_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ext_cfg_a.ext_y_axis)
+  {
+    case LSM6DSV320X_Y_EQ_Y:
+      *val = LSM6DSV320X_Y_EQ_Y;
+      break;
+
+    case LSM6DSV320X_Y_EQ_MIN_Y:
+      *val = LSM6DSV320X_Y_EQ_MIN_Y;
+      break;
+
+    case LSM6DSV320X_Y_EQ_X:
+      *val = LSM6DSV320X_Y_EQ_X;
+      break;
+
+    case LSM6DSV320X_Y_EQ_MIN_X:
+      *val = LSM6DSV320X_Y_EQ_MIN_X;
+      break;
+
+    case LSM6DSV320X_Y_EQ_MIN_Z:
+      *val = LSM6DSV320X_Y_EQ_MIN_Z;
+      break;
+
+    case LSM6DSV320X_Y_EQ_Z:
+      *val = LSM6DSV320X_Y_EQ_Z;
+      break;
+
+    default:
+      *val = LSM6DSV320X_Y_EQ_Y;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  External sensor X-axis coordinates rotation.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      X_EQ_Y, X_EQ_MIN_Y, X_EQ_X, X_EQ_MIN_X, X_EQ_MIN_Z, X_EQ_Z,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fsm_ext_sens_x_orient_set(const stmdev_ctx_t *ctx,
+                                              lsm6dsv320x_fsm_ext_sens_x_orient_t val)
+{
+  lsm6dsv320x_ext_cfg_b_t ext_cfg_b;
+  int32_t ret;
+
+  ret = lsm6dsv320x_ln_pg_read(ctx, LSM6DSV320X_EXT_CFG_B, (uint8_t *)&ext_cfg_b, 1);
+  if (ret == 0)
+  {
+    ext_cfg_b.ext_x_axis = (uint8_t)val & 0x7U;
+    ret = lsm6dsv320x_ln_pg_write(ctx, LSM6DSV320X_EXT_CFG_B, (uint8_t *)&ext_cfg_b, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  External sensor X-axis coordinates rotation.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      X_EQ_Y, X_EQ_MIN_Y, X_EQ_X, X_EQ_MIN_X, X_EQ_MIN_Z, X_EQ_Z,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fsm_ext_sens_x_orient_get(const stmdev_ctx_t *ctx,
+                                              lsm6dsv320x_fsm_ext_sens_x_orient_t *val)
+{
+  lsm6dsv320x_ext_cfg_b_t ext_cfg_b;
+  int32_t ret;
+
+  ret = lsm6dsv320x_ln_pg_read(ctx, LSM6DSV320X_EXT_CFG_B, (uint8_t *)&ext_cfg_b, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ext_cfg_b.ext_x_axis)
+  {
+    case LSM6DSV320X_X_EQ_Y:
+      *val = LSM6DSV320X_X_EQ_Y;
+      break;
+
+    case LSM6DSV320X_X_EQ_MIN_Y:
+      *val = LSM6DSV320X_X_EQ_MIN_Y;
+      break;
+
+    case LSM6DSV320X_X_EQ_X:
+      *val = LSM6DSV320X_X_EQ_X;
+      break;
+
+    case LSM6DSV320X_X_EQ_MIN_X:
+      *val = LSM6DSV320X_X_EQ_MIN_X;
+      break;
+
+    case LSM6DSV320X_X_EQ_MIN_Z:
+      *val = LSM6DSV320X_X_EQ_MIN_Z;
+      break;
+
+    case LSM6DSV320X_X_EQ_Z:
+      *val = LSM6DSV320X_X_EQ_Z;
+      break;
+
+    default:
+      *val = LSM6DSV320X_X_EQ_Y;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  High-g accelerometer peak tracking enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      0: disable, 1: enable
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_xl_hg_peak_tracking_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_emb_func_init_b_t emb_func_init_b;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_INIT_B, (uint8_t *)&emb_func_init_b, 1);
+  emb_func_init_b.pt_init = val;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_INIT_B, (uint8_t *)&emb_func_init_b, 1);
+
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  High-g accelerometer peak tracking enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      0: disable, 1: enable
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_xl_hg_peak_tracking_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_emb_func_init_b_t emb_func_init_b;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_INIT_B, (uint8_t *)&emb_func_init_b, 1);
+  *val = emb_func_init_b.pt_init;
+
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Hihg-g accelerometer sensitivity value register for FSM and MLC.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Hihg-g accelerometer sensitivity value
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_xl_hg_sensitivity_set(const stmdev_ctx_t *ctx, uint16_t val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  buff[1] = (uint8_t)(val / 256U);
+  buff[0] = (uint8_t)(val - (buff[1] * 256U));
+  ret = lsm6dsv320x_ln_pg_write(ctx, LSM6DSV320X_EMB_ADV_PG_1 + LSM6DSV320X_XL_HG_SENSITIVITY_L,
+                                (uint8_t *)&buff[0], 2);
+
+  return ret;
+}
+
+/**
+  * @brief  Hihg-g accelerometer sensitivity value register for FSM and MLC.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Hihg-g accelerometer sensitivity value
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_xl_hg_sensitivity_get(const stmdev_ctx_t *ctx, uint16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = lsm6dsv320x_ln_pg_read(ctx, LSM6DSV320X_EMB_ADV_PG_1 + LSM6DSV320X_XL_HG_SENSITIVITY_L,
+                               &buff[0], 2);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  *val = buff[1];
+  *val = (*val * 256U) + buff[0];
+
+  return ret;
+}
+
+/**
+  * @brief  FSM long counter timeout. The long counter timeout value is an unsigned integer value (16-bit format). When the long counter value reached this value, the FSM generates an interrupt.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      FSM long counter timeout. The long counter timeout value is an unsigned integer value (16-bit format). When the long counter value reached this value, the FSM generates an interrupt.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fsm_long_cnt_timeout_set(const stmdev_ctx_t *ctx, uint16_t val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  buff[1] = (uint8_t)(val / 256U);
+  buff[0] = (uint8_t)(val - (buff[1] * 256U));
+  ret = lsm6dsv320x_ln_pg_write(ctx, LSM6DSV320X_EMB_ADV_PG_1 + LSM6DSV320X_FSM_LC_TIMEOUT_L,
+                                (uint8_t *)&buff[0], 2);
+
+  return ret;
+}
+
+/**
+  * @brief  FSM long counter timeout. The long counter timeout value is an unsigned integer value (16-bit format). When the long counter value reached this value, the FSM generates an interrupt.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      FSM long counter timeout. The long counter timeout value is an unsigned integer value (16-bit format). When the long counter value reached this value, the FSM generates an interrupt.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fsm_long_cnt_timeout_get(const stmdev_ctx_t *ctx, uint16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = lsm6dsv320x_ln_pg_read(ctx, LSM6DSV320X_EMB_ADV_PG_1 + LSM6DSV320X_FSM_LC_TIMEOUT_L, &buff[0],
+                               2);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  *val = buff[1];
+  *val = (*val * 256U) + buff[0];
+
+  return ret;
+}
+
+/**
+  * @brief  FSM number of programs.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      FSM number of programs.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fsm_number_of_programs_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_fsm_programs_t fsm_programs;
+  int32_t ret;
+
+  ret = lsm6dsv320x_ln_pg_read(ctx, LSM6DSV320X_EMB_ADV_PG_1 + LSM6DSV320X_FSM_PROGRAMS,
+                               (uint8_t *)&fsm_programs, 1);
+  if (ret == 0)
+  {
+    fsm_programs.fsm_n_prog = val;
+    ret = lsm6dsv320x_ln_pg_write(ctx, LSM6DSV320X_EMB_ADV_PG_1 + LSM6DSV320X_FSM_PROGRAMS,
+                                  (uint8_t *)&fsm_programs, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FSM number of programs.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      FSM number of programs.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fsm_number_of_programs_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_fsm_programs_t fsm_programs;
+  int32_t ret;
+
+  ret = lsm6dsv320x_ln_pg_read(ctx, LSM6DSV320X_EMB_ADV_PG_1 + LSM6DSV320X_FSM_PROGRAMS,
+                               (uint8_t *)&fsm_programs, 1);
+  *val = fsm_programs.fsm_n_prog;
+
+  return ret;
+}
+
+/**
+  * @brief  FSM start address. First available address is 0x35C.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      FSM start address. First available address is 0x35C.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fsm_start_address_set(const stmdev_ctx_t *ctx, uint16_t val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  buff[1] = (uint8_t)(val / 256U);
+  buff[0] = (uint8_t)(val - (buff[1] * 256U));
+  ret = lsm6dsv320x_ln_pg_write(ctx, LSM6DSV320X_EMB_ADV_PG_1 + LSM6DSV320X_FSM_START_ADD_L,
+                                (uint8_t *)&buff[0], 2);
+
+  return ret;
+}
+
+/**
+  * @brief  FSM start address. First available address is 0x35C.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      FSM start address. First available address is 0x35C.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_fsm_start_address_get(const stmdev_ctx_t *ctx, uint16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = lsm6dsv320x_ln_pg_read(ctx, LSM6DSV320X_EMB_ADV_PG_1 + LSM6DSV320X_FSM_START_ADD_L, &buff[0],
+                               2);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  *val = buff[1];
+  *val = (*val * 256U) + buff[0];
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Free fall
+  * @brief     This section group all the functions concerning the free
+  *            fall detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Time windows configuration for Free Fall detection 1 LSB = 1/ODR_XL time[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Time windows configuration for Free Fall detection 1 LSB = 1/ODR_XL time
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ff_time_windows_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_wake_up_dur_t wake_up_dur;
+  lsm6dsv320x_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+  wake_up_dur.ff_dur = ((uint8_t)val & 0x20U) >> 5;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FREE_FALL, (uint8_t *)&free_fall, 1);
+  free_fall.ff_dur = (uint8_t)val & 0x1FU;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FREE_FALL, (uint8_t *)&free_fall, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Time windows configuration for Free Fall detection 1 LSB = 1/ODR_XL time[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Time windows configuration for Free Fall detection 1 LSB = 1/ODR_XL time
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ff_time_windows_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_wake_up_dur_t wake_up_dur;
+  lsm6dsv320x_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FREE_FALL, (uint8_t *)&free_fall, 1);
+
+  *val = (wake_up_dur.ff_dur << 5) + free_fall.ff_dur;
+
+  return ret;
+}
+
+/**
+  * @brief  Free fall threshold setting.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      156_mg, 219_mg, 250_mg, 312_mg, 344_mg, 406_mg, 469_mg, 500_mg,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ff_thresholds_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_ff_thresholds_t val)
+{
+  lsm6dsv320x_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FREE_FALL, (uint8_t *)&free_fall, 1);
+  if (ret == 0)
+  {
+    free_fall.ff_ths = (uint8_t)val & 0x7U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FREE_FALL, (uint8_t *)&free_fall, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Free fall threshold setting.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      156_mg, 219_mg, 250_mg, 312_mg, 344_mg, 406_mg, 469_mg, 500_mg,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ff_thresholds_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_ff_thresholds_t *val)
+{
+  lsm6dsv320x_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FREE_FALL, (uint8_t *)&free_fall, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (free_fall.ff_ths)
+  {
+    case LSM6DSV320X_156_mg:
+      *val = LSM6DSV320X_156_mg;
+      break;
+
+    case LSM6DSV320X_219_mg:
+      *val = LSM6DSV320X_219_mg;
+      break;
+
+    case LSM6DSV320X_250_mg:
+      *val = LSM6DSV320X_250_mg;
+      break;
+
+    case LSM6DSV320X_312_mg:
+      *val = LSM6DSV320X_312_mg;
+      break;
+
+    case LSM6DSV320X_344_mg:
+      *val = LSM6DSV320X_344_mg;
+      break;
+
+    case LSM6DSV320X_406_mg:
+      *val = LSM6DSV320X_406_mg;
+      break;
+
+    case LSM6DSV320X_469_mg:
+      *val = LSM6DSV320X_469_mg;
+      break;
+
+    case LSM6DSV320X_500_mg:
+      *val = LSM6DSV320X_500_mg;
+      break;
+
+    default:
+      *val = LSM6DSV320X_156_mg;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Machine Learning Core (MLC)
+  * @brief      This section group all the functions concerning the
+  *             usage of Machine Learning Core
+  * @{
+  *
+  */
+
+/**
+  * @brief  It enables Machine Learning Core feature (MLC). When the Machine Learning Core is enabled the Finite State Machine (FSM) programs are executed before executing the MLC algorithms.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      MLC_OFF, MLC_ON, MLC_BEFORE_FSM,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_mlc_set(const stmdev_ctx_t *ctx, lsm6dsv320x_mlc_mode_t val)
+{
+  lsm6dsv320x_emb_func_en_b_t emb_en_b;
+  lsm6dsv320x_emb_func_en_a_t emb_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_EN_A, (uint8_t *)&emb_en_a, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_EN_B, (uint8_t *)&emb_en_b, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  switch (val)
+  {
+    case LSM6DSV320X_MLC_OFF:
+      emb_en_a.mlc_before_fsm_en = 0;
+      emb_en_b.mlc_en = 0;
+      break;
+    case LSM6DSV320X_MLC_ON:
+      emb_en_a.mlc_before_fsm_en = 0;
+      emb_en_b.mlc_en = 1;
+      break;
+    case LSM6DSV320X_MLC_ON_BEFORE_FSM:
+      emb_en_a.mlc_before_fsm_en = 1;
+      emb_en_b.mlc_en = 0;
+      break;
+    default:
+      break;
+  }
+
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_EN_A, (uint8_t *)&emb_en_a, 1);
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_EN_B, (uint8_t *)&emb_en_b, 1);
+
+exit:
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  It enables Machine Learning Core feature (MLC). When the Machine Learning Core is enabled the Finite State Machine (FSM) programs are executed before executing the MLC algorithms.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      MLC_OFF, MLC_ON, MLC_BEFORE_FSM,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_mlc_get(const stmdev_ctx_t *ctx, lsm6dsv320x_mlc_mode_t *val)
+{
+  lsm6dsv320x_emb_func_en_b_t emb_en_b;
+  lsm6dsv320x_emb_func_en_a_t emb_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_EN_A, (uint8_t *)&emb_en_a, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_EN_B, (uint8_t *)&emb_en_b, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  if (emb_en_a.mlc_before_fsm_en == 0U && emb_en_b.mlc_en == 0U)
+  {
+    *val = LSM6DSV320X_MLC_OFF;
+  }
+  else if (emb_en_a.mlc_before_fsm_en == 0U && emb_en_b.mlc_en == 1U)
+  {
+    *val = LSM6DSV320X_MLC_ON;
+  }
+  else if (emb_en_a.mlc_before_fsm_en == 1U)
+  {
+    *val = LSM6DSV320X_MLC_ON_BEFORE_FSM;
+  }
+  else
+  {
+    /* Do nothing */
+  }
+
+exit:
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Machine Learning Core Output Data Rate (ODR) configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      MLC_15Hz, MLC_30Hz, MLC_60Hz, MLC_120Hz, MLC_240Hz, MLC_480Hz, MLC_960Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_mlc_data_rate_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_mlc_data_rate_t val)
+{
+  lsm6dsv320x_mlc_odr_t mlc_odr;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_MLC_ODR, (uint8_t *)&mlc_odr, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  mlc_odr.mlc_odr = (uint8_t)val & 0x07U;
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_MLC_ODR, (uint8_t *)&mlc_odr, 1);
+
+exit:
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Machine Learning Core Output Data Rate (ODR) configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      MLC_15Hz, MLC_30Hz, MLC_60Hz, MLC_120Hz, MLC_240Hz, MLC_480Hz, MLC_960Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_mlc_data_rate_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_mlc_data_rate_t *val)
+{
+  lsm6dsv320x_mlc_odr_t mlc_odr;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_MLC_ODR, (uint8_t *)&mlc_odr, 1);
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (mlc_odr.mlc_odr)
+  {
+    case 0:
+      *val = LSM6DSV320X_MLC_15Hz;
+      break;
+
+    case 1:
+      *val = LSM6DSV320X_MLC_30Hz;
+      break;
+
+    case 2:
+      *val = LSM6DSV320X_MLC_60Hz;
+      break;
+
+    case 3:
+      *val = LSM6DSV320X_MLC_120Hz;
+      break;
+
+    case 4:
+      *val = LSM6DSV320X_MLC_240Hz;
+      break;
+
+    case 5:
+      *val = LSM6DSV320X_MLC_480Hz;
+      break;
+
+    case 6:
+      *val = LSM6DSV320X_MLC_960Hz;
+      break;
+
+    default:
+      *val = LSM6DSV320X_MLC_15Hz;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Output value of all MLC decision trees.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Output value of all MLC decision trees.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_mlc_out_get(const stmdev_ctx_t *ctx, lsm6dsv320x_mlc_out_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_MLC1_SRC, (uint8_t *)val, 8);
+  }
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  External sensor sensitivity value register for the Machine Learning Core. This register corresponds to the conversion value of the external sensor. The register value is expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits).Default value is 0x3C00 (when using an external magnetometer this value corresponds to 1 gauss/LSB).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      External sensor sensitivity value register for the Machine Learning Core. This register corresponds to the conversion value of the external sensor. The register value is expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits).Default value is 0x3C00 (when using an external magnetometer this value corresponds to 1 gauss/LSB).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_mlc_ext_sens_sensitivity_set(const stmdev_ctx_t *ctx, uint16_t val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  buff[1] = (uint8_t)(val / 256U);
+  buff[0] = (uint8_t)(val - (buff[1] * 256U));
+
+  ret = lsm6dsv320x_ln_pg_write(ctx, LSM6DSV320X_EMB_ADV_PG_1 + LSM6DSV320X_MLC_EXT_SENSITIVITY_L,
+                                (uint8_t *)&buff[0], 2);
+
+  return ret;
+}
+
+/**
+  * @brief  External sensor sensitivity value register for the Machine Learning Core. This register corresponds to the conversion value of the external sensor. The register value is expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits).Default value is 0x3C00 (when using an external magnetometer this value corresponds to 1 gauss/LSB).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      External sensor sensitivity value register for the Machine Learning Core. This register corresponds to the conversion value of the external sensor. The register value is expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits).Default value is 0x3C00 (when using an external magnetometer this value corresponds to 1 gauss/LSB).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_mlc_ext_sens_sensitivity_get(const stmdev_ctx_t *ctx,
+                                                 uint16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = lsm6dsv320x_ln_pg_read(ctx, LSM6DSV320X_EMB_ADV_PG_1 + LSM6DSV320X_MLC_EXT_SENSITIVITY_L,
+                               &buff[0], 2);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  *val = buff[1];
+  *val = (*val * 256U) + buff[0];
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Optical Image Stabilization (OIS)
+  * @brief     This section groups all the functions concerning
+  *            Optical Image Stabilization (OIS).
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable the full control of OIS configurations from the UI (User Interface).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      OIS_CTRL_FROM_OIS, OIS_CTRL_FROM_UI,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ois_ctrl_mode_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_ois_ctrl_mode_t val)
+{
+  lsm6dsv320x_func_cfg_access_t func_cfg_access;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  if (ret == 0)
+  {
+    func_cfg_access.ois_ctrl_from_ui = (uint8_t)val & 0x1U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable the full control of OIS configurations from the UI (User Interface).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      OIS_CTRL_FROM_OIS, OIS_CTRL_FROM_UI,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ois_ctrl_mode_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_ois_ctrl_mode_t *val)
+{
+  lsm6dsv320x_func_cfg_access_t func_cfg_access;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (func_cfg_access.ois_ctrl_from_ui)
+  {
+    case LSM6DSV320X_OIS_CTRL_FROM_OIS:
+      *val = LSM6DSV320X_OIS_CTRL_FROM_OIS;
+      break;
+
+    case LSM6DSV320X_OIS_CTRL_FROM_UI:
+      *val = LSM6DSV320X_OIS_CTRL_FROM_UI;
+      break;
+
+    default:
+      *val = LSM6DSV320X_OIS_CTRL_FROM_OIS;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Resets the control registers of OIS from the UI (User Interface)[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Resets the control registers of OIS from the UI (User Interface)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ois_reset_set(const stmdev_ctx_t *ctx, int8_t val)
+{
+  lsm6dsv320x_func_cfg_access_t func_cfg_access;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  if (ret == 0)
+  {
+    func_cfg_access.if2_reset = (uint8_t)val;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Resets the control registers of OIS from the UI (User Interface)[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Resets the control registers of OIS from the UI (User Interface)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ois_reset_get(const stmdev_ctx_t *ctx, int8_t *val)
+{
+  lsm6dsv320x_func_cfg_access_t func_cfg_access;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  *val = (int8_t)func_cfg_access.if2_reset;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable/disable pull up on OIS interface.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enable/disable pull up on OIS interface.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ois_interface_pull_up_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_pin_ctrl_t pin_ctrl;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  if (ret == 0)
+  {
+    pin_ctrl.ois_pu_dis = val;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable/disable pull up on OIS interface.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enable/disable pull up on OIS interface.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ois_interface_pull_up_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_pin_ctrl_t pin_ctrl;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  *val = pin_ctrl.ois_pu_dis;
+
+  return ret;
+}
+
+/**
+  * @brief  Handshake for (User Interface) UI / (OIS interface) IF2 shared registers. ACK: This bit acknowledges the handshake. If the secondary interface is not accessing the shared registers, this bit is set to 1 by the device and the R/W operation on the UI_IF2_SHARED registers is allowed on the primary interface. REQ: This bit is used by the primary interface controller to request access to the UI_IF2_SHARED registers. When the R/W operation is finished, the controller must reset this bit.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Handshake for (User Interface) UI / (OIS interface) IF2 shared registers. ACK: This bit acknowledges the handshake. If the secondary interface is not accessing the shared registers, this bit is set to 1 by the device and the R/W operation on the UI_IF2_SHARED registers is allowed on the primary interface. REQ: This bit is used by the primary interface controller to request access to the UI_IF2_SHARED registers. When the R/W operation is finished, the controller must reset this bit.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ois_handshake_from_ui_set(const stmdev_ctx_t *ctx,
+                                              lsm6dsv320x_ois_handshake_t val)
+{
+  lsm6dsv320x_ui_handshake_ctrl_t ui_handshake_ctrl;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_UI_HANDSHAKE_CTRL, (uint8_t *)&ui_handshake_ctrl, 1);
+  if (ret == 0)
+  {
+    ui_handshake_ctrl.ui_shared_ack = val.ack;
+    ui_handshake_ctrl.ui_shared_req = val.req;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_UI_HANDSHAKE_CTRL, (uint8_t *)&ui_handshake_ctrl, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Handshake for (User Interface) UI / (OIS interface) IF2 shared registers. ACK: This bit acknowledges the handshake. If the secondary interface is not accessing the shared registers, this bit is set to 1 by the device and the R/W operation on the UI_IF2_SHARED registers is allowed on the primary interface. REQ: This bit is used by the primary interface controller to request access to the UI_IF2_SHARED registers. When the R/W operation is finished, the controller must reset this bit.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Handshake for (User Interface) UI / (OIS interface) IF2 shared registers. ACK: This bit acknowledges the handshake. If the secondary interface is not accessing the shared registers, this bit is set to 1 by the device and the R/W operation on the UI_IF2_SHARED registers is allowed on the primary interface. REQ: This bit is used by the primary interface controller to request access to the UI_IF2_SHARED registers. When the R/W operation is finished, the controller must reset this bit.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ois_handshake_from_ui_get(const stmdev_ctx_t *ctx,
+                                              lsm6dsv320x_ois_handshake_t *val)
+{
+  lsm6dsv320x_ui_handshake_ctrl_t ui_handshake_ctrl;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_UI_HANDSHAKE_CTRL, (uint8_t *)&ui_handshake_ctrl, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->ack = ui_handshake_ctrl.ui_shared_ack;
+  val->req = ui_handshake_ctrl.ui_shared_req;
+
+  return ret;
+}
+
+/**
+  * @brief  Handshake for (User Interface) UI / (OIS interface) IF2 shared registers. ACK: This bit acknowledges the handshake. If the secondary interface is not accessing the shared registers, this bit is set to 1 by the device and the R/W operation on the UI_IF2_SHARED registers is allowed on the primary interface. REQ: This bit is used by the primary interface controller to request access to the UI_IF2_SHARED registers. When the R/W operation is finished, the controller must reset this bit.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Handshake for (User Interface) UI / (OIS interface) IF2 shared registers. ACK: This bit acknowledges the handshake. If the secondary interface is not accessing the shared registers, this bit is set to 1 by the device and the R/W operation on the UI_IF2_SHARED registers is allowed on the primary interface. REQ: This bit is used by the primary interface controller to request access to the UI_IF2_SHARED registers. When the R/W operation is finished, the controller must reset this bit.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ois_handshake_from_ois_set(const stmdev_ctx_t *ctx,
+                                               lsm6dsv320x_ois_handshake_t val)
+{
+  lsm6dsv320x_if2_handshake_ctrl_t if2_handshake_ctrl;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_IF2_HANDSHAKE_CTRL, (uint8_t *)&if2_handshake_ctrl, 1);
+  if (ret == 0)
+  {
+    if2_handshake_ctrl.if2_shared_ack = val.ack;
+    if2_handshake_ctrl.if2_shared_req = val.req;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_IF2_HANDSHAKE_CTRL, (uint8_t *)&if2_handshake_ctrl, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Handshake for (User Interface) UI / (OIS interface) IF2 shared registers. ACK: This bit acknowledges the handshake. If the secondary interface is not accessing the shared registers, this bit is set to 1 by the device and the R/W operation on the UI_IF2_SHARED registers is allowed on the primary interface. REQ: This bit is used by the primary interface controller to request access to the UI_IF2_SHARED registers. When the R/W operation is finished, the controller must reset this bit.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Handshake for (User Interface) UI / (OIS interface) IF2 shared registers. ACK: This bit acknowledges the handshake. If the secondary interface is not accessing the shared registers, this bit is set to 1 by the device and the R/W operation on the UI_IF2_SHARED registers is allowed on the primary interface. REQ: This bit is used by the primary interface controller to request access to the UI_IF2_SHARED registers. When the R/W operation is finished, the controller must reset this bit.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ois_handshake_from_ois_get(const stmdev_ctx_t *ctx,
+                                               lsm6dsv320x_ois_handshake_t *val)
+{
+  lsm6dsv320x_if2_handshake_ctrl_t if2_handshake_ctrl;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_IF2_HANDSHAKE_CTRL, (uint8_t *)&if2_handshake_ctrl, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->ack = if2_handshake_ctrl.if2_shared_ack;
+  val->req = if2_handshake_ctrl.if2_shared_req;
+
+  return ret;
+}
+
+/**
+  * @brief  User interface (UI) / IF2 (OIS) shared registers[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      User interface (UI) / IF2 (OIS) shared registers
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ois_shared_set(const stmdev_ctx_t *ctx, uint8_t val[6])
+{
+  int32_t ret;
+
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_UI_IF2_SHARED_0, val, 6);
+
+  return ret;
+}
+
+/**
+  * @brief  User interface (UI) / IF2 (OIS) shared registers[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      User interface (UI) / IF2 (OIS) shared registers
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ois_shared_get(const stmdev_ctx_t *ctx, uint8_t val[6])
+{
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_UI_IF2_SHARED_0, val, 6);
+
+  return ret;
+}
+
+/**
+  * @brief  In User Interface (UI) full control mode, enables IF2 (OIS Interface) for reading OIS data. This function works also on OIS (UI_CTRL1_OIS = IF2_CTRL1_OIS).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      In User Interface (UI) full control mode, enables IF2 (OIS Interface) for reading OIS data.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ois_on_if2_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_ui_ctrl1_ois_t ui_ctrl1_ois;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
+  if (ret == 0)
+  {
+    ui_ctrl1_ois.if2_spi_read_en = val;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  In User Interface (UI) full control mode, enables IF2 (OIS Interface) for reading OIS data. This function works also on OIS (UI_CTRL1_OIS = IF2_CTRL1_OIS).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      In User Interface (UI) full control mode, enables IF2 (OIS Interface) for reading OIS data.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ois_on_if2_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_ui_ctrl1_ois_t ui_ctrl1_ois;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
+  *val = ui_ctrl1_ois.if2_spi_read_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enables gyroscope/accelerometer OIS chain. This function works also on OIS (UI_CTRL1_OIS = IF2_CTRL1_OIS).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables gyroscope/accelerometer OIS chain.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ois_chain_set(const stmdev_ctx_t *ctx, lsm6dsv320x_ois_chain_t val)
+{
+  lsm6dsv320x_ui_ctrl1_ois_t ui_ctrl1_ois;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
+  if (ret == 0)
+  {
+    ui_ctrl1_ois.ois_g_en = val.gy;
+    ui_ctrl1_ois.ois_xl_en = val.xl;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables gyroscope/accelerometer OIS chain.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables gyroscope/accelerometer OIS chain.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ois_chain_get(const stmdev_ctx_t *ctx, lsm6dsv320x_ois_chain_t *val)
+{
+  lsm6dsv320x_ui_ctrl1_ois_t ui_ctrl1_ois;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->gy = ui_ctrl1_ois.ois_g_en;
+  val->xl = ui_ctrl1_ois.ois_xl_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope OIS full-scale selection[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      OIS_250dps, OIS_500dps, OIS_1000dps, OIS_2000dps,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ois_gy_full_scale_set(const stmdev_ctx_t *ctx,
+                                          lsm6dsv320x_ois_gy_full_scale_t val)
+{
+  lsm6dsv320x_ui_ctrl2_ois_t ui_ctrl2_ois;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_UI_CTRL2_OIS, (uint8_t *)&ui_ctrl2_ois, 1);
+  if (ret == 0)
+  {
+    ui_ctrl2_ois.fs_g_ois = (uint8_t)val & 0x03U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_UI_CTRL2_OIS, (uint8_t *)&ui_ctrl2_ois, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope OIS full-scale selection[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      OIS_250dps, OIS_500dps, OIS_1000dps, OIS_2000dps,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ois_gy_full_scale_get(const stmdev_ctx_t *ctx,
+                                          lsm6dsv320x_ois_gy_full_scale_t *val)
+{
+  lsm6dsv320x_ui_ctrl2_ois_t ui_ctrl2_ois;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_UI_CTRL2_OIS, (uint8_t *)&ui_ctrl2_ois, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ui_ctrl2_ois.fs_g_ois)
+  {
+    case LSM6DSV320X_OIS_250dps:
+      *val = LSM6DSV320X_OIS_250dps;
+      break;
+
+    case LSM6DSV320X_OIS_500dps:
+      *val = LSM6DSV320X_OIS_500dps;
+      break;
+
+    case LSM6DSV320X_OIS_1000dps:
+      *val = LSM6DSV320X_OIS_1000dps;
+      break;
+
+    case LSM6DSV320X_OIS_2000dps:
+      *val = LSM6DSV320X_OIS_2000dps;
+      break;
+
+    default:
+      *val = LSM6DSV320X_OIS_250dps;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer OIS channel full-scale.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      OIS_2g, OIS_4g, OIS_8g, OIS_16g,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ois_xl_full_scale_set(const stmdev_ctx_t *ctx,
+                                          lsm6dsv320x_ois_xl_full_scale_t val)
+{
+  lsm6dsv320x_ui_ctrl3_ois_t ui_ctrl3_ois;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_UI_CTRL3_OIS, (uint8_t *)&ui_ctrl3_ois, 1);
+  if (ret == 0)
+  {
+    ui_ctrl3_ois.fs_xl_ois = (uint8_t)val & 0x3U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_UI_CTRL3_OIS, (uint8_t *)&ui_ctrl3_ois, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer OIS channel full-scale.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      OIS_2g, OIS_4g, OIS_8g, OIS_16g,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ois_xl_full_scale_get(const stmdev_ctx_t *ctx,
+                                          lsm6dsv320x_ois_xl_full_scale_t *val)
+{
+  lsm6dsv320x_ui_ctrl3_ois_t ui_ctrl3_ois;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_UI_CTRL3_OIS, (uint8_t *)&ui_ctrl3_ois, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ui_ctrl3_ois.fs_xl_ois)
+  {
+    case LSM6DSV320X_OIS_2g:
+      *val = LSM6DSV320X_OIS_2g;
+      break;
+
+    case LSM6DSV320X_OIS_4g:
+      *val = LSM6DSV320X_OIS_4g;
+      break;
+
+    case LSM6DSV320X_OIS_8g:
+      *val = LSM6DSV320X_OIS_8g;
+      break;
+
+    case LSM6DSV320X_OIS_16g:
+      *val = LSM6DSV320X_OIS_16g;
+      break;
+
+    default:
+      *val = LSM6DSV320X_OIS_2g;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Orientation 6D (and 4D)
+  * @brief     This section groups all the functions concerning six position
+  *            detection (6D).
+  * @{
+  *
+  */
+
+/**
+  * @brief  Threshold for 4D/6D function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      DEG_80, DEG_70, DEG_60, DEG_50,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_6d_threshold_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv320x_6d_threshold_t val)
+{
+  lsm6dsv320x_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
+  if (ret == 0)
+  {
+    tap_ths_6d.sixd_ths = (uint8_t)val & 0x03U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Threshold for 4D/6D function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      DEG_80, DEG_70, DEG_60, DEG_50,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_6d_threshold_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv320x_6d_threshold_t *val)
+{
+  lsm6dsv320x_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (tap_ths_6d.sixd_ths)
+  {
+    case LSM6DSV320X_DEG_80:
+      *val = LSM6DSV320X_DEG_80;
+      break;
+
+    case LSM6DSV320X_DEG_70:
+      *val = LSM6DSV320X_DEG_70;
+      break;
+
+    case LSM6DSV320X_DEG_60:
+      *val = LSM6DSV320X_DEG_60;
+      break;
+
+    case LSM6DSV320X_DEG_50:
+      *val = LSM6DSV320X_DEG_50;
+      break;
+
+    default:
+      *val = LSM6DSV320X_DEG_80;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable. Z-axis position detection is disabled.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      4D orientation detection enable. Z-axis position detection is disabled.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_4d_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
+  if (ret == 0)
+  {
+    tap_ths_6d.d4d_en = val;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable. Z-axis position detection is disabled.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      4D orientation detection enable. Z-axis position detection is disabled.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_4d_mode_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
+  *val = tap_ths_6d.d4d_en;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  SenseWire (I3C)
+  * @brief     This section group all the functions concerning the
+  *            usage of SenseWire (I3C)
+  * @{
+  *
+  */
+
+/**
+  * @brief  I3C configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      rst_mode, ibi_time, if2_ta0_pid
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_i3c_config_set(const stmdev_ctx_t *ctx,
+                                   lsm6dsv320x_i3c_config_t val)
+{
+  lsm6dsv320x_pin_ctrl_t pin_ctrl;
+  lsm6dsv320x_ctrl5_t ctrl5;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL5, (uint8_t *)&ctrl5, 1);
+  if (ret == 0)
+  {
+    pin_ctrl.ibhr_por_en = (uint8_t)val.rst_mode & 0x01U;
+    ctrl5.bus_act_sel = (uint8_t)val.ibi_time & 0x03U;
+    ctrl5.if2_ta0_pid = (uint8_t)val.if2_ta0_pid & 0x01U;
+
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+    ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL5, (uint8_t *)&ctrl5, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  I3C configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      rst_mode, ibi_time, if2_ta0_pid
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_i3c_config_get(const stmdev_ctx_t *ctx,
+                                   lsm6dsv320x_i3c_config_t *val)
+{
+  lsm6dsv320x_pin_ctrl_t pin_ctrl;
+  lsm6dsv320x_ctrl5_t ctrl5;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (pin_ctrl.ibhr_por_en)
+  {
+    case LSM6DSV320X_SW_RST_DYN_ADDRESS_RST:
+      val->rst_mode = LSM6DSV320X_SW_RST_DYN_ADDRESS_RST;
+      break;
+
+    case LSM6DSV320X_I3C_GLOBAL_RST:
+      val->rst_mode = LSM6DSV320X_I3C_GLOBAL_RST;
+      break;
+
+    default:
+      val->rst_mode = LSM6DSV320X_SW_RST_DYN_ADDRESS_RST;
+      break;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL5, (uint8_t *)&ctrl5, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl5.bus_act_sel)
+  {
+    case 0:
+      val->ibi_time = LSM6DSV320X_IBI_50us;
+      break;
+
+    case 1:
+      val->ibi_time = LSM6DSV320X_IBI_2us;
+      break;
+
+    case 2:
+      val->ibi_time = LSM6DSV320X_IBI_1ms;
+      break;
+
+    case 3:
+      val->ibi_time = LSM6DSV320X_IBI_50ms;
+      break;
+
+    default:
+      val->ibi_time = LSM6DSV320X_IBI_50us;
+      break;
+  }
+
+  val->if2_ta0_pid = ctrl5.if2_ta0_pid;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Sensor hub
+  * @brief     This section groups all the functions that manage the
+  *            sensor hub.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Sensor Hub controller I2C pull-up enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Sensor Hub controller I2C pull-up enable.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sh_controller_interface_pull_up_set(const stmdev_ctx_t *ctx,
+                                                        uint8_t val)
+{
+  lsm6dsv320x_if_cfg_t if_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  if (ret == 0)
+  {
+    if_cfg.shub_pu_en = val;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor Hub controller I2C pull-up enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Sensor Hub controller I2C pull-up enable.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sh_controller_interface_pull_up_get(const stmdev_ctx_t *ctx,
+                                                        uint8_t *val)
+{
+  lsm6dsv320x_if_cfg_t if_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  *val = if_cfg.shub_pu_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub output registers.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Sensor hub output registers.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sh_read_data_raw_get(const stmdev_ctx_t *ctx, uint8_t *val,
+                                         uint8_t len)
+{
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_SENSOR_HUB_1, val, len);
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Number of external sensors to be read by the sensor hub.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      TGT_0, TGT_0_1, TGT_0_1_2, TGT_0_1_2_3,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sh_target_connected_set(const stmdev_ctx_t *ctx,
+                                            lsm6dsv320x_sh_target_connected_t val)
+{
+  lsm6dsv320x_controller_config_t controller_config;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  controller_config.aux_sens_on = (uint8_t)val & 0x3U;
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+
+exit:
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Number of external sensors to be read by the sensor hub.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      TGT_0, TGT_0_1, TGT_0_1_2, TGT_0_1_2_3,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sh_target_connected_get(const stmdev_ctx_t *ctx,
+                                            lsm6dsv320x_sh_target_connected_t *val)
+{
+  lsm6dsv320x_controller_config_t controller_config;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (controller_config.aux_sens_on)
+  {
+    case LSM6DSV320X_TGT_0:
+      *val = LSM6DSV320X_TGT_0;
+      break;
+
+    case LSM6DSV320X_TGT_0_1:
+      *val = LSM6DSV320X_TGT_0_1;
+      break;
+
+    case LSM6DSV320X_TGT_0_1_2:
+      *val = LSM6DSV320X_TGT_0_1_2;
+      break;
+
+    case LSM6DSV320X_TGT_0_1_2_3:
+      *val = LSM6DSV320X_TGT_0_1_2_3;
+      break;
+
+    default:
+      *val = LSM6DSV320X_TGT_0;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub I2C controller enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Sensor hub I2C controller enable.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sh_controller_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_controller_config_t controller_config;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  controller_config.controller_on = val;
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+
+exit:
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub I2C controller enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Sensor hub I2C controller enable.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sh_controller_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_controller_config_t controller_config;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+
+  *val = controller_config.controller_on;
+
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  I2C interface pass-through.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      I2C interface pass-through.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sh_pass_through_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_controller_config_t controller_config;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  controller_config.pass_through_mode = val;
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+
+exit:
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  I2C interface pass-through.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      I2C interface pass-through.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sh_pass_through_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_controller_config_t controller_config;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+
+  *val = controller_config.pass_through_mode;
+
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub trigger signal selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SH_TRG_XL_GY_DRDY, SH_TRIG_INT2,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sh_syncro_mode_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_sh_syncro_mode_t val)
+{
+  lsm6dsv320x_controller_config_t controller_config;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  controller_config.start_config = (uint8_t)val & 0x01U;
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+
+exit:
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub trigger signal selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SH_TRG_XL_GY_DRDY, SH_TRIG_INT2,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sh_syncro_mode_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_sh_syncro_mode_t *val)
+{
+  lsm6dsv320x_controller_config_t controller_config;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (controller_config.start_config)
+  {
+    case LSM6DSV320X_SH_TRG_XL_GY_DRDY:
+      *val = LSM6DSV320X_SH_TRG_XL_GY_DRDY;
+      break;
+
+    case LSM6DSV320X_SH_TRIG_INT2:
+      *val = LSM6DSV320X_SH_TRIG_INT2;
+      break;
+
+    default:
+      *val = LSM6DSV320X_SH_TRG_XL_GY_DRDY;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Target 0 write operation is performed only at the first sensor hub cycle.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      EACH_SH_CYCLE, ONLY_FIRST_CYCLE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sh_write_mode_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_sh_write_mode_t val)
+{
+  lsm6dsv320x_controller_config_t controller_config;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  controller_config.write_once = (uint8_t)val & 0x01U;
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+
+exit:
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Target 0 write operation is performed only at the first sensor hub cycle.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      EACH_SH_CYCLE, ONLY_FIRST_CYCLE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sh_write_mode_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_sh_write_mode_t *val)
+{
+  lsm6dsv320x_controller_config_t controller_config;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (controller_config.write_once)
+  {
+    case LSM6DSV320X_EACH_SH_CYCLE:
+      *val = LSM6DSV320X_EACH_SH_CYCLE;
+      break;
+
+    case LSM6DSV320X_ONLY_FIRST_CYCLE:
+      *val = LSM6DSV320X_ONLY_FIRST_CYCLE;
+      break;
+
+    default:
+      *val = LSM6DSV320X_EACH_SH_CYCLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Reset Controller logic and output registers. Must be set to ‘1’ and then set it to ‘0’.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Reset Controller logic and output registers. Must be set to ‘1’ and then set it to ‘0’.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sh_reset_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_controller_config_t controller_config;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  controller_config.rst_controller_regs = val;
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+
+exit:
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Reset Controller logic and output registers. Must be set to ‘1’ and then set it to ‘0’.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Reset Controller logic and output registers. Must be set to ‘1’ and then set it to ‘0’.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sh_reset_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_controller_config_t controller_config;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+
+  *val = controller_config.rst_controller_regs;
+
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Configure target 0 for perform a write.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      a structure that contain
+  *                      - uint8_t tgt1_add;    8 bit i2c device address
+  *                      - uint8_t tgt1_subadd; 8 bit register device address
+  *                      - uint8_t tgt1_data;   8 bit data to write
+  * @retval             interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sh_cfg_write(const stmdev_ctx_t *ctx,
+                                 lsm6dsv320x_sh_cfg_write_t *val)
+{
+  lsm6dsv320x_tgt0_add_t reg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_SENSOR_HUB_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  reg.target0_add = val->tgt0_add;
+  reg.rw_0 = 0;
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TGT0_ADD, (uint8_t *)&reg, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TGT0_SUBADD,
+                              &(val->tgt0_subadd), 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_DATAWRITE_TGT0,
+                              &(val->tgt0_data), 1);
+
+exit:
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Rate at which the controller communicates.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SH_15Hz, SH_30Hz, SH_60Hz, SH_120Hz, SH_240Hz, SH_480Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sh_data_rate_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv320x_sh_data_rate_t val)
+{
+  lsm6dsv320x_tgt0_config_t tgt0_config;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TGT0_CONFIG, (uint8_t *)&tgt0_config, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  tgt0_config.shub_odr = (uint8_t)val & 0x07U;
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TGT0_CONFIG, (uint8_t *)&tgt0_config, 1);
+
+exit:
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Rate at which the controller communicates.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SH_15Hz, SH_30Hz, SH_60Hz, SH_120Hz, SH_240Hz, SH_480Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sh_data_rate_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv320x_sh_data_rate_t *val)
+{
+  lsm6dsv320x_tgt0_config_t tgt0_config;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TGT0_CONFIG, (uint8_t *)&tgt0_config, 1);
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (tgt0_config.shub_odr)
+  {
+    case LSM6DSV320X_SH_15Hz:
+      *val = LSM6DSV320X_SH_15Hz;
+      break;
+
+    case LSM6DSV320X_SH_30Hz:
+      *val = LSM6DSV320X_SH_30Hz;
+      break;
+
+    case LSM6DSV320X_SH_60Hz:
+      *val = LSM6DSV320X_SH_60Hz;
+      break;
+
+    case LSM6DSV320X_SH_120Hz:
+      *val = LSM6DSV320X_SH_120Hz;
+      break;
+
+    case LSM6DSV320X_SH_240Hz:
+      *val = LSM6DSV320X_SH_240Hz;
+      break;
+
+    case LSM6DSV320X_SH_480Hz:
+      *val = LSM6DSV320X_SH_480Hz;
+      break;
+
+    default:
+      *val = LSM6DSV320X_SH_15Hz;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Configure target idx for perform a read.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Structure that contain
+  *                      - uint8_t tgt_add;    8 bit i2c device address
+  *                      - uint8_t tgt_subadd; 8 bit register device address
+  *                      - uint8_t tgt_len;    num of bit to read
+  * @retval             interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sh_tgt_cfg_read(const stmdev_ctx_t *ctx, uint8_t idx,
+                                    lsm6dsv320x_sh_cfg_read_t *val)
+{
+  lsm6dsv320x_tgt0_add_t tgt_add;
+  lsm6dsv320x_tgt0_config_t tgt_config;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_SENSOR_HUB_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  tgt_add.target0_add = val->tgt_add;
+  tgt_add.rw_0 = 1;
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TGT0_ADD + idx * 3U,
+                              (uint8_t *)&tgt_add, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TGT0_SUBADD + idx * 3U,
+                              &(val->tgt_subadd), 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TGT0_CONFIG + idx * 3U,
+                             (uint8_t *)&tgt_config, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  tgt_config.target0_numop = val->tgt_len;
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TGT0_CONFIG + idx * 3U,
+                              (uint8_t *)&tgt_config, 1);
+
+exit:
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub source register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      union of registers from STATUS_CONTROLLER to
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sh_status_get(const stmdev_ctx_t *ctx,
+                                  lsm6dsv320x_status_controller_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_STATUS_CONTROLLER_MAINPAGE, (uint8_t *) val, 1);
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Serial interfaces
+  * @brief     This section groups all the functions concerning
+  *            serial interfaces management (not auxiliary)
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enables pull-up on SDO pin of UI (User Interface).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables pull-up on SDO pin of UI (User Interface).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ui_sdo_pull_up_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_pin_ctrl_t pin_ctrl;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  if (ret == 0)
+  {
+    pin_ctrl.sdo_pu_en = val;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables pull-up on SDO pin of UI (User Interface).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables pull-up on SDO pin of UI (User Interface).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ui_sdo_pull_up_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_pin_ctrl_t pin_ctrl;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  *val = pin_ctrl.sdo_pu_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Pad strength.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Pad strength
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_pad_strength_set(const stmdev_ctx_t *ctx, lsm6dsv320x_pad_strength_t val)
+{
+  lsm6dsv320x_pin_ctrl_t pin_ctrl;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  if (ret == 0)
+  {
+    pin_ctrl.io_pad_strength = val;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Pad strength.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Pad strength
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_pad_strength_get(const stmdev_ctx_t *ctx, lsm6dsv320x_pad_strength_t *val)
+{
+  lsm6dsv320x_pin_ctrl_t pin_ctrl;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  switch (pin_ctrl.io_pad_strength)
+  {
+    case 0:
+      *val = LSM6DSV320X_PAD_LOW_STRENGTH;
+      break;
+
+    case 1:
+      *val = LSM6DSV320X_PAD_MIDDLE_STRENGTH;
+      break;
+
+    case 2:
+    default:
+      *val = LSM6DSV320X_PAD_HIGH_STRENGTH;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Disables I2C and I3C on UI (User Interface).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      I2C_I3C_ENABLE, I2C_I3C_DISABLE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ui_i2c_i3c_mode_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_ui_i2c_i3c_mode_t val)
+{
+  lsm6dsv320x_if_cfg_t if_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  if (ret == 0)
+  {
+    if_cfg.i2c_i3c_disable = (uint8_t)val & 0x1U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Disables I2C and I3C on UI (User Interface).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      I2C_I3C_ENABLE, I2C_I3C_DISABLE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ui_i2c_i3c_mode_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_ui_i2c_i3c_mode_t *val)
+{
+  lsm6dsv320x_if_cfg_t if_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (if_cfg.i2c_i3c_disable)
+  {
+    case LSM6DSV320X_I2C_I3C_ENABLE:
+      *val = LSM6DSV320X_I2C_I3C_ENABLE;
+      break;
+
+    case LSM6DSV320X_I2C_I3C_DISABLE:
+      *val = LSM6DSV320X_I2C_I3C_DISABLE;
+      break;
+
+    default:
+      *val = LSM6DSV320X_I2C_I3C_ENABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SPI_4_WIRE, SPI_3_WIRE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_spi_mode_set(const stmdev_ctx_t *ctx, lsm6dsv320x_spi_mode_t val)
+{
+  lsm6dsv320x_if_cfg_t if_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  if (ret == 0)
+  {
+    if_cfg.sim = (uint8_t)val & 0x01U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SPI_4_WIRE, SPI_3_WIRE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_spi_mode_get(const stmdev_ctx_t *ctx, lsm6dsv320x_spi_mode_t *val)
+{
+  lsm6dsv320x_if_cfg_t if_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (if_cfg.sim)
+  {
+    case LSM6DSV320X_SPI_4_WIRE:
+      *val = LSM6DSV320X_SPI_4_WIRE;
+      break;
+
+    case LSM6DSV320X_SPI_3_WIRE:
+      *val = LSM6DSV320X_SPI_3_WIRE;
+      break;
+
+    default:
+      *val = LSM6DSV320X_SPI_4_WIRE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables pull-up on SDA pin.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables pull-up on SDA pin.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ui_sda_pull_up_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_if_cfg_t if_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  if (ret == 0)
+  {
+    if_cfg.sda_pu_en = val;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables pull-up on SDA pin.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables pull-up on SDA pin.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_ui_sda_pull_up_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_if_cfg_t if_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  *val = if_cfg.sda_pu_en;
+
+  return ret;
+}
+
+/**
+  * @brief  IF2 (OIS Inteface) Serial Interface Mode selection. This function works also on OIS (UI_CTRL1_OIS = IF2_CTRL1_OIS).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SPI_4_WIRE, SPI_3_WIRE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_if2_spi_mode_set(const stmdev_ctx_t *ctx, lsm6dsv320x_spi_mode_t val)
+{
+  lsm6dsv320x_ui_ctrl1_ois_t ui_ctrl1_ois;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
+  if (ret == 0)
+  {
+    ui_ctrl1_ois.sim_ois = (uint8_t)val & 0x01U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  IF2 (OIS Inteface) Serial Interface Mode selection. This function works also on OIS (UI_CTRL1_OIS = IF2_CTRL1_OIS).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SPI_4_WIRE, SPI_3_WIRE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_if2_spi_mode_get(const stmdev_ctx_t *ctx, lsm6dsv320x_spi_mode_t *val)
+{
+  lsm6dsv320x_ui_ctrl1_ois_t ui_ctrl1_ois;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ui_ctrl1_ois.sim_ois)
+  {
+    case LSM6DSV320X_SPI_4_WIRE:
+      *val = LSM6DSV320X_SPI_4_WIRE;
+      break;
+
+    case LSM6DSV320X_SPI_3_WIRE:
+      *val = LSM6DSV320X_SPI_3_WIRE;
+      break;
+
+    default:
+      *val = LSM6DSV320X_SPI_4_WIRE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Significant motion detection
+  * @brief     This section groups all the functions that manage the
+  *            significant motion detection.
+  * @{
+  *
+  */
+
+
+/**
+  * @brief  Enables significant motion detection function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables significant motion detection function.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sigmot_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  emb_func_en_a.sign_motion_en = val;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Enables significant motion detection function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables significant motion detection function.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sigmot_mode_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  *val = emb_func_en_a.sign_motion_en;
+
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Step Counter (Pedometer)
+  * @brief     This section groups all the functions that manage pedometer.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Step counter mode[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Step counter mode
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_stpcnt_mode_set(const stmdev_ctx_t *ctx,
+                                    lsm6dsv320x_stpcnt_mode_t val)
+{
+  lsm6dsv320x_emb_func_en_a_t emb_func_en_a;
+  lsm6dsv320x_emb_func_en_b_t emb_func_en_b;
+  lsm6dsv320x_pedo_cmd_reg_t pedo_cmd_reg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  if ((val.false_step_rej == PROPERTY_ENABLE)
+      && ((emb_func_en_a.mlc_before_fsm_en & emb_func_en_b.mlc_en) ==
+          PROPERTY_DISABLE))
+  {
+    emb_func_en_a.mlc_before_fsm_en = PROPERTY_ENABLE;
+  }
+
+  emb_func_en_a.pedo_en = val.step_counter_enable;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+
+exit:
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = lsm6dsv320x_ln_pg_read(ctx, LSM6DSV320X_EMB_ADV_PG_1 + LSM6DSV320X_PEDO_CMD_REG,
+                                 (uint8_t *)&pedo_cmd_reg, 1);
+    pedo_cmd_reg.fp_rejection_en = val.false_step_rej;
+    ret += lsm6dsv320x_ln_pg_write(ctx, LSM6DSV320X_EMB_ADV_PG_1 + LSM6DSV320X_PEDO_CMD_REG,
+                                   (uint8_t *)&pedo_cmd_reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Step counter mode[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      false_step_rej, step_counter, step_detector,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_stpcnt_mode_get(const stmdev_ctx_t *ctx,
+                                    lsm6dsv320x_stpcnt_mode_t *val)
+{
+  lsm6dsv320x_emb_func_en_a_t emb_func_en_a;
+  lsm6dsv320x_pedo_cmd_reg_t pedo_cmd_reg;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_ln_pg_read(ctx, LSM6DSV320X_EMB_ADV_PG_1 + LSM6DSV320X_PEDO_CMD_REG,
+                               (uint8_t *)&pedo_cmd_reg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->false_step_rej = pedo_cmd_reg.fp_rejection_en;
+  val->step_counter_enable = emb_func_en_a.pedo_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Step counter output, number of detected steps.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Step counter output, number of detected steps.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_stpcnt_steps_get(const stmdev_ctx_t *ctx, uint16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_STEP_COUNTER_L, &buff[0], 2);
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  *val = buff[1];
+  *val = (*val * 256U) + buff[0];
+
+  return ret;
+}
+
+/**
+  * @brief  Reset step counter.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Reset step counter.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_stpcnt_rst_step_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_emb_func_src_t emb_func_src;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  emb_func_src.pedo_rst_step = val;
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
+
+exit:
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Reset step counter.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Reset step counter.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_stpcnt_rst_step_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_emb_func_src_t emb_func_src;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
+  *val = emb_func_src.pedo_rst_step;
+
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Pedometer debounce configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Pedometer debounce configuration.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_stpcnt_debounce_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_pedo_deb_steps_conf_t pedo_deb_steps_conf;
+  int32_t ret;
+
+  ret = lsm6dsv320x_ln_pg_read(ctx, LSM6DSV320X_EMB_ADV_PG_1 + LSM6DSV320X_PEDO_DEB_STEPS_CONF,
+                               (uint8_t *)&pedo_deb_steps_conf, 1);
+  if (ret == 0)
+  {
+    pedo_deb_steps_conf.deb_step = val;
+    ret = lsm6dsv320x_ln_pg_write(ctx, LSM6DSV320X_EMB_ADV_PG_1 + LSM6DSV320X_PEDO_DEB_STEPS_CONF,
+                                  (uint8_t *)&pedo_deb_steps_conf, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Pedometer debounce configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Pedometer debounce configuration.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_stpcnt_debounce_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_pedo_deb_steps_conf_t pedo_deb_steps_conf;
+  int32_t ret;
+
+  ret = lsm6dsv320x_ln_pg_read(ctx, LSM6DSV320X_EMB_ADV_PG_1 + LSM6DSV320X_PEDO_DEB_STEPS_CONF,
+                               (uint8_t *)&pedo_deb_steps_conf, 1);
+  *val = pedo_deb_steps_conf.deb_step;
+
+  return ret;
+}
+
+/**
+  * @brief  Time period register for step detection on delta time.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Time period register for step detection on delta time.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_stpcnt_period_set(const stmdev_ctx_t *ctx, uint16_t val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  buff[1] = (uint8_t)(val / 256U);
+  buff[0] = (uint8_t)(val - (buff[1] * 256U));
+  ret = lsm6dsv320x_ln_pg_write(ctx, LSM6DSV320X_EMB_ADV_PG_1 + LSM6DSV320X_PEDO_SC_DELTAT_L,
+                                (uint8_t *)&buff[0], 2);
+
+  return ret;
+}
+
+/**
+  * @brief  Time period register for step detection on delta time.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Time period register for step detection on delta time.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_stpcnt_period_get(const stmdev_ctx_t *ctx, uint16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = lsm6dsv320x_ln_pg_read(ctx, LSM6DSV320X_EMB_ADV_PG_1 + LSM6DSV320X_PEDO_SC_DELTAT_L, &buff[0],
+                               2);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  *val = buff[1];
+  *val = (*val * 256U) + buff[0];
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Sensor Fusion Low Power (SFLP)
+  * @brief     This section groups all the functions that manage pedometer.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable SFLP Game Rotation Vector (6x).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enable/Disable game rotation value (0/1).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sflp_game_rotation_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  emb_func_en_a.sflp_game_en = val;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_EN_A,
+                               (uint8_t *)&emb_func_en_a, 1);
+
+exit:
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Enable SFLP Game Rotation Vector (6x).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enable/Disable game rotation value (0/1).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sflp_game_rotation_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  *val = emb_func_en_a.sflp_game_en;
+
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  SFLP Data Rate (ODR) configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SFLP_15Hz, SFLP_30Hz, SFLP_60Hz, SFLP_120Hz, SFLP_240Hz, SFLP_480Hz
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sflp_data_rate_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_sflp_data_rate_t val)
+{
+  lsm6dsv320x_sflp_odr_t sflp_odr;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_SFLP_ODR, (uint8_t *)&sflp_odr, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  sflp_odr.sflp_game_odr = (uint8_t)val & 0x07U;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_SFLP_ODR, (uint8_t *)&sflp_odr, 1);
+
+exit:
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  SFLP Data Rate (ODR) configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SFLP_15Hz, SFLP_30Hz, SFLP_60Hz, SFLP_120Hz, SFLP_240Hz, SFLP_480Hz
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_sflp_data_rate_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_sflp_data_rate_t *val)
+{
+  lsm6dsv320x_sflp_odr_t sflp_odr;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_SFLP_ODR, (uint8_t *)&sflp_odr, 1);
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (sflp_odr.sflp_game_odr)
+  {
+    case LSM6DSV320X_SFLP_15Hz:
+      *val = LSM6DSV320X_SFLP_15Hz;
+      break;
+
+    case LSM6DSV320X_SFLP_30Hz:
+      *val = LSM6DSV320X_SFLP_30Hz;
+      break;
+
+    case LSM6DSV320X_SFLP_60Hz:
+      *val = LSM6DSV320X_SFLP_60Hz;
+      break;
+
+    case LSM6DSV320X_SFLP_120Hz:
+      *val = LSM6DSV320X_SFLP_120Hz;
+      break;
+
+    case LSM6DSV320X_SFLP_240Hz:
+      *val = LSM6DSV320X_SFLP_240Hz;
+      break;
+
+    case LSM6DSV320X_SFLP_480Hz:
+      *val = LSM6DSV320X_SFLP_480Hz;
+      break;
+
+    default:
+      *val = LSM6DSV320X_SFLP_15Hz;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Tap - Double Tap
+  * @brief     This section groups all the functions that manage the
+  *            tap and double tap event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable axis for Tap - Double Tap detection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enable axis for Tap - Double Tap detection.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_tap_detection_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_tap_detection_t val)
+{
+  lsm6dsv320x_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  if (ret == 0)
+  {
+    tap_cfg0.tap_x_en = val.tap_x_en;
+    tap_cfg0.tap_y_en = val.tap_y_en;
+    tap_cfg0.tap_z_en = val.tap_z_en;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable axis for Tap - Double Tap detection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enable axis for Tap - Double Tap detection.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_tap_detection_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_tap_detection_t *val)
+{
+  lsm6dsv320x_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->tap_x_en = tap_cfg0.tap_x_en;
+  val->tap_y_en = tap_cfg0.tap_y_en;
+  val->tap_z_en = tap_cfg0.tap_z_en;
+
+  return ret;
+}
+
+/**
+  * @brief  axis Tap - Double Tap recognition thresholds.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      axis Tap - Double Tap recognition thresholds.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_tap_thresholds_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_tap_thresholds_t val)
+{
+  lsm6dsv320x_tap_ths_6d_t tap_ths_6d;
+  lsm6dsv320x_tap_cfg2_t tap_cfg2;
+  lsm6dsv320x_tap_cfg1_t tap_cfg1;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  tap_cfg1.tap_ths_x = val.x;
+  tap_cfg2.tap_ths_y = val.y;
+  tap_ths_6d.tap_ths_z = val.z;
+
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  axis Tap - Double Tap recognition thresholds.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      axis Tap - Double Tap recognition thresholds.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_tap_thresholds_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_tap_thresholds_t *val)
+{
+  lsm6dsv320x_tap_ths_6d_t tap_ths_6d;
+  lsm6dsv320x_tap_cfg2_t tap_cfg2;
+  lsm6dsv320x_tap_cfg1_t tap_cfg1;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->x  = tap_cfg1.tap_ths_x;
+  val->y = tap_cfg2.tap_ths_y;
+  val->z = tap_ths_6d.tap_ths_z;
+
+  return ret;
+}
+
+/**
+  * @brief  Selection of axis priority for TAP detection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      XYZ , YXZ , XZY, ZYX , YZX , ZXY ,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_tap_axis_priority_set(const stmdev_ctx_t *ctx,
+                                          lsm6dsv320x_tap_axis_priority_t val)
+{
+  lsm6dsv320x_tap_cfg1_t tap_cfg1;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+  if (ret == 0)
+  {
+    tap_cfg1.tap_priority = (uint8_t)val & 0x7U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selection of axis priority for TAP detection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      XYZ , YXZ , XZY, ZYX , YZX , ZXY ,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_tap_axis_priority_get(const stmdev_ctx_t *ctx,
+                                          lsm6dsv320x_tap_axis_priority_t *val)
+{
+  lsm6dsv320x_tap_cfg1_t tap_cfg1;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (tap_cfg1.tap_priority)
+  {
+    case LSM6DSV320X_XYZ :
+      *val = LSM6DSV320X_XYZ ;
+      break;
+
+    case LSM6DSV320X_YXZ :
+      *val = LSM6DSV320X_YXZ ;
+      break;
+
+    case LSM6DSV320X_XZY:
+      *val = LSM6DSV320X_XZY;
+      break;
+
+    case LSM6DSV320X_ZYX :
+      *val = LSM6DSV320X_ZYX ;
+      break;
+
+    case LSM6DSV320X_YZX :
+      *val = LSM6DSV320X_YZX ;
+      break;
+
+    case LSM6DSV320X_ZXY :
+      *val = LSM6DSV320X_ZXY ;
+      break;
+
+    default:
+      *val = LSM6DSV320X_XYZ ;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Time windows configuration for Tap - Double Tap SHOCK, QUIET, DUR : SHOCK Maximum duration is the maximum time of an overthreshold signal detection to be recognized as a tap event. The default value of these bits is 00b which corresponds to 4/ODR_XL time. If the SHOCK bits are set to a different value, 1LSB corresponds to 8/ODR_XL time. QUIET Expected quiet time after a tap detection. Quiet time is the time after the first detected tap in which there must not be any overthreshold event. The default value of these bits is 00b which corresponds to 2/ODR_XL time. If the QUIET bits are set to a different value, 1LSB corresponds to 4/ODR_XL time. DUR Duration of maximum time gap for double tap recognition. When double tap recognition is enabled, this register expresses the maximum time between two consecutive detected taps to determine a double tap event. The default value of these bits is 0000b which corresponds to 16/ODR_XL time. If the DUR_[3:0] bits are set to a different value, 1LSB corresponds to 32/ODR_XL time.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Time windows configuration for Tap - Double Tap SHOCK, QUIET, DUR : SHOCK Maximum duration is the maximum time of an overthreshold signal detection to be recognized as a tap event. The default value of these bits is 00b which corresponds to 4/ODR_XL time. If the SHOCK bits are set to a different value, 1LSB corresponds to 8/ODR_XL time. QUIET Expected quiet time after a tap detection. Quiet time is the time after the first detected tap in which there must not be any overthreshold event. The default value of these bits is 00b which corresponds to 2/ODR_XL time. If the QUIET bits are set to a different value, 1LSB corresponds to 4/ODR_XL time. DUR Duration of maximum time gap for double tap recognition. When double tap recognition is enabled, this register expresses the maximum time between two consecutive detected taps to determine a double tap event. The default value of these bits is 0000b which corresponds to 16/ODR_XL time. If the DUR_[3:0] bits are set to a different value, 1LSB corresponds to 32/ODR_XL time.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_tap_time_windows_set(const stmdev_ctx_t *ctx,
+                                         lsm6dsv320x_tap_time_windows_t val)
+{
+  lsm6dsv320x_tap_dur_t tap_dur;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TAP_DUR, (uint8_t *)&tap_dur, 1);
+  if (ret == 0)
+  {
+    tap_dur.shock = val.shock;
+    tap_dur.quiet = val.quiet;
+    tap_dur.dur = val.tap_gap;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TAP_DUR, (uint8_t *)&tap_dur, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Time windows configuration for Tap - Double Tap SHOCK, QUIET, DUR : SHOCK Maximum duration is the maximum time of an overthreshold signal detection to be recognized as a tap event. The default value of these bits is 00b which corresponds to 4/ODR_XL time. If the SHOCK bits are set to a different value, 1LSB corresponds to 8/ODR_XL time. QUIET Expected quiet time after a tap detection. Quiet time is the time after the first detected tap in which there must not be any overthreshold event. The default value of these bits is 00b which corresponds to 2/ODR_XL time. If the QUIET bits are set to a different value, 1LSB corresponds to 4/ODR_XL time. DUR Duration of maximum time gap for double tap recognition. When double tap recognition is enabled, this register expresses the maximum time between two consecutive detected taps to determine a double tap event. The default value of these bits is 0000b which corresponds to 16/ODR_XL time. If the DUR_[3:0] bits are set to a different value, 1LSB corresponds to 32/ODR_XL time.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Time windows configuration for Tap - Double Tap SHOCK, QUIET, DUR : SHOCK Maximum duration is the maximum time of an overthreshold signal detection to be recognized as a tap event. The default value of these bits is 00b which corresponds to 4/ODR_XL time. If the SHOCK bits are set to a different value, 1LSB corresponds to 8/ODR_XL time. QUIET Expected quiet time after a tap detection. Quiet time is the time after the first detected tap in which there must not be any overthreshold event. The default value of these bits is 00b which corresponds to 2/ODR_XL time. If the QUIET bits are set to a different value, 1LSB corresponds to 4/ODR_XL time. DUR Duration of maximum time gap for double tap recognition. When double tap recognition is enabled, this register expresses the maximum time between two consecutive detected taps to determine a double tap event. The default value of these bits is 0000b which corresponds to 16/ODR_XL time. If the DUR_[3:0] bits are set to a different value, 1LSB corresponds to 32/ODR_XL time.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_tap_time_windows_get(const stmdev_ctx_t *ctx,
+                                         lsm6dsv320x_tap_time_windows_t *val)
+{
+  lsm6dsv320x_tap_dur_t tap_dur;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TAP_DUR, (uint8_t *)&tap_dur, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->shock = tap_dur.shock;
+  val->quiet = tap_dur.quiet;
+  val->tap_gap = tap_dur.dur;
+
+  return ret;
+}
+
+/**
+  * @brief  Single/double-tap event enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      ONLY_SINGLE, BOTH_SINGLE_DOUBLE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_tap_mode_set(const stmdev_ctx_t *ctx, lsm6dsv320x_tap_mode_t val)
+{
+  lsm6dsv320x_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
+  if (ret == 0)
+  {
+    wake_up_ths.single_double_tap = (uint8_t)val & 0x01U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Single/double-tap event enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      ONLY_SINGLE, BOTH_SINGLE_DOUBLE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_tap_mode_get(const stmdev_ctx_t *ctx, lsm6dsv320x_tap_mode_t *val)
+{
+  lsm6dsv320x_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (wake_up_ths.single_double_tap)
+  {
+    case LSM6DSV320X_ONLY_SINGLE:
+      *val = LSM6DSV320X_ONLY_SINGLE;
+      break;
+
+    case LSM6DSV320X_BOTH_SINGLE_DOUBLE:
+      *val = LSM6DSV320X_BOTH_SINGLE_DOUBLE;
+      break;
+
+    default:
+      *val = LSM6DSV320X_ONLY_SINGLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Tilt detection
+  * @brief     This section groups all the functions that manage the tilt
+  *            event detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Tilt calculation.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Tilt calculation.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_tilt_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  emb_func_en_a.tilt_en = val;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Tilt calculation.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Tilt calculation.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_tilt_mode_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  *val = emb_func_en_a.tilt_en;
+
+  ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Timestamp
+  * @brief     This section groups all the functions that manage the
+  *            timestamp generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Timestamp data output.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Timestamp data output.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_timestamp_raw_get(const stmdev_ctx_t *ctx, uint32_t *val)
+{
+  uint8_t buff[4];
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TIMESTAMP0, &buff[0], 4);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  *val = buff[3];
+  *val = (*val * 256U) + buff[2];
+  *val = (*val * 256U) + buff[1];
+  *val = (*val * 256U) + buff[0];
+
+  return ret;
+}
+
+/**
+  * @brief  Enables timestamp counter.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables timestamp counter.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_timestamp_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv320x_functions_enable_t functions_enable;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
+  if (ret == 0)
+  {
+    functions_enable.timestamp_en = val;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables timestamp counter.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables timestamp counter.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_timestamp_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv320x_functions_enable_t functions_enable;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
+  *val = functions_enable.timestamp_en;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Wake Up - Activity - Inactivity (Sleep)
+  * @brief     This section groups all the functions that manage the Wake Up
+  *            event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable activity/inactivity (sleep) function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      XL_AND_GY_NOT_AFFECTED, XL_LOW_POWER_GY_NOT_AFFECTED, XL_LOW_POWER_GY_SLEEP, XL_LOW_POWER_GY_POWER_DOWN,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_act_mode_set(const stmdev_ctx_t *ctx, lsm6dsv320x_act_mode_t val)
+{
+  lsm6dsv320x_functions_enable_t functions_enable;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
+  if (ret == 0)
+  {
+    functions_enable.inact_en = (uint8_t)val & 0x3U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable activity/inactivity (sleep) function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      XL_AND_GY_NOT_AFFECTED, XL_LOW_POWER_GY_NOT_AFFECTED, XL_LOW_POWER_GY_SLEEP, XL_LOW_POWER_GY_POWER_DOWN,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_act_mode_get(const stmdev_ctx_t *ctx, lsm6dsv320x_act_mode_t *val)
+{
+  lsm6dsv320x_functions_enable_t functions_enable;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (functions_enable.inact_en)
+  {
+    case LSM6DSV320X_XL_AND_GY_NOT_AFFECTED:
+      *val = LSM6DSV320X_XL_AND_GY_NOT_AFFECTED;
+      break;
+
+    case LSM6DSV320X_XL_LOW_POWER_GY_NOT_AFFECTED:
+      *val = LSM6DSV320X_XL_LOW_POWER_GY_NOT_AFFECTED;
+      break;
+
+    case LSM6DSV320X_XL_LOW_POWER_GY_SLEEP:
+      *val = LSM6DSV320X_XL_LOW_POWER_GY_SLEEP;
+      break;
+
+    case LSM6DSV320X_XL_LOW_POWER_GY_POWER_DOWN:
+      *val = LSM6DSV320X_XL_LOW_POWER_GY_POWER_DOWN;
+      break;
+
+    default:
+      *val = LSM6DSV320X_XL_AND_GY_NOT_AFFECTED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Duration in the transition from Stationary to Motion (from Inactivity to Activity).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SLEEP_TO_ACT_AT_1ST_SAMPLE, SLEEP_TO_ACT_AT_2ND_SAMPLE, SLEEP_TO_ACT_AT_3RD_SAMPLE, SLEEP_TO_ACT_AT_4th_SAMPLE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_act_from_sleep_to_act_dur_set(const stmdev_ctx_t *ctx,
+                                                  lsm6dsv320x_act_from_sleep_to_act_dur_t val)
+{
+  lsm6dsv320x_inactivity_dur_t inactivity_dur;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
+  if (ret == 0)
+  {
+    inactivity_dur.inact_dur = (uint8_t)val & 0x3U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Duration in the transition from Stationary to Motion (from Inactivity to Activity).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SLEEP_TO_ACT_AT_1ST_SAMPLE, SLEEP_TO_ACT_AT_2ND_SAMPLE, SLEEP_TO_ACT_AT_3RD_SAMPLE, SLEEP_TO_ACT_AT_4th_SAMPLE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_act_from_sleep_to_act_dur_get(const stmdev_ctx_t *ctx,
+                                                  lsm6dsv320x_act_from_sleep_to_act_dur_t *val)
+{
+  lsm6dsv320x_inactivity_dur_t inactivity_dur;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (inactivity_dur.inact_dur)
+  {
+    case LSM6DSV320X_SLEEP_TO_ACT_AT_1ST_SAMPLE:
+      *val = LSM6DSV320X_SLEEP_TO_ACT_AT_1ST_SAMPLE;
+      break;
+
+    case LSM6DSV320X_SLEEP_TO_ACT_AT_2ND_SAMPLE:
+      *val = LSM6DSV320X_SLEEP_TO_ACT_AT_2ND_SAMPLE;
+      break;
+
+    case LSM6DSV320X_SLEEP_TO_ACT_AT_3RD_SAMPLE:
+      *val = LSM6DSV320X_SLEEP_TO_ACT_AT_3RD_SAMPLE;
+      break;
+
+    case LSM6DSV320X_SLEEP_TO_ACT_AT_4th_SAMPLE:
+      *val = LSM6DSV320X_SLEEP_TO_ACT_AT_4th_SAMPLE;
+      break;
+
+    default:
+      *val = LSM6DSV320X_SLEEP_TO_ACT_AT_1ST_SAMPLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects the accelerometer data rate during Inactivity.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      1Hz875, 15Hz, 30Hz, 60Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_act_sleep_xl_odr_set(const stmdev_ctx_t *ctx,
+                                         lsm6dsv320x_act_sleep_xl_odr_t val)
+{
+  lsm6dsv320x_inactivity_dur_t inactivity_dur;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
+  if (ret == 0)
+  {
+    inactivity_dur.xl_inact_odr = (uint8_t)val & 0x03U;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects the accelerometer data rate during Inactivity.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      1Hz875, 15Hz, 30Hz, 60Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_act_sleep_xl_odr_get(const stmdev_ctx_t *ctx,
+                                         lsm6dsv320x_act_sleep_xl_odr_t *val)
+{
+  lsm6dsv320x_inactivity_dur_t inactivity_dur;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (inactivity_dur.xl_inact_odr)
+  {
+    case LSM6DSV320X_1Hz875:
+      *val = LSM6DSV320X_1Hz875;
+      break;
+
+    case LSM6DSV320X_15Hz:
+      *val = LSM6DSV320X_15Hz;
+      break;
+
+    case LSM6DSV320X_30Hz:
+      *val = LSM6DSV320X_30Hz;
+      break;
+
+    case LSM6DSV320X_60Hz:
+      *val = LSM6DSV320X_60Hz;
+      break;
+
+    default:
+      *val = LSM6DSV320X_1Hz875;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Wakeup and activity/inactivity threshold.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Wakeup and activity/inactivity threshold.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_act_thresholds_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_act_thresholds_t *val)
+{
+  lsm6dsv320x_inactivity_ths_t inactivity_ths;
+  lsm6dsv320x_inactivity_dur_t inactivity_dur;
+  lsm6dsv320x_wake_up_ths_t wake_up_ths;
+  lsm6dsv320x_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_INACTIVITY_THS, (uint8_t *)&inactivity_ths, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  inactivity_dur.wu_inact_ths_w = val->inactivity_cfg.wu_inact_ths_w;
+  inactivity_dur.xl_inact_odr = val->inactivity_cfg.xl_inact_odr;
+  inactivity_dur.inact_dur = val->inactivity_cfg.inact_dur;
+
+  inactivity_ths.inact_ths = val->inactivity_ths;
+  wake_up_ths.wk_ths = val->threshold;
+  wake_up_dur.wake_dur = val->duration;
+
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_INACTIVITY_THS, (uint8_t *)&inactivity_ths, 1);
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Wakeup and activity/inactivity threshold.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Wakeup and activity/inactivity threshold.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_act_thresholds_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_act_thresholds_t *val)
+{
+  lsm6dsv320x_inactivity_dur_t inactivity_dur;
+  lsm6dsv320x_inactivity_ths_t inactivity_ths;
+  lsm6dsv320x_wake_up_ths_t wake_up_ths;
+  lsm6dsv320x_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_INACTIVITY_THS, (uint8_t *)&inactivity_ths, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
+  ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->inactivity_cfg.wu_inact_ths_w = inactivity_dur.wu_inact_ths_w;
+  val->inactivity_cfg.xl_inact_odr = inactivity_dur.xl_inact_odr;
+  val->inactivity_cfg.inact_dur = inactivity_dur.inact_dur;
+
+  val->inactivity_ths = inactivity_ths.inact_ths;
+  val->threshold = wake_up_ths.wk_ths;
+  val->duration = wake_up_dur.wake_dur;
+
+  return ret;
+}
+
+/**
+  * @brief  Time windows configuration for Wake Up - Activity - Inactivity (SLEEP, WAKE). Duration to go in sleep mode. Default value: 0000 (this corresponds to 16 ODR) 1 LSB = 512/ODR_XL time. Wake up duration event. 1 LSB = 1/ODR_XL time. [set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Time windows configuration for Wake Up - Activity - Inactivity (SLEEP, WAKE). Duration to go in sleep mode. Default value: 0000 (this corresponds to 16 ODR) 1 LSB = 512/ODR_XL time. Wake up duration event. 1 LSB = 1/ODR_XL time.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_act_wkup_time_windows_set(const stmdev_ctx_t *ctx,
+                                              lsm6dsv320x_act_wkup_time_windows_t val)
+{
+  lsm6dsv320x_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+  if (ret == 0)
+  {
+    wake_up_dur.wake_dur = val.shock;
+    wake_up_dur.sleep_dur = val.quiet;
+    ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Time windows configuration for Wake Up - Activity - Inactivity (SLEEP, WAKE). Duration to go in sleep mode. Default value: 0000 (this corresponds to 16 ODR) 1 LSB = 512/ODR_XL time. Wake up duration event. 1 LSB = 1/ODR_XL time. [get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Time windows configuration for Wake Up - Activity - Inactivity (SLEEP, WAKE). Duration to go in sleep mode. Default value: 0000 (this corresponds to 16 ODR) 1 LSB = 512/ODR_XL time. Wake up duration event. 1 LSB = 1/ODR_XL time.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv320x_act_wkup_time_windows_get(const stmdev_ctx_t *ctx,
+                                              lsm6dsv320x_act_wkup_time_windows_t *val)
+{
+  lsm6dsv320x_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->shock = wake_up_dur.wake_dur;
+  val->quiet = wake_up_dur.sleep_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */

--- a/sensor/stmemsc/lsm6dsv320x_STdC/driver/lsm6dsv320x_reg.h
+++ b/sensor/stmemsc/lsm6dsv320x_STdC/driver/lsm6dsv320x_reg.h
@@ -1,0 +1,5813 @@
+/**
+  ******************************************************************************
+  * @file    lsm6dsv320x_reg.h
+  * @author  Sensors Software Solution Team
+  * @brief   This file contains all the functions prototypes for the
+  *          lsm6dsv320x_reg.c driver.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2025 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef LSM6DSV320X_REGS_H
+#define LSM6DSV320X_REGS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <stddef.h>
+#include <math.h>
+
+/** @addtogroup LSM6DSV320X
+  * @{
+  *
+  */
+
+/** @defgroup  Endianness definitions
+  * @{
+  *
+  */
+
+#ifndef DRV_BYTE_ORDER
+#ifndef __BYTE_ORDER__
+
+#define DRV_LITTLE_ENDIAN 1234
+#define DRV_BIG_ENDIAN    4321
+
+/** if _BYTE_ORDER is not defined, choose the endianness of your architecture
+  * by uncommenting the define which fits your platform endianness
+  */
+//#define DRV_BYTE_ORDER    DRV_BIG_ENDIAN
+#define DRV_BYTE_ORDER    DRV_LITTLE_ENDIAN
+
+#else /* defined __BYTE_ORDER__ */
+
+#define DRV_LITTLE_ENDIAN  __ORDER_LITTLE_ENDIAN__
+#define DRV_BIG_ENDIAN     __ORDER_BIG_ENDIAN__
+#define DRV_BYTE_ORDER     __BYTE_ORDER__
+
+#endif /* __BYTE_ORDER__*/
+#endif /* DRV_BYTE_ORDER */
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup STMicroelectronics sensors common types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t bit0                         : 1;
+  uint8_t bit1                         : 1;
+  uint8_t bit2                         : 1;
+  uint8_t bit3                         : 1;
+  uint8_t bit4                         : 1;
+  uint8_t bit5                         : 1;
+  uint8_t bit6                         : 1;
+  uint8_t bit7                         : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t bit7                         : 1;
+  uint8_t bit6                         : 1;
+  uint8_t bit5                         : 1;
+  uint8_t bit4                         : 1;
+  uint8_t bit3                         : 1;
+  uint8_t bit2                         : 1;
+  uint8_t bit1                         : 1;
+  uint8_t bit0                         : 1;
+#endif /* DRV_BYTE_ORDER */
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+/** @addtogroup  Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, const uint8_t *, uint16_t);
+typedef int32_t (*stmdev_read_ptr)(void *, uint8_t, uint8_t *, uint16_t);
+typedef void (*stmdev_mdelay_ptr)(uint32_t millisec);
+
+typedef struct
+{
+  /** Component mandatory fields **/
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
+  /** Component optional fields **/
+  stmdev_mdelay_ptr   mdelay;
+  /** Customizable optional pointer **/
+  void *handle;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+  *              You can create a sensor configuration by your own or using
+  *              Unico / Unicleo tools available on STMicroelectronics
+  *              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct
+{
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup LSM6DSV320X_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> D5 if SA0=1 -> D7 **/
+#define LSM6DSV320X_I2C_ADD_L                      0xD5U
+#define LSM6DSV320X_I2C_ADD_H                      0xD7U
+
+/** Device Identification (Who am I) **/
+#define LSM6DSV320X_ID                             0x73U
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup bitfields page main
+  * @{
+  *
+  */
+
+#define LSM6DSV320X_FUNC_CFG_ACCESS                0x1U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ois_ctrl_from_ui             : 1;
+  uint8_t if2_reset                    : 1;
+  uint8_t sw_por                       : 1;
+  uint8_t fsm_wr_ctrl_en               : 1;
+  uint8_t not_used0                    : 2;
+  uint8_t shub_reg_access              : 1;
+  uint8_t emb_func_reg_access          : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t emb_func_reg_access          : 1;
+  uint8_t shub_reg_access              : 1;
+  uint8_t not_used0                    : 2;
+  uint8_t fsm_wr_ctrl_en               : 1;
+  uint8_t sw_por                       : 1;
+  uint8_t if2_reset                    : 1;
+  uint8_t ois_ctrl_from_ui             : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_func_cfg_access_t;
+
+#define LSM6DSV320X_PIN_CTRL                       0x2U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t io_pad_strength              : 2;
+  uint8_t not_used0                    : 3;
+  uint8_t ibhr_por_en                  : 1;
+  uint8_t sdo_pu_en                    : 1;
+  uint8_t ois_pu_dis                   : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ois_pu_dis                   : 1;
+  uint8_t sdo_pu_en                    : 1;
+  uint8_t ibhr_por_en                  : 1;
+  uint8_t not_used0                    : 3;
+  uint8_t io_pad_strength              : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_pin_ctrl_t;
+
+#define LSM6DSV320X_IF_CFG                         0x3U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t i2c_i3c_disable              : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t sim                          : 1;
+  uint8_t pp_od                        : 1;
+  uint8_t h_lactive                    : 1;
+  uint8_t asf_ctrl                     : 1;
+  uint8_t shub_pu_en                   : 1;
+  uint8_t sda_pu_en                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sda_pu_en                    : 1;
+  uint8_t shub_pu_en                   : 1;
+  uint8_t asf_ctrl                     : 1;
+  uint8_t h_lactive                    : 1;
+  uint8_t pp_od                        : 1;
+  uint8_t sim                          : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t i2c_i3c_disable              : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_if_cfg_t;
+
+#define LSM6DSV320X_ODR_TRIG_CFG                   0x6U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t odr_trig_nodr                : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t odr_trig_nodr                : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_odr_trig_cfg_t;
+
+#define LSM6DSV320X_FIFO_CTRL1                     0x7U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t wtm                          : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t wtm                          : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fifo_ctrl1_t;
+
+#define LSM6DSV320X_FIFO_CTRL2                     0x8U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used2                    : 1;
+  uint8_t uncompr_rate                 : 2;
+  uint8_t not_used0                    : 1;
+  uint8_t odr_chg_en                   : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t fifo_compr_rt_en             : 1;
+  uint8_t stop_on_wtm                  : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t stop_on_wtm                  : 1;
+  uint8_t fifo_compr_rt_en             : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t odr_chg_en                   : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t uncompr_rate                 : 2;
+  uint8_t not_used2                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fifo_ctrl2_t;
+
+#define LSM6DSV320X_FIFO_CTRL3                     0x9U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t bdr_xl                       : 4;
+  uint8_t bdr_gy                       : 4;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t bdr_gy                       : 4;
+  uint8_t bdr_xl                       : 4;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fifo_ctrl3_t;
+
+#define LSM6DSV320X_FIFO_CTRL4                     0x0AU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fifo_mode                    : 3;
+  uint8_t g_eis_fifo_en                : 1;
+  uint8_t odr_t_batch                  : 2;
+  uint8_t dec_ts_batch                 : 2;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t dec_ts_batch                 : 2;
+  uint8_t odr_t_batch                  : 2;
+  uint8_t g_eis_fifo_en                : 1;
+  uint8_t fifo_mode                    : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fifo_ctrl4_t;
+
+#define LSM6DSV320X_COUNTER_BDR_REG1               0x0BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t cnt_bdr_th                   : 2;
+  uint8_t not_used0                    : 1;
+  uint8_t xl_hg_batch_en               : 1;
+  uint8_t not_used2                    : 1;
+  uint8_t trig_counter_bdr             : 2;
+  uint8_t not_used1                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 1;
+  uint8_t trig_counter_bdr             : 2;
+  uint8_t not_used2                    : 1;
+  uint8_t xl_hg_batch_en               : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t cnt_bdr_th                   : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_counter_bdr_reg1_t;
+
+#define LSM6DSV320X_COUNTER_BDR_REG2               0x0CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t cnt_bdr_th                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t cnt_bdr_th                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_counter_bdr_reg2_t;
+
+#define LSM6DSV320X_INT1_CTRL                      0x0DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t int1_drdy_xl                 : 1;
+  uint8_t int1_drdy_g                  : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t int1_fifo_th                 : 1;
+  uint8_t int1_fifo_ovr                : 1;
+  uint8_t int1_fifo_full               : 1;
+  uint8_t int1_cnt_bdr                 : 1;
+  uint8_t not_used1                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 1;
+  uint8_t int1_cnt_bdr                 : 1;
+  uint8_t int1_fifo_full               : 1;
+  uint8_t int1_fifo_ovr                : 1;
+  uint8_t int1_fifo_th                 : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t int1_drdy_g                  : 1;
+  uint8_t int1_drdy_xl                 : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_int1_ctrl_t;
+
+#define LSM6DSV320X_INT2_CTRL                      0x0EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t int2_drdy_xl                 : 1;
+  uint8_t int2_drdy_g                  : 1;
+  uint8_t int2_drdy_g_eis              : 1;
+  uint8_t int2_fifo_th                 : 1;
+  uint8_t int2_fifo_ovr                : 1;
+  uint8_t int2_fifo_full               : 1;
+  uint8_t int2_cnt_bdr                 : 1;
+  uint8_t int2_emb_func_endop          : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t int2_emb_func_endop          : 1;
+  uint8_t int2_cnt_bdr                 : 1;
+  uint8_t int2_fifo_full               : 1;
+  uint8_t int2_fifo_ovr                : 1;
+  uint8_t int2_fifo_th                 : 1;
+  uint8_t int2_drdy_g_eis              : 1;
+  uint8_t int2_drdy_g                  : 1;
+  uint8_t int2_drdy_xl                 : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_int2_ctrl_t;
+
+#define LSM6DSV320X_WHO_AM_I                       0x0FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t id                           : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t id                           : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_who_am_i_t;
+
+#define LSM6DSV320X_CTRL1                          0x10U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t odr_xl                       : 4;
+  uint8_t op_mode_xl                   : 3;
+  uint8_t not_used0                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 1;
+  uint8_t op_mode_xl                   : 3;
+  uint8_t odr_xl                       : 4;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ctrl1_t;
+
+#define LSM6DSV320X_CTRL2                          0x11U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t odr_g                        : 4;
+  uint8_t op_mode_g                    : 3;
+  uint8_t not_used0                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 1;
+  uint8_t op_mode_g                    : 3;
+  uint8_t odr_g                        : 4;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ctrl2_t;
+
+#define LSM6DSV320X_CTRL3                          0x12U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sw_reset                     : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t if_inc                       : 1;
+  uint8_t not_used1                    : 3;
+  uint8_t bdu                          : 1;
+  uint8_t boot                         : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t boot                         : 1;
+  uint8_t bdu                          : 1;
+  uint8_t not_used1                    : 3;
+  uint8_t if_inc                       : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t sw_reset                     : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ctrl3_t;
+
+#define LSM6DSV320X_CTRL4                          0x13U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t int2_in_lh                   : 1;
+  uint8_t drdy_pulsed                  : 1;
+  uint8_t int2_drdy_temp               : 1;
+  uint8_t drdy_mask                    : 1;
+  uint8_t int2_on_int1                 : 1;
+  uint8_t not_used0                    : 3;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 3;
+  uint8_t int2_on_int1                 : 1;
+  uint8_t drdy_mask                    : 1;
+  uint8_t int2_drdy_temp               : 1;
+  uint8_t drdy_pulsed                  : 1;
+  uint8_t int2_in_lh                   : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ctrl4_t;
+
+#define LSM6DSV320X_CTRL5                          0x14U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t int_en_i3c                   : 1;
+  uint8_t bus_act_sel                  : 2;
+  uint8_t not_used0                    : 4;
+  uint8_t if2_ta0_pid                  : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t if2_ta0_pid                  : 1;
+  uint8_t not_used0                    : 4;
+  uint8_t not_used0                    : 4;
+  uint8_t bus_act_sel                  : 2;
+  uint8_t int_en_i3c                   : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ctrl5_t;
+
+#define LSM6DSV320X_CTRL6                          0x15U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fs_g                         : 3;
+  uint8_t not_used1                    : 1;
+  uint8_t lpf1_g_bw                    : 3;
+  uint8_t not_used0                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 1;
+  uint8_t lpf1_g_bw                    : 3;
+  uint8_t not_used1                    : 1;
+  uint8_t fs_g                         : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ctrl6_t;
+
+#define LSM6DSV320X_CTRL7                          0x16U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t lpf1_g_en                    : 1;
+  uint8_t not_used0                    : 5;
+  uint8_t int2_drdy_xl_hg              : 1;
+  uint8_t int1_drdy_xl_hg              : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t int1_drdy_xl_hg              : 1;
+  uint8_t int2_drdy_xl_hg              : 1;
+  uint8_t not_used0                    : 5;
+  uint8_t lpf1_g_en                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ctrl7_t;
+
+#define LSM6DSV320X_CTRL8                          0x17U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fs_xl                        : 2;
+  uint8_t not_used0                    : 3;
+  uint8_t hp_lpf2_xl_bw                : 3;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t hp_lpf2_xl_bw                : 3;
+  uint8_t not_used0                    : 3;
+  uint8_t fs_xl                        : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ctrl8_t;
+
+#define LSM6DSV320X_CTRL9                          0x18U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t usr_off_on_out               : 1;
+  uint8_t usr_off_w                    : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t lpf2_xl_en                   : 1;
+  uint8_t hp_slope_xl_en               : 1;
+  uint8_t xl_fastsettl_mode            : 1;
+  uint8_t hp_ref_mode_xl               : 1;
+  uint8_t not_used1                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 1;
+  uint8_t hp_ref_mode_xl               : 1;
+  uint8_t xl_fastsettl_mode            : 1;
+  uint8_t hp_slope_xl_en               : 1;
+  uint8_t lpf2_xl_en                   : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t usr_off_w                    : 1;
+  uint8_t usr_off_on_out               : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ctrl9_t;
+
+#define LSM6DSV320X_CTRL10                         0x19U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t st_xl                        : 2;
+  uint8_t st_g                         : 2;
+  uint8_t not_used0                    : 2;
+  uint8_t emb_func_debug               : 1;
+  uint8_t not_used1                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 1;
+  uint8_t emb_func_debug               : 1;
+  uint8_t not_used0                    : 2;
+  uint8_t st_g                         : 2;
+  uint8_t st_xl                        : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ctrl10_t;
+
+#define LSM6DSV320X_CTRL_STATUS                    0x1AU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 2;
+  uint8_t fsm_wr_ctrl_status           : 1;
+  uint8_t not_used1                    : 5;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 5;
+  uint8_t fsm_wr_ctrl_status           : 1;
+  uint8_t not_used0                    : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ctrl_status_t;
+
+#define LSM6DSV320X_FIFO_STATUS1                   0x1BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t diff_fifo                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t diff_fifo                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fifo_status1_t;
+
+#define LSM6DSV320X_FIFO_STATUS2                   0x1CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t diff_fifo                    : 1;
+  uint8_t not_used0                    : 2;
+  uint8_t fifo_ovr_latched             : 1;
+  uint8_t counter_bdr_ia               : 1;
+  uint8_t fifo_full_ia                 : 1;
+  uint8_t fifo_ovr_ia                  : 1;
+  uint8_t fifo_wtm_ia                  : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fifo_wtm_ia                  : 1;
+  uint8_t fifo_ovr_ia                  : 1;
+  uint8_t fifo_full_ia                 : 1;
+  uint8_t counter_bdr_ia               : 1;
+  uint8_t fifo_ovr_latched             : 1;
+  uint8_t not_used0                    : 2;
+  uint8_t diff_fifo                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fifo_status2_t;
+
+#define LSM6DSV320X_ALL_INT_SRC                    0x1DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ff_ia                        : 1;
+  uint8_t wu_ia                        : 1;
+  uint8_t tap_ia                       : 1;
+  uint8_t hg_ia                        : 1;
+  uint8_t d6d_ia                       : 1;
+  uint8_t sleep_change_ia              : 1;
+  uint8_t shub_ia                      : 1;
+  uint8_t emb_func_ia                  : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t emb_func_ia                  : 1;
+  uint8_t shub_ia                      : 1;
+  uint8_t sleep_change_ia              : 1;
+  uint8_t d6d_ia                       : 1;
+  uint8_t hg_ia                        : 1;
+  uint8_t tap_ia                       : 1;
+  uint8_t wu_ia                        : 1;
+  uint8_t ff_ia                        : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_all_int_src_t;
+
+#define LSM6DSV320X_STATUS_REG                     0x1EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t xlda                         : 1;
+  uint8_t gda                          : 1;
+  uint8_t tda                          : 1;
+  uint8_t xlhgda                       : 1;
+  uint8_t gda_eis                      : 1;
+  uint8_t ois_drdy                     : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t timestamp_endcount           : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t timestamp_endcount           : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t ois_drdy                     : 1;
+  uint8_t gda_eis                      : 1;
+  uint8_t xlhgda                       : 1;
+  uint8_t tda                          : 1;
+  uint8_t gda                          : 1;
+  uint8_t xlda                         : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_status_reg_t;
+
+#define LSM6DSV320X_OUT_TEMP_L                     0x20U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t temp                         : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t temp                         : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_out_temp_l_t;
+
+#define LSM6DSV320X_OUT_TEMP_H                     0x21U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t temp                         : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t temp                         : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_out_temp_h_t;
+
+#define LSM6DSV320X_OUTX_L_G                       0x22U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t outx_g                       : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t outx_g                       : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_outx_l_g_t;
+
+#define LSM6DSV320X_OUTX_H_G                       0x23U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t outx_g                       : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t outx_g                       : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_outx_h_g_t;
+
+#define LSM6DSV320X_OUTY_L_G                       0x24U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t outy_g                       : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t outy_g                       : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_outy_l_g_t;
+
+#define LSM6DSV320X_OUTY_H_G                       0x25U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t outy_g                       : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t outy_g                       : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_outy_h_g_t;
+
+#define LSM6DSV320X_OUTZ_L_G                       0x26U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t outz_g                       : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t outz_g                       : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_outz_l_g_t;
+
+#define LSM6DSV320X_OUTZ_H_G                       0x27U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t outz_g                       : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t outz_g                       : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_outz_h_g_t;
+
+#define LSM6DSV320X_OUTX_L_A                       0x28U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t outx_a                       : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t outx_a                       : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_outx_l_a_t;
+
+#define LSM6DSV320X_OUTX_H_A                       0x29U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t outx_a                       : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t outx_a                       : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_outx_h_a_t;
+
+#define LSM6DSV320X_OUTY_L_A                       0x2AU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t outy_a                       : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t outy_a                       : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_outy_l_a_t;
+
+#define LSM6DSV320X_OUTY_H_A                       0x2BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t outy_a                       : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t outy_a                       : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_outy_h_a_t;
+
+#define LSM6DSV320X_OUTZ_L_A                       0x2CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t outz_a                       : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t outz_a                       : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_outz_l_a_t;
+
+#define LSM6DSV320X_OUTZ_H_A                       0x2DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t outz_a                       : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t outz_a                       : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_outz_h_a_t;
+
+#define LSM6DSV320X_UI_OUTX_L_G_OIS_EIS            0x2EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ui_outx_g_ois_eis            : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ui_outx_g_ois_eis            : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ui_outx_l_g_ois_eis_t;
+
+#define LSM6DSV320X_UI_OUTX_H_G_OIS_EIS            0x2FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ui_outx_g_ois_eis            : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ui_outx_g_ois_eis            : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ui_outx_h_g_ois_eis_t;
+
+#define LSM6DSV320X_UI_OUTY_L_G_OIS_EIS            0x30U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ui_outy_g_ois_eis            : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ui_outy_g_ois_eis            : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ui_outy_l_g_ois_eis_t;
+
+#define LSM6DSV320X_UI_OUTY_H_G_OIS_EIS            0x31U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ui_outy_g_ois_eis            : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ui_outy_g_ois_eis            : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ui_outy_h_g_ois_eis_t;
+
+#define LSM6DSV320X_UI_OUTZ_L_G_OIS_EIS            0x32U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ui_outz_g_ois_eis            : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ui_outz_g_ois_eis            : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ui_outz_l_g_ois_eis_t;
+
+#define LSM6DSV320X_UI_OUTZ_H_G_OIS_EIS            0x33U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ui_outz_g_ois_eis            : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ui_outz_g_ois_eis            : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ui_outz_h_g_ois_eis_t;
+
+#define LSM6DSV320X_UI_OUTX_L_A_OIS_HG             0x34U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ui_outx_a_ois_hg             : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ui_outx_a_ois_hg             : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ui_outx_l_a_ois_hg_t;
+
+#define LSM6DSV320X_UI_OUTX_H_A_OIS_HG             0x35U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ui_outx_a_ois_hg             : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ui_outx_a_ois_hg             : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ui_outx_h_a_ois_hg_t;
+
+#define LSM6DSV320X_UI_OUTY_L_A_OIS_HG             0x36U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ui_outy_a_ois_hg             : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ui_outy_a_ois_hg             : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ui_outy_l_a_ois_hg_t;
+
+#define LSM6DSV320X_UI_OUTY_H_A_OIS_HG             0x37U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ui_outy_a_ois_hg             : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ui_outy_a_ois_hg             : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ui_outy_h_a_ois_hg_t;
+
+#define LSM6DSV320X_UI_OUTZ_L_A_OIS_HG             0x38U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ui_outz_a_ois_hg             : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ui_outz_a_ois_hg             : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ui_outz_l_a_ois_hg_t;
+
+#define LSM6DSV320X_UI_OUTZ_H_A_OIS_HG             0x39U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ui_outz_a_ois_hg             : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ui_outz_a_ois_hg             : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ui_outz_h_a_ois_hg_t;
+
+#define LSM6DSV320X_TIMESTAMP0                     0x40U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t timestamp                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t timestamp                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_timestamp0_t;
+
+#define LSM6DSV320X_TIMESTAMP1                     0x41U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t timestamp                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t timestamp                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_timestamp1_t;
+
+#define LSM6DSV320X_TIMESTAMP2                     0x42U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t timestamp                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t timestamp                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_timestamp2_t;
+
+#define LSM6DSV320X_TIMESTAMP3                     0x43U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t timestamp                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t timestamp                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_timestamp3_t;
+
+#define LSM6DSV320X_UI_STATUS_REG_OIS              0x44U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t xlda_ois                     : 1;
+  uint8_t gda_ois                      : 1;
+  uint8_t gyro_settling                : 1;
+  uint8_t not_used0                    : 5;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 5;
+  uint8_t gyro_settling                : 1;
+  uint8_t gda_ois                      : 1;
+  uint8_t xlda_ois                     : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ui_status_reg_ois_t;
+
+#define LSM6DSV320X_WAKE_UP_SRC                    0x45U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t z_wu                         : 1;
+  uint8_t y_wu                         : 1;
+  uint8_t x_wu                         : 1;
+  uint8_t wu_ia                        : 1;
+  uint8_t sleep_state                  : 1;
+  uint8_t ff_ia                        : 1;
+  uint8_t sleep_change_ia              : 1;
+  uint8_t not_used0                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 1;
+  uint8_t sleep_change_ia              : 1;
+  uint8_t ff_ia                        : 1;
+  uint8_t sleep_state                  : 1;
+  uint8_t wu_ia                        : 1;
+  uint8_t x_wu                         : 1;
+  uint8_t y_wu                         : 1;
+  uint8_t z_wu                         : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_wake_up_src_t;
+
+#define LSM6DSV320X_TAP_SRC                        0x46U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t z_tap                        : 1;
+  uint8_t y_tap                        : 1;
+  uint8_t x_tap                        : 1;
+  uint8_t tap_sign                     : 1;
+  uint8_t double_tap                   : 1;
+  uint8_t single_tap                   : 1;
+  uint8_t tap_ia                       : 1;
+  uint8_t not_used0                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 1;
+  uint8_t tap_ia                       : 1;
+  uint8_t single_tap                   : 1;
+  uint8_t double_tap                   : 1;
+  uint8_t tap_sign                     : 1;
+  uint8_t x_tap                        : 1;
+  uint8_t y_tap                        : 1;
+  uint8_t z_tap                        : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_tap_src_t;
+
+#define LSM6DSV320X_D6D_SRC                        0x47U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t xl                           : 1;
+  uint8_t xh                           : 1;
+  uint8_t yl                           : 1;
+  uint8_t yh                           : 1;
+  uint8_t zl                           : 1;
+  uint8_t zh                           : 1;
+  uint8_t d6d_ia                       : 1;
+  uint8_t not_used0                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 1;
+  uint8_t d6d_ia                       : 1;
+  uint8_t zh                           : 1;
+  uint8_t zl                           : 1;
+  uint8_t yh                           : 1;
+  uint8_t yl                           : 1;
+  uint8_t xh                           : 1;
+  uint8_t xl                           : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_d6d_src_t;
+
+#define LSM6DSV320X_STATUS_CONTROLLER_MAINPAGE     0x48U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sens_hub_endop               : 1;
+  uint8_t not_used0                    : 2;
+  uint8_t target0_nack                 : 1;
+  uint8_t target1_nack                 : 1;
+  uint8_t target2_nack                 : 1;
+  uint8_t target3_nack                 : 1;
+  uint8_t wr_once_done                 : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t wr_once_done                 : 1;
+  uint8_t target3_nack                 : 1;
+  uint8_t target2_nack                 : 1;
+  uint8_t target1_nack                 : 1;
+  uint8_t target0_nack                 : 1;
+  uint8_t not_used0                    : 2;
+  uint8_t sens_hub_endop               : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_status_controller_mainpage_t;
+
+#define LSM6DSV320X_EMB_FUNC_STATUS_MAINPAGE       0x49U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 3;
+  uint8_t is_step_det                  : 1;
+  uint8_t is_tilt                      : 1;
+  uint8_t is_sigmot                    : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t is_fsm_lc                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t is_fsm_lc                    : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t is_sigmot                    : 1;
+  uint8_t is_tilt                      : 1;
+  uint8_t is_step_det                  : 1;
+  uint8_t not_used0                    : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_emb_func_status_mainpage_t;
+
+#define LSM6DSV320X_FSM_STATUS_MAINPAGE            0x4AU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t is_fsm1                      : 1;
+  uint8_t is_fsm2                      : 1;
+  uint8_t is_fsm3                      : 1;
+  uint8_t is_fsm4                      : 1;
+  uint8_t is_fsm5                      : 1;
+  uint8_t is_fsm6                      : 1;
+  uint8_t is_fsm7                      : 1;
+  uint8_t is_fsm8                      : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t is_fsm8                      : 1;
+  uint8_t is_fsm7                      : 1;
+  uint8_t is_fsm6                      : 1;
+  uint8_t is_fsm5                      : 1;
+  uint8_t is_fsm4                      : 1;
+  uint8_t is_fsm3                      : 1;
+  uint8_t is_fsm2                      : 1;
+  uint8_t is_fsm1                      : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_status_mainpage_t;
+
+#define LSM6DSV320X_MLC_STATUS_MAINPAGE            0x4BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t is_mlc1                      : 1;
+  uint8_t is_mlc2                      : 1;
+  uint8_t is_mlc3                      : 1;
+  uint8_t is_mlc4                      : 1;
+  uint8_t is_mlc5                      : 1;
+  uint8_t is_mlc6                      : 1;
+  uint8_t is_mlc7                      : 1;
+  uint8_t is_mlc8                      : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t is_mlc8                      : 1;
+  uint8_t is_mlc7                      : 1;
+  uint8_t is_mlc6                      : 1;
+  uint8_t is_mlc5                      : 1;
+  uint8_t is_mlc4                      : 1;
+  uint8_t is_mlc3                      : 1;
+  uint8_t is_mlc2                      : 1;
+  uint8_t is_mlc1                      : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_mlc_status_mainpage_t;
+
+#define LSM6DSV320X_HG_WAKE_UP_SRC                 0x4CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t hg_z_wu                      : 1;
+  uint8_t hg_y_wu                      : 1;
+  uint8_t hg_x_wu                      : 1;
+  uint8_t hg_wu_ia                     : 1;
+  uint8_t hg_wu_change_ia              : 1;
+  uint8_t hg_shock_state               : 1;
+  uint8_t hg_shock_change_ia           : 1;
+  uint8_t not_used0                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 1;
+  uint8_t hg_shock_change_ia           : 1;
+  uint8_t hg_shock_state               : 1;
+  uint8_t hg_wu_change_ia              : 1;
+  uint8_t hg_wu_ia                     : 1;
+  uint8_t hg_x_wu                      : 1;
+  uint8_t hg_y_wu                      : 1;
+  uint8_t hg_z_wu                      : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_hg_wake_up_src_t;
+
+#define LSM6DSV320X_CTRL2_XL_HG                    0x4DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t xl_hg_st                     : 2;
+  uint8_t not_used0                    : 2;
+  uint8_t hg_usr_off_on_wu             : 1;
+  uint8_t not_used1                    : 3;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 3;
+  uint8_t hg_usr_off_on_wu             : 1;
+  uint8_t not_used0                    : 2;
+  uint8_t xl_hg_st                     : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ctrl2_xl_hg_t;
+
+#define LSM6DSV320X_CTRL1_XL_HG                    0x4EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fs_xl_hg                     : 3;
+  uint8_t odr_xl_hg                    : 3;
+  uint8_t hg_usr_off_on_out            : 1;
+  uint8_t xl_hg_regout_en              : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t xl_hg_regout_en              : 1;
+  uint8_t hg_usr_off_on_out            : 1;
+  uint8_t odr_xl_hg                    : 3;
+  uint8_t fs_xl_hg                     : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ctrl1_xl_hg_t;
+
+#define LSM6DSV320X_INTERNAL_FREQ                  0x4FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t freq_fine                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t freq_fine                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_internal_freq_t;
+
+#define LSM6DSV320X_FUNCTIONS_ENABLE               0x50U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t inact_en                     : 2;
+  uint8_t not_used0                    : 1;
+  uint8_t dis_rst_lir_all_int          : 1;
+  uint8_t not_used1                    : 2;
+  uint8_t timestamp_en                 : 1;
+  uint8_t interrupts_enable            : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t interrupts_enable            : 1;
+  uint8_t timestamp_en                 : 1;
+  uint8_t not_used1                    : 2;
+  uint8_t dis_rst_lir_all_int          : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t inact_en                     : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_functions_enable_t;
+
+#define LSM6DSV320X_HG_FUNCTIONS_ENABLE            0x52U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t hg_shock_dur                 : 4;
+  uint8_t int1_hg_wu                   : 1;
+  uint8_t int2_hg_wu                   : 1;
+  uint8_t hg_wu_change_int_sel         : 1;
+  uint8_t hg_interrupts_enable         : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t hg_interrupts_enable         : 1;
+  uint8_t hg_wu_change_int_sel         : 1;
+  uint8_t int2_hg_wu                   : 1;
+  uint8_t int1_hg_wu                   : 1;
+  uint8_t hg_shock_dur                 : 4;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_hg_functions_enable_t;
+
+#define LSM6DSV320X_HG_WAKE_UP_THS                 0x53U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t hg_wk_ths                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t hg_wk_ths                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_hg_wake_up_ths_t;
+
+#define LSM6DSV320X_INACTIVITY_DUR                 0x54U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t inact_dur                    : 2;
+  uint8_t xl_inact_odr                 : 2;
+  uint8_t wu_inact_ths_w               : 3;
+  uint8_t sleep_status_on_int          : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sleep_status_on_int          : 1;
+  uint8_t wu_inact_ths_w               : 3;
+  uint8_t xl_inact_odr                 : 2;
+  uint8_t inact_dur                    : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_inactivity_dur_t;
+
+#define LSM6DSV320X_INACTIVITY_THS                 0x55U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t inact_ths                    : 6;
+  uint8_t int1_hg_shock_change         : 1;
+  uint8_t int2_hg_shock_change         : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t int2_hg_shock_change         : 1;
+  uint8_t int1_hg_shock_change         : 1;
+  uint8_t inact_ths                    : 6;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_inactivity_ths_t;
+
+#define LSM6DSV320X_TAP_CFG0                       0x56U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t lir                          : 1;
+  uint8_t tap_z_en                     : 1;
+  uint8_t tap_y_en                     : 1;
+  uint8_t tap_x_en                     : 1;
+  uint8_t slope_fds                    : 1;
+  uint8_t hw_func_mask_xl_settl        : 1;
+  uint8_t low_pass_on_6d               : 1;
+  uint8_t not_used1                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 1;
+  uint8_t low_pass_on_6d               : 1;
+  uint8_t hw_func_mask_xl_settl        : 1;
+  uint8_t slope_fds                    : 1;
+  uint8_t tap_x_en                     : 1;
+  uint8_t tap_y_en                     : 1;
+  uint8_t tap_z_en                     : 1;
+  uint8_t lir                          : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_tap_cfg0_t;
+
+#define LSM6DSV320X_TAP_CFG1                       0x57U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t tap_ths_x                    : 5;
+  uint8_t tap_priority                 : 3;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t tap_priority                 : 3;
+  uint8_t tap_ths_x                    : 5;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_tap_cfg1_t;
+
+#define LSM6DSV320X_TAP_CFG2                       0x58U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t tap_ths_y                    : 5;
+  uint8_t not_used0                    : 3;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 3;
+  uint8_t tap_ths_y                    : 5;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_tap_cfg2_t;
+
+#define LSM6DSV320X_TAP_THS_6D                     0x59U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t tap_ths_z                    : 5;
+  uint8_t sixd_ths                     : 2;
+  uint8_t d4d_en                       : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t d4d_en                       : 1;
+  uint8_t sixd_ths                     : 2;
+  uint8_t tap_ths_z                    : 5;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_tap_ths_6d_t;
+
+#define LSM6DSV320X_TAP_DUR                        0x5AU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t shock                        : 2;
+  uint8_t quiet                        : 2;
+  uint8_t dur                          : 4;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t dur                          : 4;
+  uint8_t quiet                        : 2;
+  uint8_t shock                        : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_tap_dur_t;
+
+#define LSM6DSV320X_WAKE_UP_THS                    0x5BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t wk_ths                       : 6;
+  uint8_t usr_off_on_wu                : 1;
+  uint8_t single_double_tap            : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t single_double_tap            : 1;
+  uint8_t usr_off_on_wu                : 1;
+  uint8_t wk_ths                       : 6;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_wake_up_ths_t;
+
+#define LSM6DSV320X_WAKE_UP_DUR                    0x5CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sleep_dur                    : 4;
+  uint8_t not_used0                    : 1;
+  uint8_t wake_dur                     : 2;
+  uint8_t ff_dur                       : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ff_dur                       : 1;
+  uint8_t wake_dur                     : 2;
+  uint8_t not_used0                    : 1;
+  uint8_t sleep_dur                    : 4;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_wake_up_dur_t;
+
+#define LSM6DSV320X_FREE_FALL                      0x5DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ff_ths                       : 3;
+  uint8_t ff_dur                       : 5;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ff_dur                       : 5;
+  uint8_t ff_ths                       : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_free_fall_t;
+
+#define LSM6DSV320X_MD1_CFG                        0x5EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t int1_shub                    : 1;
+  uint8_t int1_emb_func                : 1;
+  uint8_t int1_6d                      : 1;
+  uint8_t int1_double_tap              : 1;
+  uint8_t int1_ff                      : 1;
+  uint8_t int1_wu                      : 1;
+  uint8_t int1_single_tap              : 1;
+  uint8_t int1_sleep_change            : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t int1_sleep_change            : 1;
+  uint8_t int1_single_tap              : 1;
+  uint8_t int1_wu                      : 1;
+  uint8_t int1_ff                      : 1;
+  uint8_t int1_double_tap              : 1;
+  uint8_t int1_6d                      : 1;
+  uint8_t int1_emb_func                : 1;
+  uint8_t int1_shub                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_md1_cfg_t;
+
+#define LSM6DSV320X_MD2_CFG                        0x5FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t int2_timestamp               : 1;
+  uint8_t int2_emb_func                : 1;
+  uint8_t int2_6d                      : 1;
+  uint8_t int2_double_tap              : 1;
+  uint8_t int2_ff                      : 1;
+  uint8_t int2_wu                      : 1;
+  uint8_t int2_single_tap              : 1;
+  uint8_t int2_sleep_change            : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t int2_sleep_change            : 1;
+  uint8_t int2_single_tap              : 1;
+  uint8_t int2_wu                      : 1;
+  uint8_t int2_ff                      : 1;
+  uint8_t int2_double_tap              : 1;
+  uint8_t int2_6d                      : 1;
+  uint8_t int2_emb_func                : 1;
+  uint8_t int2_timestamp               : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_md2_cfg_t;
+
+#define LSM6DSV320X_HAODR_CFG                      0x62U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t haodr_sel                    : 2;
+  uint8_t not_used0                    : 6;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 6;
+  uint8_t haodr_sel                    : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_haodr_cfg_t;
+
+#define LSM6DSV320X_EMB_FUNC_CFG                   0x63U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 3;
+  uint8_t emb_func_disable             : 1;
+  uint8_t emb_func_irq_mask_xl_settl   : 1;
+  uint8_t emb_func_irq_mask_g_settl    : 1;
+  uint8_t emb_func_irq_mask_xl_hg_settl: 1;
+  uint8_t hg_usr_off_on_emb_func       : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t hg_usr_off_on_emb_func       : 1;
+  uint8_t emb_func_irq_mask_xl_hg_settl: 1;
+  uint8_t emb_func_irq_mask_g_settl    : 1;
+  uint8_t emb_func_irq_mask_xl_settl   : 1;
+  uint8_t emb_func_disable             : 1;
+  uint8_t not_used0                    : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_emb_func_cfg_t;
+
+#define LSM6DSV320X_UI_HANDSHAKE_CTRL              0x64U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ui_shared_req                : 1;
+  uint8_t ui_shared_ack                : 1;
+  uint8_t not_used0                    : 6;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 6;
+  uint8_t ui_shared_ack                : 1;
+  uint8_t ui_shared_req                : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ui_handshake_ctrl_t;
+
+#define LSM6DSV320X_UI_IF2_SHARED_0                0x65U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ui_if2_shared                : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ui_if2_shared                : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ui_if2_shared_0_t;
+
+#define LSM6DSV320X_UI_IF2_SHARED_1                0x66U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ui_if2_shared                : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ui_if2_shared                : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ui_if2_shared_1_t;
+
+#define LSM6DSV320X_UI_IF2_SHARED_2                0x67U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ui_if2_shared                : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ui_if2_shared                : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ui_if2_shared_2_t;
+
+#define LSM6DSV320X_UI_IF2_SHARED_3                0x68U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ui_if2_shared                : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ui_if2_shared                : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ui_if2_shared_3_t;
+
+#define LSM6DSV320X_UI_IF2_SHARED_4                0x69U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ui_if2_shared                : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ui_if2_shared                : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ui_if2_shared_4_t;
+
+#define LSM6DSV320X_UI_IF2_SHARED_5                0x6AU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ui_if2_shared                : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ui_if2_shared                : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ui_if2_shared_5_t;
+
+#define LSM6DSV320X_CTRL_EIS                       0x6BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fs_g_eis                     : 3;
+  uint8_t g_eis_on_g_ois_out_reg       : 1;
+  uint8_t lpf_g_eis_bw                 : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t odr_g_eis                    : 2;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t odr_g_eis                    : 2;
+  uint8_t not_used0                    : 1;
+  uint8_t lpf_g_eis_bw                 : 1;
+  uint8_t g_eis_on_g_ois_out_reg       : 1;
+  uint8_t fs_g_eis                     : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ctrl_eis_t;
+
+#define LSM6DSV320X_XL_HG_X_OFS_USR                0x6CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t xl_hg_x_ofs_usr              : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t xl_hg_x_ofs_usr              : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_hg_x_ofs_usr_t;
+
+#define LSM6DSV320X_XL_HG_Y_OFS_USR                0x6DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t xl_hg_y_ofs_usr              : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t xl_hg_y_ofs_usr              : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_hg_y_ofs_usr_t;
+
+#define LSM6DSV320X_XL_HG_Z_OFS_USR                0x6EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t xl_hg_z_ofs_usr              : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t xl_hg_z_ofs_usr              : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_hg_z_ofs_usr_t;
+
+#define LSM6DSV320X_UI_INT_OIS                     0x6FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 4;
+  uint8_t st_ois_clampdis              : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t drdy_mask_ois                : 1;
+  uint8_t int2_drdy_ois                : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t int2_drdy_ois                : 1;
+  uint8_t drdy_mask_ois                : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t st_ois_clampdis              : 1;
+  uint8_t not_used0                    : 4;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ui_int_ois_t;
+
+#define LSM6DSV320X_UI_CTRL1_OIS                   0x70U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t if2_spi_read_en              : 1;
+  uint8_t ois_g_en                     : 1;
+  uint8_t ois_xl_en                    : 1;
+  uint8_t not_used0                    : 2;
+  uint8_t sim_ois                      : 1;
+  uint8_t not_used1                    : 2;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 2;
+  uint8_t sim_ois                      : 1;
+  uint8_t not_used0                    : 2;
+  uint8_t ois_xl_en                    : 1;
+  uint8_t ois_g_en                     : 1;
+  uint8_t if2_spi_read_en              : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ui_ctrl1_ois_t;
+
+#define LSM6DSV320X_UI_CTRL2_OIS                   0x71U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fs_g_ois                     : 3;
+  uint8_t lpf1_g_ois_bw                : 2;
+  uint8_t not_used0                    : 3;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 3;
+  uint8_t lpf1_g_ois_bw                : 2;
+  uint8_t fs_g_ois                     : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ui_ctrl2_ois_t;
+
+#define LSM6DSV320X_UI_CTRL3_OIS                   0x72U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fs_xl_ois                    : 2;
+  uint8_t not_used0                    : 1;
+  uint8_t lpf_xl_ois_bw                : 3;
+  uint8_t not_used1                    : 2;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 2;
+  uint8_t lpf_xl_ois_bw                : 3;
+  uint8_t not_used0                    : 1;
+  uint8_t fs_xl_ois                    : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ui_ctrl3_ois_t;
+
+#define LSM6DSV320X_X_OFS_USR                      0x73U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t x_ofs_usr                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t x_ofs_usr                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_x_ofs_usr_t;
+
+#define LSM6DSV320X_Y_OFS_USR                      0x74U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t y_ofs_usr                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t y_ofs_usr                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_y_ofs_usr_t;
+
+#define LSM6DSV320X_Z_OFS_USR                      0x75U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t z_ofs_usr                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t z_ofs_usr                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_z_ofs_usr_t;
+
+#define LSM6DSV320X_FIFO_DATA_OUT_TAG              0x78U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 1;
+  uint8_t tag_cnt                      : 2;
+  uint8_t tag_sensor                   : 5;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t tag_sensor                   : 5;
+  uint8_t tag_cnt                      : 2;
+  uint8_t not_used0                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fifo_data_out_tag_t;
+
+#define LSM6DSV320X_FIFO_DATA_OUT_X_L              0x79U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fifo_data_out                : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fifo_data_out                : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fifo_data_out_x_l_t;
+
+#define LSM6DSV320X_FIFO_DATA_OUT_X_H              0x7AU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fifo_data_out                : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fifo_data_out                : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fifo_data_out_x_h_t;
+
+#define LSM6DSV320X_FIFO_DATA_OUT_Y_L              0x7BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fifo_data_out                : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fifo_data_out                : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fifo_data_out_y_l_t;
+
+#define LSM6DSV320X_FIFO_DATA_OUT_Y_H              0x7CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fifo_data_out                : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fifo_data_out                : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fifo_data_out_y_h_t;
+
+#define LSM6DSV320X_FIFO_DATA_OUT_Z_L              0x7DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fifo_data_out                : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fifo_data_out                : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fifo_data_out_z_l_t;
+
+#define LSM6DSV320X_FIFO_DATA_OUT_Z_H              0x7EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fifo_data_out                : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fifo_data_out                : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fifo_data_out_z_h_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup bitfields page if2
+  * @{
+  *
+  */
+
+#define LSM6DSV320X_IF2_WHO_AM_I                   0x0FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t id                           : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t id                           : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_if2_who_am_i_t;
+
+#define LSM6DSV320X_IF2_STATUS_REG_OIS             0x1EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t xlda                         : 1;
+  uint8_t gda                          : 1;
+  uint8_t gyro_settling                : 1;
+  uint8_t not_used0                    : 5;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 5;
+  uint8_t gyro_settling                : 1;
+  uint8_t gda                          : 1;
+  uint8_t xlda                         : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_if2_status_reg_ois_t;
+
+#define LSM6DSV320X_IF2_OUT_TEMP_L                 0x20U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t temp                         : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t temp                         : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_if2_out_temp_l_t;
+
+#define LSM6DSV320X_IF2_OUT_TEMP_H                 0x21U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t temp                         : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t temp                         : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_if2_out_temp_h_t;
+
+#define LSM6DSV320X_IF2_OUTX_L_G_OIS               0x22U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t if2_outx_g_ois               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t if2_outx_g_ois               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_if2_outx_l_g_ois_t;
+
+#define LSM6DSV320X_IF2_OUTX_H_G_OIS               0x23U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t if2_outx_g_ois               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t if2_outx_g_ois               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_if2_outx_h_g_ois_t;
+
+#define LSM6DSV320X_IF2_OUTY_L_G_OIS               0x24U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t if2_outy_g_ois               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t if2_outy_g_ois               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_if2_outy_l_g_ois_t;
+
+#define LSM6DSV320X_IF2_OUTY_H_G_OIS               0x25U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t if2_outy_g_ois               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t if2_outy_g_ois               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_if2_outy_h_g_ois_t;
+
+#define LSM6DSV320X_IF2_OUTZ_L_G_OIS               0x26U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t if2_outz_g_ois               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t if2_outz_g_ois               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_if2_outz_l_g_ois_t;
+
+#define LSM6DSV320X_IF2_OUTZ_H_G_OIS               0x27U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t if2_outz_g_ois               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t if2_outz_g_ois               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_if2_outz_h_g_ois_t;
+
+#define LSM6DSV320X_IF2_OUTX_L_A_OIS               0x28U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t if2_outx_a_ois               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t if2_outx_a_ois               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_if2_outx_l_a_ois_t;
+
+#define LSM6DSV320X_IF2_OUTX_H_A_OIS               0x29U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t if2_outx_a_ois               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t if2_outx_a_ois               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_if2_outx_h_a_ois_t;
+
+#define LSM6DSV320X_IF2_OUTY_L_A_OIS               0x2AU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t if2_outy_a_ois               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t if2_outy_a_ois               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_if2_outy_l_a_ois_t;
+
+#define LSM6DSV320X_IF2_OUTY_H_A_OIS               0x2BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t if2_outy_a_ois               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t if2_outy_a_ois               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_if2_outy_h_a_ois_t;
+
+#define LSM6DSV320X_IF2_OUTZ_L_A_OIS               0x2CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t if2_outz_a_ois               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t if2_outz_a_ois               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_if2_outz_l_a_ois_t;
+
+#define LSM6DSV320X_IF2_OUTZ_H_A_OIS               0x2DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t if2_outz_a_ois               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t if2_outz_a_ois               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_if2_outz_h_a_ois_t;
+
+#define LSM6DSV320X_IF2_HANDSHAKE_CTRL             0x6EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t if2_shared_ack               : 1;
+  uint8_t if2_shared_req               : 1;
+  uint8_t not_used0                    : 6;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 6;
+  uint8_t if2_shared_req               : 1;
+  uint8_t if2_shared_ack               : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_if2_handshake_ctrl_t;
+
+#define LSM6DSV320X_IF2_INT_OIS                    0x6FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t st_xl_ois                    : 2;
+  uint8_t st_g_ois                     : 2;
+  uint8_t st_ois_clampdis              : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t drdy_mask_ois                : 1;
+  uint8_t int2_drdy_ois                : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t int2_drdy_ois                : 1;
+  uint8_t drdy_mask_ois                : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t st_ois_clampdis              : 1;
+  uint8_t st_g_ois                     : 2;
+  uint8_t st_xl_ois                    : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_if2_int_ois_t;
+
+#define LSM6DSV320X_IF2_CTRL1_OIS                  0x70U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t if2_spi_read_en              : 1;
+  uint8_t ois_g_en                     : 1;
+  uint8_t ois_xl_en                    : 1;
+  uint8_t not_used0                    : 2;
+  uint8_t sim_ois                      : 1;
+  uint8_t not_used1                    : 2;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 2;
+  uint8_t sim_ois                      : 1;
+  uint8_t not_used0                    : 2;
+  uint8_t ois_xl_en                    : 1;
+  uint8_t ois_g_en                     : 1;
+  uint8_t if2_spi_read_en              : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_if2_ctrl1_ois_t;
+
+#define LSM6DSV320X_IF2_CTRL2_OIS                  0x71U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fs_g_ois                     : 3;
+  uint8_t lpf1_g_ois_bw                : 2;
+  uint8_t not_used0                    : 3;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 3;
+  uint8_t lpf1_g_ois_bw                : 2;
+  uint8_t fs_g_ois                     : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_if2_ctrl2_ois_t;
+
+#define LSM6DSV320X_IF2_CTRL3_OIS                  0x72U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fs_xl_ois                    : 2;
+  uint8_t not_used0                    : 1;
+  uint8_t lpf_xl_ois_bw                : 3;
+  uint8_t not_used1                    : 2;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 2;
+  uint8_t lpf_xl_ois_bw                : 3;
+  uint8_t not_used0                    : 1;
+  uint8_t fs_xl_ois                    : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_if2_ctrl3_ois_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup bitfields page embedded
+  * @{
+  *
+  */
+
+#define LSM6DSV320X_PAGE_SEL                       0x2U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 4;
+  uint8_t page_sel                     : 4;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t page_sel                     : 4;
+  uint8_t not_used0                    : 4;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_page_sel_t;
+
+#define LSM6DSV320X_EMB_FUNC_EN_A                  0x4U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 1;
+  uint8_t sflp_game_en                 : 1;
+  uint8_t not_used2                    : 1;
+  uint8_t pedo_en                      : 1;
+  uint8_t tilt_en                      : 1;
+  uint8_t sign_motion_en               : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t mlc_before_fsm_en            : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t mlc_before_fsm_en            : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t sign_motion_en               : 1;
+  uint8_t tilt_en                      : 1;
+  uint8_t pedo_en                      : 1;
+  uint8_t not_used2                    : 1;
+  uint8_t sflp_game_en                 : 1;
+  uint8_t not_used0                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_emb_func_en_a_t;
+
+#define LSM6DSV320X_EMB_FUNC_EN_B                  0x5U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_en                       : 1;
+  uint8_t not_used0                    : 2;
+  uint8_t fifo_compr_en                : 1;
+  uint8_t mlc_en                       : 1;
+  uint8_t not_used1                    : 3;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 3;
+  uint8_t mlc_en                       : 1;
+  uint8_t fifo_compr_en                : 1;
+  uint8_t not_used0                    : 2;
+  uint8_t fsm_en                       : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_emb_func_en_b_t;
+
+#define LSM6DSV320X_EMB_FUNC_EXEC_STATUS           0x7U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t emb_func_endop               : 1;
+  uint8_t emb_func_exec_ovr            : 1;
+  uint8_t not_used0                    : 6;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 6;
+  uint8_t emb_func_exec_ovr            : 1;
+  uint8_t emb_func_endop               : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_emb_func_exec_status_t;
+
+#define LSM6DSV320X_PAGE_ADDRESS                   0x8U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t page_addr                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t page_addr                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_page_address_t;
+
+#define LSM6DSV320X_PAGE_VALUE                     0x9U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t page_value                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t page_value                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_page_value_t;
+
+#define LSM6DSV320X_EMB_FUNC_INT1                  0x0AU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 3;
+  uint8_t int1_step_detector           : 1;
+  uint8_t int1_tilt                    : 1;
+  uint8_t int1_sig_mot                 : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t int1_fsm_lc                  : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t int1_fsm_lc                  : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t int1_sig_mot                 : 1;
+  uint8_t int1_tilt                    : 1;
+  uint8_t int1_step_detector           : 1;
+  uint8_t not_used0                    : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_emb_func_int1_t;
+
+#define LSM6DSV320X_FSM_INT1                       0x0BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t int1_fsm1                    : 1;
+  uint8_t int1_fsm2                    : 1;
+  uint8_t int1_fsm3                    : 1;
+  uint8_t int1_fsm4                    : 1;
+  uint8_t int1_fsm5                    : 1;
+  uint8_t int1_fsm6                    : 1;
+  uint8_t int1_fsm7                    : 1;
+  uint8_t int1_fsm8                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t int1_fsm8                    : 1;
+  uint8_t int1_fsm7                    : 1;
+  uint8_t int1_fsm6                    : 1;
+  uint8_t int1_fsm5                    : 1;
+  uint8_t int1_fsm4                    : 1;
+  uint8_t int1_fsm3                    : 1;
+  uint8_t int1_fsm2                    : 1;
+  uint8_t int1_fsm1                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_int1_t;
+
+#define LSM6DSV320X_MLC_INT1                       0x0DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t int1_mlc1                    : 1;
+  uint8_t int1_mlc2                    : 1;
+  uint8_t int1_mlc3                    : 1;
+  uint8_t int1_mlc4                    : 1;
+  uint8_t int1_mlc5                    : 1;
+  uint8_t int1_mlc6                    : 1;
+  uint8_t int1_mlc7                    : 1;
+  uint8_t int1_mlc8                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t int1_mlc8                    : 1;
+  uint8_t int1_mlc7                    : 1;
+  uint8_t int1_mlc6                    : 1;
+  uint8_t int1_mlc5                    : 1;
+  uint8_t int1_mlc4                    : 1;
+  uint8_t int1_mlc3                    : 1;
+  uint8_t int1_mlc2                    : 1;
+  uint8_t int1_mlc1                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_mlc_int1_t;
+
+#define LSM6DSV320X_EMB_FUNC_INT2                  0x0EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 3;
+  uint8_t int2_step_detector           : 1;
+  uint8_t int2_tilt                    : 1;
+  uint8_t int2_sig_mot                 : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t int2_fsm_lc                  : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t int2_fsm_lc                  : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t int2_sig_mot                 : 1;
+  uint8_t int2_tilt                    : 1;
+  uint8_t int2_step_detector           : 1;
+  uint8_t not_used0                    : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_emb_func_int2_t;
+
+#define LSM6DSV320X_FSM_INT2                       0x0FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t int2_fsm1                    : 1;
+  uint8_t int2_fsm2                    : 1;
+  uint8_t int2_fsm3                    : 1;
+  uint8_t int2_fsm4                    : 1;
+  uint8_t int2_fsm5                    : 1;
+  uint8_t int2_fsm6                    : 1;
+  uint8_t int2_fsm7                    : 1;
+  uint8_t int2_fsm8                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t int2_fsm8                    : 1;
+  uint8_t int2_fsm7                    : 1;
+  uint8_t int2_fsm6                    : 1;
+  uint8_t int2_fsm5                    : 1;
+  uint8_t int2_fsm4                    : 1;
+  uint8_t int2_fsm3                    : 1;
+  uint8_t int2_fsm2                    : 1;
+  uint8_t int2_fsm1                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_int2_t;
+
+#define LSM6DSV320X_MLC_INT2                       0x11U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t int2_mlc1                    : 1;
+  uint8_t int2_mlc2                    : 1;
+  uint8_t int2_mlc3                    : 1;
+  uint8_t int2_mlc4                    : 1;
+  uint8_t int2_mlc5                    : 1;
+  uint8_t int2_mlc6                    : 1;
+  uint8_t int2_mlc7                    : 1;
+  uint8_t int2_mlc8                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t int2_mlc8                    : 1;
+  uint8_t int2_mlc7                    : 1;
+  uint8_t int2_mlc6                    : 1;
+  uint8_t int2_mlc5                    : 1;
+  uint8_t int2_mlc4                    : 1;
+  uint8_t int2_mlc3                    : 1;
+  uint8_t int2_mlc2                    : 1;
+  uint8_t int2_mlc1                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_mlc_int2_t;
+
+#define LSM6DSV320X_EMB_FUNC_STATUS                0x12U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 3;
+  uint8_t is_step_det                  : 1;
+  uint8_t is_tilt                      : 1;
+  uint8_t is_sigmot                    : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t is_fsm_lc                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t is_fsm_lc                    : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t is_sigmot                    : 1;
+  uint8_t is_tilt                      : 1;
+  uint8_t is_step_det                  : 1;
+  uint8_t not_used0                    : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_emb_func_status_t;
+
+#define LSM6DSV320X_FSM_STATUS                     0x13U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t is_fsm1                      : 1;
+  uint8_t is_fsm2                      : 1;
+  uint8_t is_fsm3                      : 1;
+  uint8_t is_fsm4                      : 1;
+  uint8_t is_fsm5                      : 1;
+  uint8_t is_fsm6                      : 1;
+  uint8_t is_fsm7                      : 1;
+  uint8_t is_fsm8                      : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t is_fsm8                      : 1;
+  uint8_t is_fsm7                      : 1;
+  uint8_t is_fsm6                      : 1;
+  uint8_t is_fsm5                      : 1;
+  uint8_t is_fsm4                      : 1;
+  uint8_t is_fsm3                      : 1;
+  uint8_t is_fsm2                      : 1;
+  uint8_t is_fsm1                      : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_status_t;
+
+#define LSM6DSV320X_MLC_STATUS                     0x15U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t is_mlc1                      : 1;
+  uint8_t is_mlc2                      : 1;
+  uint8_t is_mlc3                      : 1;
+  uint8_t is_mlc4                      : 1;
+  uint8_t is_mlc5                      : 1;
+  uint8_t is_mlc6                      : 1;
+  uint8_t is_mlc7                      : 1;
+  uint8_t is_mlc8                      : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t is_mlc8                      : 1;
+  uint8_t is_mlc7                      : 1;
+  uint8_t is_mlc6                      : 1;
+  uint8_t is_mlc5                      : 1;
+  uint8_t is_mlc4                      : 1;
+  uint8_t is_mlc3                      : 1;
+  uint8_t is_mlc2                      : 1;
+  uint8_t is_mlc1                      : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_mlc_status_t;
+
+#define LSM6DSV320X_PAGE_RW                        0x17U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 5;
+  uint8_t page_read                    : 1;
+  uint8_t page_write                   : 1;
+  uint8_t emb_func_lir                 : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t emb_func_lir                 : 1;
+  uint8_t page_write                   : 1;
+  uint8_t page_read                    : 1;
+  uint8_t not_used0                    : 5;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_page_rw_t;
+
+#define LSM6DSV320X_SFLP_GBIASX_L                  0x18U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gbiasx                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gbiasx                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sflp_gbiasx_l_t;
+
+#define LSM6DSV320X_SFLP_GBIASX_H                  0x19U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gbiasx                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gbiasx                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sflp_gbiasx_h_t;
+
+#define LSM6DSV320X_SFLP_GBIASY_L                  0x1AU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gbiasy                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gbiasy                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sflp_gbiasy_l_t;
+
+#define LSM6DSV320X_SFLP_GBIASY_H                  0x1BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gbiasy                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gbiasy                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sflp_gbiasy_h_t;
+
+#define LSM6DSV320X_SFLP_GBIASZ_L                  0x1CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gbiasz                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gbiasz                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sflp_gbiasz_l_t;
+
+#define LSM6DSV320X_SFLP_GBIASZ_H                  0x1DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gbiasz                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gbiasz                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sflp_gbiasz_h_t;
+
+#define LSM6DSV320X_SFLP_GRAVX_L                   0x1EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gravx                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gravx                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sflp_gravx_l_t;
+
+#define LSM6DSV320X_SFLP_GRAVX_H                   0x1FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gravx                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gravx                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sflp_gravx_h_t;
+
+#define LSM6DSV320X_SFLP_GRAVY_L                   0x20U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gravy                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gravy                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sflp_gravy_l_t;
+
+#define LSM6DSV320X_SFLP_GRAVY_H                   0x21U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gravy                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gravy                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sflp_gravy_h_t;
+
+#define LSM6DSV320X_SFLP_GRAVZ_L                   0x22U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gravz                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gravz                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sflp_gravz_l_t;
+
+#define LSM6DSV320X_SFLP_GRAVZ_H                   0x23U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gravz                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gravz                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sflp_gravz_h_t;
+
+#define LSM6DSV320X_SFLP_QUATW_L                   0x2AU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_quatw                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_quatw                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sflp_quatw_l_t;
+
+#define LSM6DSV320X_SFLP_QUATW_H                   0x2BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_quatw                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_quatw                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sflp_quatw_h_t;
+
+#define LSM6DSV320X_SFLP_QUATX_L                   0x2CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_quatx                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_quatx                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sflp_quatx_l_t;
+
+#define LSM6DSV320X_SFLP_QUATX_H                   0x2DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_quatx                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_quatx                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sflp_quatx_h_t;
+
+#define LSM6DSV320X_SFLP_QUATY_L                   0x2EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_quaty                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_quaty                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sflp_quaty_l_t;
+
+#define LSM6DSV320X_SFLP_QUATY_H                   0x2FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_quaty                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_quaty                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sflp_quaty_h_t;
+
+#define LSM6DSV320X_SFLP_QUATZ_L                   0x30U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_quatz                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_quatz                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sflp_quatz_l_t;
+
+#define LSM6DSV320X_SFLP_QUATZ_H                   0x31U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_quatz                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_quatz                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sflp_quatz_h_t;
+
+#define LSM6DSV320X_SFLP_GBIASX_INIT_L             0x32U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gbiasx_init             : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gbiasx_init             : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sflp_gbiasx_init_l_t;
+
+#define LSM6DSV320X_SFLP_GBIASX_INIT_H             0x33U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gbiasx_init             : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gbiasx_init             : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sflp_gbiasx_init_h_t;
+
+#define LSM6DSV320X_SFLP_GBIASY_INIT_L             0x34U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gbiasy_init             : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gbiasy_init             : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sflp_gbiasy_init_l_t;
+
+#define LSM6DSV320X_SFLP_GBIASY_INIT_H             0x35U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gbiasy_init             : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gbiasy_init             : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sflp_gbiasy_init_h_t;
+
+#define LSM6DSV320X_SFLP_GBIASZ_INIT_L             0x36U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gbiasz_init             : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gbiasz_init             : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sflp_gbiasz_init_l_t;
+
+#define LSM6DSV320X_SFLP_GBIASZ_INIT_H             0x37U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gbiasz_init             : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gbiasz_init             : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sflp_gbiasz_init_h_t;
+
+#define LSM6DSV320X_EMB_FUNC_FIFO_EN_A             0x44U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 1;
+  uint8_t sflp_game_fifo_en            : 1;
+  uint8_t not_used1                    : 2;
+  uint8_t sflp_gravity_fifo_en         : 1;
+  uint8_t sflp_gbias_fifo_en           : 1;
+  uint8_t step_counter_fifo_en         : 1;
+  uint8_t mlc_fifo_en                  : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t mlc_fifo_en                  : 1;
+  uint8_t step_counter_fifo_en         : 1;
+  uint8_t sflp_gbias_fifo_en           : 1;
+  uint8_t sflp_gravity_fifo_en         : 1;
+  uint8_t not_used1                    : 2;
+  uint8_t sflp_game_fifo_en            : 1;
+  uint8_t not_used0                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_emb_func_fifo_en_a_t;
+
+#define LSM6DSV320X_EMB_FUNC_FIFO_EN_B             0x45U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 1;
+  uint8_t mlc_filter_feature_fifo_en   : 1;
+  uint8_t fsm_fifo_en                  : 1;
+  uint8_t not_used1                    : 5;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 5;
+  uint8_t fsm_fifo_en                  : 1;
+  uint8_t mlc_filter_feature_fifo_en   : 1;
+  uint8_t not_used0                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_emb_func_fifo_en_b_t;
+
+#define LSM6DSV320X_FSM_ENABLE                     0x46U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm1_en                      : 1;
+  uint8_t fsm2_en                      : 1;
+  uint8_t fsm3_en                      : 1;
+  uint8_t fsm4_en                      : 1;
+  uint8_t fsm5_en                      : 1;
+  uint8_t fsm6_en                      : 1;
+  uint8_t fsm7_en                      : 1;
+  uint8_t fsm8_en                      : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm8_en                      : 1;
+  uint8_t fsm7_en                      : 1;
+  uint8_t fsm6_en                      : 1;
+  uint8_t fsm5_en                      : 1;
+  uint8_t fsm4_en                      : 1;
+  uint8_t fsm3_en                      : 1;
+  uint8_t fsm2_en                      : 1;
+  uint8_t fsm1_en                      : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_enable_t;
+
+#define LSM6DSV320X_FSM_LONG_COUNTER_L             0x48U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_lc                       : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_lc                       : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_long_counter_l_t;
+
+#define LSM6DSV320X_FSM_LONG_COUNTER_H             0x49U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_lc                       : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_lc                       : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_long_counter_h_t;
+
+#define LSM6DSV320X_INT_ACK_MASK                   0x4BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t iack_mask                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t iack_mask                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_int_ack_mask_t;
+
+#define LSM6DSV320X_FSM_OUTS1                      0x4CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm1_n_v                     : 1;
+  uint8_t fsm1_p_v                     : 1;
+  uint8_t fsm1_n_z                     : 1;
+  uint8_t fsm1_p_z                     : 1;
+  uint8_t fsm1_n_y                     : 1;
+  uint8_t fsm1_p_y                     : 1;
+  uint8_t fsm1_n_x                     : 1;
+  uint8_t fsm1_p_x                     : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm1_p_x                     : 1;
+  uint8_t fsm1_n_x                     : 1;
+  uint8_t fsm1_p_y                     : 1;
+  uint8_t fsm1_n_y                     : 1;
+  uint8_t fsm1_p_z                     : 1;
+  uint8_t fsm1_n_z                     : 1;
+  uint8_t fsm1_p_v                     : 1;
+  uint8_t fsm1_n_v                     : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_outs1_t;
+
+#define LSM6DSV320X_FSM_OUTS2                      0x4DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm2_n_v                     : 1;
+  uint8_t fsm2_p_v                     : 1;
+  uint8_t fsm2_n_z                     : 1;
+  uint8_t fsm2_p_z                     : 1;
+  uint8_t fsm2_n_y                     : 1;
+  uint8_t fsm2_p_y                     : 1;
+  uint8_t fsm2_n_x                     : 1;
+  uint8_t fsm2_p_x                     : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm2_p_x                     : 1;
+  uint8_t fsm2_n_x                     : 1;
+  uint8_t fsm2_p_y                     : 1;
+  uint8_t fsm2_n_y                     : 1;
+  uint8_t fsm2_p_z                     : 1;
+  uint8_t fsm2_n_z                     : 1;
+  uint8_t fsm2_p_v                     : 1;
+  uint8_t fsm2_n_v                     : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_outs2_t;
+
+#define LSM6DSV320X_FSM_OUTS3                      0x4EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm3_n_v                     : 1;
+  uint8_t fsm3_p_v                     : 1;
+  uint8_t fsm3_n_z                     : 1;
+  uint8_t fsm3_p_z                     : 1;
+  uint8_t fsm3_n_y                     : 1;
+  uint8_t fsm3_p_y                     : 1;
+  uint8_t fsm3_n_x                     : 1;
+  uint8_t fsm3_p_x                     : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm3_p_x                     : 1;
+  uint8_t fsm3_n_x                     : 1;
+  uint8_t fsm3_p_y                     : 1;
+  uint8_t fsm3_n_y                     : 1;
+  uint8_t fsm3_p_z                     : 1;
+  uint8_t fsm3_n_z                     : 1;
+  uint8_t fsm3_p_v                     : 1;
+  uint8_t fsm3_n_v                     : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_outs3_t;
+
+#define LSM6DSV320X_FSM_OUTS4                      0x4FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm4_n_v                     : 1;
+  uint8_t fsm4_p_v                     : 1;
+  uint8_t fsm4_n_z                     : 1;
+  uint8_t fsm4_p_z                     : 1;
+  uint8_t fsm4_n_y                     : 1;
+  uint8_t fsm4_p_y                     : 1;
+  uint8_t fsm4_n_x                     : 1;
+  uint8_t fsm4_p_x                     : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm4_p_x                     : 1;
+  uint8_t fsm4_n_x                     : 1;
+  uint8_t fsm4_p_y                     : 1;
+  uint8_t fsm4_n_y                     : 1;
+  uint8_t fsm4_p_z                     : 1;
+  uint8_t fsm4_n_z                     : 1;
+  uint8_t fsm4_p_v                     : 1;
+  uint8_t fsm4_n_v                     : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_outs4_t;
+
+#define LSM6DSV320X_FSM_OUTS5                      0x50U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm5_n_v                     : 1;
+  uint8_t fsm5_p_v                     : 1;
+  uint8_t fsm5_n_z                     : 1;
+  uint8_t fsm5_p_z                     : 1;
+  uint8_t fsm5_n_y                     : 1;
+  uint8_t fsm5_p_y                     : 1;
+  uint8_t fsm5_n_x                     : 1;
+  uint8_t fsm5_p_x                     : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm5_p_x                     : 1;
+  uint8_t fsm5_n_x                     : 1;
+  uint8_t fsm5_p_y                     : 1;
+  uint8_t fsm5_n_y                     : 1;
+  uint8_t fsm5_p_z                     : 1;
+  uint8_t fsm5_n_z                     : 1;
+  uint8_t fsm5_p_v                     : 1;
+  uint8_t fsm5_n_v                     : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_outs5_t;
+
+#define LSM6DSV320X_FSM_OUTS6                      0x51U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm6_n_v                     : 1;
+  uint8_t fsm6_p_v                     : 1;
+  uint8_t fsm6_n_z                     : 1;
+  uint8_t fsm6_p_z                     : 1;
+  uint8_t fsm6_n_y                     : 1;
+  uint8_t fsm6_p_y                     : 1;
+  uint8_t fsm6_n_x                     : 1;
+  uint8_t fsm6_p_x                     : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm6_p_x                     : 1;
+  uint8_t fsm6_n_x                     : 1;
+  uint8_t fsm6_p_y                     : 1;
+  uint8_t fsm6_n_y                     : 1;
+  uint8_t fsm6_p_z                     : 1;
+  uint8_t fsm6_n_z                     : 1;
+  uint8_t fsm6_p_v                     : 1;
+  uint8_t fsm6_n_v                     : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_outs6_t;
+
+#define LSM6DSV320X_FSM_OUTS7                      0x52U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm7_n_v                     : 1;
+  uint8_t fsm7_p_v                     : 1;
+  uint8_t fsm7_n_z                     : 1;
+  uint8_t fsm7_p_z                     : 1;
+  uint8_t fsm7_n_y                     : 1;
+  uint8_t fsm7_p_y                     : 1;
+  uint8_t fsm7_n_x                     : 1;
+  uint8_t fsm7_p_x                     : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm7_p_x                     : 1;
+  uint8_t fsm7_n_x                     : 1;
+  uint8_t fsm7_p_y                     : 1;
+  uint8_t fsm7_n_y                     : 1;
+  uint8_t fsm7_p_z                     : 1;
+  uint8_t fsm7_n_z                     : 1;
+  uint8_t fsm7_p_v                     : 1;
+  uint8_t fsm7_n_v                     : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_outs7_t;
+
+#define LSM6DSV320X_FSM_OUTS8                      0x53U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm8_n_v                     : 1;
+  uint8_t fsm8_p_v                     : 1;
+  uint8_t fsm8_n_z                     : 1;
+  uint8_t fsm8_p_z                     : 1;
+  uint8_t fsm8_n_y                     : 1;
+  uint8_t fsm8_p_y                     : 1;
+  uint8_t fsm8_n_x                     : 1;
+  uint8_t fsm8_p_x                     : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm8_p_x                     : 1;
+  uint8_t fsm8_n_x                     : 1;
+  uint8_t fsm8_p_y                     : 1;
+  uint8_t fsm8_n_y                     : 1;
+  uint8_t fsm8_p_z                     : 1;
+  uint8_t fsm8_n_z                     : 1;
+  uint8_t fsm8_p_v                     : 1;
+  uint8_t fsm8_n_v                     : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_outs8_t;
+
+#define LSM6DSV320X_SFLP_ODR                       0x5EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 3;
+  uint8_t sflp_game_odr                : 3;
+  uint8_t not_used1                    : 2;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 2;
+  uint8_t sflp_game_odr                : 3;
+  uint8_t not_used0                    : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sflp_odr_t;
+
+#define LSM6DSV320X_FSM_ODR                        0x5FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 3;
+  uint8_t fsm_odr                      : 3;
+  uint8_t not_used1                    : 2;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 2;
+  uint8_t fsm_odr                      : 3;
+  uint8_t not_used0                    : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_odr_t;
+
+#define LSM6DSV320X_MLC_ODR                        0x60U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 4;
+  uint8_t mlc_odr                      : 3;
+  uint8_t not_used1                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 1;
+  uint8_t mlc_odr                      : 3;
+  uint8_t not_used0                    : 4;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_mlc_odr_t;
+
+#define LSM6DSV320X_STEP_COUNTER_L                 0x62U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t step                         : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t step                         : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_step_counter_l_t;
+
+#define LSM6DSV320X_STEP_COUNTER_H                 0x63U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t step                         : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t step                         : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_step_counter_h_t;
+
+#define LSM6DSV320X_EMB_FUNC_SRC                   0x64U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 2;
+  uint8_t stepcounter_bit_set          : 1;
+  uint8_t step_overflow                : 1;
+  uint8_t step_count_delta_ia          : 1;
+  uint8_t step_detected                : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t pedo_rst_step                : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t pedo_rst_step                : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t step_detected                : 1;
+  uint8_t step_count_delta_ia          : 1;
+  uint8_t step_overflow                : 1;
+  uint8_t stepcounter_bit_set          : 1;
+  uint8_t not_used0                    : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_emb_func_src_t;
+
+#define LSM6DSV320X_EMB_FUNC_INIT_A                0x66U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 1;
+  uint8_t sflp_game_init               : 1;
+  uint8_t not_used2                    : 1;
+  uint8_t step_det_init                : 1;
+  uint8_t tilt_init                    : 1;
+  uint8_t sig_mot_init                 : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t mlc_before_fsm_init          : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t mlc_before_fsm_init          : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t sig_mot_init                 : 1;
+  uint8_t tilt_init                    : 1;
+  uint8_t step_det_init                : 1;
+  uint8_t not_used2                    : 1;
+  uint8_t sflp_game_init               : 1;
+  uint8_t not_used0                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_emb_func_init_a_t;
+
+#define LSM6DSV320X_EMB_FUNC_INIT_B                0x67U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_init                     : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t pt_init                      : 1;
+  uint8_t fifo_compr_init              : 1;
+  uint8_t mlc_init                     : 1;
+  uint8_t not_used1                    : 3;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 3;
+  uint8_t mlc_init                     : 1;
+  uint8_t fifo_compr_init              : 1;
+  uint8_t pt_init                      : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t fsm_init                     : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_emb_func_init_b_t;
+
+#define LSM6DSV320X_EMB_FUNC_SENSOR_CONV_EN        0x67U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t xl_hg_conv_en                : 1;
+  uint8_t gyro_conv_en                 : 1;
+  uint8_t temp_conv_en                 : 1;
+  uint8_t ext_sensor_conv_en           : 1;
+  uint8_t not_used0                    : 4;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 4;
+  uint8_t ext_sensor_conv_en           : 1;
+  uint8_t temp_conv_en                 : 1;
+  uint8_t gyro_conv_en                 : 1;
+  uint8_t xl_hg_conv_en                : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_emb_func_sensor_conv_en_t;
+
+#define LSM6DSV320X_MLC1_SRC                       0x70U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t mlc1_src                     : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t mlc1_src                     : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_mlc1_src_t;
+
+#define LSM6DSV320X_MLC2_SRC                       0x71U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t mlc2_src                     : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t mlc2_src                     : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_mlc2_src_t;
+
+#define LSM6DSV320X_MLC3_SRC                       0x72U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t mlc3_src                     : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t mlc3_src                     : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_mlc3_src_t;
+
+#define LSM6DSV320X_MLC4_SRC                       0x73U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t mlc4_src                     : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t mlc4_src                     : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_mlc4_src_t;
+
+#define LSM6DSV320X_MLC5_SRC                       0x74U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t mlc5_src                     : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t mlc5_src                     : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_mlc5_src_t;
+
+#define LSM6DSV320X_MLC6_SRC                       0x75U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t mlc6_src                     : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t mlc6_src                     : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_mlc6_src_t;
+
+#define LSM6DSV320X_MLC7_SRC                       0x76U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t mlc7_src                     : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t mlc7_src                     : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_mlc7_src_t;
+
+#define LSM6DSV320X_MLC8_SRC                       0x77U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t mlc8_src                     : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t mlc8_src                     : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_mlc8_src_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup bitfields page pg0_emb_adv
+  * @{
+  *
+  */
+#define LSM6DSV320X_EMB_ADV_PG_0                   0x000U
+
+#define LSM6DSV320X_FSM_EXT_SENSITIVITY_L          0xBAU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_s                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_s                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_ext_sensitivity_l_t;
+
+#define LSM6DSV320X_FSM_EXT_SENSITIVITY_H          0xBBU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_s                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_s                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_ext_sensitivity_h_t;
+
+#define LSM6DSV320X_FSM_EXT_OFFX_L                 0xC0U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_offx                 : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_offx                 : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_ext_offx_l_t;
+
+#define LSM6DSV320X_FSM_EXT_OFFX_H                 0xC1U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_offx                 : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_offx                 : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_ext_offx_h_t;
+
+#define LSM6DSV320X_FSM_EXT_OFFY_L                 0xC2U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_offy                 : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_offy                 : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_ext_offy_l_t;
+
+#define LSM6DSV320X_FSM_EXT_OFFY_H                 0xC3U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_offy                 : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_offy                 : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_ext_offy_h_t;
+
+#define LSM6DSV320X_FSM_EXT_OFFZ_L                 0xC4U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_offz                 : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_offz                 : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_ext_offz_l_t;
+
+#define LSM6DSV320X_FSM_EXT_OFFZ_H                 0xC5U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_offz                 : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_offz                 : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_ext_offz_h_t;
+
+#define LSM6DSV320X_FSM_EXT_MATRIX_XX_L            0xC6U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_mat_xx               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_mat_xx               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_ext_matrix_xx_l_t;
+
+#define LSM6DSV320X_FSM_EXT_MATRIX_XX_H            0xC7U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_mat_xx               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_mat_xx               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_ext_matrix_xx_h_t;
+
+#define LSM6DSV320X_FSM_EXT_MATRIX_XY_L            0xC8U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_mat_xy               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_mat_xy               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_ext_matrix_xy_l_t;
+
+#define LSM6DSV320X_FSM_EXT_MATRIX_XY_H            0xC9U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_mat_xy               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_mat_xy               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_ext_matrix_xy_h_t;
+
+#define LSM6DSV320X_FSM_EXT_MATRIX_XZ_L            0xCAU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_mat_xz               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_mat_xz               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_ext_matrix_xz_l_t;
+
+#define LSM6DSV320X_FSM_EXT_MATRIX_XZ_H            0xCBU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_mat_xz               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_mat_xz               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_ext_matrix_xz_h_t;
+
+#define LSM6DSV320X_FSM_EXT_MATRIX_YY_L            0xCCU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_mat_yy               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_mat_yy               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_ext_matrix_yy_l_t;
+
+#define LSM6DSV320X_FSM_EXT_MATRIX_YY_H            0xCDU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_mat_yy               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_mat_yy               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_ext_matrix_yy_h_t;
+
+#define LSM6DSV320X_FSM_EXT_MATRIX_YZ_L            0xCEU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_mat_yz               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_mat_yz               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_ext_matrix_yz_l_t;
+
+#define LSM6DSV320X_FSM_EXT_MATRIX_YZ_H            0xCFU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_mat_yz               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_mat_yz               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_ext_matrix_yz_h_t;
+
+#define LSM6DSV320X_FSM_EXT_MATRIX_ZZ_L            0xD0U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_mat_zz               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_mat_zz               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_ext_matrix_zz_l_t;
+
+#define LSM6DSV320X_FSM_EXT_MATRIX_ZZ_H            0xD1U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_mat_zz               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_mat_zz               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_ext_matrix_zz_h_t;
+
+#define LSM6DSV320X_EXT_CFG_A                      0xD4U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ext_z_axis                   : 3;
+  uint8_t not_used0                    : 1;
+  uint8_t ext_y_axis                   : 3;
+  uint8_t not_used1                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 1;
+  uint8_t ext_y_axis                   : 3;
+  uint8_t not_used0                    : 1;
+  uint8_t ext_z_axis                   : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ext_cfg_a_t;
+
+#define LSM6DSV320X_EXT_CFG_B                      0xD5U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ext_x_axis                   : 3;
+  uint8_t not_used0                    : 5;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 5;
+  uint8_t ext_x_axis                   : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ext_cfg_b_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup bitfields page pg1_emb_adv
+  * @{
+  *
+  */
+#define LSM6DSV320X_EMB_ADV_PG_1                   0x100U
+
+#define LSM6DSV320X_XL_HG_SENSITIVITY_L            0x58U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t xl_hg_s                      : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t xl_hg_s                      : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_xl_hg_sensitivity_l_t;
+
+#define LSM6DSV320X_XL_HG_SENSITIVITY_H            0x59U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t xl_hg_s                      : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t xl_hg_s                      : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_xl_hg_sensitivity_h_t;
+
+#define LSM6DSV320X_FSM_LC_TIMEOUT_L               0x7AU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_lc_timeout               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_lc_timeout               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_lc_timeout_l_t;
+
+#define LSM6DSV320X_FSM_LC_TIMEOUT_H               0x7BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_lc_timeout               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_lc_timeout               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_lc_timeout_h_t;
+
+#define LSM6DSV320X_FSM_PROGRAMS                   0x7CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_n_prog                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_n_prog                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_programs_t;
+
+#define LSM6DSV320X_FSM_START_ADD_L                0x7EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_start                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_start                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_start_add_l_t;
+
+#define LSM6DSV320X_FSM_START_ADD_H                0x7FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_start                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_start                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_fsm_start_add_h_t;
+
+#define LSM6DSV320X_PEDO_CMD_REG                   0x83U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 2;
+  uint8_t fp_rejection_en              : 1;
+  uint8_t carry_count_en               : 1;
+  uint8_t not_used1                    : 4;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 4;
+  uint8_t carry_count_en               : 1;
+  uint8_t fp_rejection_en              : 1;
+  uint8_t not_used0                    : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_pedo_cmd_reg_t;
+
+#define LSM6DSV320X_PEDO_DEB_STEPS_CONF            0x84U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t deb_step                     : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t deb_step                     : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_pedo_deb_steps_conf_t;
+
+#define LSM6DSV320X_PEDO_SC_DELTAT_L               0xD0U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t pd_sc                        : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t pd_sc                        : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_pedo_sc_deltat_l_t;
+
+#define LSM6DSV320X_PEDO_SC_DELTAT_H               0xD1U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t pd_sc                        : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t pd_sc                        : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_pedo_sc_deltat_h_t;
+
+#define LSM6DSV320X_MLC_EXT_SENSITIVITY_L          0xE8U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t mlc_ext_s                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t mlc_ext_s                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_mlc_ext_sensitivity_l_t;
+
+#define LSM6DSV320X_MLC_EXT_SENSITIVITY_H          0xE9U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t mlc_ext_s                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t mlc_ext_s                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_mlc_ext_sensitivity_h_t;
+
+/** @defgroup bitfields page pg2_emb_adv
+  * @{
+  *
+  */
+#define LSM6DSV320X_EMB_ADV_PG_2                   0x200U
+
+#define LSM6DSV320X_EXT_FORMAT                     0x00
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 1;
+  uint8_t ext_format_sel               : 1;
+  uint8_t not_used1                    : 6;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 6;
+  uint8_t ext_format_sel               : 1;
+  uint8_t not_used0                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ext_format_t;
+
+#define LSM6DSV320X_EXT_3BYTE_SENSITIVITY_L        0x02U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ext_3byte_s                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ext_3byte_s                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ext_3byte_sensitivity_l_t;
+
+#define LSM6DSV320X_EXT_3BYTE_SENSITIVITY_H        0x03U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ext_3byte_s                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ext_3byte_s                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ext_3byte_sensitivity_h_t;
+
+#define LSM6DSV320X_EXT_3BYTE_OFFSET_XL            0x06U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ext_3byte_off                : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ext_3byte_off                : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ext_3byte_offset_xl_t;
+
+#define LSM6DSV320X_EXT_3BYTE_OFFSET_L             0x07U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ext_3byte_off                : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ext_3byte_off                : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ext_3byte_offset_l_t;
+
+#define LSM6DSV320X_EXT_3BYTE_OFFSET_H             0x08U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ext_3byte_off                : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ext_3byte_off                : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_ext_3byte_offset_h_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup bitfields page sensor_hub
+  * @{
+  *
+  */
+
+#define LSM6DSV320X_SENSOR_HUB_1                   0x2U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub1                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub1                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sensor_hub_1_t;
+
+#define LSM6DSV320X_SENSOR_HUB_2                   0x3U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub2                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub2                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sensor_hub_2_t;
+
+#define LSM6DSV320X_SENSOR_HUB_3                   0x4U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub3                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub3                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sensor_hub_3_t;
+
+#define LSM6DSV320X_SENSOR_HUB_4                   0x5U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub4                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub4                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sensor_hub_4_t;
+
+#define LSM6DSV320X_SENSOR_HUB_5                   0x6U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub5                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub5                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sensor_hub_5_t;
+
+#define LSM6DSV320X_SENSOR_HUB_6                   0x7U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub6                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub6                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sensor_hub_6_t;
+
+#define LSM6DSV320X_SENSOR_HUB_7                   0x8U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub7                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub7                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sensor_hub_7_t;
+
+#define LSM6DSV320X_SENSOR_HUB_8                   0x9U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub8                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub8                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sensor_hub_8_t;
+
+#define LSM6DSV320X_SENSOR_HUB_9                   0x0AU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub9                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub9                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sensor_hub_9_t;
+
+#define LSM6DSV320X_SENSOR_HUB_10                  0x0BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub10                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub10                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sensor_hub_10_t;
+
+#define LSM6DSV320X_SENSOR_HUB_11                  0x0CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub11                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub11                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sensor_hub_11_t;
+
+#define LSM6DSV320X_SENSOR_HUB_12                  0x0DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub12                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub12                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sensor_hub_12_t;
+
+#define LSM6DSV320X_SENSOR_HUB_13                  0x0EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub13                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub13                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sensor_hub_13_t;
+
+#define LSM6DSV320X_SENSOR_HUB_14                  0x0FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub14                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub14                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sensor_hub_14_t;
+
+#define LSM6DSV320X_SENSOR_HUB_15                  0x10U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub15                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub15                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sensor_hub_15_t;
+
+#define LSM6DSV320X_SENSOR_HUB_16                  0x11U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub16                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub16                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sensor_hub_16_t;
+
+#define LSM6DSV320X_SENSOR_HUB_17                  0x12U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub17                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub17                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sensor_hub_17_t;
+
+#define LSM6DSV320X_SENSOR_HUB_18                  0x13U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub18                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub18                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_sensor_hub_18_t;
+
+#define LSM6DSV320X_CONTROLLER_CONFIG              0x14U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t aux_sens_on                  : 2;
+  uint8_t controller_on                : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t pass_through_mode            : 1;
+  uint8_t start_config                 : 1;
+  uint8_t write_once                   : 1;
+  uint8_t rst_controller_regs          : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t rst_controller_regs          : 1;
+  uint8_t write_once                   : 1;
+  uint8_t start_config                 : 1;
+  uint8_t pass_through_mode            : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t controller_on                : 1;
+  uint8_t aux_sens_on                  : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_controller_config_t;
+
+#define LSM6DSV320X_TGT0_ADD                       0x15U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t rw_0                         : 1;
+  uint8_t target0_add                  : 7;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t target0_add                  : 7;
+  uint8_t rw_0                         : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_tgt0_add_t;
+
+#define LSM6DSV320X_TGT0_SUBADD                    0x16U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t target0_reg                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t target0_reg                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_tgt0_subadd_t;
+
+#define LSM6DSV320X_TGT0_CONFIG                    0x17U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t target0_numop                : 3;
+  uint8_t batch_ext_sens_0_en          : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t shub_odr                     : 3;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t shub_odr                     : 3;
+  uint8_t not_used0                    : 1;
+  uint8_t batch_ext_sens_0_en          : 1;
+  uint8_t target0_numop                : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_tgt0_config_t;
+
+#define LSM6DSV320X_TGT1_ADD                       0x18U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t r_1                          : 1;
+  uint8_t target1_add                  : 7;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t target1_add                  : 7;
+  uint8_t r_1                          : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_tgt1_add_t;
+
+#define LSM6DSV320X_TGT1_SUBADD                    0x19U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t target1_reg                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t target1_reg                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_tgt1_subadd_t;
+
+#define LSM6DSV320X_TGT1_CONFIG                    0x1AU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t target1_numop                : 3;
+  uint8_t batch_ext_sens_1_en          : 1;
+  uint8_t not_used0                    : 4;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 4;
+  uint8_t batch_ext_sens_1_en          : 1;
+  uint8_t target1_numop                : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_tgt1_config_t;
+
+#define LSM6DSV320X_TGT2_ADD                       0x1BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t r_2                          : 1;
+  uint8_t target2_add                  : 7;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t target2_add                  : 7;
+  uint8_t r_2                          : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_tgt2_add_t;
+
+#define LSM6DSV320X_TGT2_SUBADD                    0x1CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t target2_reg                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t target2_reg                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_tgt2_subadd_t;
+
+#define LSM6DSV320X_TGT2_CONFIG                    0x1DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t target2_numop                : 3;
+  uint8_t batch_ext_sens_2_en          : 1;
+  uint8_t not_used0                    : 4;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 4;
+  uint8_t batch_ext_sens_2_en          : 1;
+  uint8_t target2_numop                : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_tgt2_config_t;
+
+#define LSM6DSV320X_TGT3_ADD                       0x1EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t r_3                          : 1;
+  uint8_t target3_add                  : 7;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t target3_add                  : 7;
+  uint8_t r_3                          : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_tgt3_add_t;
+
+#define LSM6DSV320X_TGT3_SUBADD                    0x1FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t target3_reg                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t target3_reg                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_tgt3_subadd_t;
+
+#define LSM6DSV320X_TGT3_CONFIG                    0x20U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t target3_numop                : 3;
+  uint8_t batch_ext_sens_3_en          : 1;
+  uint8_t not_used0                    : 4;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 4;
+  uint8_t batch_ext_sens_3_en          : 1;
+  uint8_t target3_numop                : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_tgt3_config_t;
+
+#define LSM6DSV320X_DATAWRITE_TGT0                 0x21U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t target0_dataw                : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t target0_dataw                : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_datawrite_tgt0_t;
+
+#define LSM6DSV320X_STATUS_CONTROLLER              0x22U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sens_hub_endop               : 1;
+  uint8_t not_used0                    : 2;
+  uint8_t target0_nack                 : 1;
+  uint8_t target1_nack                 : 1;
+  uint8_t target2_nack                 : 1;
+  uint8_t target3_nack                 : 1;
+  uint8_t wr_once_done                 : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t wr_once_done                 : 1;
+  uint8_t target3_nack                 : 1;
+  uint8_t target2_nack                 : 1;
+  uint8_t target1_nack                 : 1;
+  uint8_t target0_nack                 : 1;
+  uint8_t not_used0                    : 2;
+  uint8_t sens_hub_endop               : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv320x_status_controller_t;
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup LSM6DSO_Register_Union
+  * @brief    This union group all the registers having a bit-field
+  *           description.
+  *           This union is useful but it's not needed by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union
+{
+  /* master page registers */
+  lsm6dsv320x_func_cfg_access_t          func_cfg_access;
+  lsm6dsv320x_pin_ctrl_t                 pin_ctrl;
+  lsm6dsv320x_if_cfg_t                   if_cfg;
+  lsm6dsv320x_odr_trig_cfg_t             odr_trig_cfg;
+  lsm6dsv320x_fifo_ctrl1_t               fifo_ctrl1;
+  lsm6dsv320x_fifo_ctrl2_t               fifo_ctrl2;
+  lsm6dsv320x_fifo_ctrl3_t               fifo_ctrl3;
+  lsm6dsv320x_fifo_ctrl4_t               fifo_ctrl4;
+  lsm6dsv320x_counter_bdr_reg1_t         counter_bdr_reg1;
+  lsm6dsv320x_counter_bdr_reg2_t         counter_bdr_reg2;
+  lsm6dsv320x_int1_ctrl_t                int1_ctrl;
+  lsm6dsv320x_int2_ctrl_t                int2_ctrl;
+  lsm6dsv320x_who_am_i_t                 who_am_i;
+  lsm6dsv320x_ctrl1_t                    ctrl1;
+  lsm6dsv320x_ctrl2_t                    ctrl2;
+  lsm6dsv320x_ctrl3_t                    ctrl3;
+  lsm6dsv320x_ctrl4_t                    ctrl4;
+  lsm6dsv320x_ctrl5_t                    ctrl5;
+  lsm6dsv320x_ctrl6_t                    ctrl6;
+  lsm6dsv320x_ctrl7_t                    ctrl7;
+  lsm6dsv320x_ctrl8_t                    ctrl8;
+  lsm6dsv320x_ctrl9_t                    ctrl9;
+  lsm6dsv320x_ctrl10_t                   ctrl10;
+  lsm6dsv320x_ctrl_status_t              ctrl_status;
+  lsm6dsv320x_fifo_status1_t             fifo_status1;
+  lsm6dsv320x_fifo_status2_t             fifo_status2;
+  lsm6dsv320x_all_int_src_t              all_int_src;
+  lsm6dsv320x_status_reg_t               status_reg;
+  lsm6dsv320x_out_temp_l_t               out_temp_l;
+  lsm6dsv320x_out_temp_h_t               out_temp_h;
+  lsm6dsv320x_outx_l_g_t                 outx_l_g;
+  lsm6dsv320x_outx_h_g_t                 outx_h_g;
+  lsm6dsv320x_outy_l_g_t                 outy_l_g;
+  lsm6dsv320x_outy_h_g_t                 outy_h_g;
+  lsm6dsv320x_outz_l_g_t                 outz_l_g;
+  lsm6dsv320x_outz_h_g_t                 outz_h_g;
+  lsm6dsv320x_outx_l_a_t                 outx_l_a;
+  lsm6dsv320x_outx_h_a_t                 outx_h_a;
+  lsm6dsv320x_outy_l_a_t                 outy_l_a;
+  lsm6dsv320x_outy_h_a_t                 outy_h_a;
+  lsm6dsv320x_outz_l_a_t                 outz_l_a;
+  lsm6dsv320x_outz_h_a_t                 outz_h_a;
+  lsm6dsv320x_ui_outx_l_g_ois_eis_t      ui_outx_l_g_ois_eis;
+  lsm6dsv320x_ui_outx_h_g_ois_eis_t      ui_outx_h_g_ois_eis;
+  lsm6dsv320x_ui_outy_l_g_ois_eis_t      ui_outy_l_g_ois_eis;
+  lsm6dsv320x_ui_outy_h_g_ois_eis_t      ui_outy_h_g_ois_eis;
+  lsm6dsv320x_ui_outz_l_g_ois_eis_t      ui_outz_l_g_ois_eis;
+  lsm6dsv320x_ui_outz_h_g_ois_eis_t      ui_outz_h_g_ois_eis;
+  lsm6dsv320x_ui_outx_l_a_ois_hg_t       ui_outx_l_a_ois_hg;
+  lsm6dsv320x_ui_outx_h_a_ois_hg_t       ui_outx_h_a_ois_hg;
+  lsm6dsv320x_ui_outy_l_a_ois_hg_t       ui_outy_l_a_ois_hg;
+  lsm6dsv320x_ui_outy_h_a_ois_hg_t       ui_outy_h_a_ois_hg;
+  lsm6dsv320x_ui_outz_l_a_ois_hg_t       ui_outz_l_a_ois_hg;
+  lsm6dsv320x_ui_outz_h_a_ois_hg_t       ui_outz_h_a_ois_hg;
+  lsm6dsv320x_timestamp0_t               timestamp0;
+  lsm6dsv320x_timestamp1_t               timestamp1;
+  lsm6dsv320x_timestamp2_t               timestamp2;
+  lsm6dsv320x_timestamp3_t               timestamp3;
+  lsm6dsv320x_ui_status_reg_ois_t        ui_status_reg_ois;
+  lsm6dsv320x_wake_up_src_t              wake_up_src;
+  lsm6dsv320x_tap_src_t                  tap_src;
+  lsm6dsv320x_d6d_src_t                  d6d_src;
+  lsm6dsv320x_status_controller_mainpage_t   status_controller_mainpage;
+  lsm6dsv320x_emb_func_status_mainpage_t emb_func_status_mainpage;
+  lsm6dsv320x_fsm_status_mainpage_t      fsm_status_mainpage;
+  lsm6dsv320x_mlc_status_mainpage_t      mlc_status_mainpage;
+  lsm6dsv320x_hg_wake_up_src_t           hg_wake_up_src;
+  lsm6dsv320x_ctrl2_xl_hg_t              ctrl2_xl_hg;
+  lsm6dsv320x_ctrl1_xl_hg_t              ctrl1_xl_hg;
+  lsm6dsv320x_internal_freq_t            internal_freq;
+  lsm6dsv320x_functions_enable_t         functions_enable;
+  lsm6dsv320x_inactivity_dur_t           inactivity_dur;
+  lsm6dsv320x_inactivity_ths_t           inactivity_ths;
+  lsm6dsv320x_tap_cfg0_t                 tap_cfg0;
+  lsm6dsv320x_tap_cfg1_t                 tap_cfg1;
+  lsm6dsv320x_tap_cfg2_t                 tap_cfg2;
+  lsm6dsv320x_tap_ths_6d_t               tap_ths_6d;
+  lsm6dsv320x_tap_dur_t                  tap_dur;
+  lsm6dsv320x_wake_up_ths_t              wake_up_ths;
+  lsm6dsv320x_wake_up_dur_t              wake_up_dur;
+  lsm6dsv320x_free_fall_t                free_fall;
+  lsm6dsv320x_md1_cfg_t                  md1_cfg;
+  lsm6dsv320x_md2_cfg_t                  md2_cfg;
+  lsm6dsv320x_emb_func_cfg_t             emb_func_cfg;
+  lsm6dsv320x_ui_handshake_ctrl_t        ui_handshake_ctrl;
+  lsm6dsv320x_ui_if2_shared_0_t          ui_if2_shared_0;
+  lsm6dsv320x_ui_if2_shared_1_t          ui_if2_shared_1;
+  lsm6dsv320x_ui_if2_shared_2_t          ui_if2_shared_2;
+  lsm6dsv320x_ui_if2_shared_3_t          ui_if2_shared_3;
+  lsm6dsv320x_ui_if2_shared_4_t          ui_if2_shared_4;
+  lsm6dsv320x_ui_if2_shared_5_t          ui_if2_shared_5;
+  lsm6dsv320x_ctrl_eis_t                 ctrl_eis;
+  lsm6dsv320x_hg_x_ofs_usr_t             hg_x_ofs_usr;
+  lsm6dsv320x_hg_y_ofs_usr_t             hg_y_ofs_usr;
+  lsm6dsv320x_hg_z_ofs_usr_t             hg_z_ofs_usr;
+  lsm6dsv320x_ui_int_ois_t               ui_int_ois;
+  lsm6dsv320x_ui_ctrl1_ois_t             ui_ctrl1_ois;
+  lsm6dsv320x_ui_ctrl2_ois_t             ui_ctrl2_ois;
+  lsm6dsv320x_ui_ctrl3_ois_t             ui_ctrl3_ois;
+  lsm6dsv320x_x_ofs_usr_t                x_ofs_usr;
+  lsm6dsv320x_y_ofs_usr_t                y_ofs_usr;
+  lsm6dsv320x_z_ofs_usr_t                z_ofs_usr;
+  lsm6dsv320x_fifo_data_out_tag_t        fifo_data_out_tag;
+  lsm6dsv320x_fifo_data_out_x_l_t        fifo_data_out_x_l;
+  lsm6dsv320x_fifo_data_out_x_h_t        fifo_data_out_x_h;
+  lsm6dsv320x_fifo_data_out_y_l_t        fifo_data_out_y_l;
+  lsm6dsv320x_fifo_data_out_y_h_t        fifo_data_out_y_h;
+  lsm6dsv320x_fifo_data_out_z_l_t        fifo_data_out_z_l;
+  lsm6dsv320x_fifo_data_out_z_h_t        fifo_data_out_z_h;
+  /* IF2 registers */
+  lsm6dsv320x_if2_who_am_i_t             if2_who_am_i;
+  lsm6dsv320x_if2_status_reg_ois_t       if2_status_reg_ois;
+  lsm6dsv320x_if2_out_temp_l_t           if2_out_temp_l;
+  lsm6dsv320x_if2_out_temp_h_t           if2_out_temp_h;
+  lsm6dsv320x_if2_outx_l_g_ois_t         if2_outx_l_g_ois;
+  lsm6dsv320x_if2_outx_h_g_ois_t         if2_outx_h_g_ois;
+  lsm6dsv320x_if2_outy_l_g_ois_t         if2_outy_l_g_ois;
+  lsm6dsv320x_if2_outy_h_g_ois_t         if2_outy_h_g_ois;
+  lsm6dsv320x_if2_outz_l_g_ois_t         if2_outz_l_g_ois;
+  lsm6dsv320x_if2_outz_h_g_ois_t         if2_outz_h_g_ois;
+  lsm6dsv320x_if2_outx_l_a_ois_t         if2_outx_l_a_ois;
+  lsm6dsv320x_if2_outx_h_a_ois_t         if2_outx_h_a_ois;
+  lsm6dsv320x_if2_outy_l_a_ois_t         if2_outy_l_a_ois;
+  lsm6dsv320x_if2_outy_h_a_ois_t         if2_outy_h_a_ois;
+  lsm6dsv320x_if2_outz_l_a_ois_t         if2_outz_l_a_ois;
+  lsm6dsv320x_if2_outz_h_a_ois_t         if2_outz_h_a_ois;
+  lsm6dsv320x_if2_handshake_ctrl_t       if2_handshake_ctrl;
+  lsm6dsv320x_if2_int_ois_t              if2_int_ois;
+  lsm6dsv320x_if2_ctrl1_ois_t            if2_ctrl1_ois;
+  lsm6dsv320x_if2_ctrl2_ois_t            if2_ctrl2_ois;
+  lsm6dsv320x_if2_ctrl3_ois_t            if2_ctrl3_ois;
+  /* Embedded functions registers */
+  lsm6dsv320x_page_sel_t                 page_sel;
+  lsm6dsv320x_emb_func_en_a_t            emb_func_en_a;
+  lsm6dsv320x_emb_func_en_b_t            emb_func_en_b;
+  lsm6dsv320x_emb_func_exec_status_t     emb_func_exec_status;
+  lsm6dsv320x_page_address_t             page_address;
+  lsm6dsv320x_page_value_t               page_value;
+  lsm6dsv320x_emb_func_int1_t            emb_func_int1;
+  lsm6dsv320x_fsm_int1_t                 fsm_int1;
+  lsm6dsv320x_mlc_int1_t                 mlc_int1;
+  lsm6dsv320x_emb_func_int2_t            emb_func_int2;
+  lsm6dsv320x_fsm_int2_t                 fsm_int2;
+  lsm6dsv320x_mlc_int2_t                 mlc_int2;
+  lsm6dsv320x_emb_func_status_t          emb_func_status;
+  lsm6dsv320x_fsm_status_t               fsm_status;
+  lsm6dsv320x_mlc_status_t               mlc_status;
+  lsm6dsv320x_page_rw_t                  page_rw;
+  lsm6dsv320x_sflp_gbiasx_l_t            sflp_gbiasx_l;
+  lsm6dsv320x_sflp_gbiasx_h_t            sflp_gbiasx_h;
+  lsm6dsv320x_sflp_gbiasy_l_t            sflp_gbiasy_l;
+  lsm6dsv320x_sflp_gbiasy_h_t            sflp_gbiasy_h;
+  lsm6dsv320x_sflp_gbiasz_l_t            sflp_gbiasz_l;
+  lsm6dsv320x_sflp_gbiasz_h_t            sflp_gbiasz_h;
+  lsm6dsv320x_sflp_gravx_l_t             sflp_gravx_l;
+  lsm6dsv320x_sflp_gravx_h_t             sflp_gravx_h;
+  lsm6dsv320x_sflp_gravy_l_t             sflp_gravy_l;
+  lsm6dsv320x_sflp_gravy_h_t             sflp_gravy_h;
+  lsm6dsv320x_sflp_gravz_l_t             sflp_gravz_l;
+  lsm6dsv320x_sflp_gravz_h_t             sflp_gravz_h;
+  lsm6dsv320x_sflp_quatw_l_t             sflp_quatw_l;
+  lsm6dsv320x_sflp_quatw_h_t             sflp_quatw_h;
+  lsm6dsv320x_sflp_quatx_l_t             sflp_quatx_l;
+  lsm6dsv320x_sflp_quatx_h_t             sflp_quatx_h;
+  lsm6dsv320x_sflp_quaty_l_t             sflp_quaty_l;
+  lsm6dsv320x_sflp_quaty_h_t             sflp_quaty_h;
+  lsm6dsv320x_sflp_quatz_l_t             sflp_quatz_l;
+  lsm6dsv320x_sflp_quatz_h_t             sflp_quatz_h;
+  lsm6dsv320x_sflp_gbiasx_init_l_t       sflp_gbiasx_init_l;
+  lsm6dsv320x_sflp_gbiasx_init_h_t       sflp_gbiasx_init_h;
+  lsm6dsv320x_sflp_gbiasy_init_l_t       sflp_gbiasy_init_l;
+  lsm6dsv320x_sflp_gbiasy_init_h_t       sflp_gbiasy_init_h;
+  lsm6dsv320x_sflp_gbiasz_init_l_t       sflp_gbiasz_init_l;
+  lsm6dsv320x_sflp_gbiasz_init_h_t       sflp_gbiasz_init_h;
+  lsm6dsv320x_emb_func_fifo_en_a_t       emb_func_fifo_en_a;
+  lsm6dsv320x_emb_func_fifo_en_b_t       emb_func_fifo_en_b;
+  lsm6dsv320x_fsm_enable_t               fsm_enable;
+  lsm6dsv320x_fsm_long_counter_l_t       fsm_long_counter_l;
+  lsm6dsv320x_fsm_long_counter_h_t       fsm_long_counter_h;
+  lsm6dsv320x_int_ack_mask_t             int_ack_mask;
+  lsm6dsv320x_fsm_outs1_t                fsm_outs1;
+  lsm6dsv320x_fsm_outs2_t                fsm_outs2;
+  lsm6dsv320x_fsm_outs3_t                fsm_outs3;
+  lsm6dsv320x_fsm_outs4_t                fsm_outs4;
+  lsm6dsv320x_fsm_outs5_t                fsm_outs5;
+  lsm6dsv320x_fsm_outs6_t                fsm_outs6;
+  lsm6dsv320x_fsm_outs7_t                fsm_outs7;
+  lsm6dsv320x_fsm_outs8_t                fsm_outs8;
+  lsm6dsv320x_sflp_odr_t                 sflp_odr;
+  lsm6dsv320x_fsm_odr_t                  fsm_odr;
+  lsm6dsv320x_mlc_odr_t                  mlc_odr;
+  lsm6dsv320x_step_counter_l_t           step_counter_l;
+  lsm6dsv320x_step_counter_h_t           step_counter_h;
+  lsm6dsv320x_emb_func_src_t             emb_func_src;
+  lsm6dsv320x_emb_func_init_a_t          emb_func_init_a;
+  lsm6dsv320x_emb_func_init_b_t          emb_func_init_b;
+  lsm6dsv320x_emb_func_sensor_conv_en_t  emb_func_sensor_conv_en;
+  lsm6dsv320x_mlc1_src_t                 mlc1_src;
+  lsm6dsv320x_mlc2_src_t                 mlc2_src;
+  lsm6dsv320x_mlc3_src_t                 mlc3_src;
+  lsm6dsv320x_mlc4_src_t                 mlc4_src;
+  lsm6dsv320x_mlc5_src_t                 mlc5_src;
+  lsm6dsv320x_mlc6_src_t                 mlc6_src;
+  lsm6dsv320x_mlc7_src_t                 mlc7_src;
+  /* Embedded functions extended page 0 registers */
+  lsm6dsv320x_fsm_ext_sensitivity_l_t    fsm_ext_sensitivity_l;
+  lsm6dsv320x_fsm_ext_sensitivity_h_t    fsm_ext_sensitivity_h;
+  lsm6dsv320x_fsm_ext_offx_l_t           fsm_ext_offx_l;
+  lsm6dsv320x_fsm_ext_offx_h_t           fsm_ext_offx_h;
+  lsm6dsv320x_fsm_ext_offy_l_t           fsm_ext_offy_l;
+  lsm6dsv320x_fsm_ext_offy_h_t           fsm_ext_offy_h;
+  lsm6dsv320x_fsm_ext_offz_l_t           fsm_ext_offz_l;
+  lsm6dsv320x_fsm_ext_offz_h_t           fsm_ext_offz_h;
+  lsm6dsv320x_fsm_ext_matrix_xx_l_t      fsm_ext_matrix_xx_l;
+  lsm6dsv320x_fsm_ext_matrix_xx_h_t      fsm_ext_matrix_xx_h;
+  lsm6dsv320x_fsm_ext_matrix_xy_l_t      fsm_ext_matrix_xy_l;
+  lsm6dsv320x_fsm_ext_matrix_xy_h_t      fsm_ext_matrix_xy_h;
+  lsm6dsv320x_fsm_ext_matrix_xz_l_t      fsm_ext_matrix_xz_l;
+  lsm6dsv320x_fsm_ext_matrix_xz_h_t      fsm_ext_matrix_xz_h;
+  lsm6dsv320x_fsm_ext_matrix_yy_l_t      fsm_ext_matrix_yy_l;
+  lsm6dsv320x_fsm_ext_matrix_yy_h_t      fsm_ext_matrix_yy_h;
+  lsm6dsv320x_fsm_ext_matrix_yz_l_t      fsm_ext_matrix_yz_l;
+  lsm6dsv320x_fsm_ext_matrix_yz_h_t      fsm_ext_matrix_yz_h;
+  lsm6dsv320x_fsm_ext_matrix_zz_l_t      fsm_ext_matrix_zz_l;
+  lsm6dsv320x_fsm_ext_matrix_zz_h_t      fsm_ext_matrix_zz_h;
+  lsm6dsv320x_ext_cfg_a_t                ext_cfg_a;
+  lsm6dsv320x_ext_cfg_b_t                ext_cfg_b;
+  /* Embedded functions extended page 1 registers */
+  lsm6dsv320x_xl_hg_sensitivity_l_t      xl_hg_sensitivity_l;
+  lsm6dsv320x_xl_hg_sensitivity_h_t      xl_hg_sensitivity_h;
+  lsm6dsv320x_fsm_lc_timeout_l_t         fsm_lc_timeout_l;
+  lsm6dsv320x_fsm_lc_timeout_h_t         fsm_lc_timeout_h;
+  lsm6dsv320x_fsm_programs_t             fsm_programs;
+  lsm6dsv320x_fsm_start_add_l_t          fsm_start_add_l;
+  lsm6dsv320x_fsm_start_add_h_t          fsm_start_add_h;
+  lsm6dsv320x_pedo_cmd_reg_t             pedo_cmd_reg;
+  lsm6dsv320x_pedo_deb_steps_conf_t      pedo_deb_steps_conf;
+  lsm6dsv320x_pedo_sc_deltat_l_t         pedo_sc_deltat_l;
+  lsm6dsv320x_pedo_sc_deltat_h_t         pedo_sc_deltat_h;
+  lsm6dsv320x_mlc_ext_sensitivity_l_t    mlc_ext_sensitivity_l;
+  lsm6dsv320x_mlc_ext_sensitivity_h_t    mlc_ext_sensitivity_h;
+  /* Embedded functions extended page 2 registers */
+  lsm6dsv320x_ext_format_t               ext_format;
+  lsm6dsv320x_ext_3byte_sensitivity_l_t  ext_3byte_sensitivity_l;
+  lsm6dsv320x_ext_3byte_sensitivity_h_t  ext_3byte_sensitivity_h;
+  lsm6dsv320x_ext_3byte_offset_xl_t      ext_3byte_offset_xl;
+  lsm6dsv320x_ext_3byte_offset_l_t       ext_3byte_offset_l;
+  lsm6dsv320x_ext_3byte_offset_h_t       ext_3byte_offset_h;
+  /* Sensor HUB registers */
+  lsm6dsv320x_sensor_hub_1_t             sensor_hub_1;
+  lsm6dsv320x_sensor_hub_2_t             sensor_hub_2;
+  lsm6dsv320x_sensor_hub_3_t             sensor_hub_3;
+  lsm6dsv320x_sensor_hub_4_t             sensor_hub_4;
+  lsm6dsv320x_sensor_hub_5_t             sensor_hub_5;
+  lsm6dsv320x_sensor_hub_6_t             sensor_hub_6;
+  lsm6dsv320x_sensor_hub_7_t             sensor_hub_7;
+  lsm6dsv320x_sensor_hub_8_t             sensor_hub_8;
+  lsm6dsv320x_sensor_hub_9_t             sensor_hub_9;
+  lsm6dsv320x_sensor_hub_10_t            sensor_hub_10;
+  lsm6dsv320x_sensor_hub_11_t            sensor_hub_11;
+  lsm6dsv320x_sensor_hub_12_t            sensor_hub_12;
+  lsm6dsv320x_sensor_hub_13_t            sensor_hub_13;
+  lsm6dsv320x_sensor_hub_14_t            sensor_hub_14;
+  lsm6dsv320x_sensor_hub_15_t            sensor_hub_15;
+  lsm6dsv320x_sensor_hub_16_t            sensor_hub_16;
+  lsm6dsv320x_sensor_hub_17_t            sensor_hub_17;
+  lsm6dsv320x_sensor_hub_18_t            sensor_hub_18;
+  lsm6dsv320x_controller_config_t        controller_config;
+  lsm6dsv320x_tgt0_add_t                 tgt0_add;
+  lsm6dsv320x_tgt0_subadd_t              tgt0_subadd;
+  lsm6dsv320x_tgt0_config_t              tgt0_config;
+  lsm6dsv320x_tgt1_add_t                 tgt1_add;
+  lsm6dsv320x_tgt1_subadd_t              tgt1_subadd;
+  lsm6dsv320x_tgt1_config_t              tgt1_config;
+  lsm6dsv320x_tgt2_add_t                 tgt2_add;
+  lsm6dsv320x_tgt2_subadd_t              tgt2_subadd;
+  lsm6dsv320x_tgt2_config_t              tgt2_config;
+  lsm6dsv320x_tgt3_add_t                 tgt3_add;
+  lsm6dsv320x_tgt3_subadd_t              tgt3_subadd;
+  lsm6dsv320x_tgt3_config_t              tgt3_config;
+  lsm6dsv320x_datawrite_tgt0_t           datawrite_tgt0;
+  lsm6dsv320x_status_controller_t        status_controller;
+  bitwise_t                             bitwise;
+  uint8_t                               byte;
+} lsm6dsv320x_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+#ifndef __weak
+#define __weak __attribute__((weak))
+#endif /* __weak */
+
+/*
+ * These are the basic platform dependent I/O routines to read
+ * and write device registers connected on a standard bus.
+ * The driver keeps offering a default implementation based on function
+ * pointers to read/write routines for backward compatibility.
+ * The __weak directive allows the final application to overwrite
+ * them with a custom implementation.
+ */
+
+int32_t lsm6dsv320x_read_reg(const stmdev_ctx_t *ctx, uint8_t reg,
+                             uint8_t *data,
+                             uint16_t len);
+int32_t lsm6dsv320x_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
+                              uint8_t *data,
+                              uint16_t len);
+
+float_t lsm6dsv320x_from_sflp_to_mg(int16_t lsb);
+float_t lsm6dsv320x_from_fs2_to_mg(int16_t lsb);
+float_t lsm6dsv320x_from_fs4_to_mg(int16_t lsb);
+float_t lsm6dsv320x_from_fs8_to_mg(int16_t lsb);
+float_t lsm6dsv320x_from_fs16_to_mg(int16_t lsb);
+
+float_t lsm6dsv320x_from_fs32_to_mg(int16_t lsb);
+float_t lsm6dsv320x_from_fs64_to_mg(int16_t lsb);
+float_t lsm6dsv320x_from_fs128_to_mg(int16_t lsb);
+float_t lsm6dsv320x_from_fs256_to_mg(int16_t lsb);
+float_t lsm6dsv320x_from_fs320_to_mg(int16_t lsb);
+
+float_t lsm6dsv320x_from_fs500_to_mdps(int16_t lsb);
+float_t lsm6dsv320x_from_fs250_to_mdps(int16_t lsb);
+float_t lsm6dsv320x_from_fs1000_to_mdps(int16_t lsb);
+float_t lsm6dsv320x_from_fs2000_to_mdps(int16_t lsb);
+float_t lsm6dsv320x_from_fs4000_to_mdps(int16_t lsb);
+
+float_t lsm6dsv320x_from_lsb_to_celsius(int16_t lsb);
+
+uint64_t lsm6dsv320x_from_lsb_to_nsec(uint32_t lsb);
+
+float_t lsm6dsv320x_from_lsb_to_mv(int16_t lsb);
+
+float_t lsm6dsv320x_from_gbias_lsb_to_mdps(int16_t lsb);
+float_t lsm6dsv320x_from_gravity_lsb_to_mg(int16_t lsb);
+float_t lsm6dsv320x_from_quaternion_lsb_to_float(uint16_t lsb);
+
+int32_t lsm6dsv320x_xl_offset_on_out_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_xl_offset_on_out_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef struct
+{
+  float_t z_mg;
+  float_t y_mg;
+  float_t x_mg;
+} lsm6dsv320x_xl_offset_mg_t;
+int32_t lsm6dsv320x_xl_offset_mg_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv320x_xl_offset_mg_t val);
+int32_t lsm6dsv320x_xl_offset_mg_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv320x_xl_offset_mg_t *val);
+
+int32_t lsm6dsv320x_hg_xl_offset_mg_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_xl_offset_mg_t val);
+int32_t lsm6dsv320x_hg_xl_offset_mg_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_xl_offset_mg_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_READY             = 0x0,
+  LSM6DSV320X_GLOBAL_RST        = 0x1,
+  LSM6DSV320X_RESTORE_CAL_PARAM = 0x2,
+  LSM6DSV320X_RESTORE_CTRL_REGS = 0x4,
+} lsm6dsv320x_reset_t;
+int32_t lsm6dsv320x_reset_set(const stmdev_ctx_t *ctx, lsm6dsv320x_reset_t val);
+int32_t lsm6dsv320x_reset_get(const stmdev_ctx_t *ctx, lsm6dsv320x_reset_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_MAIN_MEM_BANK       = 0x0,
+  LSM6DSV320X_EMBED_FUNC_MEM_BANK = 0x1,
+  LSM6DSV320X_SENSOR_HUB_MEM_BANK = 0x2,
+} lsm6dsv320x_mem_bank_t;
+int32_t lsm6dsv320x_mem_bank_set(const stmdev_ctx_t *ctx, lsm6dsv320x_mem_bank_t val);
+int32_t lsm6dsv320x_mem_bank_get(const stmdev_ctx_t *ctx, lsm6dsv320x_mem_bank_t *val);
+
+int32_t lsm6dsv320x_device_id_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_ODR_OFF              = 0x0,
+  LSM6DSV320X_ODR_AT_1Hz875        = 0x1,
+  LSM6DSV320X_ODR_AT_7Hz5          = 0x2,
+  LSM6DSV320X_ODR_AT_15Hz          = 0x3,
+  LSM6DSV320X_ODR_AT_30Hz          = 0x4,
+  LSM6DSV320X_ODR_AT_60Hz          = 0x5,
+  LSM6DSV320X_ODR_AT_120Hz         = 0x6,
+  LSM6DSV320X_ODR_AT_240Hz         = 0x7,
+  LSM6DSV320X_ODR_AT_480Hz         = 0x8,
+  LSM6DSV320X_ODR_AT_960Hz         = 0x9,
+  LSM6DSV320X_ODR_AT_1920Hz        = 0xA,
+  LSM6DSV320X_ODR_AT_3840Hz        = 0xB,
+  LSM6DSV320X_ODR_AT_7680Hz        = 0xC,
+  LSM6DSV320X_ODR_HA01_AT_15Hz625  = 0x13,
+  LSM6DSV320X_ODR_HA01_AT_31Hz25   = 0x14,
+  LSM6DSV320X_ODR_HA01_AT_62Hz5    = 0x15,
+  LSM6DSV320X_ODR_HA01_AT_125Hz    = 0x16,
+  LSM6DSV320X_ODR_HA01_AT_250Hz    = 0x17,
+  LSM6DSV320X_ODR_HA01_AT_500Hz    = 0x18,
+  LSM6DSV320X_ODR_HA01_AT_1000Hz   = 0x19,
+  LSM6DSV320X_ODR_HA01_AT_2000Hz   = 0x1A,
+  LSM6DSV320X_ODR_HA01_AT_4000Hz   = 0x1B,
+  LSM6DSV320X_ODR_HA01_AT_8000Hz   = 0x1C,
+  LSM6DSV320X_ODR_HA02_AT_13Hz     = 0x23,
+  LSM6DSV320X_ODR_HA02_AT_26Hz     = 0x24,
+  LSM6DSV320X_ODR_HA02_AT_52Hz     = 0x25,
+  LSM6DSV320X_ODR_HA02_AT_104Hz    = 0x26,
+  LSM6DSV320X_ODR_HA02_AT_208Hz    = 0x27,
+  LSM6DSV320X_ODR_HA02_AT_417Hz    = 0x28,
+  LSM6DSV320X_ODR_HA02_AT_833Hz    = 0x29,
+  LSM6DSV320X_ODR_HA02_AT_1667Hz   = 0x2A,
+  LSM6DSV320X_ODR_HA02_AT_3333Hz   = 0x2B,
+  LSM6DSV320X_ODR_HA02_AT_6667Hz   = 0x2C,
+} lsm6dsv320x_data_rate_t;
+int32_t lsm6dsv320x_xl_data_rate_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv320x_data_rate_t val);
+int32_t lsm6dsv320x_xl_data_rate_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv320x_data_rate_t *val);
+int32_t lsm6dsv320x_gy_data_rate_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv320x_data_rate_t val);
+int32_t lsm6dsv320x_gy_data_rate_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv320x_data_rate_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_HG_XL_ODR_OFF         = 0x0,
+  LSM6DSV320X_HG_XL_ODR_AT_480Hz    = 0x3,
+  LSM6DSV320X_HG_XL_ODR_AT_960Hz    = 0x4,
+  LSM6DSV320X_HG_XL_ODR_AT_1920Hz   = 0x5,
+  LSM6DSV320X_HG_XL_ODR_AT_3840Hz   = 0x6,
+  LSM6DSV320X_HG_XL_ODR_AT_7680Hz   = 0x7,
+} lsm6dsv320x_hg_xl_data_rate_t;
+int32_t lsm6dsv320x_hg_xl_data_rate_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_hg_xl_data_rate_t val,
+                                        uint8_t reg_out_en);
+int32_t lsm6dsv320x_hg_xl_data_rate_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_hg_xl_data_rate_t *val,
+                                        uint8_t *reg_out_en);
+
+typedef enum
+{
+  LSM6DSV320X_XL_HIGH_PERFORMANCE_MD   = 0x0,
+  LSM6DSV320X_XL_HIGH_ACCURACY_ODR_MD  = 0x1,
+  LSM6DSV320X_XL_ODR_TRIGGERED_MD      = 0x3,
+  LSM6DSV320X_XL_LOW_POWER_2_AVG_MD    = 0x4,
+  LSM6DSV320X_XL_LOW_POWER_4_AVG_MD    = 0x5,
+  LSM6DSV320X_XL_LOW_POWER_8_AVG_MD    = 0x6,
+  LSM6DSV320X_XL_NORMAL_MD             = 0x7,
+} lsm6dsv320x_xl_mode_t;
+int32_t lsm6dsv320x_xl_mode_set(const stmdev_ctx_t *ctx, lsm6dsv320x_xl_mode_t val);
+int32_t lsm6dsv320x_xl_mode_get(const stmdev_ctx_t *ctx, lsm6dsv320x_xl_mode_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_GY_HIGH_PERFORMANCE_MD   = 0x0,
+  LSM6DSV320X_GY_HIGH_ACCURACY_ODR_MD  = 0x1,
+  LSM6DSV320X_GY_ODR_TRIGGERED_MD      = 0x3,
+  LSM6DSV320X_GY_SLEEP_MD              = 0x4,
+  LSM6DSV320X_GY_LOW_POWER_MD          = 0x5,
+} lsm6dsv320x_gy_mode_t;
+int32_t lsm6dsv320x_gy_mode_set(const stmdev_ctx_t *ctx, lsm6dsv320x_gy_mode_t val);
+int32_t lsm6dsv320x_gy_mode_get(const stmdev_ctx_t *ctx, lsm6dsv320x_gy_mode_t *val);
+
+int32_t lsm6dsv320x_auto_increment_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_auto_increment_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv320x_block_data_update_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_block_data_update_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv320x_odr_trig_cfg_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_odr_trig_cfg_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_DRDY_LATCHED = 0x0,
+  LSM6DSV320X_DRDY_PULSED  = 0x1,
+} lsm6dsv320x_data_ready_mode_t;
+int32_t lsm6dsv320x_data_ready_mode_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_data_ready_mode_t val);
+int32_t lsm6dsv320x_data_ready_mode_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_data_ready_mode_t *val);
+
+typedef struct
+{
+  uint8_t hg_event                     : 1;
+  uint8_t hg_wakeup_z                  : 1;
+  uint8_t hg_wakeup_y                  : 1;
+  uint8_t hg_wakeup_x                  : 1;
+  uint8_t hg_wakeup                    : 1;
+  uint8_t hg_wakeup_chg                : 1;
+  uint8_t hg_shock                     : 1;
+  uint8_t hg_shock_change              : 1;
+} lsm6dsv320x_hg_event_t;
+int32_t lsm6dsv320x_hg_event_get(const stmdev_ctx_t *ctx, lsm6dsv320x_hg_event_t *val);
+
+typedef struct
+{
+  uint8_t hg_wakeup_ths                  : 8;
+  uint8_t hg_shock_dur                   : 4;
+} lsm6dsv320x_hg_wake_up_cfg_t;
+int32_t lsm6dsv320x_hg_wake_up_cfg_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_hg_wake_up_cfg_t val);
+int32_t lsm6dsv320x_hg_wake_up_cfg_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_hg_wake_up_cfg_t *val);
+
+typedef struct
+{
+  uint8_t hg_interrupts_enable         : 1;
+  uint8_t hg_wakeup_int_sel            : 1;
+} lsm6dsv320x_hg_wu_interrupt_cfg_t;
+int32_t lsm6dsv320x_hg_wu_interrupt_cfg_set(const stmdev_ctx_t *ctx,
+                                            lsm6dsv320x_hg_wu_interrupt_cfg_t val);
+int32_t lsm6dsv320x_hg_wu_interrupt_cfg_get(const stmdev_ctx_t *ctx,
+                                            lsm6dsv320x_hg_wu_interrupt_cfg_t *val);
+
+int32_t lsm6dsv320x_hg_emb_usr_off_correction_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_hg_emb_usr_off_correction_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv320x_hg_wu_usr_off_correction_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_hg_wu_usr_off_correction_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef struct
+{
+  uint8_t enable                       : 1; /* interrupt enable */
+  uint8_t lir                          : 1; /* interrupt pulsed or latched */
+} lsm6dsv320x_interrupt_mode_t;
+int32_t lsm6dsv320x_interrupt_enable_set(const stmdev_ctx_t *ctx,
+                                         lsm6dsv320x_interrupt_mode_t val);
+int32_t lsm6dsv320x_interrupt_enable_get(const stmdev_ctx_t *ctx,
+                                         lsm6dsv320x_interrupt_mode_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_250dps  = 0x1,
+  LSM6DSV320X_500dps  = 0x2,
+  LSM6DSV320X_1000dps = 0x3,
+  LSM6DSV320X_2000dps = 0x4,
+  LSM6DSV320X_4000dps = 0x5,
+} lsm6dsv320x_gy_full_scale_t;
+int32_t lsm6dsv320x_gy_full_scale_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_gy_full_scale_t val);
+int32_t lsm6dsv320x_gy_full_scale_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_gy_full_scale_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_2g  = 0x0,
+  LSM6DSV320X_4g  = 0x1,
+  LSM6DSV320X_8g  = 0x2,
+  LSM6DSV320X_16g = 0x3,
+} lsm6dsv320x_xl_full_scale_t;
+int32_t lsm6dsv320x_xl_full_scale_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_xl_full_scale_t val);
+int32_t lsm6dsv320x_xl_full_scale_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_xl_full_scale_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_32g  = 0x0,
+  LSM6DSV320X_64g  = 0x1,
+  LSM6DSV320X_128g  = 0x2,
+  LSM6DSV320X_256g = 0x3,
+  LSM6DSV320X_320g = 0x4,
+} lsm6dsv320x_hg_xl_full_scale_t;
+int32_t lsm6dsv320x_hg_xl_full_scale_set(const stmdev_ctx_t *ctx,
+                                         lsm6dsv320x_hg_xl_full_scale_t val);
+int32_t lsm6dsv320x_hg_xl_full_scale_get(const stmdev_ctx_t *ctx,
+                                         lsm6dsv320x_hg_xl_full_scale_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_ST_DISABLE  = 0x0,
+  LSM6DSV320X_ST_POSITIVE = 0x1,
+  LSM6DSV320X_ST_NEGATIVE = 0x2,
+} lsm6dsv320x_self_test_t;
+int32_t lsm6dsv320x_xl_self_test_set(const stmdev_ctx_t *ctx, lsm6dsv320x_self_test_t val);
+int32_t lsm6dsv320x_xl_self_test_get(const stmdev_ctx_t *ctx, lsm6dsv320x_self_test_t *val);
+
+int32_t lsm6dsv320x_ois_xl_self_test_set(const stmdev_ctx_t *ctx, lsm6dsv320x_self_test_t val);
+int32_t lsm6dsv320x_ois_xl_self_test_get(const stmdev_ctx_t *ctx, lsm6dsv320x_self_test_t *val);
+
+int32_t lsm6dsv320x_gy_self_test_set(const stmdev_ctx_t *ctx, lsm6dsv320x_self_test_t val);
+int32_t lsm6dsv320x_gy_self_test_get(const stmdev_ctx_t *ctx, lsm6dsv320x_self_test_t *val);
+
+int32_t lsm6dsv320x_hg_xl_self_test_set(const stmdev_ctx_t *ctx, lsm6dsv320x_self_test_t val);
+int32_t lsm6dsv320x_hg_xl_self_test_get(const stmdev_ctx_t *ctx, lsm6dsv320x_self_test_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_OIS_GY_ST_DISABLE   = 0x0,
+  LSM6DSV320X_OIS_GY_ST_POSITIVE  = 0x1,
+  LSM6DSV320X_OIS_GY_ST_NEGATIVE  = 0x2,
+  LSM6DSV320X_OIS_GY_ST_CLAMP_POS = 0x5,
+  LSM6DSV320X_OIS_GY_ST_CLAMP_NEG = 0x6,
+
+} lsm6dsv320x_ois_gy_self_test_t;
+int32_t lsm6dsv320x_ois_gy_self_test_set(const stmdev_ctx_t *ctx,
+                                         lsm6dsv320x_ois_gy_self_test_t val);
+int32_t lsm6dsv320x_ois_gy_self_test_get(const stmdev_ctx_t *ctx,
+                                         lsm6dsv320x_ois_gy_self_test_t *val);
+
+typedef struct
+{
+  uint8_t drdy_xl                      : 1;
+  uint8_t drdy_gy                      : 1;
+  uint8_t drdy_temp                    : 1;
+  uint8_t drdy_xlhgda                  : 1;
+  uint8_t drdy_eis                     : 1;
+  uint8_t drdy_ois                     : 1;
+  uint8_t gy_settling                  : 1;
+  uint8_t timestamp                    : 1;
+  uint8_t hg                           : 1;
+  uint8_t free_fall                    : 1;
+  uint8_t wake_up                      : 1;
+  uint8_t wake_up_z                    : 1;
+  uint8_t wake_up_y                    : 1;
+  uint8_t wake_up_x                    : 1;
+  uint8_t single_tap                   : 1;
+  uint8_t double_tap                   : 1;
+  uint8_t tap_z                        : 1;
+  uint8_t tap_y                        : 1;
+  uint8_t tap_x                        : 1;
+  uint8_t tap_sign                     : 1;
+  uint8_t six_d                        : 1;
+  uint8_t six_d_xl                     : 1;
+  uint8_t six_d_xh                     : 1;
+  uint8_t six_d_yl                     : 1;
+  uint8_t six_d_yh                     : 1;
+  uint8_t six_d_zl                     : 1;
+  uint8_t six_d_zh                     : 1;
+  uint8_t sleep_change                 : 1;
+  uint8_t sleep_state                  : 1;
+  uint8_t step_detector                : 1;
+  uint8_t step_count_inc               : 1;
+  uint8_t step_count_overflow          : 1;
+  uint8_t step_on_delta_time           : 1;
+  uint8_t emb_func_stand_by            : 1;
+  uint8_t emb_func_time_exceed         : 1;
+  uint8_t tilt                         : 1;
+  uint8_t sig_mot                      : 1;
+  uint8_t fsm_lc                       : 1;
+  uint8_t fsm1                         : 1;
+  uint8_t fsm2                         : 1;
+  uint8_t fsm3                         : 1;
+  uint8_t fsm4                         : 1;
+  uint8_t fsm5                         : 1;
+  uint8_t fsm6                         : 1;
+  uint8_t fsm7                         : 1;
+  uint8_t fsm8                         : 1;
+  uint8_t mlc1                         : 1;
+  uint8_t mlc2                         : 1;
+  uint8_t mlc3                         : 1;
+  uint8_t mlc4                         : 1;
+  uint8_t mlc5                         : 1;
+  uint8_t mlc6                         : 1;
+  uint8_t mlc7                         : 1;
+  uint8_t mlc8                         : 1;
+  uint8_t sh_endop                     : 1;
+  uint8_t sh_target0_nack              : 1;
+  uint8_t sh_target1_nack              : 1;
+  uint8_t sh_target2_nack              : 1;
+  uint8_t sh_target3_nack              : 1;
+  uint8_t sh_wr_once                   : 1;
+  uint8_t fifo_bdr                     : 1;
+  uint8_t fifo_full                    : 1;
+  uint8_t fifo_ovr                     : 1;
+  uint8_t fifo_th                      : 1;
+} lsm6dsv320x_all_sources_t;
+int32_t lsm6dsv320x_all_sources_get(const stmdev_ctx_t *ctx,
+                                    lsm6dsv320x_all_sources_t *val);
+
+typedef struct
+{
+  uint8_t drdy_xl                      : 1;
+  uint8_t drdy_g                       : 1;
+  uint8_t drdy_g_eis                   : 1;
+  uint8_t drdy_temp                    : 1;
+  uint8_t fifo_th                      : 1;
+  uint8_t fifo_ovr                     : 1;
+  uint8_t fifo_full                    : 1;
+  uint8_t cnt_bdr                      : 1;
+  uint8_t timestamp                    : 1;
+  uint8_t shub                         : 1;
+  uint8_t sixd                         : 1;
+  uint8_t single_tap                   : 1;
+  uint8_t double_tap                   : 1;
+  uint8_t wakeup                       : 1;
+  uint8_t freefall                     : 1;
+  uint8_t sleep_change                 : 1;
+  uint8_t drdy_hg_xl                   : 1; /* High-g */
+  uint8_t hg_wakeup                    : 1;
+  uint8_t hg_shock_change              : 1;
+  uint8_t step_detector                : 1; /* Embedded Functions */
+  uint8_t tilt                         : 1;
+  uint8_t sig_mot                      : 1;
+  uint8_t emb_func_endop               : 1;
+  uint8_t fsm1                         : 1; /* FSM */
+  uint8_t fsm2                         : 1;
+  uint8_t fsm3                         : 1;
+  uint8_t fsm4                         : 1;
+  uint8_t fsm5                         : 1;
+  uint8_t fsm6                         : 1;
+  uint8_t fsm7                         : 1;
+  uint8_t fsm8                         : 1;
+  uint8_t mlc1                         : 1; /* MLC */
+  uint8_t mlc2                         : 1;
+  uint8_t mlc3                         : 1;
+  uint8_t mlc4                         : 1;
+  uint8_t mlc5                         : 1;
+  uint8_t mlc6                         : 1;
+  uint8_t mlc7                         : 1;
+  uint8_t mlc8                         : 1;
+} lsm6dsv320x_pin_int_route_t;
+
+int32_t lsm6dsv320x_pin_int1_route_set(const stmdev_ctx_t *ctx, lsm6dsv320x_pin_int_route_t *val);
+int32_t lsm6dsv320x_pin_int1_route_get(const stmdev_ctx_t *ctx, lsm6dsv320x_pin_int_route_t *val);
+int32_t lsm6dsv320x_pin_int2_route_set(const stmdev_ctx_t *ctx, lsm6dsv320x_pin_int_route_t *val);
+int32_t lsm6dsv320x_pin_int2_route_get(const stmdev_ctx_t *ctx, lsm6dsv320x_pin_int_route_t *val);
+
+int32_t lsm6dsv320x_pin_int1_route_hg_set(const stmdev_ctx_t *ctx,
+                                          lsm6dsv320x_pin_int_route_t *val);
+int32_t lsm6dsv320x_pin_int1_route_hg_get(const stmdev_ctx_t *ctx,
+                                          lsm6dsv320x_pin_int_route_t *val);
+int32_t lsm6dsv320x_pin_int2_route_hg_set(const stmdev_ctx_t *ctx,
+                                          lsm6dsv320x_pin_int_route_t *val);
+int32_t lsm6dsv320x_pin_int2_route_hg_get(const stmdev_ctx_t *ctx,
+                                          lsm6dsv320x_pin_int_route_t *val);
+
+int32_t lsm6dsv320x_pin_int1_route_embedded_set(const stmdev_ctx_t *ctx,
+                                                lsm6dsv320x_pin_int_route_t *val);
+int32_t lsm6dsv320x_pin_int1_route_embedded_get(const stmdev_ctx_t *ctx,
+                                                lsm6dsv320x_pin_int_route_t *val);
+int32_t lsm6dsv320x_pin_int2_route_embedded_set(const stmdev_ctx_t *ctx,
+                                                lsm6dsv320x_pin_int_route_t *val);
+int32_t lsm6dsv320x_pin_int2_route_embedded_get(const stmdev_ctx_t *ctx,
+                                                lsm6dsv320x_pin_int_route_t *val);
+
+typedef struct
+{
+  uint8_t drdy_hgxl                    : 1;
+  uint8_t drdy_xl                      : 1;
+  uint8_t drdy_gy                      : 1;
+  uint8_t drdy_temp                    : 1;
+} lsm6dsv320x_data_ready_t;
+int32_t lsm6dsv320x_flag_data_ready_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_data_ready_t *val);
+
+int32_t lsm6dsv320x_int_ack_mask_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_int_ack_mask_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv320x_temperature_raw_get(const stmdev_ctx_t *ctx, int16_t *val);
+
+int32_t lsm6dsv320x_angular_rate_raw_get(const stmdev_ctx_t *ctx, int16_t *val);
+
+int32_t lsm6dsv320x_ois_angular_rate_raw_get(const stmdev_ctx_t *ctx, int16_t *val);
+
+int32_t lsm6dsv320x_ois_eis_angular_rate_raw_get(const stmdev_ctx_t *ctx,
+                                                 int16_t *val);
+
+int32_t lsm6dsv320x_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *val);
+
+int32_t lsm6dsv320x_ois_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *val);
+
+int32_t lsm6dsv320x_hg_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *val);
+
+int32_t lsm6dsv320x_sflp_gbias_raw_get(const stmdev_ctx_t *ctx, int16_t *val);
+int32_t lsm6dsv320x_sflp_gravity_raw_get(const stmdev_ctx_t *ctx, int16_t *val);
+int32_t lsm6dsv320x_sflp_quaternion_raw_get(const stmdev_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6dsv320x_odr_cal_reg_get(const stmdev_ctx_t *ctx, int8_t *val);
+
+int32_t lsm6dsv320x_disable_embedded_function_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_disable_embedded_function_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef struct
+{
+  uint8_t xl_hg_conv_en                : 1;
+  uint8_t gyro_conv_en                 : 1;
+  uint8_t temp_conv_en                 : 1;
+  uint8_t ext_sensor_conv_en           : 1;
+} lsm6dsv320x_emb_func_conv_t;
+int32_t lsm6dsv320x_emb_func_conv_set(const stmdev_ctx_t *ctx, lsm6dsv320x_emb_func_conv_t val);
+int32_t lsm6dsv320x_emb_func_conv_get(const stmdev_ctx_t *ctx, lsm6dsv320x_emb_func_conv_t *val);
+
+int32_t lsm6dsv320x_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t address,
+                                uint8_t *buf, uint8_t len);
+int32_t lsm6dsv320x_ln_pg_read(const stmdev_ctx_t *ctx, uint16_t address, uint8_t *buf,
+                               uint8_t len);
+
+int32_t lsm6dsv320x_emb_function_dbg_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_emb_function_dbg_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_DEN_ACT_LOW  = 0x0,
+  LSM6DSV320X_DEN_ACT_HIGH = 0x1,
+} lsm6dsv320x_den_polarity_t;
+int32_t lsm6dsv320x_den_polarity_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv320x_den_polarity_t val);
+int32_t lsm6dsv320x_den_polarity_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv320x_den_polarity_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_EIS_250dps  = 0x1,
+  LSM6DSV320X_EIS_500dps  = 0x2,
+  LSM6DSV320X_EIS_1000dps = 0x3,
+  LSM6DSV320X_EIS_2000dps = 0x4,
+  LSM6DSV320X_EIS_4000dps = 0x5,
+} lsm6dsv320x_eis_gy_full_scale_t;
+int32_t lsm6dsv320x_eis_gy_full_scale_set(const stmdev_ctx_t *ctx,
+                                          lsm6dsv320x_eis_gy_full_scale_t val);
+int32_t lsm6dsv320x_eis_gy_full_scale_get(const stmdev_ctx_t *ctx,
+                                          lsm6dsv320x_eis_gy_full_scale_t *val);
+
+int32_t lsm6dsv320x_eis_gy_on_if2_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_eis_gy_on_if2_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_EIS_ODR_OFF = 0x0,
+  LSM6DSV320X_EIS_1920Hz  = 0x1,
+  LSM6DSV320X_EIS_960Hz   = 0x2,
+} lsm6dsv320x_gy_eis_data_rate_t;
+int32_t lsm6dsv320x_gy_eis_data_rate_set(const stmdev_ctx_t *ctx,
+                                         lsm6dsv320x_gy_eis_data_rate_t val);
+int32_t lsm6dsv320x_gy_eis_data_rate_get(const stmdev_ctx_t *ctx,
+                                         lsm6dsv320x_gy_eis_data_rate_t *val);
+
+int32_t lsm6dsv320x_fifo_watermark_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_fifo_watermark_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_CMP_DISABLE = 0x0,
+  LSM6DSV320X_CMP_8_TO_1  = 0x1,
+  LSM6DSV320X_CMP_16_TO_1 = 0x2,
+  LSM6DSV320X_CMP_32_TO_1 = 0x3,
+} lsm6dsv320x_fifo_compress_algo_t;
+int32_t lsm6dsv320x_fifo_compress_algo_set(const stmdev_ctx_t *ctx,
+                                           lsm6dsv320x_fifo_compress_algo_t val);
+int32_t lsm6dsv320x_fifo_compress_algo_get(const stmdev_ctx_t *ctx,
+                                           lsm6dsv320x_fifo_compress_algo_t *val);
+
+int32_t lsm6dsv320x_fifo_virtual_sens_odr_chg_set(const stmdev_ctx_t *ctx,
+                                                  uint8_t val);
+int32_t lsm6dsv320x_fifo_virtual_sens_odr_chg_get(const stmdev_ctx_t *ctx,
+                                                  uint8_t *val);
+
+int32_t lsm6dsv320x_fifo_compress_algo_real_time_set(const stmdev_ctx_t *ctx,
+                                                     uint8_t val);
+int32_t lsm6dsv320x_fifo_compress_algo_real_time_get(const stmdev_ctx_t *ctx,
+                                                     uint8_t *val);
+
+int32_t lsm6dsv320x_fifo_stop_on_wtm_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_fifo_stop_on_wtm_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_XL_NOT_BATCHED       = 0x0,
+  LSM6DSV320X_XL_BATCHED_AT_1Hz875 = 0x1,
+  LSM6DSV320X_XL_BATCHED_AT_7Hz5   = 0x2,
+  LSM6DSV320X_XL_BATCHED_AT_15Hz   = 0x3,
+  LSM6DSV320X_XL_BATCHED_AT_30Hz   = 0x4,
+  LSM6DSV320X_XL_BATCHED_AT_60Hz   = 0x5,
+  LSM6DSV320X_XL_BATCHED_AT_120Hz  = 0x6,
+  LSM6DSV320X_XL_BATCHED_AT_240Hz  = 0x7,
+  LSM6DSV320X_XL_BATCHED_AT_480Hz  = 0x8,
+  LSM6DSV320X_XL_BATCHED_AT_960Hz  = 0x9,
+  LSM6DSV320X_XL_BATCHED_AT_1920Hz = 0xa,
+  LSM6DSV320X_XL_BATCHED_AT_3840Hz = 0xb,
+  LSM6DSV320X_XL_BATCHED_AT_7680Hz = 0xc,
+} lsm6dsv320x_fifo_xl_batch_t;
+int32_t lsm6dsv320x_fifo_xl_batch_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_fifo_xl_batch_t val);
+int32_t lsm6dsv320x_fifo_xl_batch_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_fifo_xl_batch_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_GY_NOT_BATCHED       = 0x0,
+  LSM6DSV320X_GY_BATCHED_AT_1Hz875 = 0x1,
+  LSM6DSV320X_GY_BATCHED_AT_7Hz5   = 0x2,
+  LSM6DSV320X_GY_BATCHED_AT_15Hz   = 0x3,
+  LSM6DSV320X_GY_BATCHED_AT_30Hz   = 0x4,
+  LSM6DSV320X_GY_BATCHED_AT_60Hz   = 0x5,
+  LSM6DSV320X_GY_BATCHED_AT_120Hz  = 0x6,
+  LSM6DSV320X_GY_BATCHED_AT_240Hz  = 0x7,
+  LSM6DSV320X_GY_BATCHED_AT_480Hz  = 0x8,
+  LSM6DSV320X_GY_BATCHED_AT_960Hz  = 0x9,
+  LSM6DSV320X_GY_BATCHED_AT_1920Hz = 0xa,
+  LSM6DSV320X_GY_BATCHED_AT_3840Hz = 0xb,
+  LSM6DSV320X_GY_BATCHED_AT_7680Hz = 0xc,
+} lsm6dsv320x_fifo_gy_batch_t;
+int32_t lsm6dsv320x_fifo_gy_batch_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_fifo_gy_batch_t val);
+int32_t lsm6dsv320x_fifo_gy_batch_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_fifo_gy_batch_t *val);
+
+int32_t lsm6dsv320x_fifo_hg_xl_batch_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_fifo_hg_xl_batch_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_BYPASS_MODE             = 0x0,
+  LSM6DSV320X_FIFO_MODE               = 0x1,
+  LSM6DSV320X_STREAM_WTM_TO_FULL_MODE = 0x2,
+  LSM6DSV320X_STREAM_TO_FIFO_MODE     = 0x3,
+  LSM6DSV320X_BYPASS_TO_STREAM_MODE   = 0x4,
+  LSM6DSV320X_STREAM_MODE             = 0x6,
+  LSM6DSV320X_BYPASS_TO_FIFO_MODE     = 0x7,
+} lsm6dsv320x_fifo_mode_t;
+int32_t lsm6dsv320x_fifo_mode_set(const stmdev_ctx_t *ctx, lsm6dsv320x_fifo_mode_t val);
+int32_t lsm6dsv320x_fifo_mode_get(const stmdev_ctx_t *ctx,
+                                  lsm6dsv320x_fifo_mode_t *val);
+
+int32_t lsm6dsv320x_fifo_gy_eis_batch_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_fifo_gy_eis_batch_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_TEMP_NOT_BATCHED       = 0x0,
+  LSM6DSV320X_TEMP_BATCHED_AT_1Hz875 = 0x1,
+  LSM6DSV320X_TEMP_BATCHED_AT_15Hz   = 0x2,
+  LSM6DSV320X_TEMP_BATCHED_AT_60Hz   = 0x3,
+} lsm6dsv320x_fifo_temp_batch_t;
+int32_t lsm6dsv320x_fifo_temp_batch_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_fifo_temp_batch_t val);
+int32_t lsm6dsv320x_fifo_temp_batch_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_fifo_temp_batch_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_TMSTMP_NOT_BATCHED = 0x0,
+  LSM6DSV320X_TMSTMP_DEC_1       = 0x1,
+  LSM6DSV320X_TMSTMP_DEC_8       = 0x2,
+  LSM6DSV320X_TMSTMP_DEC_32      = 0x3,
+} lsm6dsv320x_fifo_timestamp_batch_t;
+int32_t lsm6dsv320x_fifo_timestamp_batch_set(const stmdev_ctx_t *ctx,
+                                             lsm6dsv320x_fifo_timestamp_batch_t val);
+int32_t lsm6dsv320x_fifo_timestamp_batch_get(const stmdev_ctx_t *ctx,
+                                             lsm6dsv320x_fifo_timestamp_batch_t *val);
+
+int32_t lsm6dsv320x_fifo_batch_counter_threshold_set(const stmdev_ctx_t *ctx,
+                                                     uint16_t val);
+int32_t lsm6dsv320x_fifo_batch_counter_threshold_get(const stmdev_ctx_t *ctx,
+                                                     uint16_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_XL_LG_BATCH_EVENT  = 0x0,
+  LSM6DSV320X_GY_BATCH_EVENT     = 0x1,
+  LSM6DSV320X_GY_EIS_BATCH_EVENT = 0x2,
+  LSM6DSV320X_XL_HG_BATCH_EVENT  = 0x3,
+} lsm6dsv320x_fifo_batch_cnt_event_t;
+int32_t lsm6dsv320x_fifo_batch_cnt_event_set(const stmdev_ctx_t *ctx,
+                                             lsm6dsv320x_fifo_batch_cnt_event_t val);
+int32_t lsm6dsv320x_fifo_batch_cnt_event_get(const stmdev_ctx_t *ctx,
+                                             lsm6dsv320x_fifo_batch_cnt_event_t *val);
+
+typedef struct
+{
+  uint16_t fifo_level                  : 9;
+  uint8_t fifo_bdr                     : 1;
+  uint8_t fifo_full                    : 1;
+  uint8_t fifo_ovr                     : 1;
+  uint8_t fifo_th                      : 1;
+} lsm6dsv320x_fifo_status_t;
+
+int32_t lsm6dsv320x_fifo_status_get(const stmdev_ctx_t *ctx,
+                                    lsm6dsv320x_fifo_status_t *val);
+
+typedef struct
+{
+  enum
+  {
+    LSM6DSV320X_FIFO_EMPTY                    = 0x0,
+    LSM6DSV320X_GY_NC_TAG                     = 0x1,
+    LSM6DSV320X_XL_NC_TAG                     = 0x2,
+    LSM6DSV320X_TEMPERATURE_TAG               = 0x3,
+    LSM6DSV320X_TIMESTAMP_TAG                 = 0x4,
+    LSM6DSV320X_CFG_CHANGE_TAG                = 0x5,
+    LSM6DSV320X_XL_NC_T_2_TAG                 = 0x6,
+    LSM6DSV320X_XL_NC_T_1_TAG                 = 0x7,
+    LSM6DSV320X_XL_2XC_TAG                    = 0x8,
+    LSM6DSV320X_XL_3XC_TAG                    = 0x9,
+    LSM6DSV320X_GY_NC_T_2_TAG                 = 0xA,
+    LSM6DSV320X_GY_NC_T_1_TAG                 = 0xB,
+    LSM6DSV320X_GY_2XC_TAG                    = 0xC,
+    LSM6DSV320X_GY_3XC_TAG                    = 0xD,
+    LSM6DSV320X_SENSORHUB_TARGET0_TAG         = 0xE,
+    LSM6DSV320X_SENSORHUB_TARGET1_TAG         = 0xF,
+    LSM6DSV320X_SENSORHUB_TARGET2_TAG         = 0x10,
+    LSM6DSV320X_SENSORHUB_TARGET3_TAG         = 0x11,
+    LSM6DSV320X_STEP_COUNTER_TAG              = 0x12,
+    LSM6DSV320X_SFLP_GAME_ROTATION_VECTOR_TAG = 0x13,
+    LSM6DSV320X_SFLP_GYROSCOPE_BIAS_TAG       = 0x16,
+    LSM6DSV320X_SFLP_GRAVITY_VECTOR_TAG       = 0x17,
+    LSM6DSV320X_HG_XL_PEAK_TAG                = 0x18,
+    LSM6DSV320X_SENSORHUB_NACK_TAG            = 0x19,
+    LSM6DSV320X_MLC_RESULT_TAG                = 0x1A,
+    LSM6DSV320X_MLC_FILTER                    = 0x1B,
+    LSM6DSV320X_MLC_FEATURE                   = 0x1C,
+    LSM6DSV320X_XL_HG_TAG                     = 0x1D,
+    LSM6DSV320X_GY_ENHANCED_EIS               = 0x1E,
+    LSM6DSV320X_FSM_RESULT_TAG                = 0x1F,
+  } tag;
+  uint8_t cnt;
+  uint8_t data[6];
+} lsm6dsv320x_fifo_out_raw_t;
+int32_t lsm6dsv320x_fifo_out_raw_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv320x_fifo_out_raw_t *val);
+
+int32_t lsm6dsv320x_fifo_stpcnt_batch_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_fifo_stpcnt_batch_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv320x_fifo_fsm_batch_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_fifo_fsm_batch_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv320x_fifo_mlc_batch_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_fifo_mlc_batch_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv320x_fifo_mlc_filt_batch_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_fifo_mlc_filt_batch_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv320x_fifo_sh_batch_target_set(const stmdev_ctx_t *ctx, uint8_t idx, uint8_t val);
+int32_t lsm6dsv320x_fifo_sh_batch_target_get(const stmdev_ctx_t *ctx, uint8_t idx, uint8_t *val);
+
+typedef struct
+{
+  uint8_t game_rotation                : 1;
+  uint8_t gravity                      : 1;
+  uint8_t gbias                        : 1;
+} lsm6dsv320x_fifo_sflp_raw_t;
+int32_t lsm6dsv320x_fifo_sflp_batch_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_fifo_sflp_raw_t val);
+int32_t lsm6dsv320x_fifo_sflp_batch_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_fifo_sflp_raw_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_AUTO          = 0x0,
+  LSM6DSV320X_ALWAYS_ACTIVE = 0x1,
+} lsm6dsv320x_filt_anti_spike_t;
+int32_t lsm6dsv320x_filt_anti_spike_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_filt_anti_spike_t val);
+int32_t lsm6dsv320x_filt_anti_spike_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_filt_anti_spike_t *val);
+
+typedef struct
+{
+  uint8_t drdy                         : 1;
+  uint8_t ois_drdy                     : 1;
+  uint8_t irq_xl                       : 1;
+  uint8_t irq_xl_hg                    : 1;
+  uint8_t irq_g                        : 1;
+} lsm6dsv320x_filt_settling_mask_t;
+int32_t lsm6dsv320x_filt_settling_mask_set(const stmdev_ctx_t *ctx,
+                                           lsm6dsv320x_filt_settling_mask_t val);
+int32_t lsm6dsv320x_filt_settling_mask_get(const stmdev_ctx_t *ctx,
+                                           lsm6dsv320x_filt_settling_mask_t *val);
+
+typedef struct
+{
+  uint8_t ois_drdy                     : 1;
+} lsm6dsv320x_filt_ois_settling_mask_t;
+int32_t lsm6dsv320x_filt_ois_settling_mask_set(const stmdev_ctx_t *ctx,
+                                               lsm6dsv320x_filt_ois_settling_mask_t val);
+int32_t lsm6dsv320x_filt_ois_settling_mask_get(const stmdev_ctx_t *ctx,
+                                               lsm6dsv320x_filt_ois_settling_mask_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_GY_ULTRA_LIGHT   = 0x0,
+  LSM6DSV320X_GY_VERY_LIGHT    = 0x1,
+  LSM6DSV320X_GY_LIGHT         = 0x2,
+  LSM6DSV320X_GY_MEDIUM        = 0x3,
+  LSM6DSV320X_GY_STRONG        = 0x4,
+  LSM6DSV320X_GY_VERY_STRONG   = 0x5,
+  LSM6DSV320X_GY_AGGRESSIVE    = 0x6,
+  LSM6DSV320X_GY_XTREME        = 0x7,
+} lsm6dsv320x_filt_gy_lp1_bandwidth_t;
+int32_t lsm6dsv320x_filt_gy_lp1_bandwidth_set(const stmdev_ctx_t *ctx,
+                                              lsm6dsv320x_filt_gy_lp1_bandwidth_t val);
+int32_t lsm6dsv320x_filt_gy_lp1_bandwidth_get(const stmdev_ctx_t *ctx,
+                                              lsm6dsv320x_filt_gy_lp1_bandwidth_t *val);
+
+int32_t lsm6dsv320x_filt_gy_lp1_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_filt_gy_lp1_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_XL_ULTRA_LIGHT = 0x0,
+  LSM6DSV320X_XL_VERY_LIGHT  = 0x1,
+  LSM6DSV320X_XL_LIGHT       = 0x2,
+  LSM6DSV320X_XL_MEDIUM      = 0x3,
+  LSM6DSV320X_XL_STRONG      = 0x4,
+  LSM6DSV320X_XL_VERY_STRONG = 0x5,
+  LSM6DSV320X_XL_AGGRESSIVE  = 0x6,
+  LSM6DSV320X_XL_XTREME      = 0x7,
+} lsm6dsv320x_filt_xl_lp2_bandwidth_t;
+int32_t lsm6dsv320x_filt_xl_lp2_bandwidth_set(const stmdev_ctx_t *ctx,
+                                              lsm6dsv320x_filt_xl_lp2_bandwidth_t val);
+int32_t lsm6dsv320x_filt_xl_lp2_bandwidth_get(const stmdev_ctx_t *ctx,
+                                              lsm6dsv320x_filt_xl_lp2_bandwidth_t *val);
+
+int32_t lsm6dsv320x_filt_xl_lp2_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_filt_xl_lp2_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv320x_filt_xl_hp_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_filt_xl_hp_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv320x_filt_xl_fast_settling_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_filt_xl_fast_settling_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_HP_MD_NORMAL    = 0x0,
+  LSM6DSV320X_HP_MD_REFERENCE = 0x1,
+} lsm6dsv320x_filt_xl_hp_mode_t;
+int32_t lsm6dsv320x_filt_xl_hp_mode_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_filt_xl_hp_mode_t val);
+int32_t lsm6dsv320x_filt_xl_hp_mode_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_filt_xl_hp_mode_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_WK_FEED_SLOPE          = 0x0,
+  LSM6DSV320X_WK_FEED_HIGH_PASS      = 0x1,
+  LSM6DSV320X_WK_FEED_LP_WITH_OFFSET = 0x2,
+} lsm6dsv320x_filt_wkup_act_feed_t;
+int32_t lsm6dsv320x_filt_wkup_act_feed_set(const stmdev_ctx_t *ctx,
+                                           lsm6dsv320x_filt_wkup_act_feed_t val);
+int32_t lsm6dsv320x_filt_wkup_act_feed_get(const stmdev_ctx_t *ctx,
+                                           lsm6dsv320x_filt_wkup_act_feed_t *val);
+
+int32_t lsm6dsv320x_mask_trigger_xl_settl_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_mask_trigger_xl_settl_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_SIXD_FEED_ODR_DIV_2 = 0x0,
+  LSM6DSV320X_SIXD_FEED_LOW_PASS  = 0x1,
+} lsm6dsv320x_filt_sixd_feed_t;
+int32_t lsm6dsv320x_filt_sixd_feed_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_filt_sixd_feed_t val);
+int32_t lsm6dsv320x_filt_sixd_feed_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_filt_sixd_feed_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_EIS_LP_NORMAL = 0x0,
+  LSM6DSV320X_EIS_LP_LIGHT  = 0x1,
+} lsm6dsv320x_filt_gy_eis_lp_bandwidth_t;
+int32_t lsm6dsv320x_filt_gy_eis_lp_bandwidth_set(const stmdev_ctx_t *ctx,
+                                                 lsm6dsv320x_filt_gy_eis_lp_bandwidth_t val);
+int32_t lsm6dsv320x_filt_gy_eis_lp_bandwidth_get(const stmdev_ctx_t *ctx,
+                                                 lsm6dsv320x_filt_gy_eis_lp_bandwidth_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_OIS_GY_LP_NORMAL     = 0x0,
+  LSM6DSV320X_OIS_GY_LP_STRONG     = 0x1,
+  LSM6DSV320X_OIS_GY_LP_AGGRESSIVE = 0x2,
+  LSM6DSV320X_OIS_GY_LP_LIGHT      = 0x3,
+} lsm6dsv320x_filt_gy_ois_lp_bandwidth_t;
+int32_t lsm6dsv320x_filt_gy_ois_lp_bandwidth_set(const stmdev_ctx_t *ctx,
+                                                 lsm6dsv320x_filt_gy_ois_lp_bandwidth_t val);
+int32_t lsm6dsv320x_filt_gy_ois_lp_bandwidth_get(const stmdev_ctx_t *ctx,
+                                                 lsm6dsv320x_filt_gy_ois_lp_bandwidth_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_OIS_XL_LP_ULTRA_LIGHT = 0x0,
+  LSM6DSV320X_OIS_XL_LP_VERY_LIGHT  = 0x1,
+  LSM6DSV320X_OIS_XL_LP_LIGHT       = 0x2,
+  LSM6DSV320X_OIS_XL_LP_NORMAL      = 0x3,
+  LSM6DSV320X_OIS_XL_LP_STRONG      = 0x4,
+  LSM6DSV320X_OIS_XL_LP_VERY_STRONG = 0x5,
+  LSM6DSV320X_OIS_XL_LP_AGGRESSIVE  = 0x6,
+  LSM6DSV320X_OIS_XL_LP_XTREME      = 0x7,
+} lsm6dsv320x_filt_xl_ois_lp_bandwidth_t;
+int32_t lsm6dsv320x_filt_xl_ois_lp_bandwidth_set(const stmdev_ctx_t *ctx,
+                                                 lsm6dsv320x_filt_xl_ois_lp_bandwidth_t val);
+int32_t lsm6dsv320x_filt_xl_ois_lp_bandwidth_get(const stmdev_ctx_t *ctx,
+                                                 lsm6dsv320x_filt_xl_ois_lp_bandwidth_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_PROTECT_CTRL_REGS = 0x0,
+  LSM6DSV320X_WRITE_CTRL_REG    = 0x1,
+} lsm6dsv320x_fsm_permission_t;
+int32_t lsm6dsv320x_fsm_permission_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_fsm_permission_t val);
+int32_t lsm6dsv320x_fsm_permission_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_fsm_permission_t *val);
+int32_t lsm6dsv320x_fsm_permission_status(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef struct
+{
+  uint8_t fsm1_en                      : 1;
+  uint8_t fsm2_en                      : 1;
+  uint8_t fsm3_en                      : 1;
+  uint8_t fsm4_en                      : 1;
+  uint8_t fsm5_en                      : 1;
+  uint8_t fsm6_en                      : 1;
+  uint8_t fsm7_en                      : 1;
+  uint8_t fsm8_en                      : 1;
+} lsm6dsv320x_fsm_mode_t;
+int32_t lsm6dsv320x_fsm_mode_set(const stmdev_ctx_t *ctx, lsm6dsv320x_fsm_mode_t val);
+int32_t lsm6dsv320x_fsm_mode_get(const stmdev_ctx_t *ctx, lsm6dsv320x_fsm_mode_t *val);
+
+int32_t lsm6dsv320x_fsm_long_cnt_set(const stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsv320x_fsm_long_cnt_get(const stmdev_ctx_t *ctx, uint16_t *val);
+
+
+typedef struct
+{
+  uint8_t fsm_outs1;
+  uint8_t fsm_outs2;
+  uint8_t fsm_outs3;
+  uint8_t fsm_outs4;
+  uint8_t fsm_outs5;
+  uint8_t fsm_outs6;
+  uint8_t fsm_outs7;
+  uint8_t fsm_outs8;
+} lsm6dsv320x_fsm_out_t;
+int32_t lsm6dsv320x_fsm_out_get(const stmdev_ctx_t *ctx, lsm6dsv320x_fsm_out_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_FSM_15Hz  = 0x0,
+  LSM6DSV320X_FSM_30Hz  = 0x1,
+  LSM6DSV320X_FSM_60Hz  = 0x2,
+  LSM6DSV320X_FSM_120Hz = 0x3,
+  LSM6DSV320X_FSM_240Hz = 0x4,
+  LSM6DSV320X_FSM_480Hz = 0x5,
+  LSM6DSV320X_FSM_960Hz = 0x6,
+} lsm6dsv320x_fsm_data_rate_t;
+int32_t lsm6dsv320x_fsm_data_rate_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_fsm_data_rate_t val);
+int32_t lsm6dsv320x_fsm_data_rate_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_fsm_data_rate_t *val);
+
+int32_t lsm6dsv320x_fsm_ext_sens_sensitivity_set(const stmdev_ctx_t *ctx,
+                                                 uint16_t val);
+int32_t lsm6dsv320x_fsm_ext_sens_sensitivity_get(const stmdev_ctx_t *ctx,
+                                                 uint16_t *val);
+
+typedef struct
+{
+  uint16_t z;
+  uint16_t y;
+  uint16_t x;
+} lsm6dsv320x_xl_fsm_ext_sens_offset_t;
+int32_t lsm6dsv320x_fsm_ext_sens_offset_set(const stmdev_ctx_t *ctx,
+                                            lsm6dsv320x_xl_fsm_ext_sens_offset_t val);
+int32_t lsm6dsv320x_fsm_ext_sens_offset_get(const stmdev_ctx_t *ctx,
+                                            lsm6dsv320x_xl_fsm_ext_sens_offset_t *val);
+
+typedef struct
+{
+  uint16_t xx;
+  uint16_t xy;
+  uint16_t xz;
+  uint16_t yy;
+  uint16_t yz;
+  uint16_t zz;
+} lsm6dsv320x_xl_fsm_ext_sens_matrix_t;
+int32_t lsm6dsv320x_fsm_ext_sens_matrix_set(const stmdev_ctx_t *ctx,
+                                            lsm6dsv320x_xl_fsm_ext_sens_matrix_t val);
+int32_t lsm6dsv320x_fsm_ext_sens_matrix_get(const stmdev_ctx_t *ctx,
+                                            lsm6dsv320x_xl_fsm_ext_sens_matrix_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_Z_EQ_Y     = 0x0,
+  LSM6DSV320X_Z_EQ_MIN_Y = 0x1,
+  LSM6DSV320X_Z_EQ_X     = 0x2,
+  LSM6DSV320X_Z_EQ_MIN_X = 0x3,
+  LSM6DSV320X_Z_EQ_MIN_Z = 0x4,
+  LSM6DSV320X_Z_EQ_Z     = 0x5,
+} lsm6dsv320x_fsm_ext_sens_z_orient_t;
+int32_t lsm6dsv320x_fsm_ext_sens_z_orient_set(const stmdev_ctx_t *ctx,
+                                              lsm6dsv320x_fsm_ext_sens_z_orient_t val);
+int32_t lsm6dsv320x_fsm_ext_sens_z_orient_get(const stmdev_ctx_t *ctx,
+                                              lsm6dsv320x_fsm_ext_sens_z_orient_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_Y_EQ_Y     = 0x0,
+  LSM6DSV320X_Y_EQ_MIN_Y = 0x1,
+  LSM6DSV320X_Y_EQ_X     = 0x2,
+  LSM6DSV320X_Y_EQ_MIN_X = 0x3,
+  LSM6DSV320X_Y_EQ_MIN_Z = 0x4,
+  LSM6DSV320X_Y_EQ_Z     = 0x5,
+} lsm6dsv320x_fsm_ext_sens_y_orient_t;
+int32_t lsm6dsv320x_fsm_ext_sens_y_orient_set(const stmdev_ctx_t *ctx,
+                                              lsm6dsv320x_fsm_ext_sens_y_orient_t val);
+int32_t lsm6dsv320x_fsm_ext_sens_y_orient_get(const stmdev_ctx_t *ctx,
+                                              lsm6dsv320x_fsm_ext_sens_y_orient_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_X_EQ_Y     = 0x0,
+  LSM6DSV320X_X_EQ_MIN_Y = 0x1,
+  LSM6DSV320X_X_EQ_X     = 0x2,
+  LSM6DSV320X_X_EQ_MIN_X = 0x3,
+  LSM6DSV320X_X_EQ_MIN_Z = 0x4,
+  LSM6DSV320X_X_EQ_Z     = 0x5,
+} lsm6dsv320x_fsm_ext_sens_x_orient_t;
+int32_t lsm6dsv320x_fsm_ext_sens_x_orient_set(const stmdev_ctx_t *ctx,
+                                              lsm6dsv320x_fsm_ext_sens_x_orient_t val);
+int32_t lsm6dsv320x_fsm_ext_sens_x_orient_get(const stmdev_ctx_t *ctx,
+                                              lsm6dsv320x_fsm_ext_sens_x_orient_t *val);
+
+int32_t lsm6dsv320x_xl_hg_peak_tracking_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_xl_hg_peak_tracking_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv320x_xl_hg_sensitivity_set(const stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsv320x_xl_hg_sensitivity_get(const stmdev_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6dsv320x_fsm_long_cnt_timeout_set(const stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsv320x_fsm_long_cnt_timeout_get(const stmdev_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6dsv320x_fsm_number_of_programs_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_fsm_number_of_programs_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv320x_fsm_start_address_set(const stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsv320x_fsm_start_address_get(const stmdev_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6dsv320x_ff_time_windows_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_ff_time_windows_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_156_mg = 0x0,
+  LSM6DSV320X_219_mg = 0x1,
+  LSM6DSV320X_250_mg = 0x2,
+  LSM6DSV320X_312_mg = 0x3,
+  LSM6DSV320X_344_mg = 0x4,
+  LSM6DSV320X_406_mg = 0x5,
+  LSM6DSV320X_469_mg = 0x6,
+  LSM6DSV320X_500_mg = 0x7,
+} lsm6dsv320x_ff_thresholds_t;
+int32_t lsm6dsv320x_ff_thresholds_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_ff_thresholds_t val);
+int32_t lsm6dsv320x_ff_thresholds_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_ff_thresholds_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_MLC_OFF                             = 0x0,
+  LSM6DSV320X_MLC_ON                              = 0x1,
+  LSM6DSV320X_MLC_ON_BEFORE_FSM                   = 0x2,
+} lsm6dsv320x_mlc_mode_t;
+int32_t lsm6dsv320x_mlc_set(const stmdev_ctx_t *ctx, lsm6dsv320x_mlc_mode_t val);
+int32_t lsm6dsv320x_mlc_get(const stmdev_ctx_t *ctx, lsm6dsv320x_mlc_mode_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_MLC_15Hz  = 0x0,
+  LSM6DSV320X_MLC_30Hz  = 0x1,
+  LSM6DSV320X_MLC_60Hz  = 0x2,
+  LSM6DSV320X_MLC_120Hz = 0x3,
+  LSM6DSV320X_MLC_240Hz = 0x4,
+  LSM6DSV320X_MLC_480Hz = 0x5,
+  LSM6DSV320X_MLC_960Hz = 0x6,
+} lsm6dsv320x_mlc_data_rate_t;
+int32_t lsm6dsv320x_mlc_data_rate_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_mlc_data_rate_t val);
+int32_t lsm6dsv320x_mlc_data_rate_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_mlc_data_rate_t *val);
+
+typedef struct
+{
+  uint8_t mlc1_src;
+  uint8_t mlc2_src;
+  uint8_t mlc3_src;
+  uint8_t mlc4_src;
+  uint8_t mlc5_src;
+  uint8_t mlc6_src;
+  uint8_t mlc7_src;
+  uint8_t mlc8_src;
+} lsm6dsv320x_mlc_out_t;
+int32_t lsm6dsv320x_mlc_out_get(const stmdev_ctx_t *ctx, lsm6dsv320x_mlc_out_t *val);
+
+int32_t lsm6dsv320x_mlc_ext_sens_sensitivity_set(const stmdev_ctx_t *ctx,
+                                                 uint16_t val);
+int32_t lsm6dsv320x_mlc_ext_sens_sensitivity_get(const stmdev_ctx_t *ctx,
+                                                 uint16_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_OIS_CTRL_FROM_OIS = 0x0,
+  LSM6DSV320X_OIS_CTRL_FROM_UI  = 0x1,
+} lsm6dsv320x_ois_ctrl_mode_t;
+int32_t lsm6dsv320x_ois_ctrl_mode_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_ois_ctrl_mode_t val);
+int32_t lsm6dsv320x_ois_ctrl_mode_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_ois_ctrl_mode_t *val);
+
+int32_t lsm6dsv320x_ois_reset_set(const stmdev_ctx_t *ctx, int8_t val);
+int32_t lsm6dsv320x_ois_reset_get(const stmdev_ctx_t *ctx, int8_t *val);
+
+int32_t lsm6dsv320x_ois_interface_pull_up_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_ois_interface_pull_up_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef struct
+{
+  uint8_t ack                          : 1;
+  uint8_t req                          : 1;
+} lsm6dsv320x_ois_handshake_t;
+int32_t lsm6dsv320x_ois_handshake_from_ui_set(const stmdev_ctx_t *ctx,
+                                              lsm6dsv320x_ois_handshake_t val);
+int32_t lsm6dsv320x_ois_handshake_from_ui_get(const stmdev_ctx_t *ctx,
+                                              lsm6dsv320x_ois_handshake_t *val);
+int32_t lsm6dsv320x_ois_handshake_from_ois_set(const stmdev_ctx_t *ctx,
+                                               lsm6dsv320x_ois_handshake_t val);
+int32_t lsm6dsv320x_ois_handshake_from_ois_get(const stmdev_ctx_t *ctx,
+                                               lsm6dsv320x_ois_handshake_t *val);
+
+int32_t lsm6dsv320x_ois_shared_set(const stmdev_ctx_t *ctx, uint8_t val[6]);
+int32_t lsm6dsv320x_ois_shared_get(const stmdev_ctx_t *ctx, uint8_t val[6]);
+
+int32_t lsm6dsv320x_ois_on_if2_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_ois_on_if2_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef struct
+{
+  uint8_t gy                           : 1;
+  uint8_t xl                           : 1;
+} lsm6dsv320x_ois_chain_t;
+int32_t lsm6dsv320x_ois_chain_set(const stmdev_ctx_t *ctx, lsm6dsv320x_ois_chain_t val);
+int32_t lsm6dsv320x_ois_chain_get(const stmdev_ctx_t *ctx,
+                                  lsm6dsv320x_ois_chain_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_OIS_250dps  = 0x1,
+  LSM6DSV320X_OIS_500dps  = 0x2,
+  LSM6DSV320X_OIS_1000dps = 0x3,
+  LSM6DSV320X_OIS_2000dps = 0x4,
+} lsm6dsv320x_ois_gy_full_scale_t;
+int32_t lsm6dsv320x_ois_gy_full_scale_set(const stmdev_ctx_t *ctx,
+                                          lsm6dsv320x_ois_gy_full_scale_t val);
+int32_t lsm6dsv320x_ois_gy_full_scale_get(const stmdev_ctx_t *ctx,
+                                          lsm6dsv320x_ois_gy_full_scale_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_OIS_2g  = 0x0,
+  LSM6DSV320X_OIS_4g  = 0x1,
+  LSM6DSV320X_OIS_8g  = 0x2,
+  LSM6DSV320X_OIS_16g = 0x3,
+} lsm6dsv320x_ois_xl_full_scale_t;
+int32_t lsm6dsv320x_ois_xl_full_scale_set(const stmdev_ctx_t *ctx,
+                                          lsm6dsv320x_ois_xl_full_scale_t val);
+int32_t lsm6dsv320x_ois_xl_full_scale_get(const stmdev_ctx_t *ctx,
+                                          lsm6dsv320x_ois_xl_full_scale_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_DEG_80 = 0x0,
+  LSM6DSV320X_DEG_70 = 0x1,
+  LSM6DSV320X_DEG_60 = 0x2,
+  LSM6DSV320X_DEG_50 = 0x3,
+} lsm6dsv320x_6d_threshold_t;
+int32_t lsm6dsv320x_6d_threshold_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv320x_6d_threshold_t val);
+int32_t lsm6dsv320x_6d_threshold_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv320x_6d_threshold_t *val);
+
+int32_t lsm6dsv320x_4d_mode_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_4d_mode_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_I2C_I3C_ENABLE  = 0x0,
+  LSM6DSV320X_I2C_I3C_DISABLE = 0x1,
+} lsm6dsv320x_ui_i2c_i3c_mode_t;
+int32_t lsm6dsv320x_ui_i2c_i3c_mode_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_ui_i2c_i3c_mode_t val);
+int32_t lsm6dsv320x_ui_i2c_i3c_mode_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_ui_i2c_i3c_mode_t *val);
+
+typedef struct
+{
+  uint8_t if2_ta0_pid                  : 1;
+  enum
+  {
+    LSM6DSV320X_SW_RST_DYN_ADDRESS_RST = 0x0,
+    LSM6DSV320X_I3C_GLOBAL_RST         = 0x1,
+  } rst_mode;
+  enum
+  {
+    LSM6DSV320X_IBI_50us = 0x0,
+    LSM6DSV320X_IBI_2us  = 0x1,
+    LSM6DSV320X_IBI_1ms  = 0x2,
+    LSM6DSV320X_IBI_50ms = 0x3,
+  } ibi_time;
+} lsm6dsv320x_i3c_config_t;
+
+int32_t lsm6dsv320x_i3c_config_set(const stmdev_ctx_t *ctx,
+                                   lsm6dsv320x_i3c_config_t val);
+int32_t lsm6dsv320x_i3c_config_get(const stmdev_ctx_t *ctx,
+                                   lsm6dsv320x_i3c_config_t *val);
+
+int32_t lsm6dsv320x_sh_controller_interface_pull_up_set(const stmdev_ctx_t *ctx,
+                                                        uint8_t val);
+int32_t lsm6dsv320x_sh_controller_interface_pull_up_get(const stmdev_ctx_t *ctx,
+                                                        uint8_t *val);
+
+int32_t lsm6dsv320x_sh_read_data_raw_get(const stmdev_ctx_t *ctx, uint8_t *val,
+                                         uint8_t len);
+
+typedef enum
+{
+  LSM6DSV320X_TGT_0       = 0x0,
+  LSM6DSV320X_TGT_0_1     = 0x1,
+  LSM6DSV320X_TGT_0_1_2   = 0x2,
+  LSM6DSV320X_TGT_0_1_2_3 = 0x3,
+} lsm6dsv320x_sh_target_connected_t;
+int32_t lsm6dsv320x_sh_target_connected_set(const stmdev_ctx_t *ctx,
+                                            lsm6dsv320x_sh_target_connected_t val);
+int32_t lsm6dsv320x_sh_target_connected_get(const stmdev_ctx_t *ctx,
+                                            lsm6dsv320x_sh_target_connected_t *val);
+
+int32_t lsm6dsv320x_sh_controller_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_sh_controller_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv320x_sh_pass_through_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_sh_pass_through_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_SH_TRG_XL_GY_DRDY = 0x0,
+  LSM6DSV320X_SH_TRIG_INT2      = 0x1,
+} lsm6dsv320x_sh_syncro_mode_t;
+int32_t lsm6dsv320x_sh_syncro_mode_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_sh_syncro_mode_t val);
+int32_t lsm6dsv320x_sh_syncro_mode_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_sh_syncro_mode_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_EACH_SH_CYCLE    = 0x0,
+  LSM6DSV320X_ONLY_FIRST_CYCLE = 0x1,
+} lsm6dsv320x_sh_write_mode_t;
+int32_t lsm6dsv320x_sh_write_mode_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_sh_write_mode_t val);
+int32_t lsm6dsv320x_sh_write_mode_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_sh_write_mode_t *val);
+
+int32_t lsm6dsv320x_sh_reset_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_sh_reset_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef struct
+{
+  uint8_t   tgt0_add;
+  uint8_t   tgt0_subadd;
+  uint8_t   tgt0_data;
+} lsm6dsv320x_sh_cfg_write_t;
+int32_t lsm6dsv320x_sh_cfg_write(const stmdev_ctx_t *ctx,
+                                 lsm6dsv320x_sh_cfg_write_t *val);
+typedef enum
+{
+  LSM6DSV320X_SH_15Hz  = 0x1,
+  LSM6DSV320X_SH_30Hz  = 0x2,
+  LSM6DSV320X_SH_60Hz  = 0x3,
+  LSM6DSV320X_SH_120Hz = 0x4,
+  LSM6DSV320X_SH_240Hz = 0x5,
+  LSM6DSV320X_SH_480Hz = 0x6,
+} lsm6dsv320x_sh_data_rate_t;
+int32_t lsm6dsv320x_sh_data_rate_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv320x_sh_data_rate_t val);
+int32_t lsm6dsv320x_sh_data_rate_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv320x_sh_data_rate_t *val);
+
+typedef struct
+{
+  uint8_t   tgt_add;
+  uint8_t   tgt_subadd;
+  uint8_t   tgt_len;
+} lsm6dsv320x_sh_cfg_read_t;
+int32_t lsm6dsv320x_sh_tgt_cfg_read(const stmdev_ctx_t *ctx, uint8_t idx,
+                                    lsm6dsv320x_sh_cfg_read_t *val);
+
+int32_t lsm6dsv320x_sh_status_get(const stmdev_ctx_t *ctx,
+                                  lsm6dsv320x_status_controller_t *val);
+
+int32_t lsm6dsv320x_ui_sdo_pull_up_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_ui_sdo_pull_up_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_PAD_LOW_STRENGTH     = 0x1,
+  LSM6DSV320X_PAD_MIDDLE_STRENGTH  = 0x2,
+  LSM6DSV320X_PAD_HIGH_STRENGTH    = 0x4,
+} lsm6dsv320x_pad_strength_t;
+int32_t lsm6dsv320x_pad_strength_set(const stmdev_ctx_t *ctx, lsm6dsv320x_pad_strength_t val);
+int32_t lsm6dsv320x_pad_strength_get(const stmdev_ctx_t *ctx, lsm6dsv320x_pad_strength_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_SPI_4_WIRE = 0x0,
+  LSM6DSV320X_SPI_3_WIRE = 0x1,
+} lsm6dsv320x_spi_mode_t;
+int32_t lsm6dsv320x_spi_mode_set(const stmdev_ctx_t *ctx, lsm6dsv320x_spi_mode_t val);
+int32_t lsm6dsv320x_spi_mode_get(const stmdev_ctx_t *ctx, lsm6dsv320x_spi_mode_t *val);
+
+int32_t lsm6dsv320x_ui_sda_pull_up_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_ui_sda_pull_up_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv320x_if2_spi_mode_set(const stmdev_ctx_t *ctx, lsm6dsv320x_spi_mode_t val);
+int32_t lsm6dsv320x_if2_spi_mode_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv320x_spi_mode_t *val);
+
+int32_t lsm6dsv320x_sigmot_mode_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_sigmot_mode_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef struct
+{
+  uint8_t step_counter_enable          : 1;
+  uint8_t false_step_rej               : 1;
+} lsm6dsv320x_stpcnt_mode_t;
+int32_t lsm6dsv320x_stpcnt_mode_set(const stmdev_ctx_t *ctx,
+                                    lsm6dsv320x_stpcnt_mode_t val);
+int32_t lsm6dsv320x_stpcnt_mode_get(const stmdev_ctx_t *ctx,
+                                    lsm6dsv320x_stpcnt_mode_t *val);
+
+int32_t lsm6dsv320x_stpcnt_steps_get(const stmdev_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6dsv320x_stpcnt_rst_step_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_stpcnt_rst_step_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv320x_stpcnt_debounce_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_stpcnt_debounce_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv320x_stpcnt_period_set(const stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsv320x_stpcnt_period_get(const stmdev_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6dsv320x_sflp_game_rotation_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_sflp_game_rotation_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef struct
+{
+  float_t gbias_x; /* dps */
+  float_t gbias_y; /* dps */
+  float_t gbias_z; /* dps */
+} lsm6dsv320x_sflp_gbias_t;
+int32_t lsm6dsv320x_sflp_game_gbias_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv320x_sflp_gbias_t *val);
+
+typedef struct
+{
+  float_t quat_w;
+  float_t quat_x;
+  float_t quat_y;
+  float_t quat_z;
+} lsm6dsv320x_quaternion_t;
+int32_t lsm6dsv320x_sflp_quaternion_get(const stmdev_ctx_t *ctx, lsm6dsv320x_quaternion_t *quat);
+
+typedef enum
+{
+  LSM6DSV320X_SFLP_15Hz  = 0x0,
+  LSM6DSV320X_SFLP_30Hz  = 0x1,
+  LSM6DSV320X_SFLP_60Hz  = 0x2,
+  LSM6DSV320X_SFLP_120Hz = 0x3,
+  LSM6DSV320X_SFLP_240Hz = 0x4,
+  LSM6DSV320X_SFLP_480Hz = 0x5,
+} lsm6dsv320x_sflp_data_rate_t;
+int32_t lsm6dsv320x_sflp_data_rate_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_sflp_data_rate_t val);
+int32_t lsm6dsv320x_sflp_data_rate_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_sflp_data_rate_t *val);
+
+typedef struct
+{
+  uint8_t tap_x_en                     : 1;
+  uint8_t tap_y_en                     : 1;
+  uint8_t tap_z_en                     : 1;
+} lsm6dsv320x_tap_detection_t;
+int32_t lsm6dsv320x_tap_detection_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_tap_detection_t val);
+int32_t lsm6dsv320x_tap_detection_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv320x_tap_detection_t *val);
+
+typedef struct
+{
+  uint8_t x                            : 5;
+  uint8_t y                            : 5;
+  uint8_t z                            : 5;
+} lsm6dsv320x_tap_thresholds_t;
+int32_t lsm6dsv320x_tap_thresholds_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_tap_thresholds_t val);
+int32_t lsm6dsv320x_tap_thresholds_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_tap_thresholds_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_XYZ  = 0x0,
+  LSM6DSV320X_YXZ  = 0x1,
+  LSM6DSV320X_XZY  = 0x2,
+  LSM6DSV320X_ZYX  = 0x3,
+  LSM6DSV320X_YZX  = 0x5,
+  LSM6DSV320X_ZXY  = 0x6,
+} lsm6dsv320x_tap_axis_priority_t;
+int32_t lsm6dsv320x_tap_axis_priority_set(const stmdev_ctx_t *ctx,
+                                          lsm6dsv320x_tap_axis_priority_t val);
+int32_t lsm6dsv320x_tap_axis_priority_get(const stmdev_ctx_t *ctx,
+                                          lsm6dsv320x_tap_axis_priority_t *val);
+
+typedef struct
+{
+  uint8_t shock                        : 2;
+  uint8_t quiet                        : 2;
+  uint8_t tap_gap                      : 4;
+} lsm6dsv320x_tap_time_windows_t;
+int32_t lsm6dsv320x_tap_time_windows_set(const stmdev_ctx_t *ctx,
+                                         lsm6dsv320x_tap_time_windows_t val);
+int32_t lsm6dsv320x_tap_time_windows_get(const stmdev_ctx_t *ctx,
+                                         lsm6dsv320x_tap_time_windows_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_ONLY_SINGLE        = 0x0,
+  LSM6DSV320X_BOTH_SINGLE_DOUBLE = 0x1,
+} lsm6dsv320x_tap_mode_t;
+int32_t lsm6dsv320x_tap_mode_set(const stmdev_ctx_t *ctx, lsm6dsv320x_tap_mode_t val);
+int32_t lsm6dsv320x_tap_mode_get(const stmdev_ctx_t *ctx, lsm6dsv320x_tap_mode_t *val);
+
+int32_t lsm6dsv320x_tilt_mode_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_tilt_mode_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv320x_timestamp_raw_get(const stmdev_ctx_t *ctx, uint32_t *val);
+
+int32_t lsm6dsv320x_timestamp_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv320x_timestamp_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_XL_AND_GY_NOT_AFFECTED       = 0x0,
+  LSM6DSV320X_XL_LOW_POWER_GY_NOT_AFFECTED = 0x1,
+  LSM6DSV320X_XL_LOW_POWER_GY_SLEEP        = 0x2,
+  LSM6DSV320X_XL_LOW_POWER_GY_POWER_DOWN   = 0x3,
+} lsm6dsv320x_act_mode_t;
+int32_t lsm6dsv320x_act_mode_set(const stmdev_ctx_t *ctx, lsm6dsv320x_act_mode_t val);
+int32_t lsm6dsv320x_act_mode_get(const stmdev_ctx_t *ctx, lsm6dsv320x_act_mode_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_SLEEP_TO_ACT_AT_1ST_SAMPLE = 0x0,
+  LSM6DSV320X_SLEEP_TO_ACT_AT_2ND_SAMPLE = 0x1,
+  LSM6DSV320X_SLEEP_TO_ACT_AT_3RD_SAMPLE = 0x2,
+  LSM6DSV320X_SLEEP_TO_ACT_AT_4th_SAMPLE = 0x3,
+} lsm6dsv320x_act_from_sleep_to_act_dur_t;
+int32_t lsm6dsv320x_act_from_sleep_to_act_dur_set(const stmdev_ctx_t *ctx,
+                                                  lsm6dsv320x_act_from_sleep_to_act_dur_t val);
+int32_t lsm6dsv320x_act_from_sleep_to_act_dur_get(const stmdev_ctx_t *ctx,
+                                                  lsm6dsv320x_act_from_sleep_to_act_dur_t *val);
+
+typedef enum
+{
+  LSM6DSV320X_1Hz875 = 0x0,
+  LSM6DSV320X_15Hz   = 0x1,
+  LSM6DSV320X_30Hz   = 0x2,
+  LSM6DSV320X_60Hz   = 0x3,
+} lsm6dsv320x_act_sleep_xl_odr_t;
+int32_t lsm6dsv320x_act_sleep_xl_odr_set(const stmdev_ctx_t *ctx,
+                                         lsm6dsv320x_act_sleep_xl_odr_t val);
+int32_t lsm6dsv320x_act_sleep_xl_odr_get(const stmdev_ctx_t *ctx,
+                                         lsm6dsv320x_act_sleep_xl_odr_t *val);
+
+typedef struct
+{
+  lsm6dsv320x_inactivity_dur_t inactivity_cfg;
+  uint8_t inactivity_ths;
+  uint8_t threshold;
+  uint8_t duration;
+} lsm6dsv320x_act_thresholds_t;
+int32_t lsm6dsv320x_act_thresholds_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_act_thresholds_t *val);
+int32_t lsm6dsv320x_act_thresholds_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv320x_act_thresholds_t *val);
+
+typedef struct
+{
+  uint8_t shock                        : 2;
+  uint8_t quiet                        : 4;
+} lsm6dsv320x_act_wkup_time_windows_t;
+int32_t lsm6dsv320x_act_wkup_time_windows_set(const stmdev_ctx_t *ctx,
+                                              lsm6dsv320x_act_wkup_time_windows_t val);
+int32_t lsm6dsv320x_act_wkup_time_windows_get(const stmdev_ctx_t *ctx,
+                                              lsm6dsv320x_act_wkup_time_windows_t *val);
+
+/**
+  * @}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*LSM6DSV320X_DRIVER_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lsm6dsv80x_STdC/driver/lsm6dsv80x_reg.c
+++ b/sensor/stmemsc/lsm6dsv80x_STdC/driver/lsm6dsv80x_reg.c
@@ -1,0 +1,10240 @@
+/**
+  ******************************************************************************
+  * @file    lsm6dsv80x_reg.c
+  * @author  Sensors Software Solution Team
+  * @brief   LSM6DSV80X driver file
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2022 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+#include "lsm6dsv80x_reg.h"
+
+/**
+  * @defgroup  LSM6DSV80X
+  * @brief     This file provides a set of functions needed to drive the
+  *            lsm6dsv80x enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup  Interfaces functions
+  * @brief     This section provide a set of functions used to read and
+  *            write a generic register of the device.
+  *            MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   communication interface handler.(ptr)
+  * @param  reg   first register address to read.
+  * @param  data  buffer for data read.(ptr)
+  * @param  len   number of consecutive register to read.
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t __weak lsm6dsv80x_read_reg(const stmdev_ctx_t *ctx, uint8_t reg,
+                                   uint8_t *data,
+                                   uint16_t len)
+{
+  int32_t ret;
+
+  if (ctx == NULL)
+  {
+    return -1;
+  }
+
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   communication interface handler.(ptr)
+  * @param  reg   first register address to write.
+  * @param  data  the buffer contains data to be written.(ptr)
+  * @param  len   number of consecutive register to write.
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t __weak lsm6dsv80x_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
+                                    uint8_t *data,
+                                    uint16_t len)
+{
+  int32_t ret;
+
+  if (ctx == NULL)
+  {
+    return -1;
+  }
+
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Private functions
+  * @brief     Section collect all the utility functions needed by APIs.
+  * @{
+  *
+  */
+
+static void bytecpy(uint8_t *target, uint8_t *source)
+{
+  if ((target != NULL) && (source != NULL))
+  {
+    *target = *source;
+  }
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Sensitivity
+  * @brief     These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+float_t lsm6dsv80x_from_sflp_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.061f;
+}
+
+float_t lsm6dsv80x_from_fs2_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.061f;
+}
+
+float_t lsm6dsv80x_from_fs4_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.122f;
+}
+
+float_t lsm6dsv80x_from_fs8_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.244f;
+}
+
+float_t lsm6dsv80x_from_fs16_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.488f;
+}
+
+float_t lsm6dsv80x_from_fs32_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.976f;
+}
+
+float_t lsm6dsv80x_from_fs64_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 1.952f;
+}
+
+float_t lsm6dsv80x_from_fs80_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 3.904;
+}
+
+float_t lsm6dsv80x_from_fs250_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb) * 8.750f;
+}
+
+float_t lsm6dsv80x_from_fs500_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb) * 17.50f;
+}
+
+float_t lsm6dsv80x_from_fs1000_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb) * 35.0f;
+}
+
+float_t lsm6dsv80x_from_fs2000_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb) * 70.0f;
+}
+
+float_t lsm6dsv80x_from_fs4000_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb) * 140.0f;
+}
+
+float_t lsm6dsv80x_from_lsb_to_celsius(int16_t lsb)
+{
+  return (((float_t)lsb / 256.0f) + 25.0f);
+}
+
+uint64_t lsm6dsv80x_from_lsb_to_nsec(uint32_t lsb)
+{
+  return ((uint64_t)lsb * 21700);
+}
+
+float_t lsm6dsv80x_from_lsb_to_mv(int16_t lsb)
+{
+  return ((float_t)lsb) / 78.0f;
+}
+
+float_t lsm6dsv80x_from_gbias_lsb_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb) * 4.375f;
+}
+
+float_t lsm6dsv80x_from_gravity_lsb_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.061f;
+}
+
+static float_t npy_half_to_float(uint16_t h);
+float_t lsm6dsv80x_from_quaternion_lsb_to_float(uint16_t lsb)
+{
+  return npy_half_to_float(lsb);
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Accelerometer user offset correction
+  * @brief      This section groups all the functions concerning the
+  *             usage of Accelerometer user offset correction
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enables accelerometer user offset correction block; it is valid for the low-pass path.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables accelerometer user offset correction block; it is valid for the low-pass path.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_xl_offset_on_out_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_ctrl9_t ctrl9;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL9, (uint8_t *)&ctrl9, 1);
+  if (ret == 0)
+  {
+    ctrl9.usr_off_on_out = val;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL9, (uint8_t *)&ctrl9, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables accelerometer user offset correction block; it is valid for the low-pass path.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables accelerometer user offset correction block; it is valid for the low-pass path.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_xl_offset_on_out_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_ctrl9_t ctrl9;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL9, (uint8_t *)&ctrl9, 1);
+  *val = ctrl9.usr_off_on_out;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer user offset correction values in mg.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Accelerometer user offset correction values in mg.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_xl_offset_mg_set(const stmdev_ctx_t *ctx,
+                                    lsm6dsv80x_xl_offset_mg_t val)
+{
+  lsm6dsv80x_z_ofs_usr_t z_ofs_usr;
+  lsm6dsv80x_y_ofs_usr_t y_ofs_usr;
+  lsm6dsv80x_x_ofs_usr_t x_ofs_usr;
+  lsm6dsv80x_ctrl9_t ctrl9;
+  int32_t ret;
+  float_t tmp;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_X_OFS_USR, (uint8_t *)&x_ofs_usr, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+
+  if ((val.x_mg < (0.0078125f * 127.0f)) && (val.x_mg > (0.0078125f * -127.0f)) &&
+      (val.y_mg < (0.0078125f * 127.0f)) && (val.y_mg > (0.0078125f * -127.0f)) &&
+      (val.z_mg < (0.0078125f * 127.0f)) && (val.z_mg > (0.0078125f * -127.0f)))
+  {
+    ctrl9.usr_off_w = 0;
+
+    tmp = val.z_mg / 0.0078125f;
+    z_ofs_usr.z_ofs_usr = (uint8_t)tmp;
+
+    tmp = val.y_mg / 0.0078125f;
+    y_ofs_usr.y_ofs_usr = (uint8_t)tmp;
+
+    tmp = val.x_mg / 0.0078125f;
+    x_ofs_usr.x_ofs_usr = (uint8_t)tmp;
+  }
+  else if ((val.x_mg < (0.125f * 127.0f)) && (val.x_mg > (0.125f * -127.0f)) &&
+           (val.y_mg < (0.125f * 127.0f)) && (val.y_mg > (0.125f * -127.0f)) &&
+           (val.z_mg < (0.125f * 127.0f)) && (val.z_mg > (0.125f * -127.0f)))
+  {
+    ctrl9.usr_off_w = 1;
+
+    tmp = val.z_mg / 0.125f;
+    z_ofs_usr.z_ofs_usr = (uint8_t)tmp;
+
+    tmp = val.y_mg / 0.125f;
+    y_ofs_usr.y_ofs_usr = (uint8_t)tmp;
+
+    tmp = val.x_mg / 0.125f;
+    x_ofs_usr.x_ofs_usr = (uint8_t)tmp;
+  }
+  else // out of limit
+  {
+    ctrl9.usr_off_w = 1;
+    z_ofs_usr.z_ofs_usr = 0xFFU;
+    y_ofs_usr.y_ofs_usr = 0xFFU;
+    x_ofs_usr.x_ofs_usr = 0xFFU;
+  }
+
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_X_OFS_USR, (uint8_t *)&x_ofs_usr, 1);
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL9, (uint8_t *)&ctrl9, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer user offset correction values in mg.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Accelerometer user offset correction values in mg.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_xl_offset_mg_get(const stmdev_ctx_t *ctx,
+                                    lsm6dsv80x_xl_offset_mg_t *val)
+{
+  lsm6dsv80x_z_ofs_usr_t z_ofs_usr;
+  lsm6dsv80x_y_ofs_usr_t y_ofs_usr;
+  lsm6dsv80x_x_ofs_usr_t x_ofs_usr;
+  lsm6dsv80x_ctrl9_t ctrl9;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL9, (uint8_t *)&ctrl9, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_X_OFS_USR, (uint8_t *)&x_ofs_usr, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  if (ctrl9.usr_off_w == PROPERTY_DISABLE)
+  {
+    val->z_mg = ((float_t)z_ofs_usr.z_ofs_usr * 0.0078125f);
+    val->y_mg = ((float_t)y_ofs_usr.y_ofs_usr * 0.0078125f);
+    val->x_mg = ((float_t)x_ofs_usr.x_ofs_usr * 0.0078125f);
+  }
+  else
+  {
+    val->z_mg = ((float_t)z_ofs_usr.z_ofs_usr * 0.125f);
+    val->y_mg = ((float_t)y_ofs_usr.y_ofs_usr * 0.125f);
+    val->x_mg = ((float_t)x_ofs_usr.x_ofs_usr * 0.125f);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  HG Accelerometer user offset correction values in mg.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Accelerometer user offset correction values in mg.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_hg_xl_offset_mg_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_xl_offset_mg_t val)
+{
+  lsm6dsv80x_hg_z_ofs_usr_t z_ofs_usr;
+  lsm6dsv80x_hg_y_ofs_usr_t y_ofs_usr;
+  lsm6dsv80x_hg_x_ofs_usr_t x_ofs_usr;
+  lsm6dsv80x_ctrl1_xl_hg_t  ctrl1_xl_hg;
+  int32_t ret;
+  float_t tmp;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL1_XL_HG, (uint8_t *)&ctrl1_xl_hg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  if ((val.x_mg < (0.25f * 127.0f)) && (val.x_mg > (0.25f * -127.0f)) &&
+      (val.y_mg < (0.25f * 127.0f)) && (val.y_mg > (0.25f * -127.0f)) &&
+      (val.z_mg < (0.25f * 127.0f)) && (val.z_mg > (0.25f * -127.0f)))
+  {
+    ctrl1_xl_hg.hg_usr_off_on_out = 1;
+
+    tmp = val.z_mg / 0.25f;
+    z_ofs_usr.xl_hg_z_ofs_usr = (uint8_t)tmp;
+
+    tmp = val.y_mg / 0.25f;
+    y_ofs_usr.xl_hg_y_ofs_usr = (uint8_t)tmp;
+
+    tmp = val.x_mg / 0.25f;
+    x_ofs_usr.xl_hg_x_ofs_usr = (uint8_t)tmp;
+  }
+  else // out of limit
+  {
+    ctrl1_xl_hg.hg_usr_off_on_out = 0;
+    z_ofs_usr.xl_hg_z_ofs_usr = 0xFFU;
+    y_ofs_usr.xl_hg_y_ofs_usr = 0xFFU;
+    x_ofs_usr.xl_hg_x_ofs_usr = 0xFFU;
+  }
+
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_XL_HG_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_XL_HG_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_XL_HG_X_OFS_USR, (uint8_t *)&x_ofs_usr, 1);
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL1_XL_HG, (uint8_t *)&ctrl1_xl_hg, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  HG Accelerometer user offset correction values in mg.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Accelerometer user offset correction values in mg.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_hg_xl_offset_mg_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_xl_offset_mg_t *val)
+{
+  lsm6dsv80x_hg_z_ofs_usr_t z_ofs_usr;
+  lsm6dsv80x_hg_y_ofs_usr_t y_ofs_usr;
+  lsm6dsv80x_hg_x_ofs_usr_t x_ofs_usr;
+  lsm6dsv80x_ctrl1_xl_hg_t  ctrl1_xl_hg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL1_XL_HG, (uint8_t *)&ctrl1_xl_hg, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_XL_HG_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_XL_HG_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_XL_HG_X_OFS_USR, (uint8_t *)&x_ofs_usr, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  if (ctrl1_xl_hg.hg_usr_off_on_out == PROPERTY_DISABLE)
+  {
+    val->z_mg = 0.0f;
+    val->y_mg = 0.0f;
+    val->x_mg = 0.0f;
+  }
+  else
+  {
+    val->z_mg = ((float_t)z_ofs_usr.xl_hg_z_ofs_usr * 0.25f);
+    val->y_mg = ((float_t)y_ofs_usr.xl_hg_y_ofs_usr * 0.25f);
+    val->x_mg = ((float_t)x_ofs_usr.xl_hg_x_ofs_usr * 0.25f);
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @brief  Reset of the device.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Reset of the device.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_reset_set(const stmdev_ctx_t *ctx, lsm6dsv80x_reset_t val)
+{
+  lsm6dsv80x_func_cfg_access_t func_cfg_access;
+  lsm6dsv80x_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL3, (uint8_t *)&ctrl3, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ctrl3.boot = ((uint8_t)val & 0x04U) >> 2;
+  ctrl3.sw_reset = ((uint8_t)val & 0x02U) >> 1;
+  func_cfg_access.sw_por = (uint8_t)val & 0x01U;
+
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL3, (uint8_t *)&ctrl3, 1);
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Global reset of the device.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Global reset of the device.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_reset_get(const stmdev_ctx_t *ctx, lsm6dsv80x_reset_t *val)
+{
+  lsm6dsv80x_func_cfg_access_t func_cfg_access;
+  lsm6dsv80x_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL3, (uint8_t *)&ctrl3, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch ((ctrl3.sw_reset << 2) + (ctrl3.boot << 1) + func_cfg_access.sw_por)
+  {
+    case LSM6DSV80X_READY:
+      *val = LSM6DSV80X_READY;
+      break;
+
+    case LSM6DSV80X_GLOBAL_RST:
+      *val = LSM6DSV80X_GLOBAL_RST;
+      break;
+
+    case LSM6DSV80X_RESTORE_CAL_PARAM:
+      *val = LSM6DSV80X_RESTORE_CAL_PARAM;
+      break;
+
+    case LSM6DSV80X_RESTORE_CTRL_REGS:
+      *val = LSM6DSV80X_RESTORE_CTRL_REGS;
+      break;
+
+    default:
+      *val = LSM6DSV80X_GLOBAL_RST;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Change memory bank.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      MAIN_MEM_BANK, EMBED_FUNC_MEM_BANK,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_mem_bank_set(const stmdev_ctx_t *ctx, lsm6dsv80x_mem_bank_t val)
+{
+  lsm6dsv80x_func_cfg_access_t func_cfg_access;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  func_cfg_access.shub_reg_access = ((uint8_t)val & 0x02U) >> 1;
+  func_cfg_access.emb_func_reg_access = (uint8_t)val & 0x01U;
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Change memory bank.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      MAIN_MEM_BANK, SENSOR_HUB_MEM_BANK, EMBED_FUNC_MEM_BANK,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_mem_bank_get(const stmdev_ctx_t *ctx, lsm6dsv80x_mem_bank_t *val)
+{
+  lsm6dsv80x_func_cfg_access_t func_cfg_access;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch ((func_cfg_access.shub_reg_access << 1) + func_cfg_access.emb_func_reg_access)
+  {
+    case LSM6DSV80X_MAIN_MEM_BANK:
+      *val = LSM6DSV80X_MAIN_MEM_BANK;
+      break;
+
+    case LSM6DSV80X_EMBED_FUNC_MEM_BANK:
+      *val = LSM6DSV80X_EMBED_FUNC_MEM_BANK;
+      break;
+
+    case LSM6DSV80X_SENSOR_HUB_MEM_BANK:
+      *val = LSM6DSV80X_SENSOR_HUB_MEM_BANK;
+      break;
+
+    default:
+      *val = LSM6DSV80X_MAIN_MEM_BANK;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Device ID.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Device ID.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_device_id_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_WHO_AM_I, val, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer output data rate (ODR) selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lsm6dsv80x_data_rate_t enum
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_xl_data_rate_set(const stmdev_ctx_t *ctx,
+                                    lsm6dsv80x_data_rate_t val)
+{
+  lsm6dsv80x_ctrl1_t ctrl1;
+  lsm6dsv80x_haodr_cfg_t haodr;
+  uint8_t sel;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL1, (uint8_t *)&ctrl1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ctrl1.odr_xl = (uint8_t)val & 0x0Fu;
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL1, (uint8_t *)&ctrl1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  sel = ((uint8_t)val >> 4) & 0xFU;
+  if (sel != 0U)
+  {
+    ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_HAODR_CFG, (uint8_t *)&haodr, 1);
+    haodr.haodr_sel = sel;
+    ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_HAODR_CFG, (uint8_t *)&haodr, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer output data rate (ODR) selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lsm6dsv80x_data_rate_t enum
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_xl_data_rate_get(const stmdev_ctx_t *ctx,
+                                    lsm6dsv80x_data_rate_t *val)
+{
+  lsm6dsv80x_ctrl1_t ctrl1;
+  lsm6dsv80x_haodr_cfg_t haodr;
+  uint8_t sel;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL1, (uint8_t *)&ctrl1, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_HAODR_CFG, (uint8_t *)&haodr, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  sel = haodr.haodr_sel;
+
+  switch (ctrl1.odr_xl)
+  {
+    case LSM6DSV80X_ODR_OFF:
+      *val = LSM6DSV80X_ODR_OFF;
+      break;
+
+    case LSM6DSV80X_ODR_AT_1Hz875:
+      *val = LSM6DSV80X_ODR_AT_1Hz875;
+      break;
+
+    case LSM6DSV80X_ODR_AT_7Hz5:
+      *val = LSM6DSV80X_ODR_AT_7Hz5;
+      break;
+
+    case LSM6DSV80X_ODR_AT_15Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV80X_ODR_AT_15Hz;
+          break;
+        case 1:
+          *val = LSM6DSV80X_ODR_HA01_AT_15Hz625;
+          break;
+        case 2:
+          *val = LSM6DSV80X_ODR_HA02_AT_13Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV80X_ODR_AT_30Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV80X_ODR_AT_30Hz;
+          break;
+        case 1:
+          *val = LSM6DSV80X_ODR_HA01_AT_31Hz25;
+          break;
+        case 2:
+          *val = LSM6DSV80X_ODR_HA02_AT_26Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV80X_ODR_AT_60Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV80X_ODR_AT_60Hz;
+          break;
+        case 1:
+          *val = LSM6DSV80X_ODR_HA01_AT_62Hz5;
+          break;
+        case 2:
+          *val = LSM6DSV80X_ODR_HA02_AT_52Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV80X_ODR_AT_120Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV80X_ODR_AT_120Hz;
+          break;
+        case 1:
+          *val = LSM6DSV80X_ODR_HA01_AT_125Hz;
+          break;
+        case 2:
+          *val = LSM6DSV80X_ODR_HA02_AT_104Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV80X_ODR_AT_240Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV80X_ODR_AT_240Hz;
+          break;
+        case 1:
+          *val = LSM6DSV80X_ODR_HA01_AT_250Hz;
+          break;
+        case 2:
+          *val = LSM6DSV80X_ODR_HA02_AT_208Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV80X_ODR_AT_480Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV80X_ODR_AT_480Hz;
+          break;
+        case 1:
+          *val = LSM6DSV80X_ODR_HA01_AT_500Hz;
+          break;
+        case 2:
+          *val = LSM6DSV80X_ODR_HA02_AT_417Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV80X_ODR_AT_960Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV80X_ODR_AT_960Hz;
+          break;
+        case 1:
+          *val = LSM6DSV80X_ODR_HA01_AT_1000Hz;
+          break;
+        case 2:
+          *val = LSM6DSV80X_ODR_HA02_AT_833Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV80X_ODR_AT_1920Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV80X_ODR_AT_1920Hz;
+          break;
+        case 1:
+          *val = LSM6DSV80X_ODR_HA01_AT_2000Hz;
+          break;
+        case 2:
+          *val = LSM6DSV80X_ODR_HA02_AT_1667Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV80X_ODR_AT_3840Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV80X_ODR_AT_3840Hz;
+          break;
+        case 1:
+          *val = LSM6DSV80X_ODR_HA01_AT_4000Hz;
+          break;
+        case 2:
+          *val = LSM6DSV80X_ODR_HA02_AT_3333Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV80X_ODR_AT_7680Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV80X_ODR_AT_7680Hz;
+          break;
+        case 1:
+          *val = LSM6DSV80X_ODR_HA01_AT_8000Hz;
+          break;
+        case 2:
+          *val = LSM6DSV80X_ODR_HA02_AT_6667Hz;
+          break;
+      }
+      break;
+
+    default:
+      *val = LSM6DSV80X_ODR_OFF;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  HG Accelerometer output data rate (ODR) selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lsm6dsv80x_hg_xl_data_rate_t enum
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_hg_xl_data_rate_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_hg_xl_data_rate_t val,
+                                       uint8_t reg_out_en)
+{
+  lsm6dsv80x_ctrl1_xl_hg_t ctrl1_xl_hg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL1_XL_HG, (uint8_t *)&ctrl1_xl_hg, 1);
+  ctrl1_xl_hg.odr_xl_hg = (uint8_t)val & 0x07U;
+  ctrl1_xl_hg.xl_hg_regout_en = reg_out_en & 0x1U;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL1_XL_HG, (uint8_t *)&ctrl1_xl_hg, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer output data rate (ODR) selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lsm6dsv80x_hg_xl_data_rate_t enum
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_hg_xl_data_rate_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_hg_xl_data_rate_t *val,
+                                       uint8_t *reg_out_en)
+{
+  lsm6dsv80x_ctrl1_xl_hg_t ctrl1_xl_hg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL1_XL_HG, (uint8_t *)&ctrl1_xl_hg, 1);
+
+  *reg_out_en = ctrl1_xl_hg.xl_hg_regout_en;
+
+  switch (ctrl1_xl_hg.odr_xl_hg)
+  {
+    case LSM6DSV80X_HG_XL_ODR_OFF:
+      *val = LSM6DSV80X_HG_XL_ODR_OFF;
+      break;
+
+    case LSM6DSV80X_HG_XL_ODR_AT_480Hz:
+      *val = LSM6DSV80X_HG_XL_ODR_AT_480Hz;
+      break;
+
+    case LSM6DSV80X_HG_XL_ODR_AT_960Hz:
+      *val = LSM6DSV80X_HG_XL_ODR_AT_960Hz;
+      break;
+
+    case LSM6DSV80X_HG_XL_ODR_AT_1920Hz:
+      *val = LSM6DSV80X_HG_XL_ODR_AT_1920Hz;
+      break;
+
+    case LSM6DSV80X_HG_XL_ODR_AT_3840Hz:
+      *val = LSM6DSV80X_HG_XL_ODR_AT_3840Hz;
+      break;
+
+    case LSM6DSV80X_HG_XL_ODR_AT_7680Hz:
+      *val = LSM6DSV80X_HG_XL_ODR_AT_7680Hz;
+      break;
+
+    default:
+      *val = LSM6DSV80X_HG_XL_ODR_OFF;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer operating mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      XL_HIGH_PERFORMANCE_MD, XL_HIGH_ACCURACY_ODR_MD, XL_LOW_POWER_2_AVG_MD, XL_LOW_POWER_4_AVG_MD, XL_LOW_POWER_8_AVG_MD, XL_NORMAL_MD,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_xl_mode_set(const stmdev_ctx_t *ctx, lsm6dsv80x_xl_mode_t val)
+{
+  lsm6dsv80x_ctrl1_t ctrl1;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL1, (uint8_t *)&ctrl1, 1);
+
+  if (ret == 0)
+  {
+    ctrl1.op_mode_xl = (uint8_t)val & 0x07U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL1, (uint8_t *)&ctrl1, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer operating mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      XL_HIGH_PERFORMANCE_MD, XL_HIGH_ACCURACY_ODR_MD, XL_LOW_POWER_2_AVG_MD, XL_LOW_POWER_4_AVG_MD, XL_LOW_POWER_8_AVG_MD, XL_NORMAL_MD,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_xl_mode_get(const stmdev_ctx_t *ctx, lsm6dsv80x_xl_mode_t *val)
+{
+  lsm6dsv80x_ctrl1_t ctrl1;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL1, (uint8_t *)&ctrl1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl1.op_mode_xl)
+  {
+    case LSM6DSV80X_XL_HIGH_PERFORMANCE_MD:
+      *val = LSM6DSV80X_XL_HIGH_PERFORMANCE_MD;
+      break;
+
+    case LSM6DSV80X_XL_HIGH_ACCURACY_ODR_MD:
+      *val = LSM6DSV80X_XL_HIGH_ACCURACY_ODR_MD;
+      break;
+
+    case LSM6DSV80X_XL_ODR_TRIGGERED_MD:
+      *val = LSM6DSV80X_XL_ODR_TRIGGERED_MD;
+      break;
+
+    case LSM6DSV80X_XL_LOW_POWER_2_AVG_MD:
+      *val = LSM6DSV80X_XL_LOW_POWER_2_AVG_MD;
+      break;
+
+    case LSM6DSV80X_XL_LOW_POWER_4_AVG_MD:
+      *val = LSM6DSV80X_XL_LOW_POWER_4_AVG_MD;
+      break;
+
+    case LSM6DSV80X_XL_LOW_POWER_8_AVG_MD:
+      *val = LSM6DSV80X_XL_LOW_POWER_8_AVG_MD;
+      break;
+
+    case LSM6DSV80X_XL_NORMAL_MD:
+      *val = LSM6DSV80X_XL_NORMAL_MD;
+      break;
+
+    default:
+      *val = LSM6DSV80X_XL_HIGH_PERFORMANCE_MD;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope output data rate (ODR) selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lsm6dsv80x_data_rate_t enum
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_gy_data_rate_set(const stmdev_ctx_t *ctx,
+                                    lsm6dsv80x_data_rate_t val)
+{
+  lsm6dsv80x_ctrl2_t ctrl2;
+  lsm6dsv80x_haodr_cfg_t haodr;
+  uint8_t sel;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL2, (uint8_t *)&ctrl2, 1);
+  ctrl2.odr_g = (uint8_t)val & 0x0Fu;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL2, (uint8_t *)&ctrl2, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  sel = ((uint8_t)val >> 4) & 0xFU;
+  if (sel != 0U)
+  {
+    ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_HAODR_CFG, (uint8_t *)&haodr, 1);
+    haodr.haodr_sel = sel;
+    ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_HAODR_CFG, (uint8_t *)&haodr, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope output data rate (ODR) selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lsm6dsv80x_data_rate_t enum
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_gy_data_rate_get(const stmdev_ctx_t *ctx,
+                                    lsm6dsv80x_data_rate_t *val)
+{
+  lsm6dsv80x_ctrl2_t ctrl2;
+  lsm6dsv80x_haodr_cfg_t haodr;
+  uint8_t sel;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL2, (uint8_t *)&ctrl2, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_HAODR_CFG, (uint8_t *)&haodr, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  sel = haodr.haodr_sel;
+
+  switch (ctrl2.odr_g)
+  {
+    case LSM6DSV80X_ODR_OFF:
+      *val = LSM6DSV80X_ODR_OFF;
+      break;
+
+    case LSM6DSV80X_ODR_AT_1Hz875:
+      *val = LSM6DSV80X_ODR_AT_1Hz875;
+      break;
+
+    case LSM6DSV80X_ODR_AT_7Hz5:
+      *val = LSM6DSV80X_ODR_AT_7Hz5;
+      break;
+
+    case LSM6DSV80X_ODR_AT_15Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV80X_ODR_AT_15Hz;
+          break;
+        case 1:
+          *val = LSM6DSV80X_ODR_HA01_AT_15Hz625;
+          break;
+        case 2:
+          *val = LSM6DSV80X_ODR_HA02_AT_13Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV80X_ODR_AT_30Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV80X_ODR_AT_30Hz;
+          break;
+        case 1:
+          *val = LSM6DSV80X_ODR_HA01_AT_31Hz25;
+          break;
+        case 2:
+          *val = LSM6DSV80X_ODR_HA02_AT_26Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV80X_ODR_AT_60Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV80X_ODR_AT_60Hz;
+          break;
+        case 1:
+          *val = LSM6DSV80X_ODR_HA01_AT_62Hz5;
+          break;
+        case 2:
+          *val = LSM6DSV80X_ODR_HA02_AT_52Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV80X_ODR_AT_120Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV80X_ODR_AT_120Hz;
+          break;
+        case 1:
+          *val = LSM6DSV80X_ODR_HA01_AT_125Hz;
+          break;
+        case 2:
+          *val = LSM6DSV80X_ODR_HA02_AT_104Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV80X_ODR_AT_240Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV80X_ODR_AT_240Hz;
+          break;
+        case 1:
+          *val = LSM6DSV80X_ODR_HA01_AT_250Hz;
+          break;
+        case 2:
+          *val = LSM6DSV80X_ODR_HA02_AT_208Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV80X_ODR_AT_480Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV80X_ODR_AT_480Hz;
+          break;
+        case 1:
+          *val = LSM6DSV80X_ODR_HA01_AT_500Hz;
+          break;
+        case 2:
+          *val = LSM6DSV80X_ODR_HA02_AT_417Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV80X_ODR_AT_960Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV80X_ODR_AT_960Hz;
+          break;
+        case 1:
+          *val = LSM6DSV80X_ODR_HA01_AT_1000Hz;
+          break;
+        case 2:
+          *val = LSM6DSV80X_ODR_HA02_AT_833Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV80X_ODR_AT_1920Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV80X_ODR_AT_1920Hz;
+          break;
+        case 1:
+          *val = LSM6DSV80X_ODR_HA01_AT_2000Hz;
+          break;
+        case 2:
+          *val = LSM6DSV80X_ODR_HA02_AT_1667Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV80X_ODR_AT_3840Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV80X_ODR_AT_3840Hz;
+          break;
+        case 1:
+          *val = LSM6DSV80X_ODR_HA01_AT_4000Hz;
+          break;
+        case 2:
+          *val = LSM6DSV80X_ODR_HA02_AT_3333Hz;
+          break;
+      }
+      break;
+
+    case LSM6DSV80X_ODR_AT_7680Hz:
+      switch (sel)
+      {
+        default:
+        case 0:
+          *val = LSM6DSV80X_ODR_AT_7680Hz;
+          break;
+        case 1:
+          *val = LSM6DSV80X_ODR_HA01_AT_8000Hz;
+          break;
+        case 2:
+          *val = LSM6DSV80X_ODR_HA02_AT_6667Hz;
+          break;
+      }
+      break;
+
+    default:
+      *val = LSM6DSV80X_ODR_OFF;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope operating mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      GY_HIGH_PERFORMANCE_MD, GY_HIGH_ACCURACY_ODR_MD, GY_SLEEP_MD, GY_LOW_POWER_MD,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_gy_mode_set(const stmdev_ctx_t *ctx, lsm6dsv80x_gy_mode_t val)
+{
+  lsm6dsv80x_ctrl2_t ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL2, (uint8_t *)&ctrl2, 1);
+  if (ret == 0)
+  {
+    ctrl2.op_mode_g = (uint8_t)val & 0x07U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL2, (uint8_t *)&ctrl2, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope operating mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      GY_HIGH_PERFORMANCE_MD, GY_HIGH_ACCURACY_ODR_MD, GY_SLEEP_MD, GY_LOW_POWER_MD,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_gy_mode_get(const stmdev_ctx_t *ctx, lsm6dsv80x_gy_mode_t *val)
+{
+  lsm6dsv80x_ctrl2_t ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL2, (uint8_t *)&ctrl2, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl2.op_mode_g)
+  {
+    case LSM6DSV80X_GY_HIGH_PERFORMANCE_MD:
+      *val = LSM6DSV80X_GY_HIGH_PERFORMANCE_MD;
+      break;
+
+    case LSM6DSV80X_GY_HIGH_ACCURACY_ODR_MD:
+      *val = LSM6DSV80X_GY_HIGH_ACCURACY_ODR_MD;
+      break;
+
+    case LSM6DSV80X_GY_ODR_TRIGGERED_MD:
+      *val = LSM6DSV80X_GY_ODR_TRIGGERED_MD;
+      break;
+
+    case LSM6DSV80X_GY_SLEEP_MD:
+      *val = LSM6DSV80X_GY_SLEEP_MD;
+      break;
+
+    case LSM6DSV80X_GY_LOW_POWER_MD:
+      *val = LSM6DSV80X_GY_LOW_POWER_MD;
+      break;
+
+    default:
+      *val = LSM6DSV80X_GY_HIGH_PERFORMANCE_MD;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a multiple byte access with a serial interface (enable by default).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Register address automatically incremented during a multiple byte access with a serial interface (enable by default).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_auto_increment_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL3, (uint8_t *)&ctrl3, 1);
+  if (ret == 0)
+  {
+    ctrl3.if_inc = val;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL3, (uint8_t *)&ctrl3, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a multiple byte access with a serial interface (enable by default).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Register address automatically incremented during a multiple byte access with a serial interface (enable by default).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_auto_increment_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL3, (uint8_t *)&ctrl3, 1);
+  *val = ctrl3.if_inc;
+
+  return ret;
+}
+
+/**
+  * @brief  Block Data Update (BDU): output registers are not updated until LSB and MSB have been read). [set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Block Data Update (BDU): output registers are not updated until LSB and MSB have been read).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_block_data_update_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL3, (uint8_t *)&ctrl3, 1);
+
+  if (ret == 0)
+  {
+    ctrl3.bdu = val;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL3, (uint8_t *)&ctrl3, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Block Data Update (BDU): output registers are not updated until LSB and MSB have been read). [get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Block Data Update (BDU): output registers are not updated until LSB and MSB have been read).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_block_data_update_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL3, (uint8_t *)&ctrl3, 1);
+  *val = ctrl3.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Configure ODR trigger. [set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      number of data in the reference period.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_odr_trig_cfg_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_odr_trig_cfg_t odr_trig;
+  int32_t ret;
+
+  if (val >= 1U && val <= 3U)
+  {
+    return -1;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_ODR_TRIG_CFG, (uint8_t *)&odr_trig, 1);
+
+  if (ret == 0)
+  {
+    odr_trig.odr_trig_nodr = val;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_ODR_TRIG_CFG, (uint8_t *)&odr_trig, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Configure ODR trigger. [get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      number of data in the reference period.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_odr_trig_cfg_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_odr_trig_cfg_t odr_trig;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_ODR_TRIG_CFG, (uint8_t *)&odr_trig, 1);
+  *val = odr_trig.odr_trig_nodr;
+
+  return ret;
+}
+
+/**
+  * @brief  Enables pulsed data-ready mode (~75 us).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      DRDY_LATCHED, DRDY_PULSED,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_data_ready_mode_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_data_ready_mode_t val)
+{
+  lsm6dsv80x_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL4, (uint8_t *)&ctrl4, 1);
+
+  if (ret == 0)
+  {
+    ctrl4.drdy_pulsed = (uint8_t)val & 0x1U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL4, (uint8_t *)&ctrl4, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables pulsed data-ready mode (~75 us).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      DRDY_LATCHED, DRDY_PULSED,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_data_ready_mode_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_data_ready_mode_t *val)
+{
+  lsm6dsv80x_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL4, (uint8_t *)&ctrl4, 1);
+
+  switch (ctrl4.drdy_pulsed)
+  {
+    case LSM6DSV80X_DRDY_LATCHED:
+      *val = LSM6DSV80X_DRDY_LATCHED;
+      break;
+
+    case LSM6DSV80X_DRDY_PULSED:
+      *val = LSM6DSV80X_DRDY_PULSED;
+      break;
+
+    default:
+      *val = LSM6DSV80X_DRDY_LATCHED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables interrupt.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      enable/disable, latched/pulsed
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_interrupt_enable_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv80x_interrupt_mode_t val)
+{
+  lsm6dsv80x_tap_cfg0_t cfg;
+  lsm6dsv80x_functions_enable_t func;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FUNCTIONS_ENABLE, (uint8_t *)&func, 1);
+  func.interrupts_enable = val.enable;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_FUNCTIONS_ENABLE, (uint8_t *)&func, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TAP_CFG0, (uint8_t *)&cfg, 1);
+  cfg.lir = val.lir;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TAP_CFG0, (uint8_t *)&cfg, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Enables latched interrupt mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      enable/disable, latched/pulsed
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_interrupt_enable_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv80x_interrupt_mode_t *val)
+{
+  lsm6dsv80x_tap_cfg0_t cfg;
+  lsm6dsv80x_functions_enable_t func;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FUNCTIONS_ENABLE, (uint8_t *)&func, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TAP_CFG0, (uint8_t *)&cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->enable = func.interrupts_enable;
+  val->lir = cfg.lir;
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope full-scale selection[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      250dps, 500dps, 1000dps, 2000dps, 4000dps,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_gy_full_scale_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_gy_full_scale_t val)
+{
+  lsm6dsv80x_ctrl6_t ctrl6;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL6, (uint8_t *)&ctrl6, 1);
+
+  if (ret == 0)
+  {
+    ctrl6.fs_g = (uint8_t)val & 0xfu;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL6, (uint8_t *)&ctrl6, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope full-scale selection[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      250dps, 500dps, 1000dps, 2000dps, 4000dps,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_gy_full_scale_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_gy_full_scale_t *val)
+{
+  lsm6dsv80x_ctrl6_t ctrl6;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL6, (uint8_t *)&ctrl6, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl6.fs_g)
+  {
+    case LSM6DSV80X_250dps:
+      *val = LSM6DSV80X_250dps;
+      break;
+
+    case LSM6DSV80X_500dps:
+      *val = LSM6DSV80X_500dps;
+      break;
+
+    case LSM6DSV80X_1000dps:
+      *val = LSM6DSV80X_1000dps;
+      break;
+
+    case LSM6DSV80X_2000dps:
+      *val = LSM6DSV80X_2000dps;
+      break;
+
+    case LSM6DSV80X_4000dps:
+      *val = LSM6DSV80X_4000dps;
+      break;
+
+    default:
+      *val = LSM6DSV80X_250dps;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      2g, 4g, 8g, 16g,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_xl_full_scale_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_xl_full_scale_t val)
+{
+  lsm6dsv80x_ctrl8_t ctrl8;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL8, (uint8_t *)&ctrl8, 1);
+
+  if (ret == 0)
+  {
+    ctrl8.fs_xl = (uint8_t)val & 0x3U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL8, (uint8_t *)&ctrl8, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      2g, 4g, 8g, 16g,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_xl_full_scale_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_xl_full_scale_t *val)
+{
+  lsm6dsv80x_ctrl8_t ctrl8;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL8, (uint8_t *)&ctrl8, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl8.fs_xl)
+  {
+    case LSM6DSV80X_2g:
+      *val = LSM6DSV80X_2g;
+      break;
+
+    case LSM6DSV80X_4g:
+      *val = LSM6DSV80X_4g;
+      break;
+
+    case LSM6DSV80X_8g:
+      *val = LSM6DSV80X_8g;
+      break;
+
+    case LSM6DSV80X_16g:
+      *val = LSM6DSV80X_16g;
+      break;
+
+    default:
+      *val = LSM6DSV80X_2g;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer HG full-scale selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lsm6dsv80x_hg_xl_full_scale_t
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_hg_xl_full_scale_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv80x_hg_xl_full_scale_t val)
+{
+  lsm6dsv80x_ctrl1_xl_hg_t ctrl1;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL1_XL_HG, (uint8_t *)&ctrl1, 1);
+
+  if (ret == 0)
+  {
+    ctrl1.fs_xl_hg = (uint8_t)val & 0x7U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL1_XL_HG, (uint8_t *)&ctrl1, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer HG full-scale selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lsm6dsv80x_hg_xl_full_scale_t
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_hg_xl_full_scale_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv80x_hg_xl_full_scale_t *val)
+{
+  lsm6dsv80x_ctrl1_xl_hg_t ctrl1;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL1_XL_HG, (uint8_t *)&ctrl1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl1.fs_xl_hg)
+  {
+    case LSM6DSV80X_32g:
+      *val = LSM6DSV80X_32g;
+      break;
+
+    case LSM6DSV80X_64g:
+      *val = LSM6DSV80X_64g;
+      break;
+
+    case LSM6DSV80X_80g:
+      *val = LSM6DSV80X_80g;
+      break;
+
+    default:
+      *val = LSM6DSV80X_32g;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer self-test selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      ST_DISABLE, ST_POSITIVE, ST_NEGATIVE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_xl_self_test_set(const stmdev_ctx_t *ctx, lsm6dsv80x_self_test_t val)
+{
+  lsm6dsv80x_ctrl10_t ctrl10;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL10, (uint8_t *)&ctrl10, 1);
+
+  if (ret == 0)
+  {
+    ctrl10.st_xl = (uint8_t)val & 0x3U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL10, (uint8_t *)&ctrl10, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer self-test selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      ST_DISABLE, ST_POSITIVE, ST_NEGATIVE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_xl_self_test_get(const stmdev_ctx_t *ctx, lsm6dsv80x_self_test_t *val)
+{
+  lsm6dsv80x_ctrl10_t ctrl10;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL10, (uint8_t *)&ctrl10, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl10.st_xl)
+  {
+    case LSM6DSV80X_ST_DISABLE:
+      *val = LSM6DSV80X_ST_DISABLE;
+      break;
+
+    case LSM6DSV80X_ST_POSITIVE:
+      *val = LSM6DSV80X_ST_POSITIVE;
+      break;
+
+    case LSM6DSV80X_ST_NEGATIVE:
+      *val = LSM6DSV80X_ST_NEGATIVE;
+      break;
+
+    default:
+      *val = LSM6DSV80X_ST_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope self-test selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      ST_DISABLE, ST_POSITIVE, ST_NEGATIVE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_gy_self_test_set(const stmdev_ctx_t *ctx, lsm6dsv80x_self_test_t val)
+{
+  lsm6dsv80x_ctrl10_t ctrl10;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL10, (uint8_t *)&ctrl10, 1);
+
+  if (ret == 0)
+  {
+    ctrl10.st_g = (uint8_t)val & 0x3U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL10, (uint8_t *)&ctrl10, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope self-test selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      ST_DISABLE, ST_POSITIVE, ST_NEGATIVE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_gy_self_test_get(const stmdev_ctx_t *ctx, lsm6dsv80x_self_test_t *val)
+{
+  lsm6dsv80x_ctrl10_t ctrl10;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL10, (uint8_t *)&ctrl10, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl10.st_g)
+  {
+    case LSM6DSV80X_ST_DISABLE:
+      *val = LSM6DSV80X_ST_DISABLE;
+      break;
+
+    case LSM6DSV80X_ST_POSITIVE:
+      *val = LSM6DSV80X_ST_POSITIVE;
+      break;
+
+    case LSM6DSV80X_ST_NEGATIVE:
+      *val = LSM6DSV80X_ST_NEGATIVE;
+      break;
+
+    default:
+      *val = LSM6DSV80X_ST_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  HG XL self-test selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      ST_DISABLE, ST_POSITIVE, ST_NEGATIVE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_hg_xl_self_test_set(const stmdev_ctx_t *ctx, lsm6dsv80x_self_test_t val)
+{
+  lsm6dsv80x_ctrl2_xl_hg_t ctrl2_xl_hg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL2_XL_HG, (uint8_t *)&ctrl2_xl_hg, 1);
+
+  if (ret == 0)
+  {
+    ctrl2_xl_hg.xl_hg_st = (uint8_t)val & 0x3U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL2_XL_HG, (uint8_t *)&ctrl2_xl_hg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  HG XL self-test selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      ST_DISABLE, ST_POSITIVE, ST_NEGATIVE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_hg_xl_self_test_get(const stmdev_ctx_t *ctx, lsm6dsv80x_self_test_t *val)
+{
+  lsm6dsv80x_ctrl2_xl_hg_t ctrl2_xl_hg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL2_XL_HG, (uint8_t *)&ctrl2_xl_hg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl2_xl_hg.xl_hg_st)
+  {
+    case LSM6DSV80X_ST_DISABLE:
+      *val = LSM6DSV80X_ST_DISABLE;
+      break;
+
+    case LSM6DSV80X_ST_POSITIVE:
+      *val = LSM6DSV80X_ST_POSITIVE;
+      break;
+
+    case LSM6DSV80X_ST_NEGATIVE:
+      *val = LSM6DSV80X_ST_NEGATIVE;
+      break;
+
+    default:
+      *val = LSM6DSV80X_ST_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   High-g
+  * @brief      This section groups all the functions that manage
+  *             High-g
+  * @{
+  *
+  */
+
+/**
+  * @brief  High-g event configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lsm6dsv80x_hg_wake_up_cfg_t structure
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_hg_wake_up_cfg_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_hg_wake_up_cfg_t val)
+{
+  lsm6dsv80x_hg_functions_enable_t hg_func;
+  lsm6dsv80x_hg_wake_up_ths_t hg_wake_up_ths;
+  uint8_t reg[2];
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_HG_FUNCTIONS_ENABLE, (uint8_t *)&hg_func, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  hg_func.hg_shock_dur = val.hg_shock_dur;
+  hg_wake_up_ths.hg_wk_ths = val.hg_wakeup_ths;
+
+  bytecpy(&reg[0], (uint8_t *)&hg_func);
+  bytecpy(&reg[1], (uint8_t *)&hg_wake_up_ths);
+
+  return lsm6dsv80x_write_reg(ctx, LSM6DSV80X_HG_FUNCTIONS_ENABLE, reg, 2);
+}
+
+/**
+  * @brief  High-g event configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lsm6dsv80x_hg_wake_up_cfg_t structure
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_hg_wake_up_cfg_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_hg_wake_up_cfg_t *val)
+{
+  lsm6dsv80x_hg_functions_enable_t hg_func;
+  lsm6dsv80x_hg_wake_up_ths_t hg_wake_up_ths;
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_HG_FUNCTIONS_ENABLE, (uint8_t *)buff, 2);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  bytecpy((uint8_t *)&hg_func, &buff[0]);
+  bytecpy((uint8_t *)&hg_wake_up_ths, &buff[1]);
+
+  val->hg_shock_dur = hg_func.hg_shock_dur;
+  val->hg_wakeup_ths = hg_wake_up_ths.hg_wk_ths;
+
+  return ret;
+}
+
+/**
+ * @brief   High-g wake-up interrupt configuration[set]
+ *
+ * @param  ctx    Read / write interface definitions.(ptr)
+ * @param  val    lsm6dsv80x_hg_wu_interrupt_cfg_t.
+ * @retval        Interface status (MANDATORY: return 0 -> no Error).
+ *
+ */
+int32_t lsm6dsv80x_hg_wu_interrupt_cfg_set(const stmdev_ctx_t *ctx,
+                                           lsm6dsv80x_hg_wu_interrupt_cfg_t val)
+{
+  lsm6dsv80x_hg_functions_enable_t hg_func;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_HG_FUNCTIONS_ENABLE, (uint8_t *)&hg_func, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  hg_func.hg_interrupts_enable        = val.hg_interrupts_enable;
+  hg_func.hg_wu_change_int_sel        = val.hg_wakeup_int_sel;
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_HG_FUNCTIONS_ENABLE, (uint8_t *)&hg_func, 1);
+
+  return ret;
+}
+
+/**
+ * @brief   High-g wake-up interrupt configuration[get]
+ *
+ * @param  ctx    Read / write interface definitions.(ptr)
+ * @param  val    lsm6dsv80x_hg_wu_interrupt_cfg_t.
+ * @retval        Interface status (MANDATORY: return 0 -> no Error).
+ *
+ */
+int32_t lsm6dsv80x_hg_wu_interrupt_cfg_get(const stmdev_ctx_t *ctx,
+                                           lsm6dsv80x_hg_wu_interrupt_cfg_t *val)
+{
+  lsm6dsv80x_hg_functions_enable_t hg_func;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_HG_FUNCTIONS_ENABLE, (uint8_t *)&hg_func, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->hg_interrupts_enable = hg_func.hg_interrupts_enable;
+  val->hg_wakeup_int_sel    = hg_func.hg_wu_change_int_sel;
+
+  return ret;
+}
+
+/**
+ * @brief   Emable/disable user offset data correction driving to hg embedded functions[set]
+ *
+ * @param  ctx    Read / write interface definitions.(ptr)
+ * @param  val    0: disable, 1: enable
+ * @retval        Interface status (MANDATORY: return 0 -> no Error).
+ *
+ */
+int32_t lsm6dsv80x_hg_emb_usr_off_correction_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_emb_func_cfg_t emb_func_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
+
+  if (ret == 0)
+  {
+    emb_func_cfg.hg_usr_off_on_emb_func = (uint8_t)val & 0x1U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief   Emable/disable user offset data correction driving to hg embedded functions[get]
+ *
+ * @param  ctx    Read / write interface definitions.(ptr)
+ * @param  val    0: disable, 1: enable
+ * @retval        Interface status (MANDATORY: return 0 -> no Error).
+ *
+ */
+int32_t lsm6dsv80x_hg_emb_usr_off_correction_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_emb_func_cfg_t emb_func_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  *val = emb_func_cfg.hg_usr_off_on_emb_func;
+
+  return ret;
+}
+
+/**
+ * @brief   Emable/disable user offset data correction driving to hg wake-up[set]
+ *
+ * @param  ctx    Read / write interface definitions.(ptr)
+ * @param  val    0: disable, 1: enable
+ * @retval        Interface status (MANDATORY: return 0 -> no Error).
+ *
+ */
+int32_t lsm6dsv80x_hg_wu_usr_off_correction_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_ctrl2_xl_hg_t ctrl2_xl_hg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL2_XL_HG, (uint8_t *)&ctrl2_xl_hg, 1);
+
+  if (ret == 0)
+  {
+    ctrl2_xl_hg.hg_usr_off_on_wu = (uint8_t)val & 0x1U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL2_XL_HG, (uint8_t *)&ctrl2_xl_hg, 1);
+  }
+
+  return ret;
+}
+
+/**
+ * @brief   Emable/disable user offset data correction driving to hg wake-up[get]
+ *
+ * @param  ctx    Read / write interface definitions.(ptr)
+ * @param  val    0: disable, 1: enable
+ * @retval        Interface status (MANDATORY: return 0 -> no Error).
+ *
+ */
+int32_t lsm6dsv80x_hg_wu_usr_off_correction_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_ctrl2_xl_hg_t ctrl2_xl_hg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL2_XL_HG, (uint8_t *)&ctrl2_xl_hg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  *val = ctrl2_xl_hg.hg_usr_off_on_wu;
+
+  return ret;
+}
+
+/**
+  * @brief   High-g event handling[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    High-g event.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsv80x_hg_event_get(const stmdev_ctx_t *ctx, lsm6dsv80x_hg_event_t *val)
+{
+  lsm6dsv80x_all_int_src_t          int_src;
+  lsm6dsv80x_hg_wake_up_src_t       wup_src;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_ALL_INT_SRC, (uint8_t *)&int_src, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->hg_event = int_src.hg_ia;
+
+  /* no High-g event */
+  if (int_src.hg_ia == 0)
+  {
+    return 0;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_HG_WAKE_UP_SRC, (uint8_t *)&wup_src, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->hg_wakeup_z     = wup_src.hg_z_wu;
+  val->hg_wakeup_y     = wup_src.hg_y_wu;
+  val->hg_wakeup_x     = wup_src.hg_x_wu;
+  val->hg_wakeup       = wup_src.hg_wu_ia;
+  val->hg_wakeup_chg   = wup_src.hg_wu_change_ia;
+  val->hg_shock        = wup_src.hg_shock_state;
+  val->hg_shock_change = wup_src.hg_shock_change_ia;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   interrupt_pins
+  * @brief      This section groups all the functions that manage
+  *             interrupt pins
+  * @{
+  *
+  */
+
+/**
+  * @brief   Select the signals that need to be routed on int1 pad.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    the signals to route on int1 pin.
+  *                (xl/g drdy, fifo, 6d/tap/wu/ff/sleep_change/cnt_bdr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsv80x_pin_int1_route_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_pin_int_route_t *val)
+{
+  lsm6dsv80x_int1_ctrl_t           int1_ctrl;
+  lsm6dsv80x_md1_cfg_t             md1_cfg;
+  int32_t ret;
+
+  /* not available on INT1 */
+  if (val->drdy_temp == 1)
+  {
+    return -1;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_INT1_CTRL, (uint8_t *)&int1_ctrl, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  int1_ctrl.int1_drdy_xl       = val->drdy_xl;
+  int1_ctrl.int1_drdy_g        = val->drdy_g;
+  int1_ctrl.int1_fifo_th       = val->fifo_th;
+  int1_ctrl.int1_fifo_ovr      = val->fifo_ovr;
+  int1_ctrl.int1_fifo_full     = val->fifo_full;
+  int1_ctrl.int1_cnt_bdr       = val->cnt_bdr;
+
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_INT1_CTRL, (uint8_t *)&int1_ctrl, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  md1_cfg.int1_shub            = val->shub;
+  md1_cfg.int1_6d              = val->sixd;
+  md1_cfg.int1_single_tap      = val->single_tap;
+  md1_cfg.int1_double_tap      = val->double_tap;
+  md1_cfg.int1_wu              = val->wakeup;
+  md1_cfg.int1_ff              = val->freefall;
+  md1_cfg.int1_sleep_change    = val->sleep_change;
+
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Report the signals that are routed on int1 pad.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    the signals that are routed on int1 pin.(ptr)
+  *                (xl/g drdy, fifo, 6d/tap/wu/ff/sleep_change/cnt_bdr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsv80x_pin_int1_route_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_pin_int_route_t *val)
+{
+  lsm6dsv80x_int1_ctrl_t           int1_ctrl;
+  lsm6dsv80x_md1_cfg_t             md1_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_INT1_CTRL, (uint8_t *)&int1_ctrl, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->drdy_xl   = int1_ctrl.int1_drdy_xl;
+  val->drdy_g    = int1_ctrl.int1_drdy_g;
+  val->fifo_th   = int1_ctrl.int1_fifo_th;
+  val->fifo_ovr  = int1_ctrl.int1_fifo_ovr;
+  val->fifo_full = int1_ctrl.int1_fifo_full;
+  val->cnt_bdr   = int1_ctrl.int1_cnt_bdr;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->shub         = md1_cfg.int1_shub;
+  val->sixd         = md1_cfg.int1_6d;
+  val->single_tap   = md1_cfg.int1_single_tap;
+  val->double_tap   = md1_cfg.int1_double_tap;
+  val->wakeup       = md1_cfg.int1_wu;
+  val->freefall     = md1_cfg.int1_ff;
+  val->sleep_change = md1_cfg.int1_sleep_change;
+
+  return ret;
+}
+
+/**
+  * @brief   Select the signals that need to be routed on int2 pad.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    the signals to route on int1 pin.
+  *                (xl/g drdy, fifo, 6d/tap/wu/ff/sleep_change/cnt_bdr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsv80x_pin_int2_route_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_pin_int_route_t *val)
+{
+  lsm6dsv80x_int2_ctrl_t           int2_ctrl;
+  lsm6dsv80x_ctrl4_t               ctrl4;
+  lsm6dsv80x_md2_cfg_t             md2_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  int2_ctrl.int2_drdy_xl          = val->drdy_xl;
+  int2_ctrl.int2_drdy_g           = val->drdy_g;
+  int2_ctrl.int2_fifo_th          = val->fifo_th;
+  int2_ctrl.int2_fifo_ovr         = val->fifo_ovr;
+  int2_ctrl.int2_fifo_full        = val->fifo_full;
+  int2_ctrl.int2_cnt_bdr          = val->cnt_bdr;
+  int2_ctrl.int2_emb_func_endop   = val->emb_func_endop;
+
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL4, (uint8_t *)&ctrl4, 1);
+  ctrl4.int2_drdy_temp         = val->drdy_temp;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL4, (uint8_t *)&ctrl4, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  md2_cfg.int2_timestamp       = val->timestamp;
+  md2_cfg.int2_6d              = val->sixd;
+  md2_cfg.int2_single_tap      = val->single_tap;
+  md2_cfg.int2_double_tap      = val->double_tap;
+  md2_cfg.int2_wu              = val->wakeup;
+  md2_cfg.int2_ff              = val->freefall;
+  md2_cfg.int2_sleep_change    = val->sleep_change;
+
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Report the signals that are routed on int2 pad.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    the signals that are routed on int1 pin.(ptr)
+  *                (xl/g drdy, fifo, 6d/tap/wu/ff/sleep_change/cnt_bdr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsv80x_pin_int2_route_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_pin_int_route_t *val)
+{
+  lsm6dsv80x_int2_ctrl_t           int2_ctrl;
+  lsm6dsv80x_ctrl4_t               ctrl4;
+  lsm6dsv80x_md2_cfg_t             md2_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->drdy_xl        = int2_ctrl.int2_drdy_xl;
+  val->drdy_g         = int2_ctrl.int2_drdy_g;
+  val->fifo_th        = int2_ctrl.int2_fifo_th;
+  val->fifo_ovr       = int2_ctrl.int2_fifo_ovr;
+  val->fifo_full      = int2_ctrl.int2_fifo_full;
+  val->cnt_bdr        = int2_ctrl.int2_cnt_bdr;
+  val->emb_func_endop = int2_ctrl.int2_emb_func_endop;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL4, (uint8_t *)&ctrl4, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->drdy_temp      = ctrl4.int2_drdy_temp;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->timestamp      = md2_cfg.int2_timestamp;
+  val->sixd           = md2_cfg.int2_6d;
+  val->single_tap     = md2_cfg.int2_single_tap;
+  val->double_tap     = md2_cfg.int2_double_tap;
+  val->wakeup         = md2_cfg.int2_wu;
+  val->freefall       = md2_cfg.int2_ff;
+  val->sleep_change   = md2_cfg.int2_sleep_change;
+
+  return ret;
+}
+
+/**
+  * @brief   Select the signals that need to be routed on int1 pad.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    the signals to route on int1 pin.
+  *                (HG events only)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsv80x_pin_int1_route_hg_set(const stmdev_ctx_t *ctx,
+                                         lsm6dsv80x_pin_int_route_t *val)
+{
+  lsm6dsv80x_ctrl7_t               ctrl7;
+  lsm6dsv80x_hg_functions_enable_t hg_func;
+  lsm6dsv80x_inactivity_ths_t      reg_shock;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL7, (uint8_t *)&ctrl7, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ctrl7.int1_drdy_xl_hg        = val->drdy_hg_xl;
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL7, (uint8_t *)&ctrl7, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_HG_FUNCTIONS_ENABLE, (uint8_t *)&hg_func, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  hg_func.int1_hg_wu        = val->hg_wakeup;
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_HG_FUNCTIONS_ENABLE, (uint8_t *)&hg_func, 1);
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_INACTIVITY_THS, (uint8_t *)&reg_shock, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  reg_shock.int1_hg_shock_change        = val->hg_shock_change;
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_INACTIVITY_THS, (uint8_t *)&reg_shock, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Report the signals that are routed on int1 pad.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    the signals that are routed on int1 pin.(ptr)
+  *                (HG events only)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsv80x_pin_int1_route_hg_get(const stmdev_ctx_t *ctx,
+                                         lsm6dsv80x_pin_int_route_t *val)
+{
+  lsm6dsv80x_ctrl7_t               ctrl7;
+  lsm6dsv80x_hg_functions_enable_t hg_func;
+  lsm6dsv80x_inactivity_ths_t      reg_shock;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL7, (uint8_t *)&ctrl7, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->drdy_hg_xl = ctrl7.int1_drdy_xl_hg;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_HG_FUNCTIONS_ENABLE, (uint8_t *)&hg_func, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->hg_wakeup = hg_func.int1_hg_wu;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_INACTIVITY_THS, (uint8_t *)&reg_shock, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->hg_shock_change = reg_shock.int1_hg_shock_change;
+
+  return ret;
+}
+
+/**
+  * @brief   Select the signals that need to be routed on int2 pad.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    the signals to route on int2 pin.
+  *                (HG events only)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsv80x_pin_int2_route_hg_set(const stmdev_ctx_t *ctx,
+                                         lsm6dsv80x_pin_int_route_t *val)
+{
+  lsm6dsv80x_ctrl7_t               ctrl7;
+  lsm6dsv80x_hg_functions_enable_t hg_func;
+  lsm6dsv80x_inactivity_ths_t      reg_shock;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL7, (uint8_t *)&ctrl7, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ctrl7.int2_drdy_xl_hg        = val->drdy_hg_xl;
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL7, (uint8_t *)&ctrl7, 1);
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_HG_FUNCTIONS_ENABLE, (uint8_t *)&hg_func, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  hg_func.int2_hg_wu        = val->hg_wakeup;
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_HG_FUNCTIONS_ENABLE, (uint8_t *)&hg_func, 1);
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_INACTIVITY_THS, (uint8_t *)&reg_shock, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  reg_shock.int2_hg_shock_change        = val->hg_shock_change;
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_INACTIVITY_THS, (uint8_t *)&reg_shock, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Report the signals that are routed on int2 pad.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    the signals that are routed on int2 pin.(ptr)
+  *                (HG events only)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsv80x_pin_int2_route_hg_get(const stmdev_ctx_t *ctx,
+                                         lsm6dsv80x_pin_int_route_t *val)
+{
+  lsm6dsv80x_ctrl7_t               ctrl7;
+  lsm6dsv80x_hg_functions_enable_t hg_func;
+  lsm6dsv80x_inactivity_ths_t      reg_shock;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL7, (uint8_t *)&ctrl7, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->drdy_hg_xl = ctrl7.int2_drdy_xl_hg;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_HG_FUNCTIONS_ENABLE, (uint8_t *)&hg_func, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->hg_wakeup = hg_func.int2_hg_wu;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_INACTIVITY_THS, (uint8_t *)&reg_shock, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->hg_shock_change = reg_shock.int2_hg_shock_change;
+
+  return ret;
+}
+
+/**
+  * @brief   Select the signals that need to be routed on int1 pad.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    the signals to route on int1 pin.
+  *                (embedded events)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsv80x_pin_int1_route_embedded_set(const stmdev_ctx_t *ctx,
+                                               lsm6dsv80x_pin_int_route_t *val)
+{
+  lsm6dsv80x_md1_cfg_t             md1_cfg;
+  lsm6dsv80x_emb_func_int1_t       emb_func_int1;
+  lsm6dsv80x_fsm_int1_t            fsm_int1;
+  lsm6dsv80x_mlc_int1_t            mlc_int1;
+  int32_t ret;
+
+  /* Embedded Functions */
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_INT1, (uint8_t *)&emb_func_int1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  emb_func_int1.int1_step_detector = val->step_detector;
+  emb_func_int1.int1_tilt = val->tilt;
+  emb_func_int1.int1_sig_mot = val->sig_mot;
+
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_INT1, (uint8_t *)&emb_func_int1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  md1_cfg.int1_emb_func = 1;
+
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_MD1_CFG, (uint8_t *)&md1_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  /* FSM */
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FSM_INT1, (uint8_t *)&fsm_int1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  fsm_int1.int1_fsm1 = val->fsm1;
+  fsm_int1.int1_fsm2 = val->fsm2;
+  fsm_int1.int1_fsm3 = val->fsm3;
+  fsm_int1.int1_fsm4 = val->fsm4;
+  fsm_int1.int1_fsm5 = val->fsm5;
+  fsm_int1.int1_fsm6 = val->fsm6;
+  fsm_int1.int1_fsm7 = val->fsm7;
+  fsm_int1.int1_fsm8 = val->fsm8;
+
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_FSM_INT1, (uint8_t *)&fsm_int1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  /* MLC */
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_MLC_INT1, (uint8_t *)&mlc_int1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  mlc_int1.int1_mlc1 = val->mlc1;
+  mlc_int1.int1_mlc2 = val->mlc2;
+  mlc_int1.int1_mlc3 = val->mlc3;
+  mlc_int1.int1_mlc4 = val->mlc4;
+  mlc_int1.int1_mlc5 = val->mlc5;
+  mlc_int1.int1_mlc6 = val->mlc6;
+  mlc_int1.int1_mlc7 = val->mlc7;
+  mlc_int1.int1_mlc8 = val->mlc8;
+
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_MLC_INT1, (uint8_t *)&mlc_int1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   Report the signals that are routed on int1 pad.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    the signals to route on int1 pin.
+  *                (embedded events)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsv80x_pin_int1_route_embedded_get(const stmdev_ctx_t *ctx,
+                                               lsm6dsv80x_pin_int_route_t *val)
+{
+  lsm6dsv80x_emb_func_int1_t       emb_func_int1;
+  lsm6dsv80x_fsm_int1_t            fsm_int1;
+  lsm6dsv80x_mlc_int1_t            mlc_int1;
+  int32_t ret;
+
+  /* Embedded Functions */
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_INT1, (uint8_t *)&emb_func_int1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->step_detector = emb_func_int1.int1_step_detector;
+  val->sig_mot       = emb_func_int1.int1_sig_mot;
+  val->tilt          = emb_func_int1.int1_tilt;
+
+  /* FSM */
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FSM_INT1, (uint8_t *)&fsm_int1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->fsm1 = fsm_int1.int1_fsm1;
+  val->fsm2 = fsm_int1.int1_fsm2;
+  val->fsm3 = fsm_int1.int1_fsm3;
+  val->fsm4 = fsm_int1.int1_fsm4;
+  val->fsm5 = fsm_int1.int1_fsm5;
+  val->fsm6 = fsm_int1.int1_fsm6;
+  val->fsm7 = fsm_int1.int1_fsm7;
+  val->fsm8 = fsm_int1.int1_fsm8;
+
+  /* MLC */
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_MLC_INT1, (uint8_t *)&mlc_int1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->mlc1 = mlc_int1.int1_mlc1;
+  val->mlc2 = mlc_int1.int1_mlc2;
+  val->mlc3 = mlc_int1.int1_mlc3;
+  val->mlc4 = mlc_int1.int1_mlc4;
+  val->mlc5 = mlc_int1.int1_mlc5;
+  val->mlc6 = mlc_int1.int1_mlc6;
+  val->mlc7 = mlc_int1.int1_mlc7;
+  val->mlc8 = mlc_int1.int1_mlc8;
+
+  return ret;
+}
+
+/**
+  * @brief   Select the signals that need to be routed on int2 pad[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    the signals to route on int2 pin.
+  *                (embedded events)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsv80x_pin_int2_route_embedded_set(const stmdev_ctx_t *ctx,
+                                               lsm6dsv80x_pin_int_route_t *val)
+{
+  lsm6dsv80x_md2_cfg_t             md2_cfg;
+  lsm6dsv80x_emb_func_int2_t       emb_func_int2;
+  lsm6dsv80x_fsm_int2_t            fsm_int2;
+  lsm6dsv80x_mlc_int2_t            mlc_int2;
+  int32_t ret;
+
+  /* Embedded Functions */
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_INT2, (uint8_t *)&emb_func_int2, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  emb_func_int2.int2_step_detector = val->step_detector;
+  emb_func_int2.int2_tilt = val->tilt;
+  emb_func_int2.int2_sig_mot = val->sig_mot;
+
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_INT2, (uint8_t *)&emb_func_int2, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  md2_cfg.int2_emb_func = 1;
+
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_MD2_CFG, (uint8_t *)&md2_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  /* FSM */
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FSM_INT2, (uint8_t *)&fsm_int2, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  fsm_int2.int2_fsm1 = val->fsm1;
+  fsm_int2.int2_fsm2 = val->fsm2;
+  fsm_int2.int2_fsm3 = val->fsm3;
+  fsm_int2.int2_fsm4 = val->fsm4;
+  fsm_int2.int2_fsm5 = val->fsm5;
+  fsm_int2.int2_fsm6 = val->fsm6;
+  fsm_int2.int2_fsm7 = val->fsm7;
+  fsm_int2.int2_fsm8 = val->fsm8;
+
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_FSM_INT2, (uint8_t *)&fsm_int2, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  /* MLC */
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_MLC_INT2, (uint8_t *)&mlc_int2, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  mlc_int2.int2_mlc1 = val->mlc1;
+  mlc_int2.int2_mlc2 = val->mlc2;
+  mlc_int2.int2_mlc3 = val->mlc3;
+  mlc_int2.int2_mlc4 = val->mlc4;
+  mlc_int2.int2_mlc5 = val->mlc5;
+  mlc_int2.int2_mlc6 = val->mlc6;
+  mlc_int2.int2_mlc7 = val->mlc7;
+  mlc_int2.int2_mlc8 = val->mlc8;
+
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_MLC_INT2, (uint8_t *)&mlc_int2, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   Report the signals that are routed on int2 pad.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    the signals to route on int2 pin.
+  *                (embedded events)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsv80x_pin_int2_route_embedded_get(const stmdev_ctx_t *ctx,
+                                               lsm6dsv80x_pin_int_route_t *val)
+{
+  lsm6dsv80x_emb_func_int2_t       emb_func_int2;
+  lsm6dsv80x_fsm_int2_t            fsm_int2;
+  lsm6dsv80x_mlc_int2_t            mlc_int2;
+  int32_t ret;
+
+  /* Embedded Functions */
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_INT2, (uint8_t *)&emb_func_int2, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->step_detector = emb_func_int2.int2_step_detector;
+  val->sig_mot       = emb_func_int2.int2_sig_mot;
+  val->tilt          = emb_func_int2.int2_tilt;
+
+  /* FSM */
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FSM_INT2, (uint8_t *)&fsm_int2, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->fsm1 = fsm_int2.int2_fsm1;
+  val->fsm2 = fsm_int2.int2_fsm2;
+  val->fsm3 = fsm_int2.int2_fsm3;
+  val->fsm4 = fsm_int2.int2_fsm4;
+  val->fsm5 = fsm_int2.int2_fsm5;
+  val->fsm6 = fsm_int2.int2_fsm6;
+  val->fsm7 = fsm_int2.int2_fsm7;
+  val->fsm8 = fsm_int2.int2_fsm8;
+
+  /* MLC */
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_MLC_INT2, (uint8_t *)&mlc_int2, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->mlc1 = mlc_int2.int2_mlc1;
+  val->mlc2 = mlc_int2.int2_mlc2;
+  val->mlc3 = mlc_int2.int2_mlc3;
+  val->mlc4 = mlc_int2.int2_mlc4;
+  val->mlc5 = mlc_int2.int2_mlc5;
+  val->mlc6 = mlc_int2.int2_mlc6;
+  val->mlc7 = mlc_int2.int2_mlc7;
+  val->mlc8 = mlc_int2.int2_mlc8;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @brief  Get the status of all the interrupt sources.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the status of all the interrupt sources.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_all_sources_get(const stmdev_ctx_t *ctx,
+                                   lsm6dsv80x_all_sources_t *val)
+{
+  lsm6dsv80x_emb_func_status_mainpage_t emb_func_status_mainpage;
+  lsm6dsv80x_emb_func_exec_status_t emb_func_exec_status;
+  lsm6dsv80x_fsm_status_mainpage_t fsm_status_mainpage;
+  lsm6dsv80x_mlc_status_mainpage_t mlc_status_mainpage;
+  lsm6dsv80x_functions_enable_t functions_enable;
+  lsm6dsv80x_emb_func_src_t emb_func_src;
+  lsm6dsv80x_fifo_status2_t fifo_status2;
+  lsm6dsv80x_all_int_src_t all_int_src;
+  lsm6dsv80x_wake_up_src_t wake_up_src;
+  lsm6dsv80x_status_reg_t status_reg;
+  lsm6dsv80x_d6d_src_t d6d_src;
+  lsm6dsv80x_tap_src_t tap_src;
+  lsm6dsv80x_status_controller_t status_shub;
+  uint8_t buff[7];
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
+  functions_enable.dis_rst_lir_all_int = PROPERTY_ENABLE;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FIFO_STATUS1, (uint8_t *)&buff, 4);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  bytecpy((uint8_t *)&fifo_status2, &buff[1]);
+  bytecpy((uint8_t *)&all_int_src, &buff[2]);
+  bytecpy((uint8_t *)&status_reg, &buff[3]);
+
+  val->fifo_ovr = fifo_status2.fifo_ovr_ia;
+  val->fifo_bdr = fifo_status2.counter_bdr_ia;
+  val->fifo_full = fifo_status2.fifo_full_ia;
+  val->fifo_th = fifo_status2.fifo_wtm_ia;
+
+  val->hg = all_int_src.hg_ia;
+  val->free_fall = all_int_src.ff_ia;
+  val->wake_up = all_int_src.wu_ia;
+  val->six_d = all_int_src.d6d_ia;
+
+  val->drdy_xl = status_reg.xlda;
+  val->drdy_gy = status_reg.gda;
+  val->drdy_temp = status_reg.tda;
+  val->drdy_xlhgda = status_reg.xlhgda;
+  val->timestamp = status_reg.timestamp_endcount;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
+  functions_enable.dis_rst_lir_all_int = PROPERTY_DISABLE;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_WAKE_UP_SRC, (uint8_t *)&buff, 7);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  bytecpy((uint8_t *)&wake_up_src, &buff[0]);
+  bytecpy((uint8_t *)&tap_src, &buff[1]);
+  bytecpy((uint8_t *)&d6d_src, &buff[2]);
+  bytecpy((uint8_t *)&emb_func_status_mainpage, &buff[4]);
+  bytecpy((uint8_t *)&fsm_status_mainpage, &buff[5]);
+  bytecpy((uint8_t *)&mlc_status_mainpage, &buff[6]);
+
+  val->sleep_change = wake_up_src.sleep_change_ia;
+  val->wake_up_x = wake_up_src.x_wu;
+  val->wake_up_y = wake_up_src.y_wu;
+  val->wake_up_z = wake_up_src.z_wu;
+  val->sleep_state = wake_up_src.sleep_state;
+
+  val->tap_x = tap_src.x_tap;
+  val->tap_y = tap_src.y_tap;
+  val->tap_z = tap_src.z_tap;
+  val->tap_sign = tap_src.tap_sign;
+  val->double_tap = tap_src.double_tap;
+  val->single_tap = tap_src.single_tap;
+
+  val->six_d_zl = d6d_src.zl;
+  val->six_d_zh = d6d_src.zh;
+  val->six_d_yl = d6d_src.yl;
+  val->six_d_yh = d6d_src.yh;
+  val->six_d_xl = d6d_src.xl;
+  val->six_d_xh = d6d_src.xh;
+
+  val->step_detector = emb_func_status_mainpage.is_step_det;
+  val->tilt = emb_func_status_mainpage.is_tilt;
+  val->sig_mot = emb_func_status_mainpage.is_sigmot;
+  val->fsm_lc = emb_func_status_mainpage.is_fsm_lc;
+
+  val->fsm1 = fsm_status_mainpage.is_fsm1;
+  val->fsm2 = fsm_status_mainpage.is_fsm2;
+  val->fsm3 = fsm_status_mainpage.is_fsm3;
+  val->fsm4 = fsm_status_mainpage.is_fsm4;
+  val->fsm5 = fsm_status_mainpage.is_fsm5;
+  val->fsm6 = fsm_status_mainpage.is_fsm6;
+  val->fsm7 = fsm_status_mainpage.is_fsm7;
+  val->fsm8 = fsm_status_mainpage.is_fsm8;
+
+  val->mlc1 = mlc_status_mainpage.is_mlc1;
+  val->mlc2 = mlc_status_mainpage.is_mlc2;
+  val->mlc3 = mlc_status_mainpage.is_mlc3;
+  val->mlc4 = mlc_status_mainpage.is_mlc4;
+  val->mlc5 = mlc_status_mainpage.is_mlc5;
+  val->mlc6 = mlc_status_mainpage.is_mlc6;
+  val->mlc7 = mlc_status_mainpage.is_mlc7;
+  val->mlc8 = mlc_status_mainpage.is_mlc8;
+
+
+  /* embedded func */
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_EXEC_STATUS, (uint8_t *)&emb_func_exec_status,
+                             1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->emb_func_stand_by = emb_func_exec_status.emb_func_endop;
+  val->emb_func_time_exceed = emb_func_exec_status.emb_func_exec_ovr;
+  val->step_count_inc = emb_func_src.stepcounter_bit_set;
+  val->step_count_overflow = emb_func_src.step_overflow;
+  val->step_on_delta_time = emb_func_src.step_count_delta_ia;
+
+  val->step_detector = emb_func_src.step_detected;
+
+  /* sensor hub */
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_STATUS_CONTROLLER_MAINPAGE, (uint8_t *)&status_shub, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->sh_endop = status_shub.sens_hub_endop;
+  val->sh_wr_once = status_shub.wr_once_done;
+  val->sh_target3_nack = status_shub.target3_nack;
+  val->sh_target2_nack = status_shub.target2_nack;
+  val->sh_target1_nack = status_shub.target1_nack;
+  val->sh_target0_nack = status_shub.target0_nack;
+
+  return ret;
+}
+
+int32_t lsm6dsv80x_flag_data_ready_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_data_ready_t *val)
+{
+  lsm6dsv80x_status_reg_t status;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_STATUS_REG, (uint8_t *)&status, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->drdy_hgxl = status.xlhgda;
+  val->drdy_xl = status.xlda;
+  val->drdy_gy = status.gda;
+  val->drdy_temp = status.tda;
+
+  return ret;
+}
+
+/**
+  * @brief  Mask status bit reset[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Mask to prevent status bit being reset
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_int_ack_mask_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  int32_t ret;
+
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_INT_ACK_MASK, &val, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Mask status bit reset[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Mask to prevent status bit being reset
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_int_ack_mask_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_INT_ACK_MASK, val, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature data output register[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Temperature data output register
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_temperature_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_OUT_TEMP_L, &buff[0], 2);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  *val = (int16_t)buff[1];
+  *val = (*val * 256) + (int16_t)buff[0];
+
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Angular rate sensor.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_angular_rate_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
+{
+  uint8_t buff[6];
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_OUTX_L_G, &buff[0], 6);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val[0] = (int16_t)buff[1];
+  val[0] = (val[0] * 256) + (int16_t)buff[0];
+  val[1] = (int16_t)buff[3];
+  val[1] = (val[1] * 256) + (int16_t)buff[2];
+  val[2] = (int16_t)buff[5];
+  val[2] = (val[2] * 256) + (int16_t)buff[4];
+
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Linear acceleration sensor.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
+{
+  uint8_t buff[6];
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_OUTX_L_A, &buff[0], 6);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val[0] = (int16_t)buff[1];
+  val[0] = (val[0] * 256) + (int16_t)buff[0];
+  val[1] = (int16_t)buff[3];
+  val[1] = (val[1] * 256) + (int16_t)buff[2];
+  val[2] = (int16_t)buff[5];
+  val[2] = (val[2] * 256) + (int16_t)buff[4];
+
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor for hg channel mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Linear acceleration sensor or High-G channel mode.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_hg_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
+{
+  uint8_t buff[6];
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_UI_OUTX_L_A_HG, &buff[0], 6);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val[0] = (int16_t)buff[1];
+  val[0] = (val[0] * 256) + (int16_t)buff[0];
+  val[1] = (int16_t)buff[3];
+  val[1] = (val[1] * 256) + (int16_t)buff[2];
+  val[2] = (int16_t)buff[5];
+  val[2] = (val[2] * 256) + (int16_t)buff[4];
+
+  return ret;
+}
+
+/**
+  * @brief  SFLP gbias.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SFLP gbias raw array.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sflp_gbias_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
+{
+  uint8_t buff[6];
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_SFLP_GBIASX_L, &buff[0], 6);
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val[0] = (int16_t)buff[1];
+  val[0] = (val[0] * 256) + (int16_t)buff[0];
+  val[1] = (int16_t)buff[3];
+  val[1] = (val[1] * 256) + (int16_t)buff[2];
+  val[2] = (int16_t)buff[5];
+  val[2] = (val[2] * 256) + (int16_t)buff[4];
+
+  return ret;
+}
+
+/**
+  * @brief  SFLP gravity.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SFLP gravity raw array.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sflp_gravity_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
+{
+  uint8_t buff[6];
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_SFLP_GRAVX_L, &buff[0], 6);
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val[0] = (int16_t)buff[1];
+  val[0] = (val[0] * 256) + (int16_t)buff[0];
+  val[1] = (int16_t)buff[3];
+  val[1] = (val[1] * 256) + (int16_t)buff[2];
+  val[2] = (int16_t)buff[5];
+  val[2] = (val[2] * 256) + (int16_t)buff[4];
+
+  return ret;
+}
+
+/**
+  * @brief  SFLP raw quaternions.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      pointer to SFLP quaternions raw array.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sflp_quaternion_raw_get(const stmdev_ctx_t *ctx, uint16_t *val)
+{
+  uint8_t buff[8];
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_SFLP_QUATW_L, &buff[0], 8);
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val[0] = (uint16_t)buff[1];
+  val[0] = (val[0] * 256) + (uint16_t)buff[0];
+  val[1] = (uint16_t)buff[3];
+  val[1] = (val[1] * 256) + (uint16_t)buff[2];
+  val[2] = (uint16_t)buff[5];
+  val[2] = (val[2] * 256) + (uint16_t)buff[4];
+  val[3] = (uint16_t)buff[7];
+  val[3] = (val[3] * 256) + (uint16_t)buff[6];
+
+  return ret;
+}
+
+/**
+  * @brief  SFLP quaternions.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      pointer to SFLP quaternions raw array.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sflp_quaternion_get(const stmdev_ctx_t *ctx, lsm6dsv80x_quaternion_t *quat)
+{
+  uint16_t val[4];
+  int32_t ret;
+
+  ret = lsm6dsv80x_sflp_quaternion_raw_get(ctx, val);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  quat->quat_w = lsm6dsv80x_from_quaternion_lsb_to_float(val[0]);
+  quat->quat_x = lsm6dsv80x_from_quaternion_lsb_to_float(val[1]);
+  quat->quat_y = lsm6dsv80x_from_quaternion_lsb_to_float(val[2]);
+  quat->quat_z = lsm6dsv80x_from_quaternion_lsb_to_float(val[3]);
+
+  return ret;
+}
+
+/**
+  * @brief  Difference in percentage of the effective ODR (and timestamp rate) with respect to the typical. Step: 0.13%. 8-bit format, 2's complement.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Difference in percentage of the effective ODR (and timestamp rate) with respect to the typical. Step: 0.13%. 8-bit format, 2's complement.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_odr_cal_reg_get(const stmdev_ctx_t *ctx, int8_t *val)
+{
+  lsm6dsv80x_internal_freq_t internal_freq;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_INTERNAL_FREQ, (uint8_t *)&internal_freq, 1);
+  *val = (int8_t)internal_freq.freq_fine;
+
+  return ret;
+}
+
+/**
+  * @defgroup Common
+  * @brief     This section groups common useful functions.
+  * @{/
+  *
+  */
+
+/**
+  * @brief  Disable Embedded functions.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      1 (disable) or 0 (enable) embedded functions
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_disable_embedded_function_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_emb_func_cfg_t emb_func_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
+  emb_func_cfg.emb_func_disable = val & 0x1U;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Disable Embedded functions.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      1 (disable) or 0 (enable) embedded functions
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_disable_embedded_function_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_emb_func_cfg_t emb_func_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
+  *val = emb_func_cfg.emb_func_disable;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable/Disable embedded function sensor conversion.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      0 (disable) or 1 (enable) embedded functions sensor conversion
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_emb_func_conv_set(const stmdev_ctx_t *ctx, lsm6dsv80x_emb_func_conv_t val)
+{
+  lsm6dsv80x_emb_func_sensor_conv_en_t conv_reg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_SENSOR_CONV_EN, (uint8_t *)&conv_reg, 1);
+  conv_reg.xl_hg_conv_en = val.xl_hg_conv_en;
+  conv_reg.gyro_conv_en = val.gyro_conv_en;
+  conv_reg.temp_conv_en = val.temp_conv_en;
+  conv_reg.ext_sensor_conv_en = val.ext_sensor_conv_en;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_SENSOR_CONV_EN, (uint8_t *)&conv_reg, 1);
+
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Enable/Disable embedded function sensor conversion.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      0 (disable) or 1 (enable) embedded functions sensor conversion
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_emb_func_conv_get(const stmdev_ctx_t *ctx, lsm6dsv80x_emb_func_conv_t *val)
+{
+  lsm6dsv80x_emb_func_sensor_conv_en_t conv_reg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_SENSOR_CONV_EN, (uint8_t *)&conv_reg, 1);
+  val->xl_hg_conv_en  = conv_reg.xl_hg_conv_en;
+  val->gyro_conv_en = conv_reg.gyro_conv_en;
+  val->temp_conv_en = conv_reg.temp_conv_en;
+  val->ext_sensor_conv_en = conv_reg.ext_sensor_conv_en;
+
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Write buffer in a page.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Write buffer in a page.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t address,
+                               uint8_t *buf, uint8_t len)
+{
+  lsm6dsv80x_page_address_t  page_address;
+  lsm6dsv80x_page_sel_t page_sel;
+  lsm6dsv80x_page_rw_t page_rw;
+  uint8_t msb;
+  uint8_t lsb;
+  int32_t ret;
+  uint8_t i ;
+
+  msb = ((uint8_t)(address >> 8) & 0x0FU);
+  lsb = (uint8_t)address & 0xFFU;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  /* set page write */
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_PAGE_RW, (uint8_t *)&page_rw, 1);
+  page_rw.page_read = PROPERTY_DISABLE;
+  page_rw.page_write = PROPERTY_ENABLE;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_PAGE_RW, (uint8_t *)&page_rw, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  /* select page */
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  page_sel.page_sel = msb;
+  page_sel.not_used0 = 1; // Default value
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  /* set page addr */
+  page_address.page_addr = lsb;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_PAGE_ADDRESS,
+                              (uint8_t *)&page_address, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  for (i = 0; ((i < len) && (ret == 0)); i++)
+  {
+    ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_PAGE_VALUE, &buf[i], 1);
+    if (ret != 0)
+    {
+      goto exit;
+    }
+
+    lsb++;
+
+    /* Check if page wrap */
+    if (((lsb & 0xFFU) == 0x00U) && (ret == 0))
+    {
+      msb++;
+      ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_PAGE_SEL, (uint8_t *)&page_sel, 1);
+      if (ret != 0)
+      {
+        goto exit;
+      }
+
+      page_sel.page_sel = msb;
+      page_sel.not_used0 = 1; // Default value
+      ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_PAGE_SEL, (uint8_t *)&page_sel, 1);
+      if (ret != 0)
+      {
+        goto exit;
+      }
+    }
+  }
+
+  page_sel.page_sel = 0;
+  page_sel.not_used0 = 1;// Default value
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  /* unset page write */
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_PAGE_RW, (uint8_t *)&page_rw, 1);
+  page_rw.page_read = PROPERTY_DISABLE;
+  page_rw.page_write = PROPERTY_DISABLE;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_PAGE_RW, (uint8_t *)&page_rw, 1);
+
+exit:
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Read buffer in a page.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Write buffer in a page.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_ln_pg_read(const stmdev_ctx_t *ctx, uint16_t address, uint8_t *buf,
+                              uint8_t len)
+{
+  lsm6dsv80x_page_address_t  page_address;
+  lsm6dsv80x_page_sel_t page_sel;
+  lsm6dsv80x_page_rw_t page_rw;
+  uint8_t msb;
+  uint8_t lsb;
+  int32_t ret;
+  uint8_t i ;
+
+  msb = ((uint8_t)(address >> 8) & 0x0FU);
+  lsb = (uint8_t)address & 0xFFU;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  /* set page write */
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_PAGE_RW, (uint8_t *)&page_rw, 1);
+  page_rw.page_read = PROPERTY_ENABLE;
+  page_rw.page_write = PROPERTY_DISABLE;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_PAGE_RW, (uint8_t *)&page_rw, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  /* select page */
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  page_sel.page_sel = msb;
+  page_sel.not_used0 = 1; // Default value
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  /* set page addr */
+  page_address.page_addr = lsb;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_PAGE_ADDRESS,
+                              (uint8_t *)&page_address, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  for (i = 0; ((i < len) && (ret == 0)); i++)
+  {
+    ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_PAGE_VALUE, &buf[i], 1);
+    if (ret != 0)
+    {
+      goto exit;
+    }
+
+    lsb++;
+
+    /* Check if page wrap */
+    if (((lsb & 0xFFU) == 0x00U) && (ret == 0))
+    {
+      msb++;
+      ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_PAGE_SEL, (uint8_t *)&page_sel, 1);
+      if (ret != 0)
+      {
+        goto exit;
+      }
+
+      page_sel.page_sel = msb;
+      page_sel.not_used0 = 1; // Default value
+      ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_PAGE_SEL, (uint8_t *)&page_sel, 1);
+      if (ret != 0)
+      {
+        goto exit;
+      }
+    }
+  }
+
+  page_sel.page_sel = 0;
+  page_sel.not_used0 = 1;// Default value
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_PAGE_SEL, (uint8_t *)&page_sel, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  /* unset page write */
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_PAGE_RW, (uint8_t *)&page_rw, 1);
+  page_rw.page_read = PROPERTY_DISABLE;
+  page_rw.page_write = PROPERTY_DISABLE;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_PAGE_RW, (uint8_t *)&page_rw, 1);
+
+exit:
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Enable debug mode for embedded functions [set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      0, 1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_emb_function_dbg_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_ctrl10_t ctrl10;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL10, (uint8_t *)&ctrl10, 1);
+
+  if (ret == 0)
+  {
+    ctrl10.emb_func_debug = val;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL10, (uint8_t *)&ctrl10, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable debug mode for embedded functions [get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      0, 1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_emb_function_dbg_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_ctrl10_t ctrl10;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL10, (uint8_t *)&ctrl10, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  *val = ctrl10.emb_func_debug;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Data ENable (DEN)
+  * @brief     This section groups all the functions concerning
+  *            DEN functionality.
+  * @{
+  *
+  */
+
+/**
+  * @brief  It changes the polarity of INT2 pin input trigger for data enable (DEN) or embedded functions.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      DEN_ACT_LOW, DEN_ACT_HIGH,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_den_polarity_set(const stmdev_ctx_t *ctx,
+                                    lsm6dsv80x_den_polarity_t val)
+{
+  lsm6dsv80x_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL4, (uint8_t *)&ctrl4, 1);
+
+  if (ret == 0)
+  {
+    ctrl4.int2_in_lh = (uint8_t)val & 0x1U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL4, (uint8_t *)&ctrl4, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  It changes the polarity of INT2 pin input trigger for data enable (DEN) or embedded functions.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      DEN_ACT_LOW, DEN_ACT_HIGH,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_den_polarity_get(const stmdev_ctx_t *ctx,
+                                    lsm6dsv80x_den_polarity_t *val)
+{
+  lsm6dsv80x_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL4, (uint8_t *)&ctrl4, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl4.int2_in_lh)
+  {
+    case LSM6DSV80X_DEN_ACT_LOW:
+      *val = LSM6DSV80X_DEN_ACT_LOW;
+      break;
+
+    case LSM6DSV80X_DEN_ACT_HIGH:
+      *val = LSM6DSV80X_DEN_ACT_HIGH;
+      break;
+
+    default:
+      *val = LSM6DSV80X_DEN_ACT_LOW;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  FIFO
+  * @brief     This section group all the functions concerning the FIFO usage
+  * @{
+  *
+  */
+
+/**
+  * @brief  FIFO watermark threshold (1 LSb = TAG (1 Byte) + 1 sensor (6 Bytes) written in FIFO).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      FIFO watermark threshold (1 LSb = TAG (1 Byte) + 1 sensor (6 Bytes) written in FIFO).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_watermark_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_fifo_ctrl1_t fifo_ctrl1;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
+
+  if (ret == 0)
+  {
+    fifo_ctrl1.wtm = val;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark threshold (1 LSb = TAG (1 Byte) + 1 sensor (6 Bytes) written in FIFO).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      FIFO watermark threshold (1 LSb = TAG (1 Byte) + 1 sensor (6 Bytes) written in FIFO).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_watermark_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_fifo_ctrl1_t fifo_ctrl1;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
+  *val = fifo_ctrl1.wtm;
+
+  return ret;
+}
+
+/**
+  * @brief  It configures the compression algorithm to write non-compressed data at each rate.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      CMP_DISABLE, CMP_ALWAYS, CMP_8_TO_1, CMP_16_TO_1, CMP_32_TO_1,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_compress_algo_set(const stmdev_ctx_t *ctx,
+                                          lsm6dsv80x_fifo_compress_algo_t val)
+{
+  lsm6dsv80x_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+  if (ret == 0)
+  {
+    fifo_ctrl2.uncompr_rate = (uint8_t)val & 0x03U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  It configures the compression algorithm to write non-compressed data at each rate.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      CMP_DISABLE, CMP_ALWAYS, CMP_8_TO_1, CMP_16_TO_1, CMP_32_TO_1,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_compress_algo_get(const stmdev_ctx_t *ctx,
+                                          lsm6dsv80x_fifo_compress_algo_t *val)
+{
+  lsm6dsv80x_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (fifo_ctrl2.uncompr_rate)
+  {
+    case LSM6DSV80X_CMP_DISABLE:
+      *val = LSM6DSV80X_CMP_DISABLE;
+      break;
+
+    case LSM6DSV80X_CMP_8_TO_1:
+      *val = LSM6DSV80X_CMP_8_TO_1;
+      break;
+
+    case LSM6DSV80X_CMP_16_TO_1:
+      *val = LSM6DSV80X_CMP_16_TO_1;
+      break;
+
+    case LSM6DSV80X_CMP_32_TO_1:
+      *val = LSM6DSV80X_CMP_32_TO_1;
+      break;
+
+    default:
+      *val = LSM6DSV80X_CMP_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables ODR CHANGE virtual sensor to be batched in FIFO.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables ODR CHANGE virtual sensor to be batched in FIFO.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_virtual_sens_odr_chg_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+  if (ret == 0)
+  {
+    fifo_ctrl2.odr_chg_en = val;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables ODR CHANGE virtual sensor to be batched in FIFO.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables ODR CHANGE virtual sensor to be batched in FIFO.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_virtual_sens_odr_chg_get(const stmdev_ctx_t *ctx,
+                                                 uint8_t *val)
+{
+  lsm6dsv80x_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+  *val = fifo_ctrl2.odr_chg_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enables/Disables compression algorithm runtime.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables/Disables compression algorithm runtime.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_compress_algo_real_time_set(const stmdev_ctx_t *ctx,
+                                                    uint8_t val)
+{
+  lsm6dsv80x_emb_func_en_b_t emb_func_en_b;
+  lsm6dsv80x_fifo_ctrl2_t fifo_ctrl2;
+
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+  fifo_ctrl2.fifo_compr_rt_en = val;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
+  emb_func_en_b.fifo_compr_en = val;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Enables/Disables compression algorithm runtime.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables/Disables compression algorithm runtime.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_compress_algo_real_time_get(const stmdev_ctx_t *ctx,
+                                                    uint8_t *val)
+{
+  lsm6dsv80x_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+
+  *val = fifo_ctrl2.fifo_compr_rt_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at threshold level.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Sensing chain FIFO stop values memorization at threshold level.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_stop_on_wtm_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+  if (ret == 0)
+  {
+    fifo_ctrl2.stop_on_wtm = val;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at threshold level.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Sensing chain FIFO stop values memorization at threshold level.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_stop_on_wtm_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
+  *val = fifo_ctrl2.stop_on_wtm;
+
+  return ret;
+}
+
+/**
+  * @brief  Selects Batch Data Rate (write frequency in FIFO) for accelerometer data.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      XL_NOT_BATCHED, XL_BATCHED_AT_1Hz875, XL_BATCHED_AT_7Hz5, XL_BATCHED_AT_15Hz, XL_BATCHED_AT_30Hz, XL_BATCHED_AT_60Hz, XL_BATCHED_AT_120Hz, XL_BATCHED_AT_240Hz, XL_BATCHED_AT_480Hz, XL_BATCHED_AT_960Hz, XL_BATCHED_AT_1920Hz, XL_BATCHED_AT_3840Hz, XL_BATCHED_AT_7680Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_xl_batch_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_fifo_xl_batch_t val)
+{
+  lsm6dsv80x_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FIFO_CTRL3, (uint8_t *)&fifo_ctrl3, 1);
+  if (ret == 0)
+  {
+    fifo_ctrl3.bdr_xl = (uint8_t)val & 0xFu;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_FIFO_CTRL3, (uint8_t *)&fifo_ctrl3, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects Batch Data Rate (write frequency in FIFO) for accelerometer data.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      XL_NOT_BATCHED, XL_BATCHED_AT_1Hz875, XL_BATCHED_AT_7Hz5, XL_BATCHED_AT_15Hz, XL_BATCHED_AT_30Hz, XL_BATCHED_AT_60Hz, XL_BATCHED_AT_120Hz, XL_BATCHED_AT_240Hz, XL_BATCHED_AT_480Hz, XL_BATCHED_AT_960Hz, XL_BATCHED_AT_1920Hz, XL_BATCHED_AT_3840Hz, XL_BATCHED_AT_7680Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_xl_batch_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_fifo_xl_batch_t *val)
+{
+  lsm6dsv80x_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FIFO_CTRL3, (uint8_t *)&fifo_ctrl3, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (fifo_ctrl3.bdr_xl)
+  {
+    case LSM6DSV80X_XL_NOT_BATCHED:
+      *val = LSM6DSV80X_XL_NOT_BATCHED;
+      break;
+
+    case LSM6DSV80X_XL_BATCHED_AT_1Hz875:
+      *val = LSM6DSV80X_XL_BATCHED_AT_1Hz875;
+      break;
+
+    case LSM6DSV80X_XL_BATCHED_AT_7Hz5:
+      *val = LSM6DSV80X_XL_BATCHED_AT_7Hz5;
+      break;
+
+    case LSM6DSV80X_XL_BATCHED_AT_15Hz:
+      *val = LSM6DSV80X_XL_BATCHED_AT_15Hz;
+      break;
+
+    case LSM6DSV80X_XL_BATCHED_AT_30Hz:
+      *val = LSM6DSV80X_XL_BATCHED_AT_30Hz;
+      break;
+
+    case LSM6DSV80X_XL_BATCHED_AT_60Hz:
+      *val = LSM6DSV80X_XL_BATCHED_AT_60Hz;
+      break;
+
+    case LSM6DSV80X_XL_BATCHED_AT_120Hz:
+      *val = LSM6DSV80X_XL_BATCHED_AT_120Hz;
+      break;
+
+    case LSM6DSV80X_XL_BATCHED_AT_240Hz:
+      *val = LSM6DSV80X_XL_BATCHED_AT_240Hz;
+      break;
+
+    case LSM6DSV80X_XL_BATCHED_AT_480Hz:
+      *val = LSM6DSV80X_XL_BATCHED_AT_480Hz;
+      break;
+
+    case LSM6DSV80X_XL_BATCHED_AT_960Hz:
+      *val = LSM6DSV80X_XL_BATCHED_AT_960Hz;
+      break;
+
+    case LSM6DSV80X_XL_BATCHED_AT_1920Hz:
+      *val = LSM6DSV80X_XL_BATCHED_AT_1920Hz;
+      break;
+
+    case LSM6DSV80X_XL_BATCHED_AT_3840Hz:
+      *val = LSM6DSV80X_XL_BATCHED_AT_3840Hz;
+      break;
+
+    case LSM6DSV80X_XL_BATCHED_AT_7680Hz:
+      *val = LSM6DSV80X_XL_BATCHED_AT_7680Hz;
+      break;
+
+    default:
+      *val = LSM6DSV80X_XL_NOT_BATCHED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects Batch Data Rate (write frequency in FIFO) for gyroscope data.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      GY_NOT_BATCHED, GY_BATCHED_AT_1Hz875, GY_BATCHED_AT_7Hz5, GY_BATCHED_AT_15Hz, GY_BATCHED_AT_30Hz, GY_BATCHED_AT_60Hz, GY_BATCHED_AT_120Hz, GY_BATCHED_AT_240Hz, GY_BATCHED_AT_480Hz, GY_BATCHED_AT_960Hz, GY_BATCHED_AT_1920Hz, GY_BATCHED_AT_3840Hz, GY_BATCHED_AT_7680Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_gy_batch_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_fifo_gy_batch_t val)
+{
+  lsm6dsv80x_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FIFO_CTRL3, (uint8_t *)&fifo_ctrl3, 1);
+  if (ret == 0)
+  {
+    fifo_ctrl3.bdr_gy = (uint8_t)val & 0x0Fu;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_FIFO_CTRL3, (uint8_t *)&fifo_ctrl3, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects Batch Data Rate (write frequency in FIFO) for gyroscope data.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      GY_NOT_BATCHED, GY_BATCHED_AT_1Hz875, GY_BATCHED_AT_7Hz5, GY_BATCHED_AT_15Hz, GY_BATCHED_AT_30Hz, GY_BATCHED_AT_60Hz, GY_BATCHED_AT_120Hz, GY_BATCHED_AT_240Hz, GY_BATCHED_AT_480Hz, GY_BATCHED_AT_960Hz, GY_BATCHED_AT_1920Hz, GY_BATCHED_AT_3840Hz, GY_BATCHED_AT_7680Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_gy_batch_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_fifo_gy_batch_t *val)
+{
+  lsm6dsv80x_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FIFO_CTRL3, (uint8_t *)&fifo_ctrl3, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (fifo_ctrl3.bdr_gy)
+  {
+    case LSM6DSV80X_GY_NOT_BATCHED:
+      *val = LSM6DSV80X_GY_NOT_BATCHED;
+      break;
+
+    case LSM6DSV80X_GY_BATCHED_AT_1Hz875:
+      *val = LSM6DSV80X_GY_BATCHED_AT_1Hz875;
+      break;
+
+    case LSM6DSV80X_GY_BATCHED_AT_7Hz5:
+      *val = LSM6DSV80X_GY_BATCHED_AT_7Hz5;
+      break;
+
+    case LSM6DSV80X_GY_BATCHED_AT_15Hz:
+      *val = LSM6DSV80X_GY_BATCHED_AT_15Hz;
+      break;
+
+    case LSM6DSV80X_GY_BATCHED_AT_30Hz:
+      *val = LSM6DSV80X_GY_BATCHED_AT_30Hz;
+      break;
+
+    case LSM6DSV80X_GY_BATCHED_AT_60Hz:
+      *val = LSM6DSV80X_GY_BATCHED_AT_60Hz;
+      break;
+
+    case LSM6DSV80X_GY_BATCHED_AT_120Hz:
+      *val = LSM6DSV80X_GY_BATCHED_AT_120Hz;
+      break;
+
+    case LSM6DSV80X_GY_BATCHED_AT_240Hz:
+      *val = LSM6DSV80X_GY_BATCHED_AT_240Hz;
+      break;
+
+    case LSM6DSV80X_GY_BATCHED_AT_480Hz:
+      *val = LSM6DSV80X_GY_BATCHED_AT_480Hz;
+      break;
+
+    case LSM6DSV80X_GY_BATCHED_AT_960Hz:
+      *val = LSM6DSV80X_GY_BATCHED_AT_960Hz;
+      break;
+
+    case LSM6DSV80X_GY_BATCHED_AT_1920Hz:
+      *val = LSM6DSV80X_GY_BATCHED_AT_1920Hz;
+      break;
+
+    case LSM6DSV80X_GY_BATCHED_AT_3840Hz:
+      *val = LSM6DSV80X_GY_BATCHED_AT_3840Hz;
+      break;
+
+    case LSM6DSV80X_GY_BATCHED_AT_7680Hz:
+      *val = LSM6DSV80X_GY_BATCHED_AT_7680Hz;
+      break;
+
+    default:
+      *val = LSM6DSV80X_GY_NOT_BATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO Batch for hg XL data.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      0 (disable) / 1 (enabled)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_hg_xl_batch_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_counter_bdr_reg1_t cbdr_reg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_COUNTER_BDR_REG1, (uint8_t *)&cbdr_reg, 1);
+  if (ret == 0)
+  {
+    cbdr_reg.xl_hg_batch_en = (uint8_t)val & 0x01U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_COUNTER_BDR_REG1, (uint8_t *)&cbdr_reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO Batch for hg XL data.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      0 (disable) / 1 (enabled)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_hg_xl_batch_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_counter_bdr_reg1_t cbdr_reg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_COUNTER_BDR_REG1, (uint8_t *)&cbdr_reg, 1);
+  *val = cbdr_reg.xl_hg_batch_en;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      BYPASS_MODE, FIFO_MODE, STREAM_WTM_TO_FULL_MODE, STREAM_TO_FIFO_MODE, BYPASS_TO_STREAM_MODE, STREAM_MODE, BYPASS_TO_FIFO_MODE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_mode_set(const stmdev_ctx_t *ctx, lsm6dsv80x_fifo_mode_t val)
+{
+  lsm6dsv80x_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
+  if (ret == 0)
+  {
+    fifo_ctrl4.fifo_mode = (uint8_t)val & 0x07U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      BYPASS_MODE, FIFO_MODE, STREAM_WTM_TO_FULL_MODE, STREAM_TO_FIFO_MODE, BYPASS_TO_STREAM_MODE, STREAM_MODE, BYPASS_TO_FIFO_MODE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_mode_get(const stmdev_ctx_t *ctx, lsm6dsv80x_fifo_mode_t *val)
+{
+  lsm6dsv80x_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (fifo_ctrl4.fifo_mode)
+  {
+    case LSM6DSV80X_BYPASS_MODE:
+      *val = LSM6DSV80X_BYPASS_MODE;
+      break;
+
+    case LSM6DSV80X_FIFO_MODE:
+      *val = LSM6DSV80X_FIFO_MODE;
+      break;
+
+    case LSM6DSV80X_STREAM_WTM_TO_FULL_MODE:
+      *val = LSM6DSV80X_STREAM_WTM_TO_FULL_MODE;
+      break;
+
+    case LSM6DSV80X_STREAM_TO_FIFO_MODE:
+      *val = LSM6DSV80X_STREAM_TO_FIFO_MODE;
+      break;
+
+    case LSM6DSV80X_BYPASS_TO_STREAM_MODE:
+      *val = LSM6DSV80X_BYPASS_TO_STREAM_MODE;
+      break;
+
+    case LSM6DSV80X_STREAM_MODE:
+      *val = LSM6DSV80X_STREAM_MODE;
+      break;
+
+    case LSM6DSV80X_BYPASS_TO_FIFO_MODE:
+      *val = LSM6DSV80X_BYPASS_TO_FIFO_MODE;
+      break;
+
+    default:
+      *val = LSM6DSV80X_BYPASS_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects batch data rate (write frequency in FIFO) for temperature data.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      TEMP_NOT_BATCHED, TEMP_BATCHED_AT_1Hz875, TEMP_BATCHED_AT_15Hz, TEMP_BATCHED_AT_60Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_temp_batch_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_fifo_temp_batch_t val)
+{
+  lsm6dsv80x_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
+  if (ret == 0)
+  {
+    fifo_ctrl4.odr_t_batch = (uint8_t)val & 0x03U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects batch data rate (write frequency in FIFO) for temperature data.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      TEMP_NOT_BATCHED, TEMP_BATCHED_AT_1Hz875, TEMP_BATCHED_AT_15Hz, TEMP_BATCHED_AT_60Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_temp_batch_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_fifo_temp_batch_t *val)
+{
+  lsm6dsv80x_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (fifo_ctrl4.odr_t_batch)
+  {
+    case LSM6DSV80X_TEMP_NOT_BATCHED:
+      *val = LSM6DSV80X_TEMP_NOT_BATCHED;
+      break;
+
+    case LSM6DSV80X_TEMP_BATCHED_AT_1Hz875:
+      *val = LSM6DSV80X_TEMP_BATCHED_AT_1Hz875;
+      break;
+
+    case LSM6DSV80X_TEMP_BATCHED_AT_15Hz:
+      *val = LSM6DSV80X_TEMP_BATCHED_AT_15Hz;
+      break;
+
+    case LSM6DSV80X_TEMP_BATCHED_AT_60Hz:
+      *val = LSM6DSV80X_TEMP_BATCHED_AT_60Hz;
+      break;
+
+    default:
+      *val = LSM6DSV80X_TEMP_NOT_BATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects decimation for timestamp batching in FIFO. Write rate will be the maximum rate between XL and GYRO BDR divided by decimation decoder.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      TMSTMP_NOT_BATCHED, TMSTMP_DEC_1, TMSTMP_DEC_8, TMSTMP_DEC_32,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_timestamp_batch_set(const stmdev_ctx_t *ctx,
+                                            lsm6dsv80x_fifo_timestamp_batch_t val)
+{
+  lsm6dsv80x_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
+  if (ret == 0)
+  {
+    fifo_ctrl4.dec_ts_batch = (uint8_t)val & 0x03U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects decimation for timestamp batching in FIFO. Write rate will be the maximum rate between XL and GYRO BDR divided by decimation decoder.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      TMSTMP_NOT_BATCHED, TMSTMP_DEC_1, TMSTMP_DEC_8, TMSTMP_DEC_32,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_timestamp_batch_get(const stmdev_ctx_t *ctx,
+                                            lsm6dsv80x_fifo_timestamp_batch_t *val)
+{
+  lsm6dsv80x_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (fifo_ctrl4.dec_ts_batch)
+  {
+    case LSM6DSV80X_TMSTMP_NOT_BATCHED:
+      *val = LSM6DSV80X_TMSTMP_NOT_BATCHED;
+      break;
+
+    case LSM6DSV80X_TMSTMP_DEC_1:
+      *val = LSM6DSV80X_TMSTMP_DEC_1;
+      break;
+
+    case LSM6DSV80X_TMSTMP_DEC_8:
+      *val = LSM6DSV80X_TMSTMP_DEC_8;
+      break;
+
+    case LSM6DSV80X_TMSTMP_DEC_32:
+      *val = LSM6DSV80X_TMSTMP_DEC_32;
+      break;
+
+    default:
+      *val = LSM6DSV80X_TMSTMP_NOT_BATCHED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  The threshold for the internal counter of batch events. When this counter reaches the threshold, the counter is reset and the interrupt flag is set to 1.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      The threshold for the internal counter of batch events. When this counter reaches the threshold, the counter is reset and the interrupt flag is set to 1.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_batch_counter_threshold_set(const stmdev_ctx_t *ctx,
+                                                    uint16_t val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  buff[1] = (uint8_t)(val / 256U);
+  buff[0] = (uint8_t)(val - (buff[1] * 256U));
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_COUNTER_BDR_REG1, (uint8_t *)&buff[0], 2);
+
+  return ret;
+}
+
+/**
+  * @brief  The threshold for the internal counter of batch events. When this counter reaches the threshold, the counter is reset and the interrupt flag is set to 1.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      The threshold for the internal counter of batch events. When this counter reaches the threshold, the counter is reset and the interrupt flag is set to 1.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_batch_counter_threshold_get(const stmdev_ctx_t *ctx,
+                                                    uint16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_COUNTER_BDR_REG1, &buff[0], 2);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  *val = buff[1];
+  *val = (*val * 256U) + buff[0];
+
+  return ret;
+}
+
+/**
+  * @brief  Selects the trigger for the internal counter of batch events.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lsm6dsv80x_fifo_batch_cnt_event_t struct
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_batch_cnt_event_set(const stmdev_ctx_t *ctx,
+                                            lsm6dsv80x_fifo_batch_cnt_event_t val)
+{
+  lsm6dsv80x_counter_bdr_reg1_t counter_bdr_reg1;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_COUNTER_BDR_REG1, (uint8_t *)&counter_bdr_reg1, 1);
+  if (ret == 0)
+  {
+    counter_bdr_reg1.trig_counter_bdr = (uint8_t)val & 0x03U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_COUNTER_BDR_REG1, (uint8_t *)&counter_bdr_reg1, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects the trigger for the internal counter of batch events.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      lsm6dsv80x_fifo_batch_cnt_event_t struct
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_batch_cnt_event_get(const stmdev_ctx_t *ctx,
+                                            lsm6dsv80x_fifo_batch_cnt_event_t *val)
+{
+  lsm6dsv80x_counter_bdr_reg1_t counter_bdr_reg1;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_COUNTER_BDR_REG1, (uint8_t *)&counter_bdr_reg1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (counter_bdr_reg1.trig_counter_bdr)
+  {
+    case 0:
+      *val = LSM6DSV80X_XL_LG_BATCH_EVENT;
+      break;
+
+    case 1:
+      *val = LSM6DSV80X_GY_BATCH_EVENT;
+      break;
+
+    case 3:
+      *val = LSM6DSV80X_XL_HG_BATCH_EVENT;
+      break;
+
+    default:
+      *val = LSM6DSV80X_XL_LG_BATCH_EVENT;
+      break;
+  }
+
+  return ret;
+}
+
+int32_t lsm6dsv80x_fifo_status_get(const stmdev_ctx_t *ctx,
+                                   lsm6dsv80x_fifo_status_t *val)
+{
+  uint8_t buff[2];
+  lsm6dsv80x_fifo_status2_t status;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FIFO_STATUS1, (uint8_t *)&buff[0], 2);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  bytecpy((uint8_t *)&status, &buff[1]);
+
+  val->fifo_bdr = status.counter_bdr_ia;
+  val->fifo_ovr = status.fifo_ovr_ia;
+  val->fifo_full = status.fifo_full_ia;
+  val->fifo_th = status.fifo_wtm_ia;
+
+  val->fifo_level = (uint16_t)buff[1] & 0x01U;
+  val->fifo_level = (val->fifo_level * 256U) + buff[0];
+
+  return ret;
+}
+
+
+/**
+  * @brief  FIFO data output[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      FIFO tag
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_out_raw_get(const stmdev_ctx_t *ctx,
+                                    lsm6dsv80x_fifo_out_raw_t *val)
+{
+  lsm6dsv80x_fifo_data_out_tag_t fifo_data_out_tag;
+  uint8_t buff[7];
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FIFO_DATA_OUT_TAG, buff, 7);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  bytecpy((uint8_t *)&fifo_data_out_tag, &buff[0]);
+
+  switch (fifo_data_out_tag.tag_sensor)
+  {
+    case 0:
+      val->tag = LSM6DSV80X_FIFO_EMPTY;
+      break;
+
+    case 1:
+      val->tag = LSM6DSV80X_GY_NC_TAG;
+      break;
+
+    case 2:
+      val->tag = LSM6DSV80X_XL_NC_TAG;
+      break;
+
+    case 3:
+      val->tag = LSM6DSV80X_TIMESTAMP_TAG;
+      break;
+
+    case 4:
+      val->tag = LSM6DSV80X_TEMPERATURE_TAG;
+      break;
+
+    case 5:
+      val->tag = LSM6DSV80X_CFG_CHANGE_TAG;
+      break;
+
+    case 6:
+      val->tag = LSM6DSV80X_XL_NC_T_2_TAG;
+      break;
+
+    case 7:
+      val->tag = LSM6DSV80X_XL_NC_T_1_TAG;
+      break;
+
+    case 8:
+      val->tag = LSM6DSV80X_XL_2XC_TAG;
+      break;
+
+    case 9:
+      val->tag = LSM6DSV80X_XL_3XC_TAG;
+      break;
+
+    case 0xA:
+      val->tag = LSM6DSV80X_GY_NC_T_2_TAG;
+      break;
+
+    case 0xB:
+      val->tag = LSM6DSV80X_GY_NC_T_1_TAG;
+      break;
+
+    case 0xC:
+      val->tag = LSM6DSV80X_GY_2XC_TAG;
+      break;
+
+    case 0xD:
+      val->tag = LSM6DSV80X_GY_3XC_TAG;
+      break;
+
+    case 0xE:
+      val->tag = LSM6DSV80X_SENSORHUB_TARGET0_TAG;
+      break;
+
+    case 0xF:
+      val->tag = LSM6DSV80X_SENSORHUB_TARGET1_TAG;
+      break;
+
+    case 0x10:
+      val->tag = LSM6DSV80X_SENSORHUB_TARGET2_TAG;
+      break;
+
+    case 0x11:
+      val->tag = LSM6DSV80X_SENSORHUB_TARGET3_TAG;
+      break;
+
+    case 0x12:
+      val->tag = LSM6DSV80X_STEP_COUNTER_TAG;
+      break;
+
+    case 0x13:
+      val->tag = LSM6DSV80X_SFLP_GAME_ROTATION_VECTOR_TAG;
+      break;
+
+    case 0x16:
+      val->tag = LSM6DSV80X_SFLP_GYROSCOPE_BIAS_TAG;
+      break;
+
+    case 0x17:
+      val->tag = LSM6DSV80X_SFLP_GRAVITY_VECTOR_TAG;
+      break;
+
+    case 0x18:
+      val->tag = LSM6DSV80X_HG_XL_PEAK_TAG;
+      break;
+
+    case 0x19:
+      val->tag = LSM6DSV80X_SENSORHUB_NACK_TAG;
+      break;
+
+    case 0x1A:
+      val->tag = LSM6DSV80X_MLC_RESULT_TAG;
+      break;
+
+    case 0x1B:
+      val->tag = LSM6DSV80X_MLC_FILTER;
+      break;
+
+    case 0x1C:
+      val->tag = LSM6DSV80X_MLC_FEATURE;
+      break;
+
+    case 0x1D:
+      val->tag = LSM6DSV80X_XL_HG_TAG;
+      break;
+
+    case 0x1F:
+      val->tag = LSM6DSV80X_FSM_RESULT_TAG;
+      break;
+
+    default:
+      val->tag = LSM6DSV80X_FIFO_EMPTY;
+      break;
+  }
+
+  val->cnt = fifo_data_out_tag.tag_cnt;
+
+  val->data[0] = buff[1];
+  val->data[1] = buff[2];
+  val->data[2] = buff[3];
+  val->data[3] = buff[4];
+  val->data[4] = buff[5];
+  val->data[5] = buff[6];
+
+  return ret;
+}
+
+/**
+  * @brief  Batching in FIFO buffer of step counter value.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Batching in FIFO buffer of step counter value.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_stpcnt_batch_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_emb_func_fifo_en_a_t emb_func_fifo_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
+  emb_func_fifo_en_a.step_counter_fifo_en = val;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
+
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Batching in FIFO buffer of step counter value.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Batching in FIFO buffer of step counter value.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_stpcnt_batch_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_emb_func_fifo_en_a_t emb_func_fifo_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
+  *val = emb_func_fifo_en_a.step_counter_fifo_en;
+
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Batching in FIFO buffer of finite state machine results.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Batching in FIFO buffer of finite state machine results.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_fsm_batch_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_emb_func_fifo_en_b_t emb_func_fifo_en_b;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_b, 1);
+  emb_func_fifo_en_b.fsm_fifo_en = val;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_b, 1);
+
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Batching in FIFO buffer of finite state machine results.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Batching in FIFO buffer of finite state machine results.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_fsm_batch_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_emb_func_fifo_en_b_t emb_func_fifo_en_b;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_b, 1);
+  *val = emb_func_fifo_en_b.fsm_fifo_en;
+
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Batching in FIFO buffer of machine learning core results.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Batching in FIFO buffer of machine learning core results.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_mlc_batch_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_emb_func_fifo_en_a_t emb_func_fifo_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
+  emb_func_fifo_en_a.mlc_fifo_en = val;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
+
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Batching in FIFO buffer of machine learning core results.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Batching in FIFO buffer of machine learning core results.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_mlc_batch_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_emb_func_fifo_en_a_t emb_func_fifo_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
+  *val = emb_func_fifo_en_a.mlc_fifo_en;
+
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Enables batching in FIFO buffer of machine learning core filters and features.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables batching in FIFO buffer of machine learning core filters and features.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_mlc_filt_batch_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_emb_func_fifo_en_b_t emb_func_fifo_en_b;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_FIFO_EN_B, (uint8_t *)&emb_func_fifo_en_b, 1);
+  emb_func_fifo_en_b.mlc_filter_feature_fifo_en = val;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_FIFO_EN_B, (uint8_t *)&emb_func_fifo_en_b, 1);
+
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Enables batching in FIFO buffer of machine learning core filters and features.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables batching in FIFO buffer of machine learning core filters and features.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_mlc_filt_batch_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_emb_func_fifo_en_b_t emb_func_fifo_en_b;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_FIFO_EN_B, (uint8_t *)&emb_func_fifo_en_b, 1);
+  *val = emb_func_fifo_en_b.mlc_filter_feature_fifo_en;
+
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO data batching of target idx.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enable FIFO data batching of target idx.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_sh_batch_target_set(const stmdev_ctx_t *ctx, uint8_t idx, uint8_t val)
+{
+  lsm6dsv80x_tgt0_config_t tgt_config;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_SENSOR_HUB_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TGT0_CONFIG + idx * 3U, (uint8_t *)&tgt_config, 1);
+  tgt_config.batch_ext_sens_0_en = val;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TGT0_CONFIG + idx * 3U, (uint8_t *)&tgt_config, 1);
+
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO data batching of target idx.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enable FIFO data batching of target idx.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_sh_batch_target_get(const stmdev_ctx_t *ctx, uint8_t idx, uint8_t *val)
+{
+  lsm6dsv80x_tgt0_config_t tgt_config;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_SENSOR_HUB_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TGT0_CONFIG + idx * 3U, (uint8_t *)&tgt_config, 1);
+  *val = tgt_config.batch_ext_sens_0_en;
+
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Batching in FIFO buffer of SFLP.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Batching in FIFO buffer of SFLP values.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_sflp_batch_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_fifo_sflp_raw_t val)
+{
+  lsm6dsv80x_emb_func_fifo_en_a_t emb_func_fifo_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
+    emb_func_fifo_en_a.sflp_game_fifo_en = val.game_rotation;
+    emb_func_fifo_en_a.sflp_gravity_fifo_en = val.gravity;
+    emb_func_fifo_en_a.sflp_gbias_fifo_en = val.gbias;
+    ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_FIFO_EN_A,
+                                (uint8_t *)&emb_func_fifo_en_a, 1);
+  }
+
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Batching in FIFO buffer of SFLP.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Batching in FIFO buffer of SFLP values.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fifo_sflp_batch_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_fifo_sflp_raw_t *val)
+{
+  lsm6dsv80x_emb_func_fifo_en_a_t emb_func_fifo_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
+
+    val->game_rotation = emb_func_fifo_en_a.sflp_game_fifo_en;
+    val->gravity = emb_func_fifo_en_a.sflp_gravity_fifo_en;
+    val->gbias = emb_func_fifo_en_a.sflp_gbias_fifo_en;
+  }
+
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Filters
+  * @brief     This section group all the functions concerning the
+  *            filters configuration
+  * @{
+  *
+  */
+
+/**
+  * @brief  Protocol anti-spike filters.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      AUTO, ALWAYS_ACTIVE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_filt_anti_spike_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_filt_anti_spike_t val)
+{
+  lsm6dsv80x_if_cfg_t if_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_IF_CFG, (uint8_t *)&if_cfg, 1);
+
+  if (ret == 0)
+  {
+    if_cfg.asf_ctrl = (uint8_t)val & 0x01U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Protocol anti-spike filters.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      AUTO, ALWAYS_ACTIVE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_filt_anti_spike_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_filt_anti_spike_t *val)
+{
+  lsm6dsv80x_if_cfg_t if_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (if_cfg.asf_ctrl)
+  {
+    case LSM6DSV80X_AUTO:
+      *val = LSM6DSV80X_AUTO;
+      break;
+
+    case LSM6DSV80X_ALWAYS_ACTIVE:
+      *val = LSM6DSV80X_ALWAYS_ACTIVE;
+      break;
+
+    default:
+      *val = LSM6DSV80X_AUTO;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  It masks DRDY and Interrupts RQ until filter settling ends.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      It masks DRDY and Interrupts RQ until filter settling ends.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_filt_settling_mask_set(const stmdev_ctx_t *ctx,
+                                          lsm6dsv80x_filt_settling_mask_t val)
+{
+  lsm6dsv80x_emb_func_cfg_t emb_func_cfg;
+  lsm6dsv80x_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL4, (uint8_t *)&ctrl4, 1);
+  ctrl4.drdy_mask = val.drdy;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL4, (uint8_t *)&ctrl4, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
+  emb_func_cfg.emb_func_irq_mask_xl_settl = val.irq_xl;
+  emb_func_cfg.emb_func_irq_mask_xl_hg_settl = val.irq_xl_hg;
+  emb_func_cfg.emb_func_irq_mask_g_settl = val.irq_g;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  It masks DRDY and Interrupts RQ until filter settling ends.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      It masks DRDY and Interrupts RQ until filter settling ends.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_filt_settling_mask_get(const stmdev_ctx_t *ctx,
+                                          lsm6dsv80x_filt_settling_mask_t *val)
+{
+  lsm6dsv80x_emb_func_cfg_t emb_func_cfg;
+  lsm6dsv80x_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL4, (uint8_t *)&ctrl4, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
+
+  val->irq_xl = emb_func_cfg.emb_func_irq_mask_xl_settl;
+  val->irq_g = emb_func_cfg.emb_func_irq_mask_g_settl;
+  val->drdy = ctrl4.drdy_mask;
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope low-pass filter (LPF1) bandwidth selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      GY_ULTRA_LIGHT, GY_VERY_LIGHT, GY_LIGHT, GY_MEDIUM, GY_STRONG, GY_VERY_STRONG, GY_AGGRESSIVE, GY_XTREME,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_filt_gy_lp1_bandwidth_set(const stmdev_ctx_t *ctx,
+                                             lsm6dsv80x_filt_gy_lp1_bandwidth_t val)
+{
+  lsm6dsv80x_ctrl6_t ctrl6;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL6, (uint8_t *)&ctrl6, 1);
+  if (ret == 0)
+  {
+    ctrl6.lpf1_g_bw = (uint8_t)val & 0x0Fu;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL6, (uint8_t *)&ctrl6, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope low-pass filter (LPF1) bandwidth selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      GY_ULTRA_LIGHT, GY_VERY_LIGHT, GY_LIGHT, GY_MEDIUM, GY_STRONG, GY_VERY_STRONG, GY_AGGRESSIVE, GY_XTREME,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_filt_gy_lp1_bandwidth_get(const stmdev_ctx_t *ctx,
+                                             lsm6dsv80x_filt_gy_lp1_bandwidth_t *val)
+{
+  lsm6dsv80x_ctrl6_t ctrl6;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL6, (uint8_t *)&ctrl6, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl6.lpf1_g_bw)
+  {
+    case LSM6DSV80X_GY_ULTRA_LIGHT:
+      *val = LSM6DSV80X_GY_ULTRA_LIGHT;
+      break;
+
+    case LSM6DSV80X_GY_VERY_LIGHT:
+      *val = LSM6DSV80X_GY_VERY_LIGHT;
+      break;
+
+    case LSM6DSV80X_GY_LIGHT:
+      *val = LSM6DSV80X_GY_LIGHT;
+      break;
+
+    case LSM6DSV80X_GY_MEDIUM:
+      *val = LSM6DSV80X_GY_MEDIUM;
+      break;
+
+    case LSM6DSV80X_GY_STRONG:
+      *val = LSM6DSV80X_GY_STRONG;
+      break;
+
+    case LSM6DSV80X_GY_VERY_STRONG:
+      *val = LSM6DSV80X_GY_VERY_STRONG;
+      break;
+
+    case LSM6DSV80X_GY_AGGRESSIVE:
+      *val = LSM6DSV80X_GY_AGGRESSIVE;
+      break;
+
+    case LSM6DSV80X_GY_XTREME:
+      *val = LSM6DSV80X_GY_XTREME;
+      break;
+
+    default:
+      *val = LSM6DSV80X_GY_ULTRA_LIGHT;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  It enables gyroscope digital LPF1 filter.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      It enables gyroscope digital LPF1 filter.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_filt_gy_lp1_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_ctrl7_t ctrl7;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL7, (uint8_t *)&ctrl7, 1);
+  if (ret == 0)
+  {
+    ctrl7.lpf1_g_en = val;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL7, (uint8_t *)&ctrl7, 1);
+  }
+
+  return ret;
+}
+
+
+/**
+  * @brief  It enables gyroscope digital LPF1 filter.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      It enables gyroscope digital LPF1 filter.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_filt_gy_lp1_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_ctrl7_t ctrl7;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL7, (uint8_t *)&ctrl7, 1);
+  *val = ctrl7.lpf1_g_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer LPF2 and high pass filter configuration and cutoff setting.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      XL_ULTRA_LIGHT, XL_VERY_LIGHT, XL_LIGHT, XL_MEDIUM, XL_STRONG, XL_VERY_STRONG, XL_AGGRESSIVE, XL_XTREME,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_filt_xl_lp2_bandwidth_set(const stmdev_ctx_t *ctx,
+                                             lsm6dsv80x_filt_xl_lp2_bandwidth_t val)
+{
+  lsm6dsv80x_ctrl8_t ctrl8;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL8, (uint8_t *)&ctrl8, 1);
+  if (ret == 0)
+  {
+    ctrl8.hp_lpf2_xl_bw = (uint8_t)val & 0x07U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL8, (uint8_t *)&ctrl8, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer LPF2 and high pass filter configuration and cutoff setting.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      XL_ULTRA_LIGHT, XL_VERY_LIGHT, XL_LIGHT, XL_MEDIUM, XL_STRONG, XL_VERY_STRONG, XL_AGGRESSIVE, XL_XTREME,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_filt_xl_lp2_bandwidth_get(const stmdev_ctx_t *ctx,
+                                             lsm6dsv80x_filt_xl_lp2_bandwidth_t *val)
+{
+  lsm6dsv80x_ctrl8_t ctrl8;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL8, (uint8_t *)&ctrl8, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl8.hp_lpf2_xl_bw)
+  {
+    case LSM6DSV80X_XL_ULTRA_LIGHT:
+      *val = LSM6DSV80X_XL_ULTRA_LIGHT;
+      break;
+
+    case LSM6DSV80X_XL_VERY_LIGHT:
+      *val = LSM6DSV80X_XL_VERY_LIGHT;
+      break;
+
+    case LSM6DSV80X_XL_LIGHT:
+      *val = LSM6DSV80X_XL_LIGHT;
+      break;
+
+    case LSM6DSV80X_XL_MEDIUM:
+      *val = LSM6DSV80X_XL_MEDIUM;
+      break;
+
+    case LSM6DSV80X_XL_STRONG:
+      *val = LSM6DSV80X_XL_STRONG;
+      break;
+
+    case LSM6DSV80X_XL_VERY_STRONG:
+      *val = LSM6DSV80X_XL_VERY_STRONG;
+      break;
+
+    case LSM6DSV80X_XL_AGGRESSIVE:
+      *val = LSM6DSV80X_XL_AGGRESSIVE;
+      break;
+
+    case LSM6DSV80X_XL_XTREME:
+      *val = LSM6DSV80X_XL_XTREME;
+      break;
+
+    default:
+      *val = LSM6DSV80X_XL_ULTRA_LIGHT;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable accelerometer LPS2 (Low Pass Filter 2) filtering stage.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enable accelerometer LPS2 (Low Pass Filter 2) filtering stage.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_filt_xl_lp2_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_ctrl9_t ctrl9;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL9, (uint8_t *)&ctrl9, 1);
+  if (ret == 0)
+  {
+    ctrl9.lpf2_xl_en = val;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL9, (uint8_t *)&ctrl9, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable accelerometer LPS2 (Low Pass Filter 2) filtering stage.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enable accelerometer LPS2 (Low Pass Filter 2) filtering stage.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_filt_xl_lp2_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_ctrl9_t ctrl9;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL9, (uint8_t *)&ctrl9, 1);
+  *val = ctrl9.lpf2_xl_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer slope filter / high-pass filter selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Accelerometer slope filter / high-pass filter selection.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_filt_xl_hp_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_ctrl9_t ctrl9;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL9, (uint8_t *)&ctrl9, 1);
+  if (ret == 0)
+  {
+    ctrl9.hp_slope_xl_en = val;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL9, (uint8_t *)&ctrl9, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer slope filter / high-pass filter selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Accelerometer slope filter / high-pass filter selection.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_filt_xl_hp_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_ctrl9_t ctrl9;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL9, (uint8_t *)&ctrl9, 1);
+  *val = ctrl9.hp_slope_xl_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enables accelerometer LPF2 and HPF fast-settling mode. The filter sets the first sample.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables accelerometer LPF2 and HPF fast-settling mode. The filter sets the first sample.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_filt_xl_fast_settling_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_ctrl9_t ctrl9;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL9, (uint8_t *)&ctrl9, 1);
+  if (ret == 0)
+  {
+    ctrl9.xl_fastsettl_mode = val;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL9, (uint8_t *)&ctrl9, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables accelerometer LPF2 and HPF fast-settling mode. The filter sets the first sample.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables accelerometer LPF2 and HPF fast-settling mode. The filter sets the first sample.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_filt_xl_fast_settling_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_ctrl9_t ctrl9;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL9, (uint8_t *)&ctrl9, 1);
+  *val = ctrl9.xl_fastsettl_mode;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer high-pass filter mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      HP_MD_NORMAL, HP_MD_REFERENCE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_filt_xl_hp_mode_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_filt_xl_hp_mode_t val)
+{
+  lsm6dsv80x_ctrl9_t ctrl9;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL9, (uint8_t *)&ctrl9, 1);
+  if (ret == 0)
+  {
+    ctrl9.hp_ref_mode_xl = (uint8_t)val & 0x01U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL9, (uint8_t *)&ctrl9, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer high-pass filter mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      HP_MD_NORMAL, HP_MD_REFERENCE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_filt_xl_hp_mode_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_filt_xl_hp_mode_t *val)
+{
+  lsm6dsv80x_ctrl9_t ctrl9;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL9, (uint8_t *)&ctrl9, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl9.hp_ref_mode_xl)
+  {
+    case LSM6DSV80X_HP_MD_NORMAL:
+      *val = LSM6DSV80X_HP_MD_NORMAL;
+      break;
+
+    case LSM6DSV80X_HP_MD_REFERENCE:
+      *val = LSM6DSV80X_HP_MD_REFERENCE;
+      break;
+
+    default:
+      *val = LSM6DSV80X_HP_MD_NORMAL;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  HPF or SLOPE filter selection on wake-up and Activity/Inactivity functions.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      WK_FEED_SLOPE, WK_FEED_HIGH_PASS, WK_FEED_LP_WITH_OFFSET,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_filt_wkup_act_feed_set(const stmdev_ctx_t *ctx,
+                                          lsm6dsv80x_filt_wkup_act_feed_t val)
+{
+  lsm6dsv80x_wake_up_ths_t wake_up_ths;
+  lsm6dsv80x_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  tap_cfg0.slope_fds = (uint8_t)val & 0x01U;
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  wake_up_ths.usr_off_on_wu = ((uint8_t)val & 0x02U) >> 1;
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  HPF or SLOPE filter selection on wake-up and Activity/Inactivity functions.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      WK_FEED_SLOPE, WK_FEED_HIGH_PASS, WK_FEED_LP_WITH_OFFSET,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_filt_wkup_act_feed_get(const stmdev_ctx_t *ctx,
+                                          lsm6dsv80x_filt_wkup_act_feed_t *val)
+{
+  lsm6dsv80x_wake_up_ths_t wake_up_ths;
+  lsm6dsv80x_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch ((wake_up_ths.usr_off_on_wu << 1) + tap_cfg0.slope_fds)
+  {
+    case LSM6DSV80X_WK_FEED_SLOPE:
+      *val = LSM6DSV80X_WK_FEED_SLOPE;
+      break;
+
+    case LSM6DSV80X_WK_FEED_HIGH_PASS:
+      *val = LSM6DSV80X_WK_FEED_HIGH_PASS;
+      break;
+
+    case LSM6DSV80X_WK_FEED_LP_WITH_OFFSET:
+      *val = LSM6DSV80X_WK_FEED_LP_WITH_OFFSET;
+      break;
+
+    default:
+      *val = LSM6DSV80X_WK_FEED_SLOPE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Mask hw function triggers when xl is settling.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      0 or 1,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_mask_trigger_xl_settl_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+
+  if (ret == 0)
+  {
+    tap_cfg0.hw_func_mask_xl_settl = val & 0x01U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Mask hw function triggers when xl is settling.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      0 or 1,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_mask_trigger_xl_settl_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  *val = tap_cfg0.hw_func_mask_xl_settl;
+
+  return ret;
+}
+
+/**
+  * @brief  LPF2 filter on 6D (sixd) function selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SIXD_FEED_ODR_DIV_2, SIXD_FEED_LOW_PASS,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_filt_sixd_feed_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_filt_sixd_feed_t val)
+{
+  lsm6dsv80x_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+
+  if (ret == 0)
+  {
+    tap_cfg0.low_pass_on_6d = (uint8_t)val & 0x01U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  LPF2 filter on 6D (sixd) function selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SIXD_FEED_ODR_DIV_2, SIXD_FEED_LOW_PASS,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_filt_sixd_feed_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_filt_sixd_feed_t *val)
+{
+  lsm6dsv80x_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (tap_cfg0.low_pass_on_6d)
+  {
+    case LSM6DSV80X_SIXD_FEED_ODR_DIV_2:
+      *val = LSM6DSV80X_SIXD_FEED_ODR_DIV_2;
+      break;
+
+    case LSM6DSV80X_SIXD_FEED_LOW_PASS:
+      *val = LSM6DSV80X_SIXD_FEED_LOW_PASS;
+      break;
+
+    default:
+      *val = LSM6DSV80X_SIXD_FEED_ODR_DIV_2;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Finite State Machine (FSM)
+  * @brief     This section groups all the functions that manage the
+  *            state_machine.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enables the control of the CTRL registers to FSM (FSM can change some configurations of the device autonomously).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      PROTECT_CTRL_REGS, WRITE_CTRL_REG,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fsm_permission_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_fsm_permission_t val)
+{
+  lsm6dsv80x_func_cfg_access_t func_cfg_access;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+
+  if (ret == 0)
+  {
+    func_cfg_access.fsm_wr_ctrl_en = (uint8_t)val & 0x01U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables the control of the CTRL registers to FSM (FSM can change some configurations of the device autonomously).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      PROTECT_CTRL_REGS, WRITE_CTRL_REG,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fsm_permission_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_fsm_permission_t *val)
+{
+  lsm6dsv80x_func_cfg_access_t func_cfg_access;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (func_cfg_access.fsm_wr_ctrl_en)
+  {
+    case LSM6DSV80X_PROTECT_CTRL_REGS:
+      *val = LSM6DSV80X_PROTECT_CTRL_REGS;
+      break;
+
+    case LSM6DSV80X_WRITE_CTRL_REG:
+      *val = LSM6DSV80X_WRITE_CTRL_REG;
+      break;
+
+    default:
+      *val = LSM6DSV80X_PROTECT_CTRL_REGS;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Get the FSM permission status
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      0: All reg writable from std if - 1: some regs are under FSM control.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fsm_permission_status(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_ctrl_status_t ctrl_status;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL_STATUS, (uint8_t *)&ctrl_status, 1);
+
+  *val = ctrl_status.fsm_wr_ctrl_status;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable Finite State Machine (FSM) feature.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enable Finite State Machine (FSM) feature.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fsm_mode_set(const stmdev_ctx_t *ctx, lsm6dsv80x_fsm_mode_t val)
+{
+  lsm6dsv80x_emb_func_en_b_t emb_func_en_b;
+  lsm6dsv80x_fsm_enable_t fsm_enable;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FSM_ENABLE, (uint8_t *)&fsm_enable, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  if ((val.fsm1_en | val.fsm2_en | val.fsm3_en | val.fsm4_en
+       | val.fsm5_en | val.fsm6_en | val.fsm7_en | val.fsm8_en) == PROPERTY_ENABLE)
+  {
+    emb_func_en_b.fsm_en = PROPERTY_ENABLE;
+  }
+  else
+  {
+    emb_func_en_b.fsm_en = PROPERTY_DISABLE;
+  }
+
+  fsm_enable.fsm1_en = val.fsm1_en;
+  fsm_enable.fsm2_en = val.fsm2_en;
+  fsm_enable.fsm3_en = val.fsm3_en;
+  fsm_enable.fsm4_en = val.fsm4_en;
+  fsm_enable.fsm5_en = val.fsm5_en;
+  fsm_enable.fsm6_en = val.fsm6_en;
+  fsm_enable.fsm7_en = val.fsm7_en;
+  fsm_enable.fsm8_en = val.fsm8_en;
+
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_FSM_ENABLE, (uint8_t *)&fsm_enable, 1);
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
+
+exit:
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Enable Finite State Machine (FSM) feature.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enable Finite State Machine (FSM) feature.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fsm_mode_get(const stmdev_ctx_t *ctx, lsm6dsv80x_fsm_mode_t *val)
+{
+  lsm6dsv80x_fsm_enable_t fsm_enable;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FSM_ENABLE, (uint8_t *)&fsm_enable, 1);
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->fsm1_en = fsm_enable.fsm1_en;
+  val->fsm2_en = fsm_enable.fsm2_en;
+  val->fsm3_en = fsm_enable.fsm3_en;
+  val->fsm4_en = fsm_enable.fsm4_en;
+  val->fsm5_en = fsm_enable.fsm5_en;
+  val->fsm6_en = fsm_enable.fsm6_en;
+  val->fsm7_en = fsm_enable.fsm7_en;
+  val->fsm8_en = fsm_enable.fsm8_en;
+
+  return ret;
+}
+
+/**
+  * @brief  FSM long counter status register. Long counter value is an unsigned integer value (16-bit format).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      FSM long counter status register. Long counter value is an unsigned integer value (16-bit format).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fsm_long_cnt_set(const stmdev_ctx_t *ctx, uint16_t val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  buff[1] = (uint8_t)(val / 256U);
+  buff[0] = (uint8_t)(val - (buff[1] * 256U));
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_FSM_LONG_COUNTER_L, (uint8_t *)&buff[0], 2);
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  FSM long counter status register. Long counter value is an unsigned integer value (16-bit format).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      FSM long counter status register. Long counter value is an unsigned integer value (16-bit format).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fsm_long_cnt_get(const stmdev_ctx_t *ctx, uint16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FSM_LONG_COUNTER_L, &buff[0], 2);
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  *val = buff[1];
+  *val = (*val * 256U) + buff[0];
+
+  return ret;
+}
+
+/**
+  * @brief  FSM output registers[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      FSM output registers
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fsm_out_get(const stmdev_ctx_t *ctx, lsm6dsv80x_fsm_out_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FSM_OUTS1, (uint8_t *)val, 8);
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Finite State Machine Output Data Rate (ODR) configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      FSM_15Hz, FSM_30Hz, FSM_60Hz, FSM_120Hz, FSM_240Hz, FSM_480Hz, FSM_960Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fsm_data_rate_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_fsm_data_rate_t val)
+{
+  lsm6dsv80x_fsm_odr_t fsm_odr;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FSM_ODR, (uint8_t *)&fsm_odr, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  fsm_odr.fsm_odr = (uint8_t)val & 0x07U;
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_FSM_ODR, (uint8_t *)&fsm_odr, 1);
+
+exit:
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Finite State Machine Output Data Rate (ODR) configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      FSM_15Hz, FSM_30Hz, FSM_60Hz, FSM_120Hz, FSM_240Hz, FSM_480Hz, FSM_960Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fsm_data_rate_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_fsm_data_rate_t *val)
+{
+  lsm6dsv80x_fsm_odr_t fsm_odr;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FSM_ODR, (uint8_t *)&fsm_odr, 1);
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (fsm_odr.fsm_odr)
+  {
+    case LSM6DSV80X_FSM_15Hz:
+      *val = LSM6DSV80X_FSM_15Hz;
+      break;
+
+    case LSM6DSV80X_FSM_30Hz:
+      *val = LSM6DSV80X_FSM_30Hz;
+      break;
+
+    case LSM6DSV80X_FSM_60Hz:
+      *val = LSM6DSV80X_FSM_60Hz;
+      break;
+
+    case LSM6DSV80X_FSM_120Hz:
+      *val = LSM6DSV80X_FSM_120Hz;
+      break;
+
+    case LSM6DSV80X_FSM_240Hz:
+      *val = LSM6DSV80X_FSM_240Hz;
+      break;
+
+    case LSM6DSV80X_FSM_480Hz:
+      *val = LSM6DSV80X_FSM_480Hz;
+      break;
+
+    case LSM6DSV80X_FSM_960Hz:
+      *val = LSM6DSV80X_FSM_960Hz;
+      break;
+
+    default:
+      *val = LSM6DSV80X_FSM_15Hz;
+      break;
+  }
+
+  return ret;
+}
+
+/*
+ * Original conversion routines taken from: https://github.com/numpy/numpy
+ *
+ * uint16_t npy_floatbits_to_halfbits(uint32_t f);
+ * uint16_t npy_float_to_half(float_t f);
+ * uint32_t npy_halfbits_to_floatbits(uint16_t h)
+ * float_t  npy_half_to_float(uint16_t h)
+ *
+ * Released under BSD-3-Clause License
+ */
+typedef union
+{
+  float_t f;
+  uint32_t fbits;
+} hf_conv_t;
+
+static uint16_t npy_floatbits_to_halfbits(uint32_t f)
+{
+  uint32_t f_exp, f_sig;
+  uint16_t h_sgn, h_exp, h_sig;
+
+  h_sgn = (uint16_t)((f & 0x80000000u) >> 16);
+  f_exp = (f & 0x7f800000u);
+
+  /* Exponent overflow/NaN converts to signed inf/NaN */
+  if (f_exp >= 0x47800000u)
+  {
+    if (f_exp == 0x7f800000u)
+    {
+      /* Inf or NaN */
+      f_sig = (f & 0x007fffffu);
+      if (f_sig != 0U)
+      {
+        /* NaN - propagate the flag in the significand... */
+        uint16_t ret = (uint16_t)(0x7c00u + (f_sig >> 13));
+        /* ...but make sure it stays a NaN */
+        if (ret == 0x7c00u)
+        {
+          ret++;
+        }
+        return h_sgn + ret;
+      }
+      else
+      {
+        /* signed inf */
+        return (uint16_t)(h_sgn + 0x7c00u);
+      }
+    }
+    else
+    {
+      /* overflow to signed inf */
+#if NPY_HALF_GENERATE_OVERFLOW
+      npy_set_floatstatus_overflow();
+#endif
+      return (uint16_t)(h_sgn + 0x7c00u);
+    }
+  }
+
+  /* Exponent underflow converts to a subnormal half or signed zero */
+  if (f_exp <= 0x38000000u)
+  {
+    /*
+     * Signed zeros, subnormal floats, and floats with small
+     * exponents all convert to signed zero half-floats.
+     */
+    if (f_exp < 0x33000000u)
+    {
+#if NPY_HALF_GENERATE_UNDERFLOW
+      /* If f != 0, it underflowed to 0 */
+      if ((f & 0x7fffffff) != 0)
+      {
+        npy_set_floatstatus_underflow();
+      }
+#endif
+      return h_sgn;
+    }
+    /* Make the subnormal significand */
+    f_exp >>= 23;
+    f_sig = (0x00800000u + (f & 0x007fffffu));
+#if NPY_HALF_GENERATE_UNDERFLOW
+    /* If it's not exactly represented, it underflowed */
+    if ((f_sig & (((uint32_t)1 << (126 - f_exp)) - 1)) != 0)
+    {
+      npy_set_floatstatus_underflow();
+    }
+#endif
+    /*
+     * Usually the significand is shifted by 13. For subnormals an
+     * additional shift needs to occur. This shift is one for the largest
+     * exponent giving a subnormal `f_exp = 0x38000000 >> 23 = 112`, which
+     * offsets the new first bit. At most the shift can be 1+10 bits.
+     */
+    f_sig >>= (113U - f_exp);
+    /* Handle rounding by adding 1 to the bit beyond half precision */
+#if NPY_HALF_ROUND_TIES_TO_EVEN
+    /*
+     * If the last bit in the half significand is 0 (already even), and
+     * the remaining bit pattern is 1000...0, then we do not add one
+     * to the bit after the half significand. However, the (113 - f_exp)
+     * shift can lose up to 11 bits, so the || checks them in the original.
+     * In all other cases, we can just add one.
+     */
+    if (((f_sig & 0x00003fffu) != 0x00001000u) || (f & 0x000007ffu))
+    {
+      f_sig += 0x00001000u;
+    }
+#else
+    f_sig += 0x00001000u;
+#endif
+    h_sig = (uint16_t)(f_sig >> 13);
+    /*
+     * If the rounding causes a bit to spill into h_exp, it will
+     * increment h_exp from zero to one and h_sig will be zero.
+     * This is the correct result.
+     */
+    return (uint16_t)(h_sgn + h_sig);
+  }
+
+  /* Regular case with no overflow or underflow */
+  h_exp = (uint16_t)((f_exp - 0x38000000u) >> 13);
+  /* Handle rounding by adding 1 to the bit beyond half precision */
+  f_sig = (f & 0x007fffffu);
+#if NPY_HALF_ROUND_TIES_TO_EVEN
+  /*
+   * If the last bit in the half significand is 0 (already even), and
+   * the remaining bit pattern is 1000...0, then we do not add one
+   * to the bit after the half significand.  In all other cases, we do.
+   */
+  if ((f_sig & 0x00003fffu) != 0x00001000u)
+  {
+    f_sig += 0x00001000u;
+  }
+#else
+  f_sig += 0x00001000u;
+#endif
+  h_sig = (uint16_t)(f_sig >> 13);
+  /*
+   * If the rounding causes a bit to spill into h_exp, it will
+   * increment h_exp by one and h_sig will be zero.  This is the
+   * correct result.  h_exp may increment to 15, at greatest, in
+   * which case the result overflows to a signed inf.
+   */
+#if NPY_HALF_GENERATE_OVERFLOW
+  h_sig += h_exp;
+  if (h_sig == 0x7c00u)
+  {
+    npy_set_floatstatus_overflow();
+  }
+  return h_sgn + h_sig;
+#else
+  return h_sgn + h_exp + h_sig;
+#endif
+}
+
+static uint16_t npy_float_to_half(float_t f)
+{
+  hf_conv_t conv;
+
+  conv.f = f;
+  return npy_floatbits_to_halfbits(conv.fbits);
+}
+
+static uint32_t npy_halfbits_to_floatbits(uint16_t h)
+{
+  uint16_t h_exp = (h & 0x7c00u);
+  uint32_t f_sgn = ((uint32_t)h & 0x8000u) << 16;
+  switch (h_exp)
+  {
+    case 0x0000u:   // 0 or subnormal
+    {
+      uint16_t h_sig = (h & 0x03ffu);
+      // Signed zero
+      if (h_sig == 0)
+      {
+        return f_sgn;
+      }
+      // Subnormal
+      h_sig <<= 1;
+      while ((h_sig & 0x0400u) == 0)
+      {
+        h_sig <<= 1;
+        h_exp++;
+      }
+      uint32_t f_exp = ((uint32_t)(127 - 15 - h_exp)) << 23;
+      uint32_t f_sig = ((uint32_t)(h_sig & 0x03ffu)) << 13;
+      return f_sgn + f_exp + f_sig;
+    }
+    case 0x7c00u: // inf or NaN
+      // All-ones exponent and a copy of the significand
+      return f_sgn + 0x7f800000u + (((uint32_t)(h & 0x03ffu)) << 13);
+    default: // normalized
+      // Just need to adjust the exponent and shift
+      return f_sgn + (((uint32_t)(h & 0x7fffu) + 0x1c000u) << 13);
+  }
+}
+
+static float_t npy_half_to_float(uint16_t h)
+{
+  hf_conv_t conv;
+
+  conv.fbits = npy_halfbits_to_floatbits(h);
+
+  return conv.f;
+}
+
+/**
+  * @brief  SFLP GBIAS value. The register value is expressed as half-precision
+  *         floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent
+  *          bits; F: 10 fraction bits).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      GBIAS x/y/z val.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sflp_game_gbias_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_sflp_gbias_t *val)
+{
+  lsm6dsv80x_sflp_data_rate_t sflp_odr;
+  uint16_t gbias_hf[3];
+  float_t k = 0.005f;
+  int32_t ret;
+
+  ret = lsm6dsv80x_sflp_data_rate_get(ctx, &sflp_odr);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  /* Calculate k factor */
+  switch (sflp_odr)
+  {
+    default:
+    case LSM6DSV80X_SFLP_15Hz:
+      k = 0.04f;
+      break;
+    case LSM6DSV80X_SFLP_30Hz:
+      k = 0.02f;
+      break;
+    case LSM6DSV80X_SFLP_60Hz:
+      k = 0.01f;
+      break;
+    case LSM6DSV80X_SFLP_120Hz:
+      k = 0.005f;
+      break;
+    case LSM6DSV80X_SFLP_240Hz:
+      k = 0.0025f;
+      break;
+    case LSM6DSV80X_SFLP_480Hz:
+      k = 0.00125f;
+      break;
+  }
+
+  /* compute gbias as half precision float in order to be put in embedded advanced feature register */
+  gbias_hf[0] = npy_float_to_half(val->gbias_x * (3.14159265358979323846f / 180.0f) / k);
+  gbias_hf[1] = npy_float_to_half(val->gbias_y * (3.14159265358979323846f / 180.0f) / k);
+  gbias_hf[2] = npy_float_to_half(val->gbias_z * (3.14159265358979323846f / 180.0f) / k);
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_SFLP_GBIASX_INIT_L, (uint8_t *)&gbias_hf[0], 6);
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  External sensor sensitivity value register for the Finite State Machine (r/w). This register corresponds to the conversion value of the external sensor. The register value is expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits). Default value is 0x1624 (when using an external magnetometer this value corresponds to 0.0015 gauss/LSB).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      External sensor sensitivity value register for the Finite State Machine (r/w). This register corresponds to the conversion value of the external sensor. The register value is expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits). Default value is 0x1624 (when using an external magnetometer this value corresponds to 0.0015 gauss/LSB).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fsm_ext_sens_sensitivity_set(const stmdev_ctx_t *ctx, uint16_t val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  buff[1] = (uint8_t)(val / 256U);
+  buff[0] = (uint8_t)(val - (buff[1] * 256U));
+  ret = lsm6dsv80x_ln_pg_write(ctx, LSM6DSV80X_FSM_EXT_SENSITIVITY_L, (uint8_t *)&buff[0], 2);
+
+  return ret;
+}
+
+/**
+  * @brief  External sensor sensitivity value register for the Finite State Machine (r/w). This register corresponds to the conversion value of the external sensor. The register value is expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits). Default value is 0x1624 (when using an external magnetometer this value corresponds to 0.0015 gauss/LSB).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      External sensor sensitivity value register for the Finite State Machine (r/w). This register corresponds to the conversion value of the external sensor. The register value is expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits). Default value is 0x1624 (when using an external magnetometer this value corresponds to 0.0015 gauss/LSB).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fsm_ext_sens_sensitivity_get(const stmdev_ctx_t *ctx,
+                                                uint16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = lsm6dsv80x_ln_pg_read(ctx, LSM6DSV80X_FSM_EXT_SENSITIVITY_L, &buff[0], 2);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  *val = buff[1];
+  *val = (*val * 256U) + buff[0];
+
+  return ret;
+}
+
+/**
+  * @brief  External sensor offsets (X,Y,Z). The values are expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      External sensor offsets (X,Y,Z). The values are expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fsm_ext_sens_offset_set(const stmdev_ctx_t *ctx,
+                                           lsm6dsv80x_xl_fsm_ext_sens_offset_t val)
+{
+  uint8_t buff[6];
+  int32_t ret;
+
+  buff[1] = (uint8_t)(val.x / 256U);
+  buff[0] = (uint8_t)(val.x - (buff[1] * 256U));
+  buff[3] = (uint8_t)(val.y / 256U);
+  buff[2] = (uint8_t)(val.y - (buff[3] * 256U));
+  buff[5] = (uint8_t)(val.z / 256U);
+  buff[4] = (uint8_t)(val.z - (buff[5] * 256U));
+  ret = lsm6dsv80x_ln_pg_write(ctx, LSM6DSV80X_FSM_EXT_OFFX_L, (uint8_t *)&buff[0], 6);
+
+  return ret;
+}
+
+/**
+  * @brief  External sensor offsets (X,Y,Z). The values are expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      External sensor offsets (X,Y,Z). The values are expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fsm_ext_sens_offset_get(const stmdev_ctx_t *ctx,
+                                           lsm6dsv80x_xl_fsm_ext_sens_offset_t *val)
+{
+  uint8_t buff[6];
+  int32_t ret;
+
+  ret = lsm6dsv80x_ln_pg_read(ctx, LSM6DSV80X_FSM_EXT_OFFX_L, &buff[0], 6);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->x = buff[1];
+  val->x = (val->x * 256U) + buff[0];
+  val->y = buff[3];
+  val->y = (val->y * 256U) + buff[2];
+  val->z = buff[5];
+  val->z = (val->z * 256U) + buff[4];
+
+  return ret;
+}
+
+/**
+  * @brief  External sensor transformation matrix. The value is expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      External sensor transformation matrix. The value is expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fsm_ext_sens_matrix_set(const stmdev_ctx_t *ctx,
+                                           lsm6dsv80x_xl_fsm_ext_sens_matrix_t val)
+{
+  uint8_t buff[12];
+  int32_t ret;
+
+  buff[1] = (uint8_t)(val.xx / 256U);
+  buff[0] = (uint8_t)(val.xx - (buff[1] * 256U));
+  buff[3] = (uint8_t)(val.xy / 256U);
+  buff[2] = (uint8_t)(val.xy - (buff[3] * 256U));
+  buff[5] = (uint8_t)(val.xz / 256U);
+  buff[4] = (uint8_t)(val.xz - (buff[5] * 256U));
+  buff[7] = (uint8_t)(val.yy / 256U);
+  buff[6] = (uint8_t)(val.yy - (buff[7] * 256U));
+  buff[9] = (uint8_t)(val.yz / 256U);
+  buff[8] = (uint8_t)(val.yz - (buff[9] * 256U));
+  buff[11] = (uint8_t)(val.zz / 256U);
+  buff[10] = (uint8_t)(val.zz - (buff[11] * 256U));
+  ret = lsm6dsv80x_ln_pg_write(ctx, LSM6DSV80X_FSM_EXT_MATRIX_XX_L, (uint8_t *)&buff[0], 12);
+
+  return ret;
+}
+
+/**
+  * @brief  External sensor transformation matrix. The value is expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      External sensor transformation matrix. The value is expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fsm_ext_sens_matrix_get(const stmdev_ctx_t *ctx,
+                                           lsm6dsv80x_xl_fsm_ext_sens_matrix_t *val)
+{
+  uint8_t buff[12];
+  int32_t ret;
+
+  ret = lsm6dsv80x_ln_pg_read(ctx, LSM6DSV80X_FSM_EXT_MATRIX_XX_L, &buff[0], 12);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->xx = buff[1];
+  val->xx = (val->xx * 256U) + buff[0];
+  val->xy = buff[3];
+  val->xy = (val->xy * 256U) + buff[2];
+  val->xz = buff[5];
+  val->xz = (val->xz * 256U) + buff[4];
+  val->yy = buff[7];
+  val->yy = (val->yy * 256U) + buff[6];
+  val->yz = buff[9];
+  val->yz = (val->yz * 256U) + buff[8];
+  val->zz = buff[11];
+  val->zz = (val->zz * 256U) + buff[10];
+
+  return ret;
+}
+
+/**
+  * @brief  External sensor z-axis coordinates rotation.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Z_EQ_Y, Z_EQ_MIN_Y, Z_EQ_X, Z_EQ_MIN_X, Z_EQ_MIN_Z, Z_EQ_Z,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fsm_ext_sens_z_orient_set(const stmdev_ctx_t *ctx,
+                                             lsm6dsv80x_fsm_ext_sens_z_orient_t val)
+{
+  lsm6dsv80x_ext_cfg_a_t ext_cfg_a;
+  int32_t ret;
+
+  ret = lsm6dsv80x_ln_pg_read(ctx, LSM6DSV80X_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
+  ext_cfg_a.ext_z_axis = (uint8_t)val & 0x07U;
+  ret += lsm6dsv80x_ln_pg_write(ctx, LSM6DSV80X_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  External sensor z-axis coordinates rotation.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Z_EQ_Y, Z_EQ_MIN_Y, Z_EQ_X, Z_EQ_MIN_X, Z_EQ_MIN_Z, Z_EQ_Z,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fsm_ext_sens_z_orient_get(const stmdev_ctx_t *ctx,
+                                             lsm6dsv80x_fsm_ext_sens_z_orient_t *val)
+{
+  lsm6dsv80x_ext_cfg_a_t ext_cfg_a;
+  int32_t ret;
+
+  ret = lsm6dsv80x_ln_pg_read(ctx, LSM6DSV80X_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ext_cfg_a.ext_z_axis)
+  {
+    case LSM6DSV80X_Z_EQ_Y:
+      *val = LSM6DSV80X_Z_EQ_Y;
+      break;
+
+    case LSM6DSV80X_Z_EQ_MIN_Y:
+      *val = LSM6DSV80X_Z_EQ_MIN_Y;
+      break;
+
+    case LSM6DSV80X_Z_EQ_X:
+      *val = LSM6DSV80X_Z_EQ_X;
+      break;
+
+    case LSM6DSV80X_Z_EQ_MIN_X:
+      *val = LSM6DSV80X_Z_EQ_MIN_X;
+      break;
+
+    case LSM6DSV80X_Z_EQ_MIN_Z:
+      *val = LSM6DSV80X_Z_EQ_MIN_Z;
+      break;
+
+    case LSM6DSV80X_Z_EQ_Z:
+      *val = LSM6DSV80X_Z_EQ_Z;
+      break;
+
+    default:
+      *val = LSM6DSV80X_Z_EQ_Y;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  External sensor Y-axis coordinates rotation.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Y_EQ_Y, Y_EQ_MIN_Y, Y_EQ_X, Y_EQ_MIN_X, Y_EQ_MIN_Z, Y_EQ_Z,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fsm_ext_sens_y_orient_set(const stmdev_ctx_t *ctx,
+                                             lsm6dsv80x_fsm_ext_sens_y_orient_t val)
+{
+  lsm6dsv80x_ext_cfg_a_t ext_cfg_a;
+  int32_t ret;
+
+  ret = lsm6dsv80x_ln_pg_read(ctx, LSM6DSV80X_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
+  if (ret == 0)
+  {
+    ext_cfg_a.ext_y_axis = (uint8_t)val & 0x7U;
+    ret = lsm6dsv80x_ln_pg_write(ctx, LSM6DSV80X_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  External sensor Y-axis coordinates rotation.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Y_EQ_Y, Y_EQ_MIN_Y, Y_EQ_X, Y_EQ_MIN_X, Y_EQ_MIN_Z, Y_EQ_Z,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fsm_ext_sens_y_orient_get(const stmdev_ctx_t *ctx,
+                                             lsm6dsv80x_fsm_ext_sens_y_orient_t *val)
+{
+  lsm6dsv80x_ext_cfg_a_t ext_cfg_a;
+  int32_t ret;
+
+  ret = lsm6dsv80x_ln_pg_read(ctx, LSM6DSV80X_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ext_cfg_a.ext_y_axis)
+  {
+    case LSM6DSV80X_Y_EQ_Y:
+      *val = LSM6DSV80X_Y_EQ_Y;
+      break;
+
+    case LSM6DSV80X_Y_EQ_MIN_Y:
+      *val = LSM6DSV80X_Y_EQ_MIN_Y;
+      break;
+
+    case LSM6DSV80X_Y_EQ_X:
+      *val = LSM6DSV80X_Y_EQ_X;
+      break;
+
+    case LSM6DSV80X_Y_EQ_MIN_X:
+      *val = LSM6DSV80X_Y_EQ_MIN_X;
+      break;
+
+    case LSM6DSV80X_Y_EQ_MIN_Z:
+      *val = LSM6DSV80X_Y_EQ_MIN_Z;
+      break;
+
+    case LSM6DSV80X_Y_EQ_Z:
+      *val = LSM6DSV80X_Y_EQ_Z;
+      break;
+
+    default:
+      *val = LSM6DSV80X_Y_EQ_Y;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  External sensor X-axis coordinates rotation.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      X_EQ_Y, X_EQ_MIN_Y, X_EQ_X, X_EQ_MIN_X, X_EQ_MIN_Z, X_EQ_Z,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fsm_ext_sens_x_orient_set(const stmdev_ctx_t *ctx,
+                                             lsm6dsv80x_fsm_ext_sens_x_orient_t val)
+{
+  lsm6dsv80x_ext_cfg_b_t ext_cfg_b;
+  int32_t ret;
+
+  ret = lsm6dsv80x_ln_pg_read(ctx, LSM6DSV80X_EXT_CFG_B, (uint8_t *)&ext_cfg_b, 1);
+  if (ret == 0)
+  {
+    ext_cfg_b.ext_x_axis = (uint8_t)val & 0x7U;
+    ret = lsm6dsv80x_ln_pg_write(ctx, LSM6DSV80X_EXT_CFG_B, (uint8_t *)&ext_cfg_b, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  External sensor X-axis coordinates rotation.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      X_EQ_Y, X_EQ_MIN_Y, X_EQ_X, X_EQ_MIN_X, X_EQ_MIN_Z, X_EQ_Z,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fsm_ext_sens_x_orient_get(const stmdev_ctx_t *ctx,
+                                             lsm6dsv80x_fsm_ext_sens_x_orient_t *val)
+{
+  lsm6dsv80x_ext_cfg_b_t ext_cfg_b;
+  int32_t ret;
+
+  ret = lsm6dsv80x_ln_pg_read(ctx, LSM6DSV80X_EXT_CFG_B, (uint8_t *)&ext_cfg_b, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ext_cfg_b.ext_x_axis)
+  {
+    case LSM6DSV80X_X_EQ_Y:
+      *val = LSM6DSV80X_X_EQ_Y;
+      break;
+
+    case LSM6DSV80X_X_EQ_MIN_Y:
+      *val = LSM6DSV80X_X_EQ_MIN_Y;
+      break;
+
+    case LSM6DSV80X_X_EQ_X:
+      *val = LSM6DSV80X_X_EQ_X;
+      break;
+
+    case LSM6DSV80X_X_EQ_MIN_X:
+      *val = LSM6DSV80X_X_EQ_MIN_X;
+      break;
+
+    case LSM6DSV80X_X_EQ_MIN_Z:
+      *val = LSM6DSV80X_X_EQ_MIN_Z;
+      break;
+
+    case LSM6DSV80X_X_EQ_Z:
+      *val = LSM6DSV80X_X_EQ_Z;
+      break;
+
+    default:
+      *val = LSM6DSV80X_X_EQ_Y;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  High-g accelerometer peak tracking enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      0: disable, 1: enable
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_xl_hg_peak_tracking_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_emb_func_init_b_t emb_func_init_b;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_INIT_B, (uint8_t *)&emb_func_init_b, 1);
+  emb_func_init_b.pt_init = val;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_INIT_B, (uint8_t *)&emb_func_init_b, 1);
+
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  High-g accelerometer peak tracking enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      0: disable, 1: enable
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_xl_hg_peak_tracking_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_emb_func_init_b_t emb_func_init_b;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_INIT_B, (uint8_t *)&emb_func_init_b, 1);
+  *val = emb_func_init_b.pt_init;
+
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Hihg-g accelerometer sensitivity value register for FSM and MLC.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Hihg-g accelerometer sensitivity value
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_xl_hg_sensitivity_set(const stmdev_ctx_t *ctx, uint16_t val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  buff[1] = (uint8_t)(val / 256U);
+  buff[0] = (uint8_t)(val - (buff[1] * 256U));
+  ret = lsm6dsv80x_ln_pg_write(ctx, LSM6DSV80X_EMB_ADV_PG_1 + LSM6DSV80X_XL_HG_SENSITIVITY_L,
+                               (uint8_t *)&buff[0], 2);
+
+  return ret;
+}
+
+/**
+  * @brief  Hihg-g accelerometer sensitivity value register for FSM and MLC.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Hihg-g accelerometer sensitivity value
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_xl_hg_sensitivity_get(const stmdev_ctx_t *ctx, uint16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = lsm6dsv80x_ln_pg_read(ctx, LSM6DSV80X_EMB_ADV_PG_1 + LSM6DSV80X_XL_HG_SENSITIVITY_L, &buff[0],
+                              2);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  *val = buff[1];
+  *val = (*val * 256U) + buff[0];
+
+  return ret;
+}
+
+/**
+  * @brief  FSM long counter timeout. The long counter timeout value is an unsigned integer value (16-bit format). When the long counter value reached this value, the FSM generates an interrupt.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      FSM long counter timeout. The long counter timeout value is an unsigned integer value (16-bit format). When the long counter value reached this value, the FSM generates an interrupt.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fsm_long_cnt_timeout_set(const stmdev_ctx_t *ctx, uint16_t val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  buff[1] = (uint8_t)(val / 256U);
+  buff[0] = (uint8_t)(val - (buff[1] * 256U));
+  ret = lsm6dsv80x_ln_pg_write(ctx, LSM6DSV80X_EMB_ADV_PG_1 + LSM6DSV80X_FSM_LC_TIMEOUT_L,
+                               (uint8_t *)&buff[0], 2);
+
+  return ret;
+}
+
+/**
+  * @brief  FSM long counter timeout. The long counter timeout value is an unsigned integer value (16-bit format). When the long counter value reached this value, the FSM generates an interrupt.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      FSM long counter timeout. The long counter timeout value is an unsigned integer value (16-bit format). When the long counter value reached this value, the FSM generates an interrupt.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fsm_long_cnt_timeout_get(const stmdev_ctx_t *ctx, uint16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = lsm6dsv80x_ln_pg_read(ctx, LSM6DSV80X_EMB_ADV_PG_1 + LSM6DSV80X_FSM_LC_TIMEOUT_L, &buff[0],
+                              2);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  *val = buff[1];
+  *val = (*val * 256U) + buff[0];
+
+  return ret;
+}
+
+/**
+  * @brief  FSM number of programs.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      FSM number of programs.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fsm_number_of_programs_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_fsm_programs_t fsm_programs;
+  int32_t ret;
+
+  ret = lsm6dsv80x_ln_pg_read(ctx, LSM6DSV80X_EMB_ADV_PG_1 + LSM6DSV80X_FSM_PROGRAMS,
+                              (uint8_t *)&fsm_programs, 1);
+  if (ret == 0)
+  {
+    fsm_programs.fsm_n_prog = val;
+    ret = lsm6dsv80x_ln_pg_write(ctx, LSM6DSV80X_EMB_ADV_PG_1 + LSM6DSV80X_FSM_PROGRAMS,
+                                 (uint8_t *)&fsm_programs, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FSM number of programs.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      FSM number of programs.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fsm_number_of_programs_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_fsm_programs_t fsm_programs;
+  int32_t ret;
+
+  ret = lsm6dsv80x_ln_pg_read(ctx, LSM6DSV80X_EMB_ADV_PG_1 + LSM6DSV80X_FSM_PROGRAMS,
+                              (uint8_t *)&fsm_programs, 1);
+  *val = fsm_programs.fsm_n_prog;
+
+  return ret;
+}
+
+/**
+  * @brief  FSM start address. First available address is 0x35C.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      FSM start address. First available address is 0x35C.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fsm_start_address_set(const stmdev_ctx_t *ctx, uint16_t val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  buff[1] = (uint8_t)(val / 256U);
+  buff[0] = (uint8_t)(val - (buff[1] * 256U));
+  ret = lsm6dsv80x_ln_pg_write(ctx, LSM6DSV80X_EMB_ADV_PG_1 + LSM6DSV80X_FSM_START_ADD_L,
+                               (uint8_t *)&buff[0], 2);
+
+  return ret;
+}
+
+/**
+  * @brief  FSM start address. First available address is 0x35C.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      FSM start address. First available address is 0x35C.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_fsm_start_address_get(const stmdev_ctx_t *ctx, uint16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = lsm6dsv80x_ln_pg_read(ctx, LSM6DSV80X_EMB_ADV_PG_1 + LSM6DSV80X_FSM_START_ADD_L, &buff[0], 2);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  *val = buff[1];
+  *val = (*val * 256U) + buff[0];
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Free fall
+  * @brief     This section group all the functions concerning the free
+  *            fall detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Time windows configuration for Free Fall detection 1 LSB = 1/ODR_XL time[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Time windows configuration for Free Fall detection 1 LSB = 1/ODR_XL time
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_ff_time_windows_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_wake_up_dur_t wake_up_dur;
+  lsm6dsv80x_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+  wake_up_dur.ff_dur = ((uint8_t)val & 0x20U) >> 5;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FREE_FALL, (uint8_t *)&free_fall, 1);
+  free_fall.ff_dur = (uint8_t)val & 0x1FU;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_FREE_FALL, (uint8_t *)&free_fall, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Time windows configuration for Free Fall detection 1 LSB = 1/ODR_XL time[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Time windows configuration for Free Fall detection 1 LSB = 1/ODR_XL time
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_ff_time_windows_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_wake_up_dur_t wake_up_dur;
+  lsm6dsv80x_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FREE_FALL, (uint8_t *)&free_fall, 1);
+
+  *val = (wake_up_dur.ff_dur << 5) + free_fall.ff_dur;
+
+  return ret;
+}
+
+/**
+  * @brief  Free fall threshold setting.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      156_mg, 219_mg, 250_mg, 312_mg, 344_mg, 406_mg, 469_mg, 500_mg,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_ff_thresholds_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_ff_thresholds_t val)
+{
+  lsm6dsv80x_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FREE_FALL, (uint8_t *)&free_fall, 1);
+  if (ret == 0)
+  {
+    free_fall.ff_ths = (uint8_t)val & 0x7U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_FREE_FALL, (uint8_t *)&free_fall, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Free fall threshold setting.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      156_mg, 219_mg, 250_mg, 312_mg, 344_mg, 406_mg, 469_mg, 500_mg,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_ff_thresholds_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_ff_thresholds_t *val)
+{
+  lsm6dsv80x_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FREE_FALL, (uint8_t *)&free_fall, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (free_fall.ff_ths)
+  {
+    case LSM6DSV80X_156_mg:
+      *val = LSM6DSV80X_156_mg;
+      break;
+
+    case LSM6DSV80X_219_mg:
+      *val = LSM6DSV80X_219_mg;
+      break;
+
+    case LSM6DSV80X_250_mg:
+      *val = LSM6DSV80X_250_mg;
+      break;
+
+    case LSM6DSV80X_312_mg:
+      *val = LSM6DSV80X_312_mg;
+      break;
+
+    case LSM6DSV80X_344_mg:
+      *val = LSM6DSV80X_344_mg;
+      break;
+
+    case LSM6DSV80X_406_mg:
+      *val = LSM6DSV80X_406_mg;
+      break;
+
+    case LSM6DSV80X_469_mg:
+      *val = LSM6DSV80X_469_mg;
+      break;
+
+    case LSM6DSV80X_500_mg:
+      *val = LSM6DSV80X_500_mg;
+      break;
+
+    default:
+      *val = LSM6DSV80X_156_mg;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Machine Learning Core (MLC)
+  * @brief      This section group all the functions concerning the
+  *             usage of Machine Learning Core
+  * @{
+  *
+  */
+
+/**
+  * @brief  It enables Machine Learning Core feature (MLC). When the Machine Learning Core is enabled the Finite State Machine (FSM) programs are executed before executing the MLC algorithms.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      MLC_OFF, MLC_ON, MLC_BEFORE_FSM,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_mlc_set(const stmdev_ctx_t *ctx, lsm6dsv80x_mlc_mode_t val)
+{
+  lsm6dsv80x_emb_func_en_b_t emb_en_b;
+  lsm6dsv80x_emb_func_en_a_t emb_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_EN_A, (uint8_t *)&emb_en_a, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_EN_B, (uint8_t *)&emb_en_b, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  switch (val)
+  {
+    case LSM6DSV80X_MLC_OFF:
+      emb_en_a.mlc_before_fsm_en = 0;
+      emb_en_b.mlc_en = 0;
+      break;
+    case LSM6DSV80X_MLC_ON:
+      emb_en_a.mlc_before_fsm_en = 0;
+      emb_en_b.mlc_en = 1;
+      break;
+    case LSM6DSV80X_MLC_ON_BEFORE_FSM:
+      emb_en_a.mlc_before_fsm_en = 1;
+      emb_en_b.mlc_en = 0;
+      break;
+    default:
+      break;
+  }
+
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_EN_A, (uint8_t *)&emb_en_a, 1);
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_EN_B, (uint8_t *)&emb_en_b, 1);
+
+exit:
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  It enables Machine Learning Core feature (MLC). When the Machine Learning Core is enabled the Finite State Machine (FSM) programs are executed before executing the MLC algorithms.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      MLC_OFF, MLC_ON, MLC_BEFORE_FSM,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_mlc_get(const stmdev_ctx_t *ctx, lsm6dsv80x_mlc_mode_t *val)
+{
+  lsm6dsv80x_emb_func_en_b_t emb_en_b;
+  lsm6dsv80x_emb_func_en_a_t emb_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_EN_A, (uint8_t *)&emb_en_a, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_EN_B, (uint8_t *)&emb_en_b, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  if (emb_en_a.mlc_before_fsm_en == 0U && emb_en_b.mlc_en == 0U)
+  {
+    *val = LSM6DSV80X_MLC_OFF;
+  }
+  else if (emb_en_a.mlc_before_fsm_en == 0U && emb_en_b.mlc_en == 1U)
+  {
+    *val = LSM6DSV80X_MLC_ON;
+  }
+  else if (emb_en_a.mlc_before_fsm_en == 1U)
+  {
+    *val = LSM6DSV80X_MLC_ON_BEFORE_FSM;
+  }
+  else
+  {
+    /* Do nothing */
+  }
+
+exit:
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Machine Learning Core Output Data Rate (ODR) configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      MLC_15Hz, MLC_30Hz, MLC_60Hz, MLC_120Hz, MLC_240Hz, MLC_480Hz, MLC_960Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_mlc_data_rate_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_mlc_data_rate_t val)
+{
+  lsm6dsv80x_mlc_odr_t mlc_odr;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_MLC_ODR, (uint8_t *)&mlc_odr, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  mlc_odr.mlc_odr = (uint8_t)val & 0x07U;
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_MLC_ODR, (uint8_t *)&mlc_odr, 1);
+
+exit:
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Machine Learning Core Output Data Rate (ODR) configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      MLC_15Hz, MLC_30Hz, MLC_60Hz, MLC_120Hz, MLC_240Hz, MLC_480Hz, MLC_960Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_mlc_data_rate_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_mlc_data_rate_t *val)
+{
+  lsm6dsv80x_mlc_odr_t mlc_odr;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_MLC_ODR, (uint8_t *)&mlc_odr, 1);
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (mlc_odr.mlc_odr)
+  {
+    case 0:
+      *val = LSM6DSV80X_MLC_15Hz;
+      break;
+
+    case 1:
+      *val = LSM6DSV80X_MLC_30Hz;
+      break;
+
+    case 2:
+      *val = LSM6DSV80X_MLC_60Hz;
+      break;
+
+    case 3:
+      *val = LSM6DSV80X_MLC_120Hz;
+      break;
+
+    case 4:
+      *val = LSM6DSV80X_MLC_240Hz;
+      break;
+
+    case 5:
+      *val = LSM6DSV80X_MLC_480Hz;
+      break;
+
+    case 6:
+      *val = LSM6DSV80X_MLC_960Hz;
+      break;
+
+    default:
+      *val = LSM6DSV80X_MLC_15Hz;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Output value of all MLC decision trees.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Output value of all MLC decision trees.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_mlc_out_get(const stmdev_ctx_t *ctx, lsm6dsv80x_mlc_out_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret == 0)
+  {
+    ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_MLC1_SRC, (uint8_t *)val, 8);
+  }
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  External sensor sensitivity value register for the Machine Learning Core. This register corresponds to the conversion value of the external sensor. The register value is expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits).Default value is 0x3C00 (when using an external magnetometer this value corresponds to 1 gauss/LSB).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      External sensor sensitivity value register for the Machine Learning Core. This register corresponds to the conversion value of the external sensor. The register value is expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits).Default value is 0x3C00 (when using an external magnetometer this value corresponds to 1 gauss/LSB).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_mlc_ext_sens_sensitivity_set(const stmdev_ctx_t *ctx, uint16_t val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  buff[1] = (uint8_t)(val / 256U);
+  buff[0] = (uint8_t)(val - (buff[1] * 256U));
+
+  ret = lsm6dsv80x_ln_pg_write(ctx, LSM6DSV80X_EMB_ADV_PG_1 + LSM6DSV80X_MLC_EXT_SENSITIVITY_L,
+                               (uint8_t *)&buff[0], 2);
+
+  return ret;
+}
+
+/**
+  * @brief  External sensor sensitivity value register for the Machine Learning Core. This register corresponds to the conversion value of the external sensor. The register value is expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits).Default value is 0x3C00 (when using an external magnetometer this value corresponds to 1 gauss/LSB).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      External sensor sensitivity value register for the Machine Learning Core. This register corresponds to the conversion value of the external sensor. The register value is expressed as half-precision floating-point format: SEEEEEFFFFFFFFFF (S: 1 sign bit; E: 5 exponent bits; F: 10 fraction bits).Default value is 0x3C00 (when using an external magnetometer this value corresponds to 1 gauss/LSB).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_mlc_ext_sens_sensitivity_get(const stmdev_ctx_t *ctx,
+                                                uint16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = lsm6dsv80x_ln_pg_read(ctx, LSM6DSV80X_EMB_ADV_PG_1 + LSM6DSV80X_MLC_EXT_SENSITIVITY_L,
+                              &buff[0], 2);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  *val = buff[1];
+  *val = (*val * 256U) + buff[0];
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Orientation 6D (and 4D)
+  * @brief     This section groups all the functions concerning six position
+  *            detection (6D).
+  * @{
+  *
+  */
+
+/**
+  * @brief  Threshold for 4D/6D function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      DEG_80, DEG_70, DEG_60, DEG_50,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_6d_threshold_set(const stmdev_ctx_t *ctx,
+                                    lsm6dsv80x_6d_threshold_t val)
+{
+  lsm6dsv80x_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
+  if (ret == 0)
+  {
+    tap_ths_6d.sixd_ths = (uint8_t)val & 0x03U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Threshold for 4D/6D function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      DEG_80, DEG_70, DEG_60, DEG_50,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_6d_threshold_get(const stmdev_ctx_t *ctx,
+                                    lsm6dsv80x_6d_threshold_t *val)
+{
+  lsm6dsv80x_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (tap_ths_6d.sixd_ths)
+  {
+    case LSM6DSV80X_DEG_80:
+      *val = LSM6DSV80X_DEG_80;
+      break;
+
+    case LSM6DSV80X_DEG_70:
+      *val = LSM6DSV80X_DEG_70;
+      break;
+
+    case LSM6DSV80X_DEG_60:
+      *val = LSM6DSV80X_DEG_60;
+      break;
+
+    case LSM6DSV80X_DEG_50:
+      *val = LSM6DSV80X_DEG_50;
+      break;
+
+    default:
+      *val = LSM6DSV80X_DEG_80;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable. Z-axis position detection is disabled.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      4D orientation detection enable. Z-axis position detection is disabled.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_4d_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
+  if (ret == 0)
+  {
+    tap_ths_6d.d4d_en = val;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable. Z-axis position detection is disabled.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      4D orientation detection enable. Z-axis position detection is disabled.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_4d_mode_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
+  *val = tap_ths_6d.d4d_en;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  SenseWire (I3C)
+  * @brief     This section group all the functions concerning the
+  *            usage of SenseWire (I3C)
+  * @{
+  *
+  */
+
+/**
+  * @brief  I3C configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      rst_mode, ibi_time, if2_ta0_pid
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_i3c_config_set(const stmdev_ctx_t *ctx,
+                                  lsm6dsv80x_i3c_config_t val)
+{
+  lsm6dsv80x_pin_ctrl_t pin_ctrl;
+  lsm6dsv80x_ctrl5_t ctrl5;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL5, (uint8_t *)&ctrl5, 1);
+  if (ret == 0)
+  {
+    pin_ctrl.ibhr_por_en = (uint8_t)val.rst_mode & 0x01U;
+    ctrl5.bus_act_sel = (uint8_t)val.ibi_time & 0x03U;
+
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+    ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL5, (uint8_t *)&ctrl5, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  I3C configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      rst_mode, ibi_time, if2_ta0_pid
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_i3c_config_get(const stmdev_ctx_t *ctx,
+                                  lsm6dsv80x_i3c_config_t *val)
+{
+  lsm6dsv80x_pin_ctrl_t pin_ctrl;
+  lsm6dsv80x_ctrl5_t ctrl5;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (pin_ctrl.ibhr_por_en)
+  {
+    case LSM6DSV80X_SW_RST_DYN_ADDRESS_RST:
+      val->rst_mode = LSM6DSV80X_SW_RST_DYN_ADDRESS_RST;
+      break;
+
+    case LSM6DSV80X_I3C_GLOBAL_RST:
+      val->rst_mode = LSM6DSV80X_I3C_GLOBAL_RST;
+      break;
+
+    default:
+      val->rst_mode = LSM6DSV80X_SW_RST_DYN_ADDRESS_RST;
+      break;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL5, (uint8_t *)&ctrl5, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (ctrl5.bus_act_sel)
+  {
+    case 0:
+      val->ibi_time = LSM6DSV80X_IBI_50us;
+      break;
+
+    case 1:
+      val->ibi_time = LSM6DSV80X_IBI_2us;
+      break;
+
+    case 2:
+      val->ibi_time = LSM6DSV80X_IBI_1ms;
+      break;
+
+    case 3:
+      val->ibi_time = LSM6DSV80X_IBI_50ms;
+      break;
+
+    default:
+      val->ibi_time = LSM6DSV80X_IBI_50us;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Sensor hub
+  * @brief     This section groups all the functions that manage the
+  *            sensor hub.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Sensor Hub controller I2C pull-up enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Sensor Hub controller I2C pull-up enable.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sh_controller_interface_pull_up_set(const stmdev_ctx_t *ctx,
+                                                       uint8_t val)
+{
+  lsm6dsv80x_if_cfg_t if_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  if (ret == 0)
+  {
+    if_cfg.shub_pu_en = val;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor Hub controller I2C pull-up enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Sensor Hub controller I2C pull-up enable.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sh_controller_interface_pull_up_get(const stmdev_ctx_t *ctx,
+                                                       uint8_t *val)
+{
+  lsm6dsv80x_if_cfg_t if_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  *val = if_cfg.shub_pu_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub output registers.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Sensor hub output registers.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sh_read_data_raw_get(const stmdev_ctx_t *ctx, uint8_t *val,
+                                        uint8_t len)
+{
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_SENSOR_HUB_1, val, len);
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Number of external sensors to be read by the sensor hub.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      TGT_0, TGT_0_1, TGT_0_1_2, TGT_0_1_2_3,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sh_target_connected_set(const stmdev_ctx_t *ctx,
+                                           lsm6dsv80x_sh_target_connected_t val)
+{
+  lsm6dsv80x_controller_config_t controller_config;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  controller_config.aux_sens_on = (uint8_t)val & 0x3U;
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+
+exit:
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Number of external sensors to be read by the sensor hub.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      TGT_0, TGT_0_1, TGT_0_1_2, TGT_0_1_2_3,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sh_target_connected_get(const stmdev_ctx_t *ctx,
+                                           lsm6dsv80x_sh_target_connected_t *val)
+{
+  lsm6dsv80x_controller_config_t controller_config;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (controller_config.aux_sens_on)
+  {
+    case LSM6DSV80X_TGT_0:
+      *val = LSM6DSV80X_TGT_0;
+      break;
+
+    case LSM6DSV80X_TGT_0_1:
+      *val = LSM6DSV80X_TGT_0_1;
+      break;
+
+    case LSM6DSV80X_TGT_0_1_2:
+      *val = LSM6DSV80X_TGT_0_1_2;
+      break;
+
+    case LSM6DSV80X_TGT_0_1_2_3:
+      *val = LSM6DSV80X_TGT_0_1_2_3;
+      break;
+
+    default:
+      *val = LSM6DSV80X_TGT_0;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub I2C controller enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Sensor hub I2C controller enable.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sh_controller_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_controller_config_t controller_config;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  controller_config.controller_on = val;
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+
+exit:
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub I2C controller enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Sensor hub I2C controller enable.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sh_controller_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_controller_config_t controller_config;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+
+  *val = controller_config.controller_on;
+
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  I2C interface pass-through.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      I2C interface pass-through.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sh_pass_through_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_controller_config_t controller_config;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  controller_config.pass_through_mode = val;
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+
+exit:
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  I2C interface pass-through.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      I2C interface pass-through.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sh_pass_through_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_controller_config_t controller_config;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+
+  *val = controller_config.pass_through_mode;
+
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub trigger signal selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SH_TRG_XL_GY_DRDY, SH_TRIG_INT2,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sh_syncro_mode_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_sh_syncro_mode_t val)
+{
+  lsm6dsv80x_controller_config_t controller_config;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  controller_config.start_config = (uint8_t)val & 0x01U;
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+
+exit:
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub trigger signal selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SH_TRG_XL_GY_DRDY, SH_TRIG_INT2,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sh_syncro_mode_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_sh_syncro_mode_t *val)
+{
+  lsm6dsv80x_controller_config_t controller_config;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (controller_config.start_config)
+  {
+    case LSM6DSV80X_SH_TRG_XL_GY_DRDY:
+      *val = LSM6DSV80X_SH_TRG_XL_GY_DRDY;
+      break;
+
+    case LSM6DSV80X_SH_TRIG_INT2:
+      *val = LSM6DSV80X_SH_TRIG_INT2;
+      break;
+
+    default:
+      *val = LSM6DSV80X_SH_TRG_XL_GY_DRDY;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Target 0 write operation is performed only at the first sensor hub cycle.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      EACH_SH_CYCLE, ONLY_FIRST_CYCLE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sh_write_mode_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_sh_write_mode_t val)
+{
+  lsm6dsv80x_controller_config_t controller_config;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  controller_config.write_once = (uint8_t)val & 0x01U;
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+
+exit:
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Target 0 write operation is performed only at the first sensor hub cycle.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      EACH_SH_CYCLE, ONLY_FIRST_CYCLE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sh_write_mode_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_sh_write_mode_t *val)
+{
+  lsm6dsv80x_controller_config_t controller_config;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (controller_config.write_once)
+  {
+    case LSM6DSV80X_EACH_SH_CYCLE:
+      *val = LSM6DSV80X_EACH_SH_CYCLE;
+      break;
+
+    case LSM6DSV80X_ONLY_FIRST_CYCLE:
+      *val = LSM6DSV80X_ONLY_FIRST_CYCLE;
+      break;
+
+    default:
+      *val = LSM6DSV80X_EACH_SH_CYCLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Reset Controller logic and output registers. Must be set to ‘1’ and then set it to ‘0’.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Reset Controller logic and output registers. Must be set to ‘1’ and then set it to ‘0’.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sh_reset_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_controller_config_t controller_config;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  controller_config.rst_controller_regs = val;
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+
+exit:
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Reset Controller logic and output registers. Must be set to ‘1’ and then set it to ‘0’.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Reset Controller logic and output registers. Must be set to ‘1’ and then set it to ‘0’.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sh_reset_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_controller_config_t controller_config;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
+
+  *val = controller_config.rst_controller_regs;
+
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Configure target 0 for perform a write.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      a structure that contain
+  *                      - uint8_t tgt1_add;    8 bit i2c device address
+  *                      - uint8_t tgt1_subadd; 8 bit register device address
+  *                      - uint8_t tgt1_data;   8 bit data to write
+  * @retval             interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sh_cfg_write(const stmdev_ctx_t *ctx,
+                                lsm6dsv80x_sh_cfg_write_t *val)
+{
+  lsm6dsv80x_tgt0_add_t reg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_SENSOR_HUB_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  reg.target0_add = val->tgt0_add;
+  reg.rw_0 = 0;
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TGT0_ADD, (uint8_t *)&reg, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TGT0_SUBADD,
+                             &(val->tgt0_subadd), 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_DATAWRITE_TGT0,
+                             &(val->tgt0_data), 1);
+
+exit:
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Rate at which the controller communicates.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SH_15Hz, SH_30Hz, SH_60Hz, SH_120Hz, SH_240Hz, SH_480Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sh_data_rate_set(const stmdev_ctx_t *ctx,
+                                    lsm6dsv80x_sh_data_rate_t val)
+{
+  lsm6dsv80x_tgt0_config_t tgt0_config;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TGT0_CONFIG, (uint8_t *)&tgt0_config, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  tgt0_config.shub_odr = (uint8_t)val & 0x07U;
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TGT0_CONFIG, (uint8_t *)&tgt0_config, 1);
+
+exit:
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Rate at which the controller communicates.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SH_15Hz, SH_30Hz, SH_60Hz, SH_120Hz, SH_240Hz, SH_480Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sh_data_rate_get(const stmdev_ctx_t *ctx,
+                                    lsm6dsv80x_sh_data_rate_t *val)
+{
+  lsm6dsv80x_tgt0_config_t tgt0_config;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_SENSOR_HUB_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TGT0_CONFIG, (uint8_t *)&tgt0_config, 1);
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (tgt0_config.shub_odr)
+  {
+    case LSM6DSV80X_SH_15Hz:
+      *val = LSM6DSV80X_SH_15Hz;
+      break;
+
+    case LSM6DSV80X_SH_30Hz:
+      *val = LSM6DSV80X_SH_30Hz;
+      break;
+
+    case LSM6DSV80X_SH_60Hz:
+      *val = LSM6DSV80X_SH_60Hz;
+      break;
+
+    case LSM6DSV80X_SH_120Hz:
+      *val = LSM6DSV80X_SH_120Hz;
+      break;
+
+    case LSM6DSV80X_SH_240Hz:
+      *val = LSM6DSV80X_SH_240Hz;
+      break;
+
+    case LSM6DSV80X_SH_480Hz:
+      *val = LSM6DSV80X_SH_480Hz;
+      break;
+
+    default:
+      *val = LSM6DSV80X_SH_15Hz;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Configure target idx for perform a read.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Structure that contain
+  *                      - uint8_t tgt_add;    8 bit i2c device address
+  *                      - uint8_t tgt_subadd; 8 bit register device address
+  *                      - uint8_t tgt_len;    num of bit to read
+  * @retval             interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sh_tgt_cfg_read(const stmdev_ctx_t *ctx, uint8_t idx,
+                                   lsm6dsv80x_sh_cfg_read_t *val)
+{
+  lsm6dsv80x_tgt0_add_t tgt_add;
+  lsm6dsv80x_tgt0_config_t tgt_config;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_SENSOR_HUB_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  tgt_add.target0_add = val->tgt_add;
+  tgt_add.rw_0 = 1;
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TGT0_ADD + idx * 3U,
+                             (uint8_t *)&tgt_add, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TGT0_SUBADD + idx * 3U,
+                             &(val->tgt_subadd), 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TGT0_CONFIG + idx * 3U,
+                            (uint8_t *)&tgt_config, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  tgt_config.target0_numop = val->tgt_len;
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TGT0_CONFIG + idx * 3U,
+                             (uint8_t *)&tgt_config, 1);
+
+exit:
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub source register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      union of registers from STATUS_CONTROLLER to
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sh_status_get(const stmdev_ctx_t *ctx,
+                                 lsm6dsv80x_status_controller_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_STATUS_CONTROLLER_MAINPAGE, (uint8_t *) val, 1);
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Serial interfaces
+  * @brief     This section groups all the functions concerning
+  *            serial interfaces management (not auxiliary)
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enables pull-up on SDO pin of UI (User Interface).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables pull-up on SDO pin of UI (User Interface).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_ui_sdo_pull_up_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_pin_ctrl_t pin_ctrl;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  if (ret == 0)
+  {
+    pin_ctrl.sdo_pu_en = val;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables pull-up on SDO pin of UI (User Interface).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables pull-up on SDO pin of UI (User Interface).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_ui_sdo_pull_up_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_pin_ctrl_t pin_ctrl;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  *val = pin_ctrl.sdo_pu_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Pad strength.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Pad strength
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_pad_strength_set(const stmdev_ctx_t *ctx, lsm6dsv80x_pad_strength_t val)
+{
+  lsm6dsv80x_pin_ctrl_t pin_ctrl;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  if (ret == 0)
+  {
+    pin_ctrl.io_pad_strength = val;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Pad strength.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Pad strength
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_pad_strength_get(const stmdev_ctx_t *ctx, lsm6dsv80x_pad_strength_t *val)
+{
+  lsm6dsv80x_pin_ctrl_t pin_ctrl;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
+  switch (pin_ctrl.io_pad_strength)
+  {
+    case 0:
+      *val = LSM6DSV80X_PAD_LOW_STRENGTH;
+      break;
+
+    case 1:
+      *val = LSM6DSV80X_PAD_MIDDLE_STRENGTH;
+      break;
+
+    case 2:
+    default:
+      *val = LSM6DSV80X_PAD_HIGH_STRENGTH;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Disables I2C and I3C on UI (User Interface).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      I2C_I3C_ENABLE, I2C_I3C_DISABLE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_ui_i2c_i3c_mode_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_ui_i2c_i3c_mode_t val)
+{
+  lsm6dsv80x_if_cfg_t if_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  if (ret == 0)
+  {
+    if_cfg.i2c_i3c_disable = (uint8_t)val & 0x1U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Disables I2C and I3C on UI (User Interface).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      I2C_I3C_ENABLE, I2C_I3C_DISABLE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_ui_i2c_i3c_mode_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_ui_i2c_i3c_mode_t *val)
+{
+  lsm6dsv80x_if_cfg_t if_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (if_cfg.i2c_i3c_disable)
+  {
+    case LSM6DSV80X_I2C_I3C_ENABLE:
+      *val = LSM6DSV80X_I2C_I3C_ENABLE;
+      break;
+
+    case LSM6DSV80X_I2C_I3C_DISABLE:
+      *val = LSM6DSV80X_I2C_I3C_DISABLE;
+      break;
+
+    default:
+      *val = LSM6DSV80X_I2C_I3C_ENABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SPI_4_WIRE, SPI_3_WIRE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_spi_mode_set(const stmdev_ctx_t *ctx, lsm6dsv80x_spi_mode_t val)
+{
+  lsm6dsv80x_if_cfg_t if_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  if (ret == 0)
+  {
+    if_cfg.sim = (uint8_t)val & 0x01U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SPI_4_WIRE, SPI_3_WIRE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_spi_mode_get(const stmdev_ctx_t *ctx, lsm6dsv80x_spi_mode_t *val)
+{
+  lsm6dsv80x_if_cfg_t if_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (if_cfg.sim)
+  {
+    case LSM6DSV80X_SPI_4_WIRE:
+      *val = LSM6DSV80X_SPI_4_WIRE;
+      break;
+
+    case LSM6DSV80X_SPI_3_WIRE:
+      *val = LSM6DSV80X_SPI_3_WIRE;
+      break;
+
+    default:
+      *val = LSM6DSV80X_SPI_4_WIRE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables pull-up on SDA pin.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables pull-up on SDA pin.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_ui_sda_pull_up_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_if_cfg_t if_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  if (ret == 0)
+  {
+    if_cfg.sda_pu_en = val;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables pull-up on SDA pin.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables pull-up on SDA pin.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_ui_sda_pull_up_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_if_cfg_t if_cfg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_IF_CFG, (uint8_t *)&if_cfg, 1);
+  *val = if_cfg.sda_pu_en;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Significant motion detection
+  * @brief     This section groups all the functions that manage the
+  *            significant motion detection.
+  * @{
+  *
+  */
+
+
+/**
+  * @brief  Enables significant motion detection function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables significant motion detection function.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sigmot_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  emb_func_en_a.sign_motion_en = val;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Enables significant motion detection function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables significant motion detection function.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sigmot_mode_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  *val = emb_func_en_a.sign_motion_en;
+
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Step Counter (Pedometer)
+  * @brief     This section groups all the functions that manage pedometer.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Step counter mode[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Step counter mode
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_stpcnt_mode_set(const stmdev_ctx_t *ctx,
+                                   lsm6dsv80x_stpcnt_mode_t val)
+{
+  lsm6dsv80x_emb_func_en_a_t emb_func_en_a;
+  lsm6dsv80x_emb_func_en_b_t emb_func_en_b;
+  lsm6dsv80x_pedo_cmd_reg_t pedo_cmd_reg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  if ((val.false_step_rej == PROPERTY_ENABLE)
+      && ((emb_func_en_a.mlc_before_fsm_en & emb_func_en_b.mlc_en) ==
+          PROPERTY_DISABLE))
+  {
+    emb_func_en_a.mlc_before_fsm_en = PROPERTY_ENABLE;
+  }
+
+  emb_func_en_a.pedo_en = val.step_counter_enable;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+
+exit:
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  if (ret == 0)
+  {
+    ret = lsm6dsv80x_ln_pg_read(ctx, LSM6DSV80X_EMB_ADV_PG_1 + LSM6DSV80X_PEDO_CMD_REG,
+                                (uint8_t *)&pedo_cmd_reg, 1);
+    pedo_cmd_reg.fp_rejection_en = val.false_step_rej;
+    ret += lsm6dsv80x_ln_pg_write(ctx, LSM6DSV80X_EMB_ADV_PG_1 + LSM6DSV80X_PEDO_CMD_REG,
+                                  (uint8_t *)&pedo_cmd_reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Step counter mode[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      false_step_rej, step_counter, step_detector,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_stpcnt_mode_get(const stmdev_ctx_t *ctx,
+                                   lsm6dsv80x_stpcnt_mode_t *val)
+{
+  lsm6dsv80x_emb_func_en_a_t emb_func_en_a;
+  lsm6dsv80x_pedo_cmd_reg_t pedo_cmd_reg;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_ln_pg_read(ctx, LSM6DSV80X_EMB_ADV_PG_1 + LSM6DSV80X_PEDO_CMD_REG,
+                              (uint8_t *)&pedo_cmd_reg, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->false_step_rej = pedo_cmd_reg.fp_rejection_en;
+  val->step_counter_enable = emb_func_en_a.pedo_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Step counter output, number of detected steps.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Step counter output, number of detected steps.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_stpcnt_steps_get(const stmdev_ctx_t *ctx, uint16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_STEP_COUNTER_L, &buff[0], 2);
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  *val = buff[1];
+  *val = (*val * 256U) + buff[0];
+
+  return ret;
+}
+
+/**
+  * @brief  Reset step counter.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Reset step counter.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_stpcnt_rst_step_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_emb_func_src_t emb_func_src;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  emb_func_src.pedo_rst_step = val;
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
+
+exit:
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Reset step counter.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Reset step counter.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_stpcnt_rst_step_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_emb_func_src_t emb_func_src;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
+  *val = emb_func_src.pedo_rst_step;
+
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Pedometer debounce configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Pedometer debounce configuration.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_stpcnt_debounce_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_pedo_deb_steps_conf_t pedo_deb_steps_conf;
+  int32_t ret;
+
+  ret = lsm6dsv80x_ln_pg_read(ctx, LSM6DSV80X_EMB_ADV_PG_1 + LSM6DSV80X_PEDO_DEB_STEPS_CONF,
+                              (uint8_t *)&pedo_deb_steps_conf, 1);
+  if (ret == 0)
+  {
+    pedo_deb_steps_conf.deb_step = val;
+    ret = lsm6dsv80x_ln_pg_write(ctx, LSM6DSV80X_EMB_ADV_PG_1 + LSM6DSV80X_PEDO_DEB_STEPS_CONF,
+                                 (uint8_t *)&pedo_deb_steps_conf, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Pedometer debounce configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Pedometer debounce configuration.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_stpcnt_debounce_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_pedo_deb_steps_conf_t pedo_deb_steps_conf;
+  int32_t ret;
+
+  ret = lsm6dsv80x_ln_pg_read(ctx, LSM6DSV80X_EMB_ADV_PG_1 + LSM6DSV80X_PEDO_DEB_STEPS_CONF,
+                              (uint8_t *)&pedo_deb_steps_conf, 1);
+  *val = pedo_deb_steps_conf.deb_step;
+
+  return ret;
+}
+
+/**
+  * @brief  Time period register for step detection on delta time.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Time period register for step detection on delta time.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_stpcnt_period_set(const stmdev_ctx_t *ctx, uint16_t val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  buff[1] = (uint8_t)(val / 256U);
+  buff[0] = (uint8_t)(val - (buff[1] * 256U));
+  ret = lsm6dsv80x_ln_pg_write(ctx, LSM6DSV80X_EMB_ADV_PG_1 + LSM6DSV80X_PEDO_SC_DELTAT_L,
+                               (uint8_t *)&buff[0], 2);
+
+  return ret;
+}
+
+/**
+  * @brief  Time period register for step detection on delta time.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Time period register for step detection on delta time.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_stpcnt_period_get(const stmdev_ctx_t *ctx, uint16_t *val)
+{
+  uint8_t buff[2];
+  int32_t ret;
+
+  ret = lsm6dsv80x_ln_pg_read(ctx, LSM6DSV80X_EMB_ADV_PG_1 + LSM6DSV80X_PEDO_SC_DELTAT_L, &buff[0],
+                              2);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  *val = buff[1];
+  *val = (*val * 256U) + buff[0];
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Sensor Fusion Low Power (SFLP)
+  * @brief     This section groups all the functions that manage pedometer.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable SFLP Game Rotation Vector (6x).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enable/Disable game rotation value (0/1).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sflp_game_rotation_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  emb_func_en_a.sflp_game_en = val;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_EN_A,
+                              (uint8_t *)&emb_func_en_a, 1);
+
+exit:
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Enable SFLP Game Rotation Vector (6x).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enable/Disable game rotation value (0/1).
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sflp_game_rotation_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  *val = emb_func_en_a.sflp_game_en;
+
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  SFLP Data Rate (ODR) configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SFLP_15Hz, SFLP_30Hz, SFLP_60Hz, SFLP_120Hz, SFLP_240Hz, SFLP_480Hz
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sflp_data_rate_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_sflp_data_rate_t val)
+{
+  lsm6dsv80x_sflp_odr_t sflp_odr;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_SFLP_ODR, (uint8_t *)&sflp_odr, 1);
+  if (ret != 0)
+  {
+    goto exit;
+  }
+
+  sflp_odr.sflp_game_odr = (uint8_t)val & 0x07U;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_SFLP_ODR, (uint8_t *)&sflp_odr, 1);
+
+exit:
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  SFLP Data Rate (ODR) configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SFLP_15Hz, SFLP_30Hz, SFLP_60Hz, SFLP_120Hz, SFLP_240Hz, SFLP_480Hz
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_sflp_data_rate_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_sflp_data_rate_t *val)
+{
+  lsm6dsv80x_sflp_odr_t sflp_odr;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_SFLP_ODR, (uint8_t *)&sflp_odr, 1);
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (sflp_odr.sflp_game_odr)
+  {
+    case LSM6DSV80X_SFLP_15Hz:
+      *val = LSM6DSV80X_SFLP_15Hz;
+      break;
+
+    case LSM6DSV80X_SFLP_30Hz:
+      *val = LSM6DSV80X_SFLP_30Hz;
+      break;
+
+    case LSM6DSV80X_SFLP_60Hz:
+      *val = LSM6DSV80X_SFLP_60Hz;
+      break;
+
+    case LSM6DSV80X_SFLP_120Hz:
+      *val = LSM6DSV80X_SFLP_120Hz;
+      break;
+
+    case LSM6DSV80X_SFLP_240Hz:
+      *val = LSM6DSV80X_SFLP_240Hz;
+      break;
+
+    case LSM6DSV80X_SFLP_480Hz:
+      *val = LSM6DSV80X_SFLP_480Hz;
+      break;
+
+    default:
+      *val = LSM6DSV80X_SFLP_15Hz;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Tap - Double Tap
+  * @brief     This section groups all the functions that manage the
+  *            tap and double tap event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable axis for Tap - Double Tap detection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enable axis for Tap - Double Tap detection.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_tap_detection_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_tap_detection_t val)
+{
+  lsm6dsv80x_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  if (ret == 0)
+  {
+    tap_cfg0.tap_x_en = val.tap_x_en;
+    tap_cfg0.tap_y_en = val.tap_y_en;
+    tap_cfg0.tap_z_en = val.tap_z_en;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable axis for Tap - Double Tap detection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enable axis for Tap - Double Tap detection.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_tap_detection_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_tap_detection_t *val)
+{
+  lsm6dsv80x_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->tap_x_en = tap_cfg0.tap_x_en;
+  val->tap_y_en = tap_cfg0.tap_y_en;
+  val->tap_z_en = tap_cfg0.tap_z_en;
+
+  return ret;
+}
+
+/**
+  * @brief  axis Tap - Double Tap recognition thresholds.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      axis Tap - Double Tap recognition thresholds.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_tap_thresholds_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_tap_thresholds_t val)
+{
+  lsm6dsv80x_tap_ths_6d_t tap_ths_6d;
+  lsm6dsv80x_tap_cfg2_t tap_cfg2;
+  lsm6dsv80x_tap_cfg1_t tap_cfg1;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  tap_cfg1.tap_ths_x = val.x;
+  tap_cfg2.tap_ths_y = val.y;
+  tap_ths_6d.tap_ths_z = val.z;
+
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  axis Tap - Double Tap recognition thresholds.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      axis Tap - Double Tap recognition thresholds.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_tap_thresholds_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_tap_thresholds_t *val)
+{
+  lsm6dsv80x_tap_ths_6d_t tap_ths_6d;
+  lsm6dsv80x_tap_cfg2_t tap_cfg2;
+  lsm6dsv80x_tap_cfg1_t tap_cfg1;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->x  = tap_cfg1.tap_ths_x;
+  val->y = tap_cfg2.tap_ths_y;
+  val->z = tap_ths_6d.tap_ths_z;
+
+  return ret;
+}
+
+/**
+  * @brief  Selection of axis priority for TAP detection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      XYZ , YXZ , XZY, ZYX , YZX , ZXY ,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_tap_axis_priority_set(const stmdev_ctx_t *ctx,
+                                         lsm6dsv80x_tap_axis_priority_t val)
+{
+  lsm6dsv80x_tap_cfg1_t tap_cfg1;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+  if (ret == 0)
+  {
+    tap_cfg1.tap_priority = (uint8_t)val & 0x7U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selection of axis priority for TAP detection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      XYZ , YXZ , XZY, ZYX , YZX , ZXY ,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_tap_axis_priority_get(const stmdev_ctx_t *ctx,
+                                         lsm6dsv80x_tap_axis_priority_t *val)
+{
+  lsm6dsv80x_tap_cfg1_t tap_cfg1;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (tap_cfg1.tap_priority)
+  {
+    case LSM6DSV80X_XYZ :
+      *val = LSM6DSV80X_XYZ ;
+      break;
+
+    case LSM6DSV80X_YXZ :
+      *val = LSM6DSV80X_YXZ ;
+      break;
+
+    case LSM6DSV80X_XZY:
+      *val = LSM6DSV80X_XZY;
+      break;
+
+    case LSM6DSV80X_ZYX :
+      *val = LSM6DSV80X_ZYX ;
+      break;
+
+    case LSM6DSV80X_YZX :
+      *val = LSM6DSV80X_YZX ;
+      break;
+
+    case LSM6DSV80X_ZXY :
+      *val = LSM6DSV80X_ZXY ;
+      break;
+
+    default:
+      *val = LSM6DSV80X_XYZ ;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Time windows configuration for Tap - Double Tap SHOCK, QUIET, DUR : SHOCK Maximum duration is the maximum time of an overthreshold signal detection to be recognized as a tap event. The default value of these bits is 00b which corresponds to 4/ODR_XL time. If the SHOCK bits are set to a different value, 1LSB corresponds to 8/ODR_XL time. QUIET Expected quiet time after a tap detection. Quiet time is the time after the first detected tap in which there must not be any overthreshold event. The default value of these bits is 00b which corresponds to 2/ODR_XL time. If the QUIET bits are set to a different value, 1LSB corresponds to 4/ODR_XL time. DUR Duration of maximum time gap for double tap recognition. When double tap recognition is enabled, this register expresses the maximum time between two consecutive detected taps to determine a double tap event. The default value of these bits is 0000b which corresponds to 16/ODR_XL time. If the DUR_[3:0] bits are set to a different value, 1LSB corresponds to 32/ODR_XL time.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Time windows configuration for Tap - Double Tap SHOCK, QUIET, DUR : SHOCK Maximum duration is the maximum time of an overthreshold signal detection to be recognized as a tap event. The default value of these bits is 00b which corresponds to 4/ODR_XL time. If the SHOCK bits are set to a different value, 1LSB corresponds to 8/ODR_XL time. QUIET Expected quiet time after a tap detection. Quiet time is the time after the first detected tap in which there must not be any overthreshold event. The default value of these bits is 00b which corresponds to 2/ODR_XL time. If the QUIET bits are set to a different value, 1LSB corresponds to 4/ODR_XL time. DUR Duration of maximum time gap for double tap recognition. When double tap recognition is enabled, this register expresses the maximum time between two consecutive detected taps to determine a double tap event. The default value of these bits is 0000b which corresponds to 16/ODR_XL time. If the DUR_[3:0] bits are set to a different value, 1LSB corresponds to 32/ODR_XL time.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_tap_time_windows_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv80x_tap_time_windows_t val)
+{
+  lsm6dsv80x_tap_dur_t tap_dur;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TAP_DUR, (uint8_t *)&tap_dur, 1);
+  if (ret == 0)
+  {
+    tap_dur.shock = val.shock;
+    tap_dur.quiet = val.quiet;
+    tap_dur.dur = val.tap_gap;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TAP_DUR, (uint8_t *)&tap_dur, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Time windows configuration for Tap - Double Tap SHOCK, QUIET, DUR : SHOCK Maximum duration is the maximum time of an overthreshold signal detection to be recognized as a tap event. The default value of these bits is 00b which corresponds to 4/ODR_XL time. If the SHOCK bits are set to a different value, 1LSB corresponds to 8/ODR_XL time. QUIET Expected quiet time after a tap detection. Quiet time is the time after the first detected tap in which there must not be any overthreshold event. The default value of these bits is 00b which corresponds to 2/ODR_XL time. If the QUIET bits are set to a different value, 1LSB corresponds to 4/ODR_XL time. DUR Duration of maximum time gap for double tap recognition. When double tap recognition is enabled, this register expresses the maximum time between two consecutive detected taps to determine a double tap event. The default value of these bits is 0000b which corresponds to 16/ODR_XL time. If the DUR_[3:0] bits are set to a different value, 1LSB corresponds to 32/ODR_XL time.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Time windows configuration for Tap - Double Tap SHOCK, QUIET, DUR : SHOCK Maximum duration is the maximum time of an overthreshold signal detection to be recognized as a tap event. The default value of these bits is 00b which corresponds to 4/ODR_XL time. If the SHOCK bits are set to a different value, 1LSB corresponds to 8/ODR_XL time. QUIET Expected quiet time after a tap detection. Quiet time is the time after the first detected tap in which there must not be any overthreshold event. The default value of these bits is 00b which corresponds to 2/ODR_XL time. If the QUIET bits are set to a different value, 1LSB corresponds to 4/ODR_XL time. DUR Duration of maximum time gap for double tap recognition. When double tap recognition is enabled, this register expresses the maximum time between two consecutive detected taps to determine a double tap event. The default value of these bits is 0000b which corresponds to 16/ODR_XL time. If the DUR_[3:0] bits are set to a different value, 1LSB corresponds to 32/ODR_XL time.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_tap_time_windows_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv80x_tap_time_windows_t *val)
+{
+  lsm6dsv80x_tap_dur_t tap_dur;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TAP_DUR, (uint8_t *)&tap_dur, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->shock = tap_dur.shock;
+  val->quiet = tap_dur.quiet;
+  val->tap_gap = tap_dur.dur;
+
+  return ret;
+}
+
+/**
+  * @brief  Single/double-tap event enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      ONLY_SINGLE, BOTH_SINGLE_DOUBLE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_tap_mode_set(const stmdev_ctx_t *ctx, lsm6dsv80x_tap_mode_t val)
+{
+  lsm6dsv80x_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
+  if (ret == 0)
+  {
+    wake_up_ths.single_double_tap = (uint8_t)val & 0x01U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Single/double-tap event enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      ONLY_SINGLE, BOTH_SINGLE_DOUBLE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_tap_mode_get(const stmdev_ctx_t *ctx, lsm6dsv80x_tap_mode_t *val)
+{
+  lsm6dsv80x_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (wake_up_ths.single_double_tap)
+  {
+    case LSM6DSV80X_ONLY_SINGLE:
+      *val = LSM6DSV80X_ONLY_SINGLE;
+      break;
+
+    case LSM6DSV80X_BOTH_SINGLE_DOUBLE:
+      *val = LSM6DSV80X_BOTH_SINGLE_DOUBLE;
+      break;
+
+    default:
+      *val = LSM6DSV80X_ONLY_SINGLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Tilt detection
+  * @brief     This section groups all the functions that manage the tilt
+  *            event detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Tilt calculation.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Tilt calculation.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_tilt_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  emb_func_en_a.tilt_en = val;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @brief  Tilt calculation.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Tilt calculation.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_tilt_mode_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_EMBED_FUNC_MEM_BANK);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
+  *val = emb_func_en_a.tilt_en;
+
+  ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Timestamp
+  * @brief     This section groups all the functions that manage the
+  *            timestamp generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Timestamp data output.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Timestamp data output.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_timestamp_raw_get(const stmdev_ctx_t *ctx, uint32_t *val)
+{
+  uint8_t buff[4];
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TIMESTAMP0, &buff[0], 4);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  *val = buff[3];
+  *val = (*val * 256U) + buff[2];
+  *val = (*val * 256U) + buff[1];
+  *val = (*val * 256U) + buff[0];
+
+  return ret;
+}
+
+/**
+  * @brief  Enables timestamp counter.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables timestamp counter.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_timestamp_set(const stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsv80x_functions_enable_t functions_enable;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
+  if (ret == 0)
+  {
+    functions_enable.timestamp_en = val;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables timestamp counter.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Enables timestamp counter.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_timestamp_get(const stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsv80x_functions_enable_t functions_enable;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
+  *val = functions_enable.timestamp_en;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  Wake Up - Activity - Inactivity (Sleep)
+  * @brief     This section groups all the functions that manage the Wake Up
+  *            event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable activity/inactivity (sleep) function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      XL_AND_GY_NOT_AFFECTED, XL_LOW_POWER_GY_NOT_AFFECTED, XL_LOW_POWER_GY_SLEEP, XL_LOW_POWER_GY_POWER_DOWN,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_act_mode_set(const stmdev_ctx_t *ctx, lsm6dsv80x_act_mode_t val)
+{
+  lsm6dsv80x_functions_enable_t functions_enable;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
+  if (ret == 0)
+  {
+    functions_enable.inact_en = (uint8_t)val & 0x3U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable activity/inactivity (sleep) function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      XL_AND_GY_NOT_AFFECTED, XL_LOW_POWER_GY_NOT_AFFECTED, XL_LOW_POWER_GY_SLEEP, XL_LOW_POWER_GY_POWER_DOWN,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_act_mode_get(const stmdev_ctx_t *ctx, lsm6dsv80x_act_mode_t *val)
+{
+  lsm6dsv80x_functions_enable_t functions_enable;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (functions_enable.inact_en)
+  {
+    case LSM6DSV80X_XL_AND_GY_NOT_AFFECTED:
+      *val = LSM6DSV80X_XL_AND_GY_NOT_AFFECTED;
+      break;
+
+    case LSM6DSV80X_XL_LOW_POWER_GY_NOT_AFFECTED:
+      *val = LSM6DSV80X_XL_LOW_POWER_GY_NOT_AFFECTED;
+      break;
+
+    case LSM6DSV80X_XL_LOW_POWER_GY_SLEEP:
+      *val = LSM6DSV80X_XL_LOW_POWER_GY_SLEEP;
+      break;
+
+    case LSM6DSV80X_XL_LOW_POWER_GY_POWER_DOWN:
+      *val = LSM6DSV80X_XL_LOW_POWER_GY_POWER_DOWN;
+      break;
+
+    default:
+      *val = LSM6DSV80X_XL_AND_GY_NOT_AFFECTED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Duration in the transition from Stationary to Motion (from Inactivity to Activity).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SLEEP_TO_ACT_AT_1ST_SAMPLE, SLEEP_TO_ACT_AT_2ND_SAMPLE, SLEEP_TO_ACT_AT_3RD_SAMPLE, SLEEP_TO_ACT_AT_4th_SAMPLE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_act_from_sleep_to_act_dur_set(const stmdev_ctx_t *ctx,
+                                                 lsm6dsv80x_act_from_sleep_to_act_dur_t val)
+{
+  lsm6dsv80x_inactivity_dur_t inactivity_dur;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
+  if (ret == 0)
+  {
+    inactivity_dur.inact_dur = (uint8_t)val & 0x3U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Duration in the transition from Stationary to Motion (from Inactivity to Activity).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      SLEEP_TO_ACT_AT_1ST_SAMPLE, SLEEP_TO_ACT_AT_2ND_SAMPLE, SLEEP_TO_ACT_AT_3RD_SAMPLE, SLEEP_TO_ACT_AT_4th_SAMPLE,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_act_from_sleep_to_act_dur_get(const stmdev_ctx_t *ctx,
+                                                 lsm6dsv80x_act_from_sleep_to_act_dur_t *val)
+{
+  lsm6dsv80x_inactivity_dur_t inactivity_dur;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (inactivity_dur.inact_dur)
+  {
+    case LSM6DSV80X_SLEEP_TO_ACT_AT_1ST_SAMPLE:
+      *val = LSM6DSV80X_SLEEP_TO_ACT_AT_1ST_SAMPLE;
+      break;
+
+    case LSM6DSV80X_SLEEP_TO_ACT_AT_2ND_SAMPLE:
+      *val = LSM6DSV80X_SLEEP_TO_ACT_AT_2ND_SAMPLE;
+      break;
+
+    case LSM6DSV80X_SLEEP_TO_ACT_AT_3RD_SAMPLE:
+      *val = LSM6DSV80X_SLEEP_TO_ACT_AT_3RD_SAMPLE;
+      break;
+
+    case LSM6DSV80X_SLEEP_TO_ACT_AT_4th_SAMPLE:
+      *val = LSM6DSV80X_SLEEP_TO_ACT_AT_4th_SAMPLE;
+      break;
+
+    default:
+      *val = LSM6DSV80X_SLEEP_TO_ACT_AT_1ST_SAMPLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects the accelerometer data rate during Inactivity.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      1Hz875, 15Hz, 30Hz, 60Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_act_sleep_xl_odr_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv80x_act_sleep_xl_odr_t val)
+{
+  lsm6dsv80x_inactivity_dur_t inactivity_dur;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
+  if (ret == 0)
+  {
+    inactivity_dur.xl_inact_odr = (uint8_t)val & 0x03U;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects the accelerometer data rate during Inactivity.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      1Hz875, 15Hz, 30Hz, 60Hz,
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_act_sleep_xl_odr_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv80x_act_sleep_xl_odr_t *val)
+{
+  lsm6dsv80x_inactivity_dur_t inactivity_dur;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  switch (inactivity_dur.xl_inact_odr)
+  {
+    case LSM6DSV80X_1Hz875:
+      *val = LSM6DSV80X_1Hz875;
+      break;
+
+    case LSM6DSV80X_15Hz:
+      *val = LSM6DSV80X_15Hz;
+      break;
+
+    case LSM6DSV80X_30Hz:
+      *val = LSM6DSV80X_30Hz;
+      break;
+
+    case LSM6DSV80X_60Hz:
+      *val = LSM6DSV80X_60Hz;
+      break;
+
+    default:
+      *val = LSM6DSV80X_1Hz875;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Wakeup and activity/inactivity threshold.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Wakeup and activity/inactivity threshold.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_act_thresholds_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_act_thresholds_t *val)
+{
+  lsm6dsv80x_inactivity_ths_t inactivity_ths;
+  lsm6dsv80x_inactivity_dur_t inactivity_dur;
+  lsm6dsv80x_wake_up_ths_t wake_up_ths;
+  lsm6dsv80x_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_INACTIVITY_THS, (uint8_t *)&inactivity_ths, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  inactivity_dur.wu_inact_ths_w = val->inactivity_cfg.wu_inact_ths_w;
+  inactivity_dur.xl_inact_odr = val->inactivity_cfg.xl_inact_odr;
+  inactivity_dur.inact_dur = val->inactivity_cfg.inact_dur;
+
+  inactivity_ths.inact_ths = val->inactivity_ths;
+  wake_up_ths.wk_ths = val->threshold;
+  wake_up_dur.wake_dur = val->duration;
+
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_INACTIVITY_THS, (uint8_t *)&inactivity_ths, 1);
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+
+  return ret;
+}
+
+/**
+  * @brief  Wakeup and activity/inactivity threshold.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Wakeup and activity/inactivity threshold.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_act_thresholds_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_act_thresholds_t *val)
+{
+  lsm6dsv80x_inactivity_dur_t inactivity_dur;
+  lsm6dsv80x_inactivity_ths_t inactivity_ths;
+  lsm6dsv80x_wake_up_ths_t wake_up_ths;
+  lsm6dsv80x_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_INACTIVITY_THS, (uint8_t *)&inactivity_ths, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
+  ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->inactivity_cfg.wu_inact_ths_w = inactivity_dur.wu_inact_ths_w;
+  val->inactivity_cfg.xl_inact_odr = inactivity_dur.xl_inact_odr;
+  val->inactivity_cfg.inact_dur = inactivity_dur.inact_dur;
+
+  val->inactivity_ths = inactivity_ths.inact_ths;
+  val->threshold = wake_up_ths.wk_ths;
+  val->duration = wake_up_dur.wake_dur;
+
+  return ret;
+}
+
+/**
+  * @brief  Time windows configuration for Wake Up - Activity - Inactivity (SLEEP, WAKE). Duration to go in sleep mode. Default value: 0000 (this corresponds to 16 ODR) 1 LSB = 512/ODR_XL time. Wake up duration event. 1 LSB = 1/ODR_XL time. [set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Time windows configuration for Wake Up - Activity - Inactivity (SLEEP, WAKE). Duration to go in sleep mode. Default value: 0000 (this corresponds to 16 ODR) 1 LSB = 512/ODR_XL time. Wake up duration event. 1 LSB = 1/ODR_XL time.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_act_wkup_time_windows_set(const stmdev_ctx_t *ctx,
+                                             lsm6dsv80x_act_wkup_time_windows_t val)
+{
+  lsm6dsv80x_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+  if (ret == 0)
+  {
+    wake_up_dur.wake_dur = val.shock;
+    wake_up_dur.sleep_dur = val.quiet;
+    ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Time windows configuration for Wake Up - Activity - Inactivity (SLEEP, WAKE). Duration to go in sleep mode. Default value: 0000 (this corresponds to 16 ODR) 1 LSB = 512/ODR_XL time. Wake up duration event. 1 LSB = 1/ODR_XL time. [get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Time windows configuration for Wake Up - Activity - Inactivity (SLEEP, WAKE). Duration to go in sleep mode. Default value: 0000 (this corresponds to 16 ODR) 1 LSB = 512/ODR_XL time. Wake up duration event. 1 LSB = 1/ODR_XL time.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsv80x_act_wkup_time_windows_get(const stmdev_ctx_t *ctx,
+                                             lsm6dsv80x_act_wkup_time_windows_t *val)
+{
+  lsm6dsv80x_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
+  if (ret != 0)
+  {
+    return ret;
+  }
+
+  val->shock = wake_up_dur.wake_dur;
+  val->quiet = wake_up_dur.sleep_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */

--- a/sensor/stmemsc/lsm6dsv80x_STdC/driver/lsm6dsv80x_reg.h
+++ b/sensor/stmemsc/lsm6dsv80x_STdC/driver/lsm6dsv80x_reg.h
@@ -1,0 +1,5097 @@
+/**
+  ******************************************************************************
+  * @file    lsm6dsv80x_reg.h
+  * @author  Sensors Software Solution Team
+  * @brief   This file contains all the functions prototypes for the
+  *          lsm6dsv80x_reg.c driver.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2022 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef LSM6DSV80X_REGS_H
+#define LSM6DSV80X_REGS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <stddef.h>
+#include <math.h>
+
+/** @addtogroup LSM6DSV80X
+  * @{
+  *
+  */
+
+/** @defgroup  Endianness definitions
+  * @{
+  *
+  */
+
+#ifndef DRV_BYTE_ORDER
+#ifndef __BYTE_ORDER__
+
+#define DRV_LITTLE_ENDIAN 1234
+#define DRV_BIG_ENDIAN    4321
+
+/** if _BYTE_ORDER is not defined, choose the endianness of your architecture
+  * by uncommenting the define which fits your platform endianness
+  */
+//#define DRV_BYTE_ORDER    DRV_BIG_ENDIAN
+#define DRV_BYTE_ORDER    DRV_LITTLE_ENDIAN
+
+#else /* defined __BYTE_ORDER__ */
+
+#define DRV_LITTLE_ENDIAN  __ORDER_LITTLE_ENDIAN__
+#define DRV_BIG_ENDIAN     __ORDER_BIG_ENDIAN__
+#define DRV_BYTE_ORDER     __BYTE_ORDER__
+
+#endif /* __BYTE_ORDER__*/
+#endif /* DRV_BYTE_ORDER */
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup STMicroelectronics sensors common types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t bit0                         : 1;
+  uint8_t bit1                         : 1;
+  uint8_t bit2                         : 1;
+  uint8_t bit3                         : 1;
+  uint8_t bit4                         : 1;
+  uint8_t bit5                         : 1;
+  uint8_t bit6                         : 1;
+  uint8_t bit7                         : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t bit7                         : 1;
+  uint8_t bit6                         : 1;
+  uint8_t bit5                         : 1;
+  uint8_t bit4                         : 1;
+  uint8_t bit3                         : 1;
+  uint8_t bit2                         : 1;
+  uint8_t bit1                         : 1;
+  uint8_t bit0                         : 1;
+#endif /* DRV_BYTE_ORDER */
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+/** @addtogroup  Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, const uint8_t *, uint16_t);
+typedef int32_t (*stmdev_read_ptr)(void *, uint8_t, uint8_t *, uint16_t);
+typedef void (*stmdev_mdelay_ptr)(uint32_t millisec);
+
+typedef struct
+{
+  /** Component mandatory fields **/
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
+  /** Component optional fields **/
+  stmdev_mdelay_ptr   mdelay;
+  /** Customizable optional pointer **/
+  void *handle;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+  *              You can create a sensor configuration by your own or using
+  *              Unico / Unicleo tools available on STMicroelectronics
+  *              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct
+{
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup LSM6DSV80X_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> D5 if SA0=1 -> D7 **/
+#define LSM6DSV80X_I2C_ADD_L                      0xD5U
+#define LSM6DSV80X_I2C_ADD_H                      0xD7U
+
+/** Device Identification (Who am I) **/
+#define LSM6DSV80X_ID                             0x73U
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup bitfields page main
+  * @{
+  *
+  */
+
+#define LSM6DSV80X_FUNC_CFG_ACCESS                0x1U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used1                    : 2;
+  uint8_t sw_por                       : 1;
+  uint8_t fsm_wr_ctrl_en               : 1;
+  uint8_t not_used0                    : 2;
+  uint8_t shub_reg_access              : 1;
+  uint8_t emb_func_reg_access          : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t emb_func_reg_access          : 1;
+  uint8_t shub_reg_access              : 1;
+  uint8_t not_used0                    : 2;
+  uint8_t fsm_wr_ctrl_en               : 1;
+  uint8_t sw_por                       : 1;
+  uint8_t not_used1                    : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_func_cfg_access_t;
+
+#define LSM6DSV80X_PIN_CTRL                       0x2U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t io_pad_strength              : 2;
+  uint8_t not_used0                    : 3;
+  uint8_t ibhr_por_en                  : 1;
+  uint8_t sdo_pu_en                    : 1;
+  uint8_t not_used1                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 1;
+  uint8_t sdo_pu_en                    : 1;
+  uint8_t ibhr_por_en                  : 1;
+  uint8_t not_used0                    : 3;
+  uint8_t io_pad_strength              : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_pin_ctrl_t;
+
+#define LSM6DSV80X_IF_CFG                         0x3U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t i2c_i3c_disable              : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t sim                          : 1;
+  uint8_t pp_od                        : 1;
+  uint8_t h_lactive                    : 1;
+  uint8_t asf_ctrl                     : 1;
+  uint8_t shub_pu_en                   : 1;
+  uint8_t sda_pu_en                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sda_pu_en                    : 1;
+  uint8_t shub_pu_en                   : 1;
+  uint8_t asf_ctrl                     : 1;
+  uint8_t h_lactive                    : 1;
+  uint8_t pp_od                        : 1;
+  uint8_t sim                          : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t i2c_i3c_disable              : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_if_cfg_t;
+
+#define LSM6DSV80X_ODR_TRIG_CFG                   0x6U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t odr_trig_nodr                : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t odr_trig_nodr                : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_odr_trig_cfg_t;
+
+#define LSM6DSV80X_FIFO_CTRL1                     0x7U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t wtm                          : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t wtm                          : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fifo_ctrl1_t;
+
+#define LSM6DSV80X_FIFO_CTRL2                     0x8U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used2                    : 1;
+  uint8_t uncompr_rate                 : 2;
+  uint8_t not_used0                    : 1;
+  uint8_t odr_chg_en                   : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t fifo_compr_rt_en             : 1;
+  uint8_t stop_on_wtm                  : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t stop_on_wtm                  : 1;
+  uint8_t fifo_compr_rt_en             : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t odr_chg_en                   : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t uncompr_rate                 : 2;
+  uint8_t not_used2                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fifo_ctrl2_t;
+
+#define LSM6DSV80X_FIFO_CTRL3                     0x9U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t bdr_xl                       : 4;
+  uint8_t bdr_gy                       : 4;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t bdr_gy                       : 4;
+  uint8_t bdr_xl                       : 4;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fifo_ctrl3_t;
+
+#define LSM6DSV80X_FIFO_CTRL4                     0x0AU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fifo_mode                    : 3;
+  uint8_t not_used0                    : 1;
+  uint8_t odr_t_batch                  : 2;
+  uint8_t dec_ts_batch                 : 2;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t dec_ts_batch                 : 2;
+  uint8_t odr_t_batch                  : 2;
+  uint8_t not_used0                    : 1;
+  uint8_t fifo_mode                    : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fifo_ctrl4_t;
+
+#define LSM6DSV80X_COUNTER_BDR_REG1               0x0BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t cnt_bdr_th                   : 2;
+  uint8_t not_used0                    : 1;
+  uint8_t xl_hg_batch_en               : 1;
+  uint8_t not_used2                    : 1;
+  uint8_t trig_counter_bdr             : 2;
+  uint8_t not_used1                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 1;
+  uint8_t trig_counter_bdr             : 2;
+  uint8_t not_used2                    : 1;
+  uint8_t xl_hg_batch_en               : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t cnt_bdr_th                   : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_counter_bdr_reg1_t;
+
+#define LSM6DSV80X_COUNTER_BDR_REG2               0x0CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t cnt_bdr_th                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t cnt_bdr_th                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_counter_bdr_reg2_t;
+
+#define LSM6DSV80X_INT1_CTRL                      0x0DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t int1_drdy_xl                 : 1;
+  uint8_t int1_drdy_g                  : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t int1_fifo_th                 : 1;
+  uint8_t int1_fifo_ovr                : 1;
+  uint8_t int1_fifo_full               : 1;
+  uint8_t int1_cnt_bdr                 : 1;
+  uint8_t not_used1                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 1;
+  uint8_t int1_cnt_bdr                 : 1;
+  uint8_t int1_fifo_full               : 1;
+  uint8_t int1_fifo_ovr                : 1;
+  uint8_t int1_fifo_th                 : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t int1_drdy_g                  : 1;
+  uint8_t int1_drdy_xl                 : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_int1_ctrl_t;
+
+#define LSM6DSV80X_INT2_CTRL                      0x0EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t int2_drdy_xl                 : 1;
+  uint8_t int2_drdy_g                  : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t int2_fifo_th                 : 1;
+  uint8_t int2_fifo_ovr                : 1;
+  uint8_t int2_fifo_full               : 1;
+  uint8_t int2_cnt_bdr                 : 1;
+  uint8_t int2_emb_func_endop          : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t int2_emb_func_endop          : 1;
+  uint8_t int2_cnt_bdr                 : 1;
+  uint8_t int2_fifo_full               : 1;
+  uint8_t int2_fifo_ovr                : 1;
+  uint8_t int2_fifo_th                 : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t int2_drdy_g                  : 1;
+  uint8_t int2_drdy_xl                 : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_int2_ctrl_t;
+
+#define LSM6DSV80X_WHO_AM_I                       0x0FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t id                           : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t id                           : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_who_am_i_t;
+
+#define LSM6DSV80X_CTRL1                          0x10U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t odr_xl                       : 4;
+  uint8_t op_mode_xl                   : 3;
+  uint8_t not_used0                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 1;
+  uint8_t op_mode_xl                   : 3;
+  uint8_t odr_xl                       : 4;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_ctrl1_t;
+
+#define LSM6DSV80X_CTRL2                          0x11U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t odr_g                        : 4;
+  uint8_t op_mode_g                    : 3;
+  uint8_t not_used0                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 1;
+  uint8_t op_mode_g                    : 3;
+  uint8_t odr_g                        : 4;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_ctrl2_t;
+
+#define LSM6DSV80X_CTRL3                          0x12U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sw_reset                     : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t if_inc                       : 1;
+  uint8_t not_used1                    : 3;
+  uint8_t bdu                          : 1;
+  uint8_t boot                         : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t boot                         : 1;
+  uint8_t bdu                          : 1;
+  uint8_t not_used1                    : 3;
+  uint8_t if_inc                       : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t sw_reset                     : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_ctrl3_t;
+
+#define LSM6DSV80X_CTRL4                          0x13U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t int2_in_lh                   : 1;
+  uint8_t drdy_pulsed                  : 1;
+  uint8_t int2_drdy_temp               : 1;
+  uint8_t drdy_mask                    : 1;
+  uint8_t int2_on_int1                 : 1;
+  uint8_t not_used0                    : 3;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 3;
+  uint8_t int2_on_int1                 : 1;
+  uint8_t drdy_mask                    : 1;
+  uint8_t int2_drdy_temp               : 1;
+  uint8_t drdy_pulsed                  : 1;
+  uint8_t int2_in_lh                   : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_ctrl4_t;
+
+#define LSM6DSV80X_CTRL5                          0x14U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t int_en_i3c                   : 1;
+  uint8_t bus_act_sel                  : 2;
+  uint8_t not_used0                    : 5;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 5;
+  uint8_t not_used0                    : 4;
+  uint8_t bus_act_sel                  : 2;
+  uint8_t int_en_i3c                   : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_ctrl5_t;
+
+#define LSM6DSV80X_CTRL6                          0x15U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fs_g                         : 3;
+  uint8_t not_used1                    : 1;
+  uint8_t lpf1_g_bw                    : 3;
+  uint8_t not_used0                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 1;
+  uint8_t lpf1_g_bw                    : 3;
+  uint8_t not_used1                    : 1;
+  uint8_t fs_g                         : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_ctrl6_t;
+
+#define LSM6DSV80X_CTRL7                          0x16U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t lpf1_g_en                    : 1;
+  uint8_t not_used0                    : 5;
+  uint8_t int2_drdy_xl_hg              : 1;
+  uint8_t int1_drdy_xl_hg              : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t int1_drdy_xl_hg              : 1;
+  uint8_t int2_drdy_xl_hg              : 1;
+  uint8_t not_used0                    : 5;
+  uint8_t lpf1_g_en                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_ctrl7_t;
+
+#define LSM6DSV80X_CTRL8                          0x17U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fs_xl                        : 2;
+  uint8_t not_used0                    : 3;
+  uint8_t hp_lpf2_xl_bw                : 3;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t hp_lpf2_xl_bw                : 3;
+  uint8_t not_used0                    : 3;
+  uint8_t fs_xl                        : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_ctrl8_t;
+
+#define LSM6DSV80X_CTRL9                          0x18U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t usr_off_on_out               : 1;
+  uint8_t usr_off_w                    : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t lpf2_xl_en                   : 1;
+  uint8_t hp_slope_xl_en               : 1;
+  uint8_t xl_fastsettl_mode            : 1;
+  uint8_t hp_ref_mode_xl               : 1;
+  uint8_t not_used1                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 1;
+  uint8_t hp_ref_mode_xl               : 1;
+  uint8_t xl_fastsettl_mode            : 1;
+  uint8_t hp_slope_xl_en               : 1;
+  uint8_t lpf2_xl_en                   : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t usr_off_w                    : 1;
+  uint8_t usr_off_on_out               : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_ctrl9_t;
+
+#define LSM6DSV80X_CTRL10                         0x19U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t st_xl                        : 2;
+  uint8_t st_g                         : 2;
+  uint8_t not_used0                    : 2;
+  uint8_t emb_func_debug               : 1;
+  uint8_t not_used1                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 1;
+  uint8_t emb_func_debug               : 1;
+  uint8_t not_used0                    : 2;
+  uint8_t st_g                         : 2;
+  uint8_t st_xl                        : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_ctrl10_t;
+
+#define LSM6DSV80X_CTRL_STATUS                    0x1AU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 2;
+  uint8_t fsm_wr_ctrl_status           : 1;
+  uint8_t not_used1                    : 5;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 5;
+  uint8_t fsm_wr_ctrl_status           : 1;
+  uint8_t not_used0                    : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_ctrl_status_t;
+
+#define LSM6DSV80X_FIFO_STATUS1                   0x1BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t diff_fifo                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t diff_fifo                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fifo_status1_t;
+
+#define LSM6DSV80X_FIFO_STATUS2                   0x1CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t diff_fifo                    : 1;
+  uint8_t not_used0                    : 2;
+  uint8_t fifo_ovr_latched             : 1;
+  uint8_t counter_bdr_ia               : 1;
+  uint8_t fifo_full_ia                 : 1;
+  uint8_t fifo_ovr_ia                  : 1;
+  uint8_t fifo_wtm_ia                  : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fifo_wtm_ia                  : 1;
+  uint8_t fifo_ovr_ia                  : 1;
+  uint8_t fifo_full_ia                 : 1;
+  uint8_t counter_bdr_ia               : 1;
+  uint8_t fifo_ovr_latched             : 1;
+  uint8_t not_used0                    : 2;
+  uint8_t diff_fifo                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fifo_status2_t;
+
+#define LSM6DSV80X_ALL_INT_SRC                    0x1DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ff_ia                        : 1;
+  uint8_t wu_ia                        : 1;
+  uint8_t tap_ia                       : 1;
+  uint8_t hg_ia                        : 1;
+  uint8_t d6d_ia                       : 1;
+  uint8_t sleep_change_ia              : 1;
+  uint8_t shub_ia                      : 1;
+  uint8_t emb_func_ia                  : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t emb_func_ia                  : 1;
+  uint8_t shub_ia                      : 1;
+  uint8_t sleep_change_ia              : 1;
+  uint8_t d6d_ia                       : 1;
+  uint8_t hg_ia                        : 1;
+  uint8_t tap_ia                       : 1;
+  uint8_t wu_ia                        : 1;
+  uint8_t ff_ia                        : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_all_int_src_t;
+
+#define LSM6DSV80X_STATUS_REG                     0x1EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t xlda                         : 1;
+  uint8_t gda                          : 1;
+  uint8_t tda                          : 1;
+  uint8_t xlhgda                       : 1;
+  uint8_t not_used0                    : 3;
+  uint8_t timestamp_endcount           : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t timestamp_endcount           : 1;
+  uint8_t not_used0                    : 3;
+  uint8_t xlhgda                       : 1;
+  uint8_t tda                          : 1;
+  uint8_t gda                          : 1;
+  uint8_t xlda                         : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_status_reg_t;
+
+#define LSM6DSV80X_OUT_TEMP_L                     0x20U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t temp                         : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t temp                         : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_out_temp_l_t;
+
+#define LSM6DSV80X_OUT_TEMP_H                     0x21U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t temp                         : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t temp                         : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_out_temp_h_t;
+
+#define LSM6DSV80X_OUTX_L_G                       0x22U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t outx_g                       : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t outx_g                       : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_outx_l_g_t;
+
+#define LSM6DSV80X_OUTX_H_G                       0x23U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t outx_g                       : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t outx_g                       : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_outx_h_g_t;
+
+#define LSM6DSV80X_OUTY_L_G                       0x24U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t outy_g                       : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t outy_g                       : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_outy_l_g_t;
+
+#define LSM6DSV80X_OUTY_H_G                       0x25U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t outy_g                       : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t outy_g                       : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_outy_h_g_t;
+
+#define LSM6DSV80X_OUTZ_L_G                       0x26U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t outz_g                       : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t outz_g                       : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_outz_l_g_t;
+
+#define LSM6DSV80X_OUTZ_H_G                       0x27U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t outz_g                       : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t outz_g                       : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_outz_h_g_t;
+
+#define LSM6DSV80X_OUTX_L_A                       0x28U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t outx_a                       : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t outx_a                       : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_outx_l_a_t;
+
+#define LSM6DSV80X_OUTX_H_A                       0x29U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t outx_a                       : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t outx_a                       : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_outx_h_a_t;
+
+#define LSM6DSV80X_OUTY_L_A                       0x2AU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t outy_a                       : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t outy_a                       : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_outy_l_a_t;
+
+#define LSM6DSV80X_OUTY_H_A                       0x2BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t outy_a                       : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t outy_a                       : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_outy_h_a_t;
+
+#define LSM6DSV80X_OUTZ_L_A                       0x2CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t outz_a                       : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t outz_a                       : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_outz_l_a_t;
+
+#define LSM6DSV80X_OUTZ_H_A                       0x2DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t outz_a                       : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t outz_a                       : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_outz_h_a_t;
+
+#define LSM6DSV80X_UI_OUTX_L_A_HG                 0x34U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ui_outx_a_hg                 : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ui_outx_a_hg                 : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_ui_outx_l_a_hg_t;
+
+#define LSM6DSV80X_UI_OUTX_H_A_HG                 0x35U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ui_outx_a_hg                 : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ui_outx_a_hg                 : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_ui_outx_h_a_hg_t;
+
+#define LSM6DSV80X_UI_OUTY_L_A_HG                 0x36U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ui_outy_a_hg                 : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ui_outy_a_hg                 : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_ui_outy_l_a_hg_t;
+
+#define LSM6DSV80X_UI_OUTY_H_A_HG                 0x37U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ui_outy_a_hg                 : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ui_outy_a_hg                 : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_ui_outy_h_a_hg_t;
+
+#define LSM6DSV80X_UI_OUTZ_L_A_HG                 0x38U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ui_outz_a_hg                 : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ui_outz_a_hg                 : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_ui_outz_l_a_hg_t;
+
+#define LSM6DSV80X_UI_OUTZ_H_A_HG                 0x39U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ui_outz_a_hg                 : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ui_outz_a_hg                 : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_ui_outz_h_a_hg_t;
+
+#define LSM6DSV80X_TIMESTAMP0                     0x40U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t timestamp                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t timestamp                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_timestamp0_t;
+
+#define LSM6DSV80X_TIMESTAMP1                     0x41U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t timestamp                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t timestamp                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_timestamp1_t;
+
+#define LSM6DSV80X_TIMESTAMP2                     0x42U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t timestamp                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t timestamp                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_timestamp2_t;
+
+#define LSM6DSV80X_TIMESTAMP3                     0x43U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t timestamp                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t timestamp                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_timestamp3_t;
+
+#define LSM6DSV80X_UI_STATUS_REG                  0x44U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used1                    : 2;
+  uint8_t gyro_settling                : 1;
+  uint8_t not_used0                    : 5;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 5;
+  uint8_t gyro_settling                : 1;
+  uint8_t not_used1                    : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_ui_status_reg_t;
+
+#define LSM6DSV80X_WAKE_UP_SRC                    0x45U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t z_wu                         : 1;
+  uint8_t y_wu                         : 1;
+  uint8_t x_wu                         : 1;
+  uint8_t wu_ia                        : 1;
+  uint8_t sleep_state                  : 1;
+  uint8_t ff_ia                        : 1;
+  uint8_t sleep_change_ia              : 1;
+  uint8_t not_used0                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 1;
+  uint8_t sleep_change_ia              : 1;
+  uint8_t ff_ia                        : 1;
+  uint8_t sleep_state                  : 1;
+  uint8_t wu_ia                        : 1;
+  uint8_t x_wu                         : 1;
+  uint8_t y_wu                         : 1;
+  uint8_t z_wu                         : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_wake_up_src_t;
+
+#define LSM6DSV80X_TAP_SRC                        0x46U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t z_tap                        : 1;
+  uint8_t y_tap                        : 1;
+  uint8_t x_tap                        : 1;
+  uint8_t tap_sign                     : 1;
+  uint8_t double_tap                   : 1;
+  uint8_t single_tap                   : 1;
+  uint8_t tap_ia                       : 1;
+  uint8_t not_used0                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 1;
+  uint8_t tap_ia                       : 1;
+  uint8_t single_tap                   : 1;
+  uint8_t double_tap                   : 1;
+  uint8_t tap_sign                     : 1;
+  uint8_t x_tap                        : 1;
+  uint8_t y_tap                        : 1;
+  uint8_t z_tap                        : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_tap_src_t;
+
+#define LSM6DSV80X_D6D_SRC                        0x47U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t xl                           : 1;
+  uint8_t xh                           : 1;
+  uint8_t yl                           : 1;
+  uint8_t yh                           : 1;
+  uint8_t zl                           : 1;
+  uint8_t zh                           : 1;
+  uint8_t d6d_ia                       : 1;
+  uint8_t not_used0                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 1;
+  uint8_t d6d_ia                       : 1;
+  uint8_t zh                           : 1;
+  uint8_t zl                           : 1;
+  uint8_t yh                           : 1;
+  uint8_t yl                           : 1;
+  uint8_t xh                           : 1;
+  uint8_t xl                           : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_d6d_src_t;
+
+#define LSM6DSV80X_STATUS_CONTROLLER_MAINPAGE     0x48U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sens_hub_endop               : 1;
+  uint8_t not_used0                    : 2;
+  uint8_t target0_nack                 : 1;
+  uint8_t target1_nack                 : 1;
+  uint8_t target2_nack                 : 1;
+  uint8_t target3_nack                 : 1;
+  uint8_t wr_once_done                 : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t wr_once_done                 : 1;
+  uint8_t target3_nack                 : 1;
+  uint8_t target2_nack                 : 1;
+  uint8_t target1_nack                 : 1;
+  uint8_t target0_nack                 : 1;
+  uint8_t not_used0                    : 2;
+  uint8_t sens_hub_endop               : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_status_controller_mainpage_t;
+
+#define LSM6DSV80X_EMB_FUNC_STATUS_MAINPAGE       0x49U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 3;
+  uint8_t is_step_det                  : 1;
+  uint8_t is_tilt                      : 1;
+  uint8_t is_sigmot                    : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t is_fsm_lc                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t is_fsm_lc                    : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t is_sigmot                    : 1;
+  uint8_t is_tilt                      : 1;
+  uint8_t is_step_det                  : 1;
+  uint8_t not_used0                    : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_emb_func_status_mainpage_t;
+
+#define LSM6DSV80X_FSM_STATUS_MAINPAGE            0x4AU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t is_fsm1                      : 1;
+  uint8_t is_fsm2                      : 1;
+  uint8_t is_fsm3                      : 1;
+  uint8_t is_fsm4                      : 1;
+  uint8_t is_fsm5                      : 1;
+  uint8_t is_fsm6                      : 1;
+  uint8_t is_fsm7                      : 1;
+  uint8_t is_fsm8                      : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t is_fsm8                      : 1;
+  uint8_t is_fsm7                      : 1;
+  uint8_t is_fsm6                      : 1;
+  uint8_t is_fsm5                      : 1;
+  uint8_t is_fsm4                      : 1;
+  uint8_t is_fsm3                      : 1;
+  uint8_t is_fsm2                      : 1;
+  uint8_t is_fsm1                      : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_status_mainpage_t;
+
+#define LSM6DSV80X_MLC_STATUS_MAINPAGE            0x4BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t is_mlc1                      : 1;
+  uint8_t is_mlc2                      : 1;
+  uint8_t is_mlc3                      : 1;
+  uint8_t is_mlc4                      : 1;
+  uint8_t is_mlc5                      : 1;
+  uint8_t is_mlc6                      : 1;
+  uint8_t is_mlc7                      : 1;
+  uint8_t is_mlc8                      : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t is_mlc8                      : 1;
+  uint8_t is_mlc7                      : 1;
+  uint8_t is_mlc6                      : 1;
+  uint8_t is_mlc5                      : 1;
+  uint8_t is_mlc4                      : 1;
+  uint8_t is_mlc3                      : 1;
+  uint8_t is_mlc2                      : 1;
+  uint8_t is_mlc1                      : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_mlc_status_mainpage_t;
+
+#define LSM6DSV80X_HG_WAKE_UP_SRC                 0x4CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t hg_z_wu                      : 1;
+  uint8_t hg_y_wu                      : 1;
+  uint8_t hg_x_wu                      : 1;
+  uint8_t hg_wu_ia                     : 1;
+  uint8_t hg_wu_change_ia              : 1;
+  uint8_t hg_shock_state               : 1;
+  uint8_t hg_shock_change_ia           : 1;
+  uint8_t not_used0                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 1;
+  uint8_t hg_shock_change_ia           : 1;
+  uint8_t hg_shock_state               : 1;
+  uint8_t hg_wu_change_ia              : 1;
+  uint8_t hg_wu_ia                     : 1;
+  uint8_t hg_x_wu                      : 1;
+  uint8_t hg_y_wu                      : 1;
+  uint8_t hg_z_wu                      : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_hg_wake_up_src_t;
+
+#define LSM6DSV80X_CTRL2_XL_HG                    0x4DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t xl_hg_st                     : 2;
+  uint8_t not_used0                    : 2;
+  uint8_t hg_usr_off_on_wu             : 1;
+  uint8_t not_used1                    : 3;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 3;
+  uint8_t hg_usr_off_on_wu             : 1;
+  uint8_t not_used0                    : 2;
+  uint8_t xl_hg_st                     : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_ctrl2_xl_hg_t;
+
+#define LSM6DSV80X_CTRL1_XL_HG                    0x4EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fs_xl_hg                     : 3;
+  uint8_t odr_xl_hg                    : 3;
+  uint8_t hg_usr_off_on_out            : 1;
+  uint8_t xl_hg_regout_en              : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t xl_hg_regout_en              : 1;
+  uint8_t hg_usr_off_on_out            : 1;
+  uint8_t odr_xl_hg                    : 3;
+  uint8_t fs_xl_hg                     : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_ctrl1_xl_hg_t;
+
+#define LSM6DSV80X_INTERNAL_FREQ                  0x4FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t freq_fine                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t freq_fine                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_internal_freq_t;
+
+#define LSM6DSV80X_FUNCTIONS_ENABLE               0x50U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t inact_en                     : 2;
+  uint8_t not_used0                    : 1;
+  uint8_t dis_rst_lir_all_int          : 1;
+  uint8_t not_used1                    : 2;
+  uint8_t timestamp_en                 : 1;
+  uint8_t interrupts_enable            : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t interrupts_enable            : 1;
+  uint8_t timestamp_en                 : 1;
+  uint8_t not_used1                    : 2;
+  uint8_t dis_rst_lir_all_int          : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t inact_en                     : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_functions_enable_t;
+
+#define LSM6DSV80X_HG_FUNCTIONS_ENABLE            0x52U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t hg_shock_dur                 : 4;
+  uint8_t int1_hg_wu                   : 1;
+  uint8_t int2_hg_wu                   : 1;
+  uint8_t hg_wu_change_int_sel         : 1;
+  uint8_t hg_interrupts_enable         : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t hg_interrupts_enable         : 1;
+  uint8_t hg_wu_change_int_sel         : 1;
+  uint8_t int2_hg_wu                   : 1;
+  uint8_t int1_hg_wu                   : 1;
+  uint8_t hg_shock_dur                 : 4;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_hg_functions_enable_t;
+
+#define LSM6DSV80X_HG_WAKE_UP_THS                 0x53U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t hg_wk_ths                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t hg_wk_ths                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_hg_wake_up_ths_t;
+
+#define LSM6DSV80X_INACTIVITY_DUR                 0x54U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t inact_dur                    : 2;
+  uint8_t xl_inact_odr                 : 2;
+  uint8_t wu_inact_ths_w               : 3;
+  uint8_t sleep_status_on_int          : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sleep_status_on_int          : 1;
+  uint8_t wu_inact_ths_w               : 3;
+  uint8_t xl_inact_odr                 : 2;
+  uint8_t inact_dur                    : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_inactivity_dur_t;
+
+#define LSM6DSV80X_INACTIVITY_THS                 0x55U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t inact_ths                    : 6;
+  uint8_t int1_hg_shock_change         : 1;
+  uint8_t int2_hg_shock_change         : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t int2_hg_shock_change         : 1;
+  uint8_t int1_hg_shock_change         : 1;
+  uint8_t inact_ths                    : 6;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_inactivity_ths_t;
+
+#define LSM6DSV80X_TAP_CFG0                       0x56U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t lir                          : 1;
+  uint8_t tap_z_en                     : 1;
+  uint8_t tap_y_en                     : 1;
+  uint8_t tap_x_en                     : 1;
+  uint8_t slope_fds                    : 1;
+  uint8_t hw_func_mask_xl_settl        : 1;
+  uint8_t low_pass_on_6d               : 1;
+  uint8_t not_used1                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 1;
+  uint8_t low_pass_on_6d               : 1;
+  uint8_t hw_func_mask_xl_settl        : 1;
+  uint8_t slope_fds                    : 1;
+  uint8_t tap_x_en                     : 1;
+  uint8_t tap_y_en                     : 1;
+  uint8_t tap_z_en                     : 1;
+  uint8_t lir                          : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_tap_cfg0_t;
+
+#define LSM6DSV80X_TAP_CFG1                       0x57U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t tap_ths_x                    : 5;
+  uint8_t tap_priority                 : 3;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t tap_priority                 : 3;
+  uint8_t tap_ths_x                    : 5;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_tap_cfg1_t;
+
+#define LSM6DSV80X_TAP_CFG2                       0x58U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t tap_ths_y                    : 5;
+  uint8_t not_used0                    : 3;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 3;
+  uint8_t tap_ths_y                    : 5;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_tap_cfg2_t;
+
+#define LSM6DSV80X_TAP_THS_6D                     0x59U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t tap_ths_z                    : 5;
+  uint8_t sixd_ths                     : 2;
+  uint8_t d4d_en                       : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t d4d_en                       : 1;
+  uint8_t sixd_ths                     : 2;
+  uint8_t tap_ths_z                    : 5;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_tap_ths_6d_t;
+
+#define LSM6DSV80X_TAP_DUR                        0x5AU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t shock                        : 2;
+  uint8_t quiet                        : 2;
+  uint8_t dur                          : 4;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t dur                          : 4;
+  uint8_t quiet                        : 2;
+  uint8_t shock                        : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_tap_dur_t;
+
+#define LSM6DSV80X_WAKE_UP_THS                    0x5BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t wk_ths                       : 6;
+  uint8_t usr_off_on_wu                : 1;
+  uint8_t single_double_tap            : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t single_double_tap            : 1;
+  uint8_t usr_off_on_wu                : 1;
+  uint8_t wk_ths                       : 6;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_wake_up_ths_t;
+
+#define LSM6DSV80X_WAKE_UP_DUR                    0x5CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sleep_dur                    : 4;
+  uint8_t not_used0                    : 1;
+  uint8_t wake_dur                     : 2;
+  uint8_t ff_dur                       : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ff_dur                       : 1;
+  uint8_t wake_dur                     : 2;
+  uint8_t not_used0                    : 1;
+  uint8_t sleep_dur                    : 4;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_wake_up_dur_t;
+
+#define LSM6DSV80X_FREE_FALL                      0x5DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ff_ths                       : 3;
+  uint8_t ff_dur                       : 5;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ff_dur                       : 5;
+  uint8_t ff_ths                       : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_free_fall_t;
+
+#define LSM6DSV80X_MD1_CFG                        0x5EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t int1_shub                    : 1;
+  uint8_t int1_emb_func                : 1;
+  uint8_t int1_6d                      : 1;
+  uint8_t int1_double_tap              : 1;
+  uint8_t int1_ff                      : 1;
+  uint8_t int1_wu                      : 1;
+  uint8_t int1_single_tap              : 1;
+  uint8_t int1_sleep_change            : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t int1_sleep_change            : 1;
+  uint8_t int1_single_tap              : 1;
+  uint8_t int1_wu                      : 1;
+  uint8_t int1_ff                      : 1;
+  uint8_t int1_double_tap              : 1;
+  uint8_t int1_6d                      : 1;
+  uint8_t int1_emb_func                : 1;
+  uint8_t int1_shub                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_md1_cfg_t;
+
+#define LSM6DSV80X_MD2_CFG                        0x5FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t int2_timestamp               : 1;
+  uint8_t int2_emb_func                : 1;
+  uint8_t int2_6d                      : 1;
+  uint8_t int2_double_tap              : 1;
+  uint8_t int2_ff                      : 1;
+  uint8_t int2_wu                      : 1;
+  uint8_t int2_single_tap              : 1;
+  uint8_t int2_sleep_change            : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t int2_sleep_change            : 1;
+  uint8_t int2_single_tap              : 1;
+  uint8_t int2_wu                      : 1;
+  uint8_t int2_ff                      : 1;
+  uint8_t int2_double_tap              : 1;
+  uint8_t int2_6d                      : 1;
+  uint8_t int2_emb_func                : 1;
+  uint8_t int2_timestamp               : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_md2_cfg_t;
+
+#define LSM6DSV80X_HAODR_CFG                      0x62U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t haodr_sel                    : 2;
+  uint8_t not_used0                    : 6;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 6;
+  uint8_t haodr_sel                    : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_haodr_cfg_t;
+
+#define LSM6DSV80X_EMB_FUNC_CFG                   0x63U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 3;
+  uint8_t emb_func_disable             : 1;
+  uint8_t emb_func_irq_mask_xl_settl   : 1;
+  uint8_t emb_func_irq_mask_g_settl    : 1;
+  uint8_t emb_func_irq_mask_xl_hg_settl: 1;
+  uint8_t hg_usr_off_on_emb_func       : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t hg_usr_off_on_emb_func       : 1;
+  uint8_t emb_func_irq_mask_xl_hg_settl: 1;
+  uint8_t emb_func_irq_mask_g_settl    : 1;
+  uint8_t emb_func_irq_mask_xl_settl   : 1;
+  uint8_t emb_func_disable             : 1;
+  uint8_t not_used0                    : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_emb_func_cfg_t;
+
+#define LSM6DSV80X_XL_HG_X_OFS_USR                0x6CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t xl_hg_x_ofs_usr              : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t xl_hg_x_ofs_usr              : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_hg_x_ofs_usr_t;
+
+#define LSM6DSV80X_XL_HG_Y_OFS_USR                0x6DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t xl_hg_y_ofs_usr              : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t xl_hg_y_ofs_usr              : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_hg_y_ofs_usr_t;
+
+#define LSM6DSV80X_XL_HG_Z_OFS_USR                0x6EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t xl_hg_z_ofs_usr              : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t xl_hg_z_ofs_usr              : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_hg_z_ofs_usr_t;
+
+#define LSM6DSV80X_X_OFS_USR                      0x73U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t x_ofs_usr                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t x_ofs_usr                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_x_ofs_usr_t;
+
+#define LSM6DSV80X_Y_OFS_USR                      0x74U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t y_ofs_usr                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t y_ofs_usr                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_y_ofs_usr_t;
+
+#define LSM6DSV80X_Z_OFS_USR                      0x75U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t z_ofs_usr                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t z_ofs_usr                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_z_ofs_usr_t;
+
+#define LSM6DSV80X_FIFO_DATA_OUT_TAG              0x78U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 1;
+  uint8_t tag_cnt                      : 2;
+  uint8_t tag_sensor                   : 5;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t tag_sensor                   : 5;
+  uint8_t tag_cnt                      : 2;
+  uint8_t not_used0                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fifo_data_out_tag_t;
+
+#define LSM6DSV80X_FIFO_DATA_OUT_X_L              0x79U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fifo_data_out                : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fifo_data_out                : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fifo_data_out_x_l_t;
+
+#define LSM6DSV80X_FIFO_DATA_OUT_X_H              0x7AU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fifo_data_out                : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fifo_data_out                : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fifo_data_out_x_h_t;
+
+#define LSM6DSV80X_FIFO_DATA_OUT_Y_L              0x7BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fifo_data_out                : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fifo_data_out                : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fifo_data_out_y_l_t;
+
+#define LSM6DSV80X_FIFO_DATA_OUT_Y_H              0x7CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fifo_data_out                : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fifo_data_out                : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fifo_data_out_y_h_t;
+
+#define LSM6DSV80X_FIFO_DATA_OUT_Z_L              0x7DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fifo_data_out                : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fifo_data_out                : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fifo_data_out_z_l_t;
+
+#define LSM6DSV80X_FIFO_DATA_OUT_Z_H              0x7EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fifo_data_out                : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fifo_data_out                : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fifo_data_out_z_h_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup bitfields page embedded
+  * @{
+  *
+  */
+
+#define LSM6DSV80X_PAGE_SEL                       0x2U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 4;
+  uint8_t page_sel                     : 4;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t page_sel                     : 4;
+  uint8_t not_used0                    : 4;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_page_sel_t;
+
+#define LSM6DSV80X_EMB_FUNC_EN_A                  0x4U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 1;
+  uint8_t sflp_game_en                 : 1;
+  uint8_t not_used2                    : 1;
+  uint8_t pedo_en                      : 1;
+  uint8_t tilt_en                      : 1;
+  uint8_t sign_motion_en               : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t mlc_before_fsm_en            : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t mlc_before_fsm_en            : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t sign_motion_en               : 1;
+  uint8_t tilt_en                      : 1;
+  uint8_t pedo_en                      : 1;
+  uint8_t not_used2                    : 1;
+  uint8_t sflp_game_en                 : 1;
+  uint8_t not_used0                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_emb_func_en_a_t;
+
+#define LSM6DSV80X_EMB_FUNC_EN_B                  0x5U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_en                       : 1;
+  uint8_t not_used0                    : 2;
+  uint8_t fifo_compr_en                : 1;
+  uint8_t mlc_en                       : 1;
+  uint8_t not_used1                    : 3;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 3;
+  uint8_t mlc_en                       : 1;
+  uint8_t fifo_compr_en                : 1;
+  uint8_t not_used0                    : 2;
+  uint8_t fsm_en                       : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_emb_func_en_b_t;
+
+#define LSM6DSV80X_EMB_FUNC_EXEC_STATUS           0x7U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t emb_func_endop               : 1;
+  uint8_t emb_func_exec_ovr            : 1;
+  uint8_t not_used0                    : 6;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 6;
+  uint8_t emb_func_exec_ovr            : 1;
+  uint8_t emb_func_endop               : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_emb_func_exec_status_t;
+
+#define LSM6DSV80X_PAGE_ADDRESS                   0x8U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t page_addr                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t page_addr                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_page_address_t;
+
+#define LSM6DSV80X_PAGE_VALUE                     0x9U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t page_value                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t page_value                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_page_value_t;
+
+#define LSM6DSV80X_EMB_FUNC_INT1                  0x0AU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 3;
+  uint8_t int1_step_detector           : 1;
+  uint8_t int1_tilt                    : 1;
+  uint8_t int1_sig_mot                 : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t int1_fsm_lc                  : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t int1_fsm_lc                  : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t int1_sig_mot                 : 1;
+  uint8_t int1_tilt                    : 1;
+  uint8_t int1_step_detector           : 1;
+  uint8_t not_used0                    : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_emb_func_int1_t;
+
+#define LSM6DSV80X_FSM_INT1                       0x0BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t int1_fsm1                    : 1;
+  uint8_t int1_fsm2                    : 1;
+  uint8_t int1_fsm3                    : 1;
+  uint8_t int1_fsm4                    : 1;
+  uint8_t int1_fsm5                    : 1;
+  uint8_t int1_fsm6                    : 1;
+  uint8_t int1_fsm7                    : 1;
+  uint8_t int1_fsm8                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t int1_fsm8                    : 1;
+  uint8_t int1_fsm7                    : 1;
+  uint8_t int1_fsm6                    : 1;
+  uint8_t int1_fsm5                    : 1;
+  uint8_t int1_fsm4                    : 1;
+  uint8_t int1_fsm3                    : 1;
+  uint8_t int1_fsm2                    : 1;
+  uint8_t int1_fsm1                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_int1_t;
+
+#define LSM6DSV80X_MLC_INT1                       0x0DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t int1_mlc1                    : 1;
+  uint8_t int1_mlc2                    : 1;
+  uint8_t int1_mlc3                    : 1;
+  uint8_t int1_mlc4                    : 1;
+  uint8_t int1_mlc5                    : 1;
+  uint8_t int1_mlc6                    : 1;
+  uint8_t int1_mlc7                    : 1;
+  uint8_t int1_mlc8                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t int1_mlc8                    : 1;
+  uint8_t int1_mlc7                    : 1;
+  uint8_t int1_mlc6                    : 1;
+  uint8_t int1_mlc5                    : 1;
+  uint8_t int1_mlc4                    : 1;
+  uint8_t int1_mlc3                    : 1;
+  uint8_t int1_mlc2                    : 1;
+  uint8_t int1_mlc1                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_mlc_int1_t;
+
+#define LSM6DSV80X_EMB_FUNC_INT2                  0x0EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 3;
+  uint8_t int2_step_detector           : 1;
+  uint8_t int2_tilt                    : 1;
+  uint8_t int2_sig_mot                 : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t int2_fsm_lc                  : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t int2_fsm_lc                  : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t int2_sig_mot                 : 1;
+  uint8_t int2_tilt                    : 1;
+  uint8_t int2_step_detector           : 1;
+  uint8_t not_used0                    : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_emb_func_int2_t;
+
+#define LSM6DSV80X_FSM_INT2                       0x0FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t int2_fsm1                    : 1;
+  uint8_t int2_fsm2                    : 1;
+  uint8_t int2_fsm3                    : 1;
+  uint8_t int2_fsm4                    : 1;
+  uint8_t int2_fsm5                    : 1;
+  uint8_t int2_fsm6                    : 1;
+  uint8_t int2_fsm7                    : 1;
+  uint8_t int2_fsm8                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t int2_fsm8                    : 1;
+  uint8_t int2_fsm7                    : 1;
+  uint8_t int2_fsm6                    : 1;
+  uint8_t int2_fsm5                    : 1;
+  uint8_t int2_fsm4                    : 1;
+  uint8_t int2_fsm3                    : 1;
+  uint8_t int2_fsm2                    : 1;
+  uint8_t int2_fsm1                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_int2_t;
+
+#define LSM6DSV80X_MLC_INT2                       0x11U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t int2_mlc1                    : 1;
+  uint8_t int2_mlc2                    : 1;
+  uint8_t int2_mlc3                    : 1;
+  uint8_t int2_mlc4                    : 1;
+  uint8_t int2_mlc5                    : 1;
+  uint8_t int2_mlc6                    : 1;
+  uint8_t int2_mlc7                    : 1;
+  uint8_t int2_mlc8                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t int2_mlc8                    : 1;
+  uint8_t int2_mlc7                    : 1;
+  uint8_t int2_mlc6                    : 1;
+  uint8_t int2_mlc5                    : 1;
+  uint8_t int2_mlc4                    : 1;
+  uint8_t int2_mlc3                    : 1;
+  uint8_t int2_mlc2                    : 1;
+  uint8_t int2_mlc1                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_mlc_int2_t;
+
+#define LSM6DSV80X_EMB_FUNC_STATUS                0x12U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 3;
+  uint8_t is_step_det                  : 1;
+  uint8_t is_tilt                      : 1;
+  uint8_t is_sigmot                    : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t is_fsm_lc                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t is_fsm_lc                    : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t is_sigmot                    : 1;
+  uint8_t is_tilt                      : 1;
+  uint8_t is_step_det                  : 1;
+  uint8_t not_used0                    : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_emb_func_status_t;
+
+#define LSM6DSV80X_FSM_STATUS                     0x13U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t is_fsm1                      : 1;
+  uint8_t is_fsm2                      : 1;
+  uint8_t is_fsm3                      : 1;
+  uint8_t is_fsm4                      : 1;
+  uint8_t is_fsm5                      : 1;
+  uint8_t is_fsm6                      : 1;
+  uint8_t is_fsm7                      : 1;
+  uint8_t is_fsm8                      : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t is_fsm8                      : 1;
+  uint8_t is_fsm7                      : 1;
+  uint8_t is_fsm6                      : 1;
+  uint8_t is_fsm5                      : 1;
+  uint8_t is_fsm4                      : 1;
+  uint8_t is_fsm3                      : 1;
+  uint8_t is_fsm2                      : 1;
+  uint8_t is_fsm1                      : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_status_t;
+
+#define LSM6DSV80X_MLC_STATUS                     0x15U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t is_mlc1                      : 1;
+  uint8_t is_mlc2                      : 1;
+  uint8_t is_mlc3                      : 1;
+  uint8_t is_mlc4                      : 1;
+  uint8_t is_mlc5                      : 1;
+  uint8_t is_mlc6                      : 1;
+  uint8_t is_mlc7                      : 1;
+  uint8_t is_mlc8                      : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t is_mlc8                      : 1;
+  uint8_t is_mlc7                      : 1;
+  uint8_t is_mlc6                      : 1;
+  uint8_t is_mlc5                      : 1;
+  uint8_t is_mlc4                      : 1;
+  uint8_t is_mlc3                      : 1;
+  uint8_t is_mlc2                      : 1;
+  uint8_t is_mlc1                      : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_mlc_status_t;
+
+#define LSM6DSV80X_PAGE_RW                        0x17U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 5;
+  uint8_t page_read                    : 1;
+  uint8_t page_write                   : 1;
+  uint8_t emb_func_lir                 : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t emb_func_lir                 : 1;
+  uint8_t page_write                   : 1;
+  uint8_t page_read                    : 1;
+  uint8_t not_used0                    : 5;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_page_rw_t;
+
+#define LSM6DSV80X_SFLP_GBIASX_L                  0x18U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gbiasx                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gbiasx                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sflp_gbiasx_l_t;
+
+#define LSM6DSV80X_SFLP_GBIASX_H                  0x19U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gbiasx                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gbiasx                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sflp_gbiasx_h_t;
+
+#define LSM6DSV80X_SFLP_GBIASY_L                  0x1AU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gbiasy                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gbiasy                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sflp_gbiasy_l_t;
+
+#define LSM6DSV80X_SFLP_GBIASY_H                  0x1BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gbiasy                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gbiasy                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sflp_gbiasy_h_t;
+
+#define LSM6DSV80X_SFLP_GBIASZ_L                  0x1CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gbiasz                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gbiasz                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sflp_gbiasz_l_t;
+
+#define LSM6DSV80X_SFLP_GBIASZ_H                  0x1DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gbiasz                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gbiasz                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sflp_gbiasz_h_t;
+
+#define LSM6DSV80X_SFLP_GRAVX_L                   0x1EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gravx                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gravx                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sflp_gravx_l_t;
+
+#define LSM6DSV80X_SFLP_GRAVX_H                   0x1FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gravx                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gravx                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sflp_gravx_h_t;
+
+#define LSM6DSV80X_SFLP_GRAVY_L                   0x20U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gravy                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gravy                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sflp_gravy_l_t;
+
+#define LSM6DSV80X_SFLP_GRAVY_H                   0x21U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gravy                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gravy                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sflp_gravy_h_t;
+
+#define LSM6DSV80X_SFLP_GRAVZ_L                   0x22U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gravz                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gravz                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sflp_gravz_l_t;
+
+#define LSM6DSV80X_SFLP_GRAVZ_H                   0x23U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gravz                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gravz                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sflp_gravz_h_t;
+
+#define LSM6DSV80X_SFLP_QUATW_L                   0x2AU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_quatw                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_quatw                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sflp_quatw_l_t;
+
+#define LSM6DSV80X_SFLP_QUATW_H                   0x2BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_quatw                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_quatw                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sflp_quatw_h_t;
+
+#define LSM6DSV80X_SFLP_QUATX_L                   0x2CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_quatx                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_quatx                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sflp_quatx_l_t;
+
+#define LSM6DSV80X_SFLP_QUATX_H                   0x2DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_quatx                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_quatx                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sflp_quatx_h_t;
+
+#define LSM6DSV80X_SFLP_QUATY_L                   0x2EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_quaty                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_quaty                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sflp_quaty_l_t;
+
+#define LSM6DSV80X_SFLP_QUATY_H                   0x2FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_quaty                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_quaty                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sflp_quaty_h_t;
+
+#define LSM6DSV80X_SFLP_QUATZ_L                   0x30U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_quatz                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_quatz                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sflp_quatz_l_t;
+
+#define LSM6DSV80X_SFLP_QUATZ_H                   0x31U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_quatz                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_quatz                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sflp_quatz_h_t;
+
+#define LSM6DSV80X_SFLP_GBIASX_INIT_L             0x32U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gbiasx_init             : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gbiasx_init             : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sflp_gbiasx_init_l_t;
+
+#define LSM6DSV80X_SFLP_GBIASX_INIT_H             0x33U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gbiasx_init             : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gbiasx_init             : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sflp_gbiasx_init_h_t;
+
+#define LSM6DSV80X_SFLP_GBIASY_INIT_L             0x34U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gbiasy_init             : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gbiasy_init             : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sflp_gbiasy_init_l_t;
+
+#define LSM6DSV80X_SFLP_GBIASY_INIT_H             0x35U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gbiasy_init             : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gbiasy_init             : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sflp_gbiasy_init_h_t;
+
+#define LSM6DSV80X_SFLP_GBIASZ_INIT_L             0x36U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gbiasz_init             : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gbiasz_init             : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sflp_gbiasz_init_l_t;
+
+#define LSM6DSV80X_SFLP_GBIASZ_INIT_H             0x37U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sflp_gbiasz_init             : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sflp_gbiasz_init             : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sflp_gbiasz_init_h_t;
+
+#define LSM6DSV80X_EMB_FUNC_FIFO_EN_A             0x44U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 1;
+  uint8_t sflp_game_fifo_en            : 1;
+  uint8_t not_used1                    : 2;
+  uint8_t sflp_gravity_fifo_en         : 1;
+  uint8_t sflp_gbias_fifo_en           : 1;
+  uint8_t step_counter_fifo_en         : 1;
+  uint8_t mlc_fifo_en                  : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t mlc_fifo_en                  : 1;
+  uint8_t step_counter_fifo_en         : 1;
+  uint8_t sflp_gbias_fifo_en           : 1;
+  uint8_t sflp_gravity_fifo_en         : 1;
+  uint8_t not_used1                    : 2;
+  uint8_t sflp_game_fifo_en            : 1;
+  uint8_t not_used0                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_emb_func_fifo_en_a_t;
+
+#define LSM6DSV80X_EMB_FUNC_FIFO_EN_B             0x45U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 1;
+  uint8_t mlc_filter_feature_fifo_en   : 1;
+  uint8_t fsm_fifo_en                  : 1;
+  uint8_t not_used1                    : 5;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 5;
+  uint8_t fsm_fifo_en                  : 1;
+  uint8_t mlc_filter_feature_fifo_en   : 1;
+  uint8_t not_used0                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_emb_func_fifo_en_b_t;
+
+#define LSM6DSV80X_FSM_ENABLE                     0x46U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm1_en                      : 1;
+  uint8_t fsm2_en                      : 1;
+  uint8_t fsm3_en                      : 1;
+  uint8_t fsm4_en                      : 1;
+  uint8_t fsm5_en                      : 1;
+  uint8_t fsm6_en                      : 1;
+  uint8_t fsm7_en                      : 1;
+  uint8_t fsm8_en                      : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm8_en                      : 1;
+  uint8_t fsm7_en                      : 1;
+  uint8_t fsm6_en                      : 1;
+  uint8_t fsm5_en                      : 1;
+  uint8_t fsm4_en                      : 1;
+  uint8_t fsm3_en                      : 1;
+  uint8_t fsm2_en                      : 1;
+  uint8_t fsm1_en                      : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_enable_t;
+
+#define LSM6DSV80X_FSM_LONG_COUNTER_L             0x48U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_lc                       : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_lc                       : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_long_counter_l_t;
+
+#define LSM6DSV80X_FSM_LONG_COUNTER_H             0x49U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_lc                       : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_lc                       : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_long_counter_h_t;
+
+#define LSM6DSV80X_INT_ACK_MASK                   0x4BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t iack_mask                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t iack_mask                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_int_ack_mask_t;
+
+#define LSM6DSV80X_FSM_OUTS1                      0x4CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm1_n_v                     : 1;
+  uint8_t fsm1_p_v                     : 1;
+  uint8_t fsm1_n_z                     : 1;
+  uint8_t fsm1_p_z                     : 1;
+  uint8_t fsm1_n_y                     : 1;
+  uint8_t fsm1_p_y                     : 1;
+  uint8_t fsm1_n_x                     : 1;
+  uint8_t fsm1_p_x                     : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm1_p_x                     : 1;
+  uint8_t fsm1_n_x                     : 1;
+  uint8_t fsm1_p_y                     : 1;
+  uint8_t fsm1_n_y                     : 1;
+  uint8_t fsm1_p_z                     : 1;
+  uint8_t fsm1_n_z                     : 1;
+  uint8_t fsm1_p_v                     : 1;
+  uint8_t fsm1_n_v                     : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_outs1_t;
+
+#define LSM6DSV80X_FSM_OUTS2                      0x4DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm2_n_v                     : 1;
+  uint8_t fsm2_p_v                     : 1;
+  uint8_t fsm2_n_z                     : 1;
+  uint8_t fsm2_p_z                     : 1;
+  uint8_t fsm2_n_y                     : 1;
+  uint8_t fsm2_p_y                     : 1;
+  uint8_t fsm2_n_x                     : 1;
+  uint8_t fsm2_p_x                     : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm2_p_x                     : 1;
+  uint8_t fsm2_n_x                     : 1;
+  uint8_t fsm2_p_y                     : 1;
+  uint8_t fsm2_n_y                     : 1;
+  uint8_t fsm2_p_z                     : 1;
+  uint8_t fsm2_n_z                     : 1;
+  uint8_t fsm2_p_v                     : 1;
+  uint8_t fsm2_n_v                     : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_outs2_t;
+
+#define LSM6DSV80X_FSM_OUTS3                      0x4EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm3_n_v                     : 1;
+  uint8_t fsm3_p_v                     : 1;
+  uint8_t fsm3_n_z                     : 1;
+  uint8_t fsm3_p_z                     : 1;
+  uint8_t fsm3_n_y                     : 1;
+  uint8_t fsm3_p_y                     : 1;
+  uint8_t fsm3_n_x                     : 1;
+  uint8_t fsm3_p_x                     : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm3_p_x                     : 1;
+  uint8_t fsm3_n_x                     : 1;
+  uint8_t fsm3_p_y                     : 1;
+  uint8_t fsm3_n_y                     : 1;
+  uint8_t fsm3_p_z                     : 1;
+  uint8_t fsm3_n_z                     : 1;
+  uint8_t fsm3_p_v                     : 1;
+  uint8_t fsm3_n_v                     : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_outs3_t;
+
+#define LSM6DSV80X_FSM_OUTS4                      0x4FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm4_n_v                     : 1;
+  uint8_t fsm4_p_v                     : 1;
+  uint8_t fsm4_n_z                     : 1;
+  uint8_t fsm4_p_z                     : 1;
+  uint8_t fsm4_n_y                     : 1;
+  uint8_t fsm4_p_y                     : 1;
+  uint8_t fsm4_n_x                     : 1;
+  uint8_t fsm4_p_x                     : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm4_p_x                     : 1;
+  uint8_t fsm4_n_x                     : 1;
+  uint8_t fsm4_p_y                     : 1;
+  uint8_t fsm4_n_y                     : 1;
+  uint8_t fsm4_p_z                     : 1;
+  uint8_t fsm4_n_z                     : 1;
+  uint8_t fsm4_p_v                     : 1;
+  uint8_t fsm4_n_v                     : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_outs4_t;
+
+#define LSM6DSV80X_FSM_OUTS5                      0x50U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm5_n_v                     : 1;
+  uint8_t fsm5_p_v                     : 1;
+  uint8_t fsm5_n_z                     : 1;
+  uint8_t fsm5_p_z                     : 1;
+  uint8_t fsm5_n_y                     : 1;
+  uint8_t fsm5_p_y                     : 1;
+  uint8_t fsm5_n_x                     : 1;
+  uint8_t fsm5_p_x                     : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm5_p_x                     : 1;
+  uint8_t fsm5_n_x                     : 1;
+  uint8_t fsm5_p_y                     : 1;
+  uint8_t fsm5_n_y                     : 1;
+  uint8_t fsm5_p_z                     : 1;
+  uint8_t fsm5_n_z                     : 1;
+  uint8_t fsm5_p_v                     : 1;
+  uint8_t fsm5_n_v                     : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_outs5_t;
+
+#define LSM6DSV80X_FSM_OUTS6                      0x51U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm6_n_v                     : 1;
+  uint8_t fsm6_p_v                     : 1;
+  uint8_t fsm6_n_z                     : 1;
+  uint8_t fsm6_p_z                     : 1;
+  uint8_t fsm6_n_y                     : 1;
+  uint8_t fsm6_p_y                     : 1;
+  uint8_t fsm6_n_x                     : 1;
+  uint8_t fsm6_p_x                     : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm6_p_x                     : 1;
+  uint8_t fsm6_n_x                     : 1;
+  uint8_t fsm6_p_y                     : 1;
+  uint8_t fsm6_n_y                     : 1;
+  uint8_t fsm6_p_z                     : 1;
+  uint8_t fsm6_n_z                     : 1;
+  uint8_t fsm6_p_v                     : 1;
+  uint8_t fsm6_n_v                     : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_outs6_t;
+
+#define LSM6DSV80X_FSM_OUTS7                      0x52U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm7_n_v                     : 1;
+  uint8_t fsm7_p_v                     : 1;
+  uint8_t fsm7_n_z                     : 1;
+  uint8_t fsm7_p_z                     : 1;
+  uint8_t fsm7_n_y                     : 1;
+  uint8_t fsm7_p_y                     : 1;
+  uint8_t fsm7_n_x                     : 1;
+  uint8_t fsm7_p_x                     : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm7_p_x                     : 1;
+  uint8_t fsm7_n_x                     : 1;
+  uint8_t fsm7_p_y                     : 1;
+  uint8_t fsm7_n_y                     : 1;
+  uint8_t fsm7_p_z                     : 1;
+  uint8_t fsm7_n_z                     : 1;
+  uint8_t fsm7_p_v                     : 1;
+  uint8_t fsm7_n_v                     : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_outs7_t;
+
+#define LSM6DSV80X_FSM_OUTS8                      0x53U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm8_n_v                     : 1;
+  uint8_t fsm8_p_v                     : 1;
+  uint8_t fsm8_n_z                     : 1;
+  uint8_t fsm8_p_z                     : 1;
+  uint8_t fsm8_n_y                     : 1;
+  uint8_t fsm8_p_y                     : 1;
+  uint8_t fsm8_n_x                     : 1;
+  uint8_t fsm8_p_x                     : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm8_p_x                     : 1;
+  uint8_t fsm8_n_x                     : 1;
+  uint8_t fsm8_p_y                     : 1;
+  uint8_t fsm8_n_y                     : 1;
+  uint8_t fsm8_p_z                     : 1;
+  uint8_t fsm8_n_z                     : 1;
+  uint8_t fsm8_p_v                     : 1;
+  uint8_t fsm8_n_v                     : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_outs8_t;
+
+#define LSM6DSV80X_SFLP_ODR                       0x5EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 3;
+  uint8_t sflp_game_odr                : 3;
+  uint8_t not_used1                    : 2;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 2;
+  uint8_t sflp_game_odr                : 3;
+  uint8_t not_used0                    : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sflp_odr_t;
+
+#define LSM6DSV80X_FSM_ODR                        0x5FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 3;
+  uint8_t fsm_odr                      : 3;
+  uint8_t not_used1                    : 2;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 2;
+  uint8_t fsm_odr                      : 3;
+  uint8_t not_used0                    : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_odr_t;
+
+#define LSM6DSV80X_MLC_ODR                        0x60U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 4;
+  uint8_t mlc_odr                      : 3;
+  uint8_t not_used1                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 1;
+  uint8_t mlc_odr                      : 3;
+  uint8_t not_used0                    : 4;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_mlc_odr_t;
+
+#define LSM6DSV80X_STEP_COUNTER_L                 0x62U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t step                         : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t step                         : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_step_counter_l_t;
+
+#define LSM6DSV80X_STEP_COUNTER_H                 0x63U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t step                         : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t step                         : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_step_counter_h_t;
+
+#define LSM6DSV80X_EMB_FUNC_SRC                   0x64U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 2;
+  uint8_t stepcounter_bit_set          : 1;
+  uint8_t step_overflow                : 1;
+  uint8_t step_count_delta_ia          : 1;
+  uint8_t step_detected                : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t pedo_rst_step                : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t pedo_rst_step                : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t step_detected                : 1;
+  uint8_t step_count_delta_ia          : 1;
+  uint8_t step_overflow                : 1;
+  uint8_t stepcounter_bit_set          : 1;
+  uint8_t not_used0                    : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_emb_func_src_t;
+
+#define LSM6DSV80X_EMB_FUNC_INIT_A                0x66U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 1;
+  uint8_t sflp_game_init               : 1;
+  uint8_t not_used2                    : 1;
+  uint8_t step_det_init                : 1;
+  uint8_t tilt_init                    : 1;
+  uint8_t sig_mot_init                 : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t mlc_before_fsm_init          : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t mlc_before_fsm_init          : 1;
+  uint8_t not_used1                    : 1;
+  uint8_t sig_mot_init                 : 1;
+  uint8_t tilt_init                    : 1;
+  uint8_t step_det_init                : 1;
+  uint8_t not_used2                    : 1;
+  uint8_t sflp_game_init               : 1;
+  uint8_t not_used0                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_emb_func_init_a_t;
+
+#define LSM6DSV80X_EMB_FUNC_INIT_B                0x67U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_init                     : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t pt_init                      : 1;
+  uint8_t fifo_compr_init              : 1;
+  uint8_t mlc_init                     : 1;
+  uint8_t not_used1                    : 3;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 3;
+  uint8_t mlc_init                     : 1;
+  uint8_t fifo_compr_init              : 1;
+  uint8_t pt_init                      : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t fsm_init                     : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_emb_func_init_b_t;
+
+#define LSM6DSV80X_EMB_FUNC_SENSOR_CONV_EN        0x67U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t xl_hg_conv_en                : 1;
+  uint8_t gyro_conv_en                 : 1;
+  uint8_t temp_conv_en                 : 1;
+  uint8_t ext_sensor_conv_en           : 1;
+  uint8_t not_used0                    : 4;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 4;
+  uint8_t ext_sensor_conv_en           : 1;
+  uint8_t temp_conv_en                 : 1;
+  uint8_t gyro_conv_en                 : 1;
+  uint8_t xl_hg_conv_en                : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_emb_func_sensor_conv_en_t;
+
+#define LSM6DSV80X_MLC1_SRC                       0x70U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t mlc1_src                     : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t mlc1_src                     : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_mlc1_src_t;
+
+#define LSM6DSV80X_MLC2_SRC                       0x71U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t mlc2_src                     : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t mlc2_src                     : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_mlc2_src_t;
+
+#define LSM6DSV80X_MLC3_SRC                       0x72U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t mlc3_src                     : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t mlc3_src                     : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_mlc3_src_t;
+
+#define LSM6DSV80X_MLC4_SRC                       0x73U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t mlc4_src                     : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t mlc4_src                     : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_mlc4_src_t;
+
+#define LSM6DSV80X_MLC5_SRC                       0x74U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t mlc5_src                     : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t mlc5_src                     : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_mlc5_src_t;
+
+#define LSM6DSV80X_MLC6_SRC                       0x75U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t mlc6_src                     : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t mlc6_src                     : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_mlc6_src_t;
+
+#define LSM6DSV80X_MLC7_SRC                       0x76U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t mlc7_src                     : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t mlc7_src                     : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_mlc7_src_t;
+
+#define LSM6DSV80X_MLC8_SRC                       0x77U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t mlc8_src                     : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t mlc8_src                     : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_mlc8_src_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup bitfields page pg0_emb_adv
+  * @{
+  *
+  */
+#define LSM6DSV80X_EMB_ADV_PG_0                   0x000U
+
+#define LSM6DSV80X_FSM_EXT_SENSITIVITY_L          0xBAU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_s                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_s                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_ext_sensitivity_l_t;
+
+#define LSM6DSV80X_FSM_EXT_SENSITIVITY_H          0xBBU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_s                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_s                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_ext_sensitivity_h_t;
+
+#define LSM6DSV80X_FSM_EXT_OFFX_L                 0xC0U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_offx                 : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_offx                 : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_ext_offx_l_t;
+
+#define LSM6DSV80X_FSM_EXT_OFFX_H                 0xC1U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_offx                 : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_offx                 : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_ext_offx_h_t;
+
+#define LSM6DSV80X_FSM_EXT_OFFY_L                 0xC2U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_offy                 : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_offy                 : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_ext_offy_l_t;
+
+#define LSM6DSV80X_FSM_EXT_OFFY_H                 0xC3U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_offy                 : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_offy                 : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_ext_offy_h_t;
+
+#define LSM6DSV80X_FSM_EXT_OFFZ_L                 0xC4U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_offz                 : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_offz                 : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_ext_offz_l_t;
+
+#define LSM6DSV80X_FSM_EXT_OFFZ_H                 0xC5U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_offz                 : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_offz                 : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_ext_offz_h_t;
+
+#define LSM6DSV80X_FSM_EXT_MATRIX_XX_L            0xC6U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_mat_xx               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_mat_xx               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_ext_matrix_xx_l_t;
+
+#define LSM6DSV80X_FSM_EXT_MATRIX_XX_H            0xC7U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_mat_xx               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_mat_xx               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_ext_matrix_xx_h_t;
+
+#define LSM6DSV80X_FSM_EXT_MATRIX_XY_L            0xC8U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_mat_xy               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_mat_xy               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_ext_matrix_xy_l_t;
+
+#define LSM6DSV80X_FSM_EXT_MATRIX_XY_H            0xC9U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_mat_xy               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_mat_xy               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_ext_matrix_xy_h_t;
+
+#define LSM6DSV80X_FSM_EXT_MATRIX_XZ_L            0xCAU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_mat_xz               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_mat_xz               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_ext_matrix_xz_l_t;
+
+#define LSM6DSV80X_FSM_EXT_MATRIX_XZ_H            0xCBU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_mat_xz               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_mat_xz               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_ext_matrix_xz_h_t;
+
+#define LSM6DSV80X_FSM_EXT_MATRIX_YY_L            0xCCU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_mat_yy               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_mat_yy               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_ext_matrix_yy_l_t;
+
+#define LSM6DSV80X_FSM_EXT_MATRIX_YY_H            0xCDU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_mat_yy               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_mat_yy               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_ext_matrix_yy_h_t;
+
+#define LSM6DSV80X_FSM_EXT_MATRIX_YZ_L            0xCEU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_mat_yz               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_mat_yz               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_ext_matrix_yz_l_t;
+
+#define LSM6DSV80X_FSM_EXT_MATRIX_YZ_H            0xCFU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_mat_yz               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_mat_yz               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_ext_matrix_yz_h_t;
+
+#define LSM6DSV80X_FSM_EXT_MATRIX_ZZ_L            0xD0U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_mat_zz               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_mat_zz               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_ext_matrix_zz_l_t;
+
+#define LSM6DSV80X_FSM_EXT_MATRIX_ZZ_H            0xD1U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_ext_mat_zz               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_ext_mat_zz               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_ext_matrix_zz_h_t;
+
+#define LSM6DSV80X_EXT_CFG_A                      0xD4U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ext_z_axis                   : 3;
+  uint8_t not_used0                    : 1;
+  uint8_t ext_y_axis                   : 3;
+  uint8_t not_used1                    : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 1;
+  uint8_t ext_y_axis                   : 3;
+  uint8_t not_used0                    : 1;
+  uint8_t ext_z_axis                   : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_ext_cfg_a_t;
+
+#define LSM6DSV80X_EXT_CFG_B                      0xD5U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ext_x_axis                   : 3;
+  uint8_t not_used0                    : 5;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 5;
+  uint8_t ext_x_axis                   : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_ext_cfg_b_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup bitfields page pg1_emb_adv
+  * @{
+  *
+  */
+#define LSM6DSV80X_EMB_ADV_PG_1                   0x100U
+
+#define LSM6DSV80X_XL_HG_SENSITIVITY_L            0x58U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t xl_hg_s                      : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t xl_hg_s                      : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_xl_hg_sensitivity_l_t;
+
+#define LSM6DSV80X_XL_HG_SENSITIVITY_H            0x59U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t xl_hg_s                      : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t xl_hg_s                      : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_xl_hg_sensitivity_h_t;
+
+#define LSM6DSV80X_FSM_LC_TIMEOUT_L               0x7AU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_lc_timeout               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_lc_timeout               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_lc_timeout_l_t;
+
+#define LSM6DSV80X_FSM_LC_TIMEOUT_H               0x7BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_lc_timeout               : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_lc_timeout               : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_lc_timeout_h_t;
+
+#define LSM6DSV80X_FSM_PROGRAMS                   0x7CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_n_prog                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_n_prog                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_programs_t;
+
+#define LSM6DSV80X_FSM_START_ADD_L                0x7EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_start                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_start                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_start_add_l_t;
+
+#define LSM6DSV80X_FSM_START_ADD_H                0x7FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t fsm_start                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t fsm_start                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_fsm_start_add_h_t;
+
+#define LSM6DSV80X_PEDO_CMD_REG                   0x83U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 2;
+  uint8_t fp_rejection_en              : 1;
+  uint8_t carry_count_en               : 1;
+  uint8_t not_used1                    : 4;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 4;
+  uint8_t carry_count_en               : 1;
+  uint8_t fp_rejection_en              : 1;
+  uint8_t not_used0                    : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_pedo_cmd_reg_t;
+
+#define LSM6DSV80X_PEDO_DEB_STEPS_CONF            0x84U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t deb_step                     : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t deb_step                     : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_pedo_deb_steps_conf_t;
+
+#define LSM6DSV80X_PEDO_SC_DELTAT_L               0xD0U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t pd_sc                        : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t pd_sc                        : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_pedo_sc_deltat_l_t;
+
+#define LSM6DSV80X_PEDO_SC_DELTAT_H               0xD1U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t pd_sc                        : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t pd_sc                        : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_pedo_sc_deltat_h_t;
+
+#define LSM6DSV80X_MLC_EXT_SENSITIVITY_L          0xE8U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t mlc_ext_s                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t mlc_ext_s                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_mlc_ext_sensitivity_l_t;
+
+#define LSM6DSV80X_MLC_EXT_SENSITIVITY_H          0xE9U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t mlc_ext_s                    : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t mlc_ext_s                    : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_mlc_ext_sensitivity_h_t;
+
+/** @defgroup bitfields page pg2_emb_adv
+  * @{
+  *
+  */
+#define LSM6DSV80X_EMB_ADV_PG_2                   0x200U
+
+#define LSM6DSV80X_EXT_FORMAT                     0x00
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used0                    : 1;
+  uint8_t ext_format_sel               : 1;
+  uint8_t not_used1                    : 6;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used1                    : 6;
+  uint8_t ext_format_sel               : 1;
+  uint8_t not_used0                    : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_ext_format_t;
+
+#define LSM6DSV80X_EXT_3BYTE_SENSITIVITY_L        0x02U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ext_3byte_s                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ext_3byte_s                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_ext_3byte_sensitivity_l_t;
+
+#define LSM6DSV80X_EXT_3BYTE_SENSITIVITY_H        0x03U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ext_3byte_s                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ext_3byte_s                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_ext_3byte_sensitivity_h_t;
+
+#define LSM6DSV80X_EXT_3BYTE_OFFSET_XL            0x06U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ext_3byte_off                : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ext_3byte_off                : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_ext_3byte_offset_xl_t;
+
+#define LSM6DSV80X_EXT_3BYTE_OFFSET_L             0x07U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ext_3byte_off                : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ext_3byte_off                : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_ext_3byte_offset_l_t;
+
+#define LSM6DSV80X_EXT_3BYTE_OFFSET_H             0x08U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t ext_3byte_off                : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t ext_3byte_off                : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_ext_3byte_offset_h_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup bitfields page sensor_hub
+  * @{
+  *
+  */
+
+#define LSM6DSV80X_SENSOR_HUB_1                   0x2U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub1                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub1                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sensor_hub_1_t;
+
+#define LSM6DSV80X_SENSOR_HUB_2                   0x3U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub2                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub2                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sensor_hub_2_t;
+
+#define LSM6DSV80X_SENSOR_HUB_3                   0x4U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub3                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub3                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sensor_hub_3_t;
+
+#define LSM6DSV80X_SENSOR_HUB_4                   0x5U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub4                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub4                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sensor_hub_4_t;
+
+#define LSM6DSV80X_SENSOR_HUB_5                   0x6U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub5                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub5                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sensor_hub_5_t;
+
+#define LSM6DSV80X_SENSOR_HUB_6                   0x7U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub6                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub6                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sensor_hub_6_t;
+
+#define LSM6DSV80X_SENSOR_HUB_7                   0x8U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub7                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub7                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sensor_hub_7_t;
+
+#define LSM6DSV80X_SENSOR_HUB_8                   0x9U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub8                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub8                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sensor_hub_8_t;
+
+#define LSM6DSV80X_SENSOR_HUB_9                   0x0AU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub9                   : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub9                   : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sensor_hub_9_t;
+
+#define LSM6DSV80X_SENSOR_HUB_10                  0x0BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub10                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub10                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sensor_hub_10_t;
+
+#define LSM6DSV80X_SENSOR_HUB_11                  0x0CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub11                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub11                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sensor_hub_11_t;
+
+#define LSM6DSV80X_SENSOR_HUB_12                  0x0DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub12                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub12                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sensor_hub_12_t;
+
+#define LSM6DSV80X_SENSOR_HUB_13                  0x0EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub13                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub13                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sensor_hub_13_t;
+
+#define LSM6DSV80X_SENSOR_HUB_14                  0x0FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub14                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub14                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sensor_hub_14_t;
+
+#define LSM6DSV80X_SENSOR_HUB_15                  0x10U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub15                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub15                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sensor_hub_15_t;
+
+#define LSM6DSV80X_SENSOR_HUB_16                  0x11U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub16                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub16                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sensor_hub_16_t;
+
+#define LSM6DSV80X_SENSOR_HUB_17                  0x12U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub17                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub17                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sensor_hub_17_t;
+
+#define LSM6DSV80X_SENSOR_HUB_18                  0x13U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sensorhub18                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t sensorhub18                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_sensor_hub_18_t;
+
+#define LSM6DSV80X_CONTROLLER_CONFIG              0x14U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t aux_sens_on                  : 2;
+  uint8_t controller_on                : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t pass_through_mode            : 1;
+  uint8_t start_config                 : 1;
+  uint8_t write_once                   : 1;
+  uint8_t rst_controller_regs          : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t rst_controller_regs          : 1;
+  uint8_t write_once                   : 1;
+  uint8_t start_config                 : 1;
+  uint8_t pass_through_mode            : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t controller_on                : 1;
+  uint8_t aux_sens_on                  : 2;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_controller_config_t;
+
+#define LSM6DSV80X_TGT0_ADD                       0x15U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t rw_0                         : 1;
+  uint8_t target0_add                  : 7;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t target0_add                  : 7;
+  uint8_t rw_0                         : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_tgt0_add_t;
+
+#define LSM6DSV80X_TGT0_SUBADD                    0x16U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t target0_reg                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t target0_reg                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_tgt0_subadd_t;
+
+#define LSM6DSV80X_TGT0_CONFIG                    0x17U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t target0_numop                : 3;
+  uint8_t batch_ext_sens_0_en          : 1;
+  uint8_t not_used0                    : 1;
+  uint8_t shub_odr                     : 3;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t shub_odr                     : 3;
+  uint8_t not_used0                    : 1;
+  uint8_t batch_ext_sens_0_en          : 1;
+  uint8_t target0_numop                : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_tgt0_config_t;
+
+#define LSM6DSV80X_TGT1_ADD                       0x18U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t r_1                          : 1;
+  uint8_t target1_add                  : 7;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t target1_add                  : 7;
+  uint8_t r_1                          : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_tgt1_add_t;
+
+#define LSM6DSV80X_TGT1_SUBADD                    0x19U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t target1_reg                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t target1_reg                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_tgt1_subadd_t;
+
+#define LSM6DSV80X_TGT1_CONFIG                    0x1AU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t target1_numop                : 3;
+  uint8_t batch_ext_sens_1_en          : 1;
+  uint8_t not_used0                    : 4;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 4;
+  uint8_t batch_ext_sens_1_en          : 1;
+  uint8_t target1_numop                : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_tgt1_config_t;
+
+#define LSM6DSV80X_TGT2_ADD                       0x1BU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t r_2                          : 1;
+  uint8_t target2_add                  : 7;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t target2_add                  : 7;
+  uint8_t r_2                          : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_tgt2_add_t;
+
+#define LSM6DSV80X_TGT2_SUBADD                    0x1CU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t target2_reg                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t target2_reg                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_tgt2_subadd_t;
+
+#define LSM6DSV80X_TGT2_CONFIG                    0x1DU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t target2_numop                : 3;
+  uint8_t batch_ext_sens_2_en          : 1;
+  uint8_t not_used0                    : 4;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 4;
+  uint8_t batch_ext_sens_2_en          : 1;
+  uint8_t target2_numop                : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_tgt2_config_t;
+
+#define LSM6DSV80X_TGT3_ADD                       0x1EU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t r_3                          : 1;
+  uint8_t target3_add                  : 7;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t target3_add                  : 7;
+  uint8_t r_3                          : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_tgt3_add_t;
+
+#define LSM6DSV80X_TGT3_SUBADD                    0x1FU
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t target3_reg                  : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t target3_reg                  : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_tgt3_subadd_t;
+
+#define LSM6DSV80X_TGT3_CONFIG                    0x20U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t target3_numop                : 3;
+  uint8_t batch_ext_sens_3_en          : 1;
+  uint8_t not_used0                    : 4;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used0                    : 4;
+  uint8_t batch_ext_sens_3_en          : 1;
+  uint8_t target3_numop                : 3;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_tgt3_config_t;
+
+#define LSM6DSV80X_DATAWRITE_TGT0                 0x21U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t target0_dataw                : 8;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t target0_dataw                : 8;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_datawrite_tgt0_t;
+
+#define LSM6DSV80X_STATUS_CONTROLLER              0x22U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t sens_hub_endop               : 1;
+  uint8_t not_used0                    : 2;
+  uint8_t target0_nack                 : 1;
+  uint8_t target1_nack                 : 1;
+  uint8_t target2_nack                 : 1;
+  uint8_t target3_nack                 : 1;
+  uint8_t wr_once_done                 : 1;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t wr_once_done                 : 1;
+  uint8_t target3_nack                 : 1;
+  uint8_t target2_nack                 : 1;
+  uint8_t target1_nack                 : 1;
+  uint8_t target0_nack                 : 1;
+  uint8_t not_used0                    : 2;
+  uint8_t sens_hub_endop               : 1;
+#endif /* DRV_BYTE_ORDER */
+} lsm6dsv80x_status_controller_t;
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup LSM6DSO_Register_Union
+  * @brief    This union group all the registers having a bit-field
+  *           description.
+  *           This union is useful but it's not needed by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union
+{
+  /* master page registers */
+  lsm6dsv80x_func_cfg_access_t          func_cfg_access;
+  lsm6dsv80x_pin_ctrl_t                 pin_ctrl;
+  lsm6dsv80x_if_cfg_t                   if_cfg;
+  lsm6dsv80x_odr_trig_cfg_t             odr_trig_cfg;
+  lsm6dsv80x_fifo_ctrl1_t               fifo_ctrl1;
+  lsm6dsv80x_fifo_ctrl2_t               fifo_ctrl2;
+  lsm6dsv80x_fifo_ctrl3_t               fifo_ctrl3;
+  lsm6dsv80x_fifo_ctrl4_t               fifo_ctrl4;
+  lsm6dsv80x_counter_bdr_reg1_t         counter_bdr_reg1;
+  lsm6dsv80x_counter_bdr_reg2_t         counter_bdr_reg2;
+  lsm6dsv80x_int1_ctrl_t                int1_ctrl;
+  lsm6dsv80x_int2_ctrl_t                int2_ctrl;
+  lsm6dsv80x_who_am_i_t                 who_am_i;
+  lsm6dsv80x_ctrl1_t                    ctrl1;
+  lsm6dsv80x_ctrl2_t                    ctrl2;
+  lsm6dsv80x_ctrl3_t                    ctrl3;
+  lsm6dsv80x_ctrl4_t                    ctrl4;
+  lsm6dsv80x_ctrl5_t                    ctrl5;
+  lsm6dsv80x_ctrl6_t                    ctrl6;
+  lsm6dsv80x_ctrl7_t                    ctrl7;
+  lsm6dsv80x_ctrl8_t                    ctrl8;
+  lsm6dsv80x_ctrl9_t                    ctrl9;
+  lsm6dsv80x_ctrl10_t                   ctrl10;
+  lsm6dsv80x_ctrl_status_t              ctrl_status;
+  lsm6dsv80x_fifo_status1_t             fifo_status1;
+  lsm6dsv80x_fifo_status2_t             fifo_status2;
+  lsm6dsv80x_all_int_src_t              all_int_src;
+  lsm6dsv80x_status_reg_t               status_reg;
+  lsm6dsv80x_out_temp_l_t               out_temp_l;
+  lsm6dsv80x_out_temp_h_t               out_temp_h;
+  lsm6dsv80x_outx_l_g_t                 outx_l_g;
+  lsm6dsv80x_outx_h_g_t                 outx_h_g;
+  lsm6dsv80x_outy_l_g_t                 outy_l_g;
+  lsm6dsv80x_outy_h_g_t                 outy_h_g;
+  lsm6dsv80x_outz_l_g_t                 outz_l_g;
+  lsm6dsv80x_outz_h_g_t                 outz_h_g;
+  lsm6dsv80x_outx_l_a_t                 outx_l_a;
+  lsm6dsv80x_outx_h_a_t                 outx_h_a;
+  lsm6dsv80x_outy_l_a_t                 outy_l_a;
+  lsm6dsv80x_outy_h_a_t                 outy_h_a;
+  lsm6dsv80x_outz_l_a_t                 outz_l_a;
+  lsm6dsv80x_outz_h_a_t                 outz_h_a;
+  lsm6dsv80x_ui_outx_l_a_hg_t           ui_outx_l_a_hg;
+  lsm6dsv80x_ui_outx_h_a_hg_t           ui_outx_h_a_hg;
+  lsm6dsv80x_ui_outy_l_a_hg_t           ui_outy_l_a_hg;
+  lsm6dsv80x_ui_outy_h_a_hg_t           ui_outy_h_a_hg;
+  lsm6dsv80x_ui_outz_l_a_hg_t           ui_outz_l_a_hg;
+  lsm6dsv80x_ui_outz_h_a_hg_t           ui_outz_h_a_hg;
+  lsm6dsv80x_timestamp0_t               timestamp0;
+  lsm6dsv80x_timestamp1_t               timestamp1;
+  lsm6dsv80x_timestamp2_t               timestamp2;
+  lsm6dsv80x_timestamp3_t               timestamp3;
+  lsm6dsv80x_wake_up_src_t              wake_up_src;
+  lsm6dsv80x_tap_src_t                  tap_src;
+  lsm6dsv80x_d6d_src_t                  d6d_src;
+  lsm6dsv80x_status_controller_mainpage_t   status_controller_mainpage;
+  lsm6dsv80x_emb_func_status_mainpage_t emb_func_status_mainpage;
+  lsm6dsv80x_fsm_status_mainpage_t      fsm_status_mainpage;
+  lsm6dsv80x_mlc_status_mainpage_t      mlc_status_mainpage;
+  lsm6dsv80x_hg_wake_up_src_t           hg_wake_up_src;
+  lsm6dsv80x_ctrl2_xl_hg_t              ctrl2_xl_hg;
+  lsm6dsv80x_ctrl1_xl_hg_t              ctrl1_xl_hg;
+  lsm6dsv80x_internal_freq_t            internal_freq;
+  lsm6dsv80x_functions_enable_t         functions_enable;
+  lsm6dsv80x_inactivity_dur_t           inactivity_dur;
+  lsm6dsv80x_inactivity_ths_t           inactivity_ths;
+  lsm6dsv80x_tap_cfg0_t                 tap_cfg0;
+  lsm6dsv80x_tap_cfg1_t                 tap_cfg1;
+  lsm6dsv80x_tap_cfg2_t                 tap_cfg2;
+  lsm6dsv80x_tap_ths_6d_t               tap_ths_6d;
+  lsm6dsv80x_tap_dur_t                  tap_dur;
+  lsm6dsv80x_wake_up_ths_t              wake_up_ths;
+  lsm6dsv80x_wake_up_dur_t              wake_up_dur;
+  lsm6dsv80x_free_fall_t                free_fall;
+  lsm6dsv80x_md1_cfg_t                  md1_cfg;
+  lsm6dsv80x_md2_cfg_t                  md2_cfg;
+  lsm6dsv80x_emb_func_cfg_t             emb_func_cfg;
+  lsm6dsv80x_hg_x_ofs_usr_t             hg_x_ofs_usr;
+  lsm6dsv80x_hg_y_ofs_usr_t             hg_y_ofs_usr;
+  lsm6dsv80x_hg_z_ofs_usr_t             hg_z_ofs_usr;
+  lsm6dsv80x_x_ofs_usr_t                x_ofs_usr;
+  lsm6dsv80x_y_ofs_usr_t                y_ofs_usr;
+  lsm6dsv80x_z_ofs_usr_t                z_ofs_usr;
+  lsm6dsv80x_fifo_data_out_tag_t        fifo_data_out_tag;
+  lsm6dsv80x_fifo_data_out_x_l_t        fifo_data_out_x_l;
+  lsm6dsv80x_fifo_data_out_x_h_t        fifo_data_out_x_h;
+  lsm6dsv80x_fifo_data_out_y_l_t        fifo_data_out_y_l;
+  lsm6dsv80x_fifo_data_out_y_h_t        fifo_data_out_y_h;
+  lsm6dsv80x_fifo_data_out_z_l_t        fifo_data_out_z_l;
+  lsm6dsv80x_fifo_data_out_z_h_t        fifo_data_out_z_h;
+  /* Embedded functions registers */
+  lsm6dsv80x_page_sel_t                 page_sel;
+  lsm6dsv80x_emb_func_en_a_t            emb_func_en_a;
+  lsm6dsv80x_emb_func_en_b_t            emb_func_en_b;
+  lsm6dsv80x_emb_func_exec_status_t     emb_func_exec_status;
+  lsm6dsv80x_page_address_t             page_address;
+  lsm6dsv80x_page_value_t               page_value;
+  lsm6dsv80x_emb_func_int1_t            emb_func_int1;
+  lsm6dsv80x_fsm_int1_t                 fsm_int1;
+  lsm6dsv80x_mlc_int1_t                 mlc_int1;
+  lsm6dsv80x_emb_func_int2_t            emb_func_int2;
+  lsm6dsv80x_fsm_int2_t                 fsm_int2;
+  lsm6dsv80x_mlc_int2_t                 mlc_int2;
+  lsm6dsv80x_emb_func_status_t          emb_func_status;
+  lsm6dsv80x_fsm_status_t               fsm_status;
+  lsm6dsv80x_mlc_status_t               mlc_status;
+  lsm6dsv80x_page_rw_t                  page_rw;
+  lsm6dsv80x_sflp_gbiasx_l_t            sflp_gbiasx_l;
+  lsm6dsv80x_sflp_gbiasx_h_t            sflp_gbiasx_h;
+  lsm6dsv80x_sflp_gbiasy_l_t            sflp_gbiasy_l;
+  lsm6dsv80x_sflp_gbiasy_h_t            sflp_gbiasy_h;
+  lsm6dsv80x_sflp_gbiasz_l_t            sflp_gbiasz_l;
+  lsm6dsv80x_sflp_gbiasz_h_t            sflp_gbiasz_h;
+  lsm6dsv80x_sflp_gravx_l_t             sflp_gravx_l;
+  lsm6dsv80x_sflp_gravx_h_t             sflp_gravx_h;
+  lsm6dsv80x_sflp_gravy_l_t             sflp_gravy_l;
+  lsm6dsv80x_sflp_gravy_h_t             sflp_gravy_h;
+  lsm6dsv80x_sflp_gravz_l_t             sflp_gravz_l;
+  lsm6dsv80x_sflp_gravz_h_t             sflp_gravz_h;
+  lsm6dsv80x_sflp_quatw_l_t             sflp_quatw_l;
+  lsm6dsv80x_sflp_quatw_h_t             sflp_quatw_h;
+  lsm6dsv80x_sflp_quatx_l_t             sflp_quatx_l;
+  lsm6dsv80x_sflp_quatx_h_t             sflp_quatx_h;
+  lsm6dsv80x_sflp_quaty_l_t             sflp_quaty_l;
+  lsm6dsv80x_sflp_quaty_h_t             sflp_quaty_h;
+  lsm6dsv80x_sflp_quatz_l_t             sflp_quatz_l;
+  lsm6dsv80x_sflp_quatz_h_t             sflp_quatz_h;
+  lsm6dsv80x_sflp_gbiasx_init_l_t       sflp_gbiasx_init_l;
+  lsm6dsv80x_sflp_gbiasx_init_h_t       sflp_gbiasx_init_h;
+  lsm6dsv80x_sflp_gbiasy_init_l_t       sflp_gbiasy_init_l;
+  lsm6dsv80x_sflp_gbiasy_init_h_t       sflp_gbiasy_init_h;
+  lsm6dsv80x_sflp_gbiasz_init_l_t       sflp_gbiasz_init_l;
+  lsm6dsv80x_sflp_gbiasz_init_h_t       sflp_gbiasz_init_h;
+  lsm6dsv80x_emb_func_fifo_en_a_t       emb_func_fifo_en_a;
+  lsm6dsv80x_emb_func_fifo_en_b_t       emb_func_fifo_en_b;
+  lsm6dsv80x_fsm_enable_t               fsm_enable;
+  lsm6dsv80x_fsm_long_counter_l_t       fsm_long_counter_l;
+  lsm6dsv80x_fsm_long_counter_h_t       fsm_long_counter_h;
+  lsm6dsv80x_int_ack_mask_t             int_ack_mask;
+  lsm6dsv80x_fsm_outs1_t                fsm_outs1;
+  lsm6dsv80x_fsm_outs2_t                fsm_outs2;
+  lsm6dsv80x_fsm_outs3_t                fsm_outs3;
+  lsm6dsv80x_fsm_outs4_t                fsm_outs4;
+  lsm6dsv80x_fsm_outs5_t                fsm_outs5;
+  lsm6dsv80x_fsm_outs6_t                fsm_outs6;
+  lsm6dsv80x_fsm_outs7_t                fsm_outs7;
+  lsm6dsv80x_fsm_outs8_t                fsm_outs8;
+  lsm6dsv80x_sflp_odr_t                 sflp_odr;
+  lsm6dsv80x_fsm_odr_t                  fsm_odr;
+  lsm6dsv80x_mlc_odr_t                  mlc_odr;
+  lsm6dsv80x_step_counter_l_t           step_counter_l;
+  lsm6dsv80x_step_counter_h_t           step_counter_h;
+  lsm6dsv80x_emb_func_src_t             emb_func_src;
+  lsm6dsv80x_emb_func_init_a_t          emb_func_init_a;
+  lsm6dsv80x_emb_func_init_b_t          emb_func_init_b;
+  lsm6dsv80x_emb_func_sensor_conv_en_t  emb_func_sensor_conv_en;
+  lsm6dsv80x_mlc1_src_t                 mlc1_src;
+  lsm6dsv80x_mlc2_src_t                 mlc2_src;
+  lsm6dsv80x_mlc3_src_t                 mlc3_src;
+  lsm6dsv80x_mlc4_src_t                 mlc4_src;
+  lsm6dsv80x_mlc5_src_t                 mlc5_src;
+  lsm6dsv80x_mlc6_src_t                 mlc6_src;
+  lsm6dsv80x_mlc7_src_t                 mlc7_src;
+  /* Embedded functions extended page 0 registers */
+  lsm6dsv80x_fsm_ext_sensitivity_l_t    fsm_ext_sensitivity_l;
+  lsm6dsv80x_fsm_ext_sensitivity_h_t    fsm_ext_sensitivity_h;
+  lsm6dsv80x_fsm_ext_offx_l_t           fsm_ext_offx_l;
+  lsm6dsv80x_fsm_ext_offx_h_t           fsm_ext_offx_h;
+  lsm6dsv80x_fsm_ext_offy_l_t           fsm_ext_offy_l;
+  lsm6dsv80x_fsm_ext_offy_h_t           fsm_ext_offy_h;
+  lsm6dsv80x_fsm_ext_offz_l_t           fsm_ext_offz_l;
+  lsm6dsv80x_fsm_ext_offz_h_t           fsm_ext_offz_h;
+  lsm6dsv80x_fsm_ext_matrix_xx_l_t      fsm_ext_matrix_xx_l;
+  lsm6dsv80x_fsm_ext_matrix_xx_h_t      fsm_ext_matrix_xx_h;
+  lsm6dsv80x_fsm_ext_matrix_xy_l_t      fsm_ext_matrix_xy_l;
+  lsm6dsv80x_fsm_ext_matrix_xy_h_t      fsm_ext_matrix_xy_h;
+  lsm6dsv80x_fsm_ext_matrix_xz_l_t      fsm_ext_matrix_xz_l;
+  lsm6dsv80x_fsm_ext_matrix_xz_h_t      fsm_ext_matrix_xz_h;
+  lsm6dsv80x_fsm_ext_matrix_yy_l_t      fsm_ext_matrix_yy_l;
+  lsm6dsv80x_fsm_ext_matrix_yy_h_t      fsm_ext_matrix_yy_h;
+  lsm6dsv80x_fsm_ext_matrix_yz_l_t      fsm_ext_matrix_yz_l;
+  lsm6dsv80x_fsm_ext_matrix_yz_h_t      fsm_ext_matrix_yz_h;
+  lsm6dsv80x_fsm_ext_matrix_zz_l_t      fsm_ext_matrix_zz_l;
+  lsm6dsv80x_fsm_ext_matrix_zz_h_t      fsm_ext_matrix_zz_h;
+  lsm6dsv80x_ext_cfg_a_t                ext_cfg_a;
+  lsm6dsv80x_ext_cfg_b_t                ext_cfg_b;
+  /* Embedded functions extended page 1 registers */
+  lsm6dsv80x_xl_hg_sensitivity_l_t      xl_hg_sensitivity_l;
+  lsm6dsv80x_xl_hg_sensitivity_h_t      xl_hg_sensitivity_h;
+  lsm6dsv80x_fsm_lc_timeout_l_t         fsm_lc_timeout_l;
+  lsm6dsv80x_fsm_lc_timeout_h_t         fsm_lc_timeout_h;
+  lsm6dsv80x_fsm_programs_t             fsm_programs;
+  lsm6dsv80x_fsm_start_add_l_t          fsm_start_add_l;
+  lsm6dsv80x_fsm_start_add_h_t          fsm_start_add_h;
+  lsm6dsv80x_pedo_cmd_reg_t             pedo_cmd_reg;
+  lsm6dsv80x_pedo_deb_steps_conf_t      pedo_deb_steps_conf;
+  lsm6dsv80x_pedo_sc_deltat_l_t         pedo_sc_deltat_l;
+  lsm6dsv80x_pedo_sc_deltat_h_t         pedo_sc_deltat_h;
+  lsm6dsv80x_mlc_ext_sensitivity_l_t    mlc_ext_sensitivity_l;
+  lsm6dsv80x_mlc_ext_sensitivity_h_t    mlc_ext_sensitivity_h;
+  /* Embedded functions extended page 2 registers */
+  lsm6dsv80x_ext_format_t               ext_format;
+  lsm6dsv80x_ext_3byte_sensitivity_l_t  ext_3byte_sensitivity_l;
+  lsm6dsv80x_ext_3byte_sensitivity_h_t  ext_3byte_sensitivity_h;
+  lsm6dsv80x_ext_3byte_offset_xl_t      ext_3byte_offset_xl;
+  lsm6dsv80x_ext_3byte_offset_l_t       ext_3byte_offset_l;
+  lsm6dsv80x_ext_3byte_offset_h_t       ext_3byte_offset_h;
+  /* Sensor HUB registers */
+  lsm6dsv80x_sensor_hub_1_t             sensor_hub_1;
+  lsm6dsv80x_sensor_hub_2_t             sensor_hub_2;
+  lsm6dsv80x_sensor_hub_3_t             sensor_hub_3;
+  lsm6dsv80x_sensor_hub_4_t             sensor_hub_4;
+  lsm6dsv80x_sensor_hub_5_t             sensor_hub_5;
+  lsm6dsv80x_sensor_hub_6_t             sensor_hub_6;
+  lsm6dsv80x_sensor_hub_7_t             sensor_hub_7;
+  lsm6dsv80x_sensor_hub_8_t             sensor_hub_8;
+  lsm6dsv80x_sensor_hub_9_t             sensor_hub_9;
+  lsm6dsv80x_sensor_hub_10_t            sensor_hub_10;
+  lsm6dsv80x_sensor_hub_11_t            sensor_hub_11;
+  lsm6dsv80x_sensor_hub_12_t            sensor_hub_12;
+  lsm6dsv80x_sensor_hub_13_t            sensor_hub_13;
+  lsm6dsv80x_sensor_hub_14_t            sensor_hub_14;
+  lsm6dsv80x_sensor_hub_15_t            sensor_hub_15;
+  lsm6dsv80x_sensor_hub_16_t            sensor_hub_16;
+  lsm6dsv80x_sensor_hub_17_t            sensor_hub_17;
+  lsm6dsv80x_sensor_hub_18_t            sensor_hub_18;
+  lsm6dsv80x_controller_config_t        controller_config;
+  lsm6dsv80x_tgt0_add_t                 tgt0_add;
+  lsm6dsv80x_tgt0_subadd_t              tgt0_subadd;
+  lsm6dsv80x_tgt0_config_t              tgt0_config;
+  lsm6dsv80x_tgt1_add_t                 tgt1_add;
+  lsm6dsv80x_tgt1_subadd_t              tgt1_subadd;
+  lsm6dsv80x_tgt1_config_t              tgt1_config;
+  lsm6dsv80x_tgt2_add_t                 tgt2_add;
+  lsm6dsv80x_tgt2_subadd_t              tgt2_subadd;
+  lsm6dsv80x_tgt2_config_t              tgt2_config;
+  lsm6dsv80x_tgt3_add_t                 tgt3_add;
+  lsm6dsv80x_tgt3_subadd_t              tgt3_subadd;
+  lsm6dsv80x_tgt3_config_t              tgt3_config;
+  lsm6dsv80x_datawrite_tgt0_t           datawrite_tgt0;
+  lsm6dsv80x_status_controller_t        status_controller;
+  bitwise_t                             bitwise;
+  uint8_t                               byte;
+} lsm6dsv80x_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+#ifndef __weak
+#define __weak __attribute__((weak))
+#endif /* __weak */
+
+/*
+ * These are the basic platform dependent I/O routines to read
+ * and write device registers connected on a standard bus.
+ * The driver keeps offering a default implementation based on function
+ * pointers to read/write routines for backward compatibility.
+ * The __weak directive allows the final application to overwrite
+ * them with a custom implementation.
+ */
+
+int32_t lsm6dsv80x_read_reg(const stmdev_ctx_t *ctx, uint8_t reg,
+                            uint8_t *data,
+                            uint16_t len);
+int32_t lsm6dsv80x_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
+                             uint8_t *data,
+                             uint16_t len);
+
+float_t lsm6dsv80x_from_sflp_to_mg(int16_t lsb);
+float_t lsm6dsv80x_from_fs2_to_mg(int16_t lsb);
+float_t lsm6dsv80x_from_fs4_to_mg(int16_t lsb);
+float_t lsm6dsv80x_from_fs8_to_mg(int16_t lsb);
+float_t lsm6dsv80x_from_fs16_to_mg(int16_t lsb);
+
+float_t lsm6dsv80x_from_fs32_to_mg(int16_t lsb);
+float_t lsm6dsv80x_from_fs64_to_mg(int16_t lsb);
+float_t lsm6dsv80x_from_fs80_to_mg(int16_t lsb);
+
+float_t lsm6dsv80x_from_fs500_to_mdps(int16_t lsb);
+float_t lsm6dsv80x_from_fs250_to_mdps(int16_t lsb);
+float_t lsm6dsv80x_from_fs1000_to_mdps(int16_t lsb);
+float_t lsm6dsv80x_from_fs2000_to_mdps(int16_t lsb);
+float_t lsm6dsv80x_from_fs4000_to_mdps(int16_t lsb);
+
+float_t lsm6dsv80x_from_lsb_to_celsius(int16_t lsb);
+
+uint64_t lsm6dsv80x_from_lsb_to_nsec(uint32_t lsb);
+
+float_t lsm6dsv80x_from_lsb_to_mv(int16_t lsb);
+
+float_t lsm6dsv80x_from_gbias_lsb_to_mdps(int16_t lsb);
+float_t lsm6dsv80x_from_gravity_lsb_to_mg(int16_t lsb);
+float_t lsm6dsv80x_from_quaternion_lsb_to_float(uint16_t lsb);
+
+int32_t lsm6dsv80x_xl_offset_on_out_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_xl_offset_on_out_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef struct
+{
+  float_t z_mg;
+  float_t y_mg;
+  float_t x_mg;
+} lsm6dsv80x_xl_offset_mg_t;
+int32_t lsm6dsv80x_xl_offset_mg_set(const stmdev_ctx_t *ctx,
+                                    lsm6dsv80x_xl_offset_mg_t val);
+int32_t lsm6dsv80x_xl_offset_mg_get(const stmdev_ctx_t *ctx,
+                                    lsm6dsv80x_xl_offset_mg_t *val);
+
+int32_t lsm6dsv80x_hg_xl_offset_mg_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_xl_offset_mg_t val);
+int32_t lsm6dsv80x_hg_xl_offset_mg_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_xl_offset_mg_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_READY             = 0x0,
+  LSM6DSV80X_GLOBAL_RST        = 0x1,
+  LSM6DSV80X_RESTORE_CAL_PARAM = 0x2,
+  LSM6DSV80X_RESTORE_CTRL_REGS = 0x4,
+} lsm6dsv80x_reset_t;
+int32_t lsm6dsv80x_reset_set(const stmdev_ctx_t *ctx, lsm6dsv80x_reset_t val);
+int32_t lsm6dsv80x_reset_get(const stmdev_ctx_t *ctx, lsm6dsv80x_reset_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_MAIN_MEM_BANK       = 0x0,
+  LSM6DSV80X_EMBED_FUNC_MEM_BANK = 0x1,
+  LSM6DSV80X_SENSOR_HUB_MEM_BANK = 0x2,
+} lsm6dsv80x_mem_bank_t;
+int32_t lsm6dsv80x_mem_bank_set(const stmdev_ctx_t *ctx, lsm6dsv80x_mem_bank_t val);
+int32_t lsm6dsv80x_mem_bank_get(const stmdev_ctx_t *ctx, lsm6dsv80x_mem_bank_t *val);
+
+int32_t lsm6dsv80x_device_id_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_ODR_OFF              = 0x0,
+  LSM6DSV80X_ODR_AT_1Hz875        = 0x1,
+  LSM6DSV80X_ODR_AT_7Hz5          = 0x2,
+  LSM6DSV80X_ODR_AT_15Hz          = 0x3,
+  LSM6DSV80X_ODR_AT_30Hz          = 0x4,
+  LSM6DSV80X_ODR_AT_60Hz          = 0x5,
+  LSM6DSV80X_ODR_AT_120Hz         = 0x6,
+  LSM6DSV80X_ODR_AT_240Hz         = 0x7,
+  LSM6DSV80X_ODR_AT_480Hz         = 0x8,
+  LSM6DSV80X_ODR_AT_960Hz         = 0x9,
+  LSM6DSV80X_ODR_AT_1920Hz        = 0xA,
+  LSM6DSV80X_ODR_AT_3840Hz        = 0xB,
+  LSM6DSV80X_ODR_AT_7680Hz        = 0xC,
+  LSM6DSV80X_ODR_HA01_AT_15Hz625  = 0x13,
+  LSM6DSV80X_ODR_HA01_AT_31Hz25   = 0x14,
+  LSM6DSV80X_ODR_HA01_AT_62Hz5    = 0x15,
+  LSM6DSV80X_ODR_HA01_AT_125Hz    = 0x16,
+  LSM6DSV80X_ODR_HA01_AT_250Hz    = 0x17,
+  LSM6DSV80X_ODR_HA01_AT_500Hz    = 0x18,
+  LSM6DSV80X_ODR_HA01_AT_1000Hz   = 0x19,
+  LSM6DSV80X_ODR_HA01_AT_2000Hz   = 0x1A,
+  LSM6DSV80X_ODR_HA01_AT_4000Hz   = 0x1B,
+  LSM6DSV80X_ODR_HA01_AT_8000Hz   = 0x1C,
+  LSM6DSV80X_ODR_HA02_AT_13Hz     = 0x23,
+  LSM6DSV80X_ODR_HA02_AT_26Hz     = 0x24,
+  LSM6DSV80X_ODR_HA02_AT_52Hz     = 0x25,
+  LSM6DSV80X_ODR_HA02_AT_104Hz    = 0x26,
+  LSM6DSV80X_ODR_HA02_AT_208Hz    = 0x27,
+  LSM6DSV80X_ODR_HA02_AT_417Hz    = 0x28,
+  LSM6DSV80X_ODR_HA02_AT_833Hz    = 0x29,
+  LSM6DSV80X_ODR_HA02_AT_1667Hz   = 0x2A,
+  LSM6DSV80X_ODR_HA02_AT_3333Hz   = 0x2B,
+  LSM6DSV80X_ODR_HA02_AT_6667Hz   = 0x2C,
+} lsm6dsv80x_data_rate_t;
+int32_t lsm6dsv80x_xl_data_rate_set(const stmdev_ctx_t *ctx,
+                                    lsm6dsv80x_data_rate_t val);
+int32_t lsm6dsv80x_xl_data_rate_get(const stmdev_ctx_t *ctx,
+                                    lsm6dsv80x_data_rate_t *val);
+int32_t lsm6dsv80x_gy_data_rate_set(const stmdev_ctx_t *ctx,
+                                    lsm6dsv80x_data_rate_t val);
+int32_t lsm6dsv80x_gy_data_rate_get(const stmdev_ctx_t *ctx,
+                                    lsm6dsv80x_data_rate_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_HG_XL_ODR_OFF         = 0x0,
+  LSM6DSV80X_HG_XL_ODR_AT_480Hz    = 0x3,
+  LSM6DSV80X_HG_XL_ODR_AT_960Hz    = 0x4,
+  LSM6DSV80X_HG_XL_ODR_AT_1920Hz   = 0x5,
+  LSM6DSV80X_HG_XL_ODR_AT_3840Hz   = 0x6,
+  LSM6DSV80X_HG_XL_ODR_AT_7680Hz   = 0x7,
+} lsm6dsv80x_hg_xl_data_rate_t;
+int32_t lsm6dsv80x_hg_xl_data_rate_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_hg_xl_data_rate_t val,
+                                       uint8_t reg_out_en);
+int32_t lsm6dsv80x_hg_xl_data_rate_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_hg_xl_data_rate_t *val,
+                                       uint8_t *reg_out_en);
+
+typedef enum
+{
+  LSM6DSV80X_XL_HIGH_PERFORMANCE_MD   = 0x0,
+  LSM6DSV80X_XL_HIGH_ACCURACY_ODR_MD  = 0x1,
+  LSM6DSV80X_XL_ODR_TRIGGERED_MD      = 0x3,
+  LSM6DSV80X_XL_LOW_POWER_2_AVG_MD    = 0x4,
+  LSM6DSV80X_XL_LOW_POWER_4_AVG_MD    = 0x5,
+  LSM6DSV80X_XL_LOW_POWER_8_AVG_MD    = 0x6,
+  LSM6DSV80X_XL_NORMAL_MD             = 0x7,
+} lsm6dsv80x_xl_mode_t;
+int32_t lsm6dsv80x_xl_mode_set(const stmdev_ctx_t *ctx, lsm6dsv80x_xl_mode_t val);
+int32_t lsm6dsv80x_xl_mode_get(const stmdev_ctx_t *ctx, lsm6dsv80x_xl_mode_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_GY_HIGH_PERFORMANCE_MD   = 0x0,
+  LSM6DSV80X_GY_HIGH_ACCURACY_ODR_MD  = 0x1,
+  LSM6DSV80X_GY_ODR_TRIGGERED_MD      = 0x3,
+  LSM6DSV80X_GY_SLEEP_MD              = 0x4,
+  LSM6DSV80X_GY_LOW_POWER_MD          = 0x5,
+} lsm6dsv80x_gy_mode_t;
+int32_t lsm6dsv80x_gy_mode_set(const stmdev_ctx_t *ctx, lsm6dsv80x_gy_mode_t val);
+int32_t lsm6dsv80x_gy_mode_get(const stmdev_ctx_t *ctx, lsm6dsv80x_gy_mode_t *val);
+
+int32_t lsm6dsv80x_auto_increment_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_auto_increment_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv80x_block_data_update_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_block_data_update_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv80x_odr_trig_cfg_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_odr_trig_cfg_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_DRDY_LATCHED = 0x0,
+  LSM6DSV80X_DRDY_PULSED  = 0x1,
+} lsm6dsv80x_data_ready_mode_t;
+int32_t lsm6dsv80x_data_ready_mode_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_data_ready_mode_t val);
+int32_t lsm6dsv80x_data_ready_mode_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_data_ready_mode_t *val);
+
+typedef struct
+{
+  uint8_t hg_event                     : 1;
+  uint8_t hg_wakeup_z                  : 1;
+  uint8_t hg_wakeup_y                  : 1;
+  uint8_t hg_wakeup_x                  : 1;
+  uint8_t hg_wakeup                    : 1;
+  uint8_t hg_wakeup_chg                : 1;
+  uint8_t hg_shock                     : 1;
+  uint8_t hg_shock_change              : 1;
+} lsm6dsv80x_hg_event_t;
+int32_t lsm6dsv80x_hg_event_get(const stmdev_ctx_t *ctx, lsm6dsv80x_hg_event_t *val);
+
+typedef struct
+{
+  uint8_t hg_wakeup_ths                  : 8;
+  uint8_t hg_shock_dur                   : 4;
+} lsm6dsv80x_hg_wake_up_cfg_t;
+int32_t lsm6dsv80x_hg_wake_up_cfg_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_hg_wake_up_cfg_t val);
+int32_t lsm6dsv80x_hg_wake_up_cfg_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_hg_wake_up_cfg_t *val);
+
+typedef struct
+{
+  uint8_t hg_interrupts_enable         : 1;
+  uint8_t hg_wakeup_int_sel            : 1;
+} lsm6dsv80x_hg_wu_interrupt_cfg_t;
+int32_t lsm6dsv80x_hg_wu_interrupt_cfg_set(const stmdev_ctx_t *ctx,
+                                           lsm6dsv80x_hg_wu_interrupt_cfg_t val);
+int32_t lsm6dsv80x_hg_wu_interrupt_cfg_get(const stmdev_ctx_t *ctx,
+                                           lsm6dsv80x_hg_wu_interrupt_cfg_t *val);
+
+int32_t lsm6dsv80x_hg_emb_usr_off_correction_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_hg_emb_usr_off_correction_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv80x_hg_wu_usr_off_correction_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_hg_wu_usr_off_correction_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef struct
+{
+  uint8_t enable                       : 1; /* interrupt enable */
+  uint8_t lir                          : 1; /* interrupt pulsed or latched */
+} lsm6dsv80x_interrupt_mode_t;
+int32_t lsm6dsv80x_interrupt_enable_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv80x_interrupt_mode_t val);
+int32_t lsm6dsv80x_interrupt_enable_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv80x_interrupt_mode_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_250dps  = 0x1,
+  LSM6DSV80X_500dps  = 0x2,
+  LSM6DSV80X_1000dps = 0x3,
+  LSM6DSV80X_2000dps = 0x4,
+  LSM6DSV80X_4000dps = 0x5,
+} lsm6dsv80x_gy_full_scale_t;
+int32_t lsm6dsv80x_gy_full_scale_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_gy_full_scale_t val);
+int32_t lsm6dsv80x_gy_full_scale_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_gy_full_scale_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_2g  = 0x0,
+  LSM6DSV80X_4g  = 0x1,
+  LSM6DSV80X_8g  = 0x2,
+  LSM6DSV80X_16g = 0x3,
+} lsm6dsv80x_xl_full_scale_t;
+int32_t lsm6dsv80x_xl_full_scale_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_xl_full_scale_t val);
+int32_t lsm6dsv80x_xl_full_scale_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_xl_full_scale_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_32g  = 0x0,
+  LSM6DSV80X_64g  = 0x1,
+  LSM6DSV80X_80g = 0x2,
+} lsm6dsv80x_hg_xl_full_scale_t;
+int32_t lsm6dsv80x_hg_xl_full_scale_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv80x_hg_xl_full_scale_t val);
+int32_t lsm6dsv80x_hg_xl_full_scale_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv80x_hg_xl_full_scale_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_ST_DISABLE  = 0x0,
+  LSM6DSV80X_ST_POSITIVE = 0x1,
+  LSM6DSV80X_ST_NEGATIVE = 0x2,
+} lsm6dsv80x_self_test_t;
+int32_t lsm6dsv80x_xl_self_test_set(const stmdev_ctx_t *ctx, lsm6dsv80x_self_test_t val);
+int32_t lsm6dsv80x_xl_self_test_get(const stmdev_ctx_t *ctx, lsm6dsv80x_self_test_t *val);
+
+int32_t lsm6dsv80x_gy_self_test_set(const stmdev_ctx_t *ctx, lsm6dsv80x_self_test_t val);
+int32_t lsm6dsv80x_gy_self_test_get(const stmdev_ctx_t *ctx, lsm6dsv80x_self_test_t *val);
+
+int32_t lsm6dsv80x_hg_xl_self_test_set(const stmdev_ctx_t *ctx, lsm6dsv80x_self_test_t val);
+int32_t lsm6dsv80x_hg_xl_self_test_get(const stmdev_ctx_t *ctx, lsm6dsv80x_self_test_t *val);
+
+typedef struct
+{
+  uint8_t drdy_xl                      : 1;
+  uint8_t drdy_gy                      : 1;
+  uint8_t drdy_temp                    : 1;
+  uint8_t drdy_xlhgda                  : 1;
+  uint8_t gy_settling                  : 1;
+  uint8_t timestamp                    : 1;
+  uint8_t hg                           : 1;
+  uint8_t free_fall                    : 1;
+  uint8_t wake_up                      : 1;
+  uint8_t wake_up_z                    : 1;
+  uint8_t wake_up_y                    : 1;
+  uint8_t wake_up_x                    : 1;
+  uint8_t single_tap                   : 1;
+  uint8_t double_tap                   : 1;
+  uint8_t tap_z                        : 1;
+  uint8_t tap_y                        : 1;
+  uint8_t tap_x                        : 1;
+  uint8_t tap_sign                     : 1;
+  uint8_t six_d                        : 1;
+  uint8_t six_d_xl                     : 1;
+  uint8_t six_d_xh                     : 1;
+  uint8_t six_d_yl                     : 1;
+  uint8_t six_d_yh                     : 1;
+  uint8_t six_d_zl                     : 1;
+  uint8_t six_d_zh                     : 1;
+  uint8_t sleep_change                 : 1;
+  uint8_t sleep_state                  : 1;
+  uint8_t step_detector                : 1;
+  uint8_t step_count_inc               : 1;
+  uint8_t step_count_overflow          : 1;
+  uint8_t step_on_delta_time           : 1;
+  uint8_t emb_func_stand_by            : 1;
+  uint8_t emb_func_time_exceed         : 1;
+  uint8_t tilt                         : 1;
+  uint8_t sig_mot                      : 1;
+  uint8_t fsm_lc                       : 1;
+  uint8_t fsm1                         : 1;
+  uint8_t fsm2                         : 1;
+  uint8_t fsm3                         : 1;
+  uint8_t fsm4                         : 1;
+  uint8_t fsm5                         : 1;
+  uint8_t fsm6                         : 1;
+  uint8_t fsm7                         : 1;
+  uint8_t fsm8                         : 1;
+  uint8_t mlc1                         : 1;
+  uint8_t mlc2                         : 1;
+  uint8_t mlc3                         : 1;
+  uint8_t mlc4                         : 1;
+  uint8_t mlc5                         : 1;
+  uint8_t mlc6                         : 1;
+  uint8_t mlc7                         : 1;
+  uint8_t mlc8                         : 1;
+  uint8_t sh_endop                     : 1;
+  uint8_t sh_target0_nack              : 1;
+  uint8_t sh_target1_nack              : 1;
+  uint8_t sh_target2_nack              : 1;
+  uint8_t sh_target3_nack              : 1;
+  uint8_t sh_wr_once                   : 1;
+  uint8_t fifo_bdr                     : 1;
+  uint8_t fifo_full                    : 1;
+  uint8_t fifo_ovr                     : 1;
+  uint8_t fifo_th                      : 1;
+} lsm6dsv80x_all_sources_t;
+int32_t lsm6dsv80x_all_sources_get(const stmdev_ctx_t *ctx,
+                                   lsm6dsv80x_all_sources_t *val);
+
+typedef struct
+{
+  uint8_t drdy_xl                      : 1;
+  uint8_t drdy_g                       : 1;
+  uint8_t drdy_temp                    : 1;
+  uint8_t fifo_th                      : 1;
+  uint8_t fifo_ovr                     : 1;
+  uint8_t fifo_full                    : 1;
+  uint8_t cnt_bdr                      : 1;
+  uint8_t timestamp                    : 1;
+  uint8_t shub                         : 1;
+  uint8_t sixd                         : 1;
+  uint8_t single_tap                   : 1;
+  uint8_t double_tap                   : 1;
+  uint8_t wakeup                       : 1;
+  uint8_t freefall                     : 1;
+  uint8_t sleep_change                 : 1;
+  uint8_t drdy_hg_xl                   : 1; /* High-g */
+  uint8_t hg_wakeup                    : 1;
+  uint8_t hg_shock_change              : 1;
+  uint8_t step_detector                : 1; /* Embedded Functions */
+  uint8_t tilt                         : 1;
+  uint8_t sig_mot                      : 1;
+  uint8_t emb_func_endop               : 1;
+  uint8_t fsm1                         : 1; /* FSM */
+  uint8_t fsm2                         : 1;
+  uint8_t fsm3                         : 1;
+  uint8_t fsm4                         : 1;
+  uint8_t fsm5                         : 1;
+  uint8_t fsm6                         : 1;
+  uint8_t fsm7                         : 1;
+  uint8_t fsm8                         : 1;
+  uint8_t mlc1                         : 1; /* MLC */
+  uint8_t mlc2                         : 1;
+  uint8_t mlc3                         : 1;
+  uint8_t mlc4                         : 1;
+  uint8_t mlc5                         : 1;
+  uint8_t mlc6                         : 1;
+  uint8_t mlc7                         : 1;
+  uint8_t mlc8                         : 1;
+} lsm6dsv80x_pin_int_route_t;
+
+int32_t lsm6dsv80x_pin_int1_route_set(const stmdev_ctx_t *ctx, lsm6dsv80x_pin_int_route_t *val);
+int32_t lsm6dsv80x_pin_int1_route_get(const stmdev_ctx_t *ctx, lsm6dsv80x_pin_int_route_t *val);
+int32_t lsm6dsv80x_pin_int2_route_set(const stmdev_ctx_t *ctx, lsm6dsv80x_pin_int_route_t *val);
+int32_t lsm6dsv80x_pin_int2_route_get(const stmdev_ctx_t *ctx, lsm6dsv80x_pin_int_route_t *val);
+
+int32_t lsm6dsv80x_pin_int1_route_hg_set(const stmdev_ctx_t *ctx, lsm6dsv80x_pin_int_route_t *val);
+int32_t lsm6dsv80x_pin_int1_route_hg_get(const stmdev_ctx_t *ctx, lsm6dsv80x_pin_int_route_t *val);
+int32_t lsm6dsv80x_pin_int2_route_hg_set(const stmdev_ctx_t *ctx, lsm6dsv80x_pin_int_route_t *val);
+int32_t lsm6dsv80x_pin_int2_route_hg_get(const stmdev_ctx_t *ctx, lsm6dsv80x_pin_int_route_t *val);
+
+int32_t lsm6dsv80x_pin_int1_route_embedded_set(const stmdev_ctx_t *ctx,
+                                               lsm6dsv80x_pin_int_route_t *val);
+int32_t lsm6dsv80x_pin_int1_route_embedded_get(const stmdev_ctx_t *ctx,
+                                               lsm6dsv80x_pin_int_route_t *val);
+int32_t lsm6dsv80x_pin_int2_route_embedded_set(const stmdev_ctx_t *ctx,
+                                               lsm6dsv80x_pin_int_route_t *val);
+int32_t lsm6dsv80x_pin_int2_route_embedded_get(const stmdev_ctx_t *ctx,
+                                               lsm6dsv80x_pin_int_route_t *val);
+
+typedef struct
+{
+  uint8_t drdy_hgxl                    : 1;
+  uint8_t drdy_xl                      : 1;
+  uint8_t drdy_gy                      : 1;
+  uint8_t drdy_temp                    : 1;
+} lsm6dsv80x_data_ready_t;
+int32_t lsm6dsv80x_flag_data_ready_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_data_ready_t *val);
+
+int32_t lsm6dsv80x_int_ack_mask_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_int_ack_mask_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv80x_temperature_raw_get(const stmdev_ctx_t *ctx, int16_t *val);
+
+int32_t lsm6dsv80x_angular_rate_raw_get(const stmdev_ctx_t *ctx, int16_t *val);
+
+int32_t lsm6dsv80x_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *val);
+
+int32_t lsm6dsv80x_hg_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *val);
+
+int32_t lsm6dsv80x_sflp_gbias_raw_get(const stmdev_ctx_t *ctx, int16_t *val);
+int32_t lsm6dsv80x_sflp_gravity_raw_get(const stmdev_ctx_t *ctx, int16_t *val);
+int32_t lsm6dsv80x_sflp_quaternion_raw_get(const stmdev_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6dsv80x_odr_cal_reg_get(const stmdev_ctx_t *ctx, int8_t *val);
+
+int32_t lsm6dsv80x_disable_embedded_function_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_disable_embedded_function_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef struct
+{
+  uint8_t xl_hg_conv_en                : 1;
+  uint8_t gyro_conv_en                 : 1;
+  uint8_t temp_conv_en                 : 1;
+  uint8_t ext_sensor_conv_en           : 1;
+} lsm6dsv80x_emb_func_conv_t;
+int32_t lsm6dsv80x_emb_func_conv_set(const stmdev_ctx_t *ctx, lsm6dsv80x_emb_func_conv_t val);
+int32_t lsm6dsv80x_emb_func_conv_get(const stmdev_ctx_t *ctx, lsm6dsv80x_emb_func_conv_t *val);
+
+int32_t lsm6dsv80x_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t address,
+                               uint8_t *buf, uint8_t len);
+int32_t lsm6dsv80x_ln_pg_read(const stmdev_ctx_t *ctx, uint16_t address, uint8_t *buf,
+                              uint8_t len);
+
+int32_t lsm6dsv80x_emb_function_dbg_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_emb_function_dbg_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_DEN_ACT_LOW  = 0x0,
+  LSM6DSV80X_DEN_ACT_HIGH = 0x1,
+} lsm6dsv80x_den_polarity_t;
+int32_t lsm6dsv80x_den_polarity_set(const stmdev_ctx_t *ctx,
+                                    lsm6dsv80x_den_polarity_t val);
+int32_t lsm6dsv80x_den_polarity_get(const stmdev_ctx_t *ctx,
+                                    lsm6dsv80x_den_polarity_t *val);
+
+int32_t lsm6dsv80x_fifo_watermark_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_fifo_watermark_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_CMP_DISABLE = 0x0,
+  LSM6DSV80X_CMP_8_TO_1  = 0x1,
+  LSM6DSV80X_CMP_16_TO_1 = 0x2,
+  LSM6DSV80X_CMP_32_TO_1 = 0x3,
+} lsm6dsv80x_fifo_compress_algo_t;
+int32_t lsm6dsv80x_fifo_compress_algo_set(const stmdev_ctx_t *ctx,
+                                          lsm6dsv80x_fifo_compress_algo_t val);
+int32_t lsm6dsv80x_fifo_compress_algo_get(const stmdev_ctx_t *ctx,
+                                          lsm6dsv80x_fifo_compress_algo_t *val);
+
+int32_t lsm6dsv80x_fifo_virtual_sens_odr_chg_set(const stmdev_ctx_t *ctx,
+                                                 uint8_t val);
+int32_t lsm6dsv80x_fifo_virtual_sens_odr_chg_get(const stmdev_ctx_t *ctx,
+                                                 uint8_t *val);
+
+int32_t lsm6dsv80x_fifo_compress_algo_real_time_set(const stmdev_ctx_t *ctx,
+                                                    uint8_t val);
+int32_t lsm6dsv80x_fifo_compress_algo_real_time_get(const stmdev_ctx_t *ctx,
+                                                    uint8_t *val);
+
+int32_t lsm6dsv80x_fifo_stop_on_wtm_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_fifo_stop_on_wtm_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_XL_NOT_BATCHED       = 0x0,
+  LSM6DSV80X_XL_BATCHED_AT_1Hz875 = 0x1,
+  LSM6DSV80X_XL_BATCHED_AT_7Hz5   = 0x2,
+  LSM6DSV80X_XL_BATCHED_AT_15Hz   = 0x3,
+  LSM6DSV80X_XL_BATCHED_AT_30Hz   = 0x4,
+  LSM6DSV80X_XL_BATCHED_AT_60Hz   = 0x5,
+  LSM6DSV80X_XL_BATCHED_AT_120Hz  = 0x6,
+  LSM6DSV80X_XL_BATCHED_AT_240Hz  = 0x7,
+  LSM6DSV80X_XL_BATCHED_AT_480Hz  = 0x8,
+  LSM6DSV80X_XL_BATCHED_AT_960Hz  = 0x9,
+  LSM6DSV80X_XL_BATCHED_AT_1920Hz = 0xa,
+  LSM6DSV80X_XL_BATCHED_AT_3840Hz = 0xb,
+  LSM6DSV80X_XL_BATCHED_AT_7680Hz = 0xc,
+} lsm6dsv80x_fifo_xl_batch_t;
+int32_t lsm6dsv80x_fifo_xl_batch_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_fifo_xl_batch_t val);
+int32_t lsm6dsv80x_fifo_xl_batch_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_fifo_xl_batch_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_GY_NOT_BATCHED       = 0x0,
+  LSM6DSV80X_GY_BATCHED_AT_1Hz875 = 0x1,
+  LSM6DSV80X_GY_BATCHED_AT_7Hz5   = 0x2,
+  LSM6DSV80X_GY_BATCHED_AT_15Hz   = 0x3,
+  LSM6DSV80X_GY_BATCHED_AT_30Hz   = 0x4,
+  LSM6DSV80X_GY_BATCHED_AT_60Hz   = 0x5,
+  LSM6DSV80X_GY_BATCHED_AT_120Hz  = 0x6,
+  LSM6DSV80X_GY_BATCHED_AT_240Hz  = 0x7,
+  LSM6DSV80X_GY_BATCHED_AT_480Hz  = 0x8,
+  LSM6DSV80X_GY_BATCHED_AT_960Hz  = 0x9,
+  LSM6DSV80X_GY_BATCHED_AT_1920Hz = 0xa,
+  LSM6DSV80X_GY_BATCHED_AT_3840Hz = 0xb,
+  LSM6DSV80X_GY_BATCHED_AT_7680Hz = 0xc,
+} lsm6dsv80x_fifo_gy_batch_t;
+int32_t lsm6dsv80x_fifo_gy_batch_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_fifo_gy_batch_t val);
+int32_t lsm6dsv80x_fifo_gy_batch_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_fifo_gy_batch_t *val);
+
+int32_t lsm6dsv80x_fifo_hg_xl_batch_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_fifo_hg_xl_batch_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_BYPASS_MODE             = 0x0,
+  LSM6DSV80X_FIFO_MODE               = 0x1,
+  LSM6DSV80X_STREAM_WTM_TO_FULL_MODE = 0x2,
+  LSM6DSV80X_STREAM_TO_FIFO_MODE     = 0x3,
+  LSM6DSV80X_BYPASS_TO_STREAM_MODE   = 0x4,
+  LSM6DSV80X_STREAM_MODE             = 0x6,
+  LSM6DSV80X_BYPASS_TO_FIFO_MODE     = 0x7,
+} lsm6dsv80x_fifo_mode_t;
+int32_t lsm6dsv80x_fifo_mode_set(const stmdev_ctx_t *ctx, lsm6dsv80x_fifo_mode_t val);
+int32_t lsm6dsv80x_fifo_mode_get(const stmdev_ctx_t *ctx,
+                                 lsm6dsv80x_fifo_mode_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_TEMP_NOT_BATCHED       = 0x0,
+  LSM6DSV80X_TEMP_BATCHED_AT_1Hz875 = 0x1,
+  LSM6DSV80X_TEMP_BATCHED_AT_15Hz   = 0x2,
+  LSM6DSV80X_TEMP_BATCHED_AT_60Hz   = 0x3,
+} lsm6dsv80x_fifo_temp_batch_t;
+int32_t lsm6dsv80x_fifo_temp_batch_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_fifo_temp_batch_t val);
+int32_t lsm6dsv80x_fifo_temp_batch_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_fifo_temp_batch_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_TMSTMP_NOT_BATCHED = 0x0,
+  LSM6DSV80X_TMSTMP_DEC_1       = 0x1,
+  LSM6DSV80X_TMSTMP_DEC_8       = 0x2,
+  LSM6DSV80X_TMSTMP_DEC_32      = 0x3,
+} lsm6dsv80x_fifo_timestamp_batch_t;
+int32_t lsm6dsv80x_fifo_timestamp_batch_set(const stmdev_ctx_t *ctx,
+                                            lsm6dsv80x_fifo_timestamp_batch_t val);
+int32_t lsm6dsv80x_fifo_timestamp_batch_get(const stmdev_ctx_t *ctx,
+                                            lsm6dsv80x_fifo_timestamp_batch_t *val);
+
+int32_t lsm6dsv80x_fifo_batch_counter_threshold_set(const stmdev_ctx_t *ctx,
+                                                    uint16_t val);
+int32_t lsm6dsv80x_fifo_batch_counter_threshold_get(const stmdev_ctx_t *ctx,
+                                                    uint16_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_XL_LG_BATCH_EVENT  = 0x0,
+  LSM6DSV80X_GY_BATCH_EVENT     = 0x1,
+  LSM6DSV80X_XL_HG_BATCH_EVENT  = 0x3,
+} lsm6dsv80x_fifo_batch_cnt_event_t;
+int32_t lsm6dsv80x_fifo_batch_cnt_event_set(const stmdev_ctx_t *ctx,
+                                            lsm6dsv80x_fifo_batch_cnt_event_t val);
+int32_t lsm6dsv80x_fifo_batch_cnt_event_get(const stmdev_ctx_t *ctx,
+                                            lsm6dsv80x_fifo_batch_cnt_event_t *val);
+
+typedef struct
+{
+  uint16_t fifo_level                  : 9;
+  uint8_t fifo_bdr                     : 1;
+  uint8_t fifo_full                    : 1;
+  uint8_t fifo_ovr                     : 1;
+  uint8_t fifo_th                      : 1;
+} lsm6dsv80x_fifo_status_t;
+
+int32_t lsm6dsv80x_fifo_status_get(const stmdev_ctx_t *ctx,
+                                   lsm6dsv80x_fifo_status_t *val);
+
+typedef struct
+{
+  enum
+  {
+    LSM6DSV80X_FIFO_EMPTY                    = 0x0,
+    LSM6DSV80X_GY_NC_TAG                     = 0x1,
+    LSM6DSV80X_XL_NC_TAG                     = 0x2,
+    LSM6DSV80X_TEMPERATURE_TAG               = 0x3,
+    LSM6DSV80X_TIMESTAMP_TAG                 = 0x4,
+    LSM6DSV80X_CFG_CHANGE_TAG                = 0x5,
+    LSM6DSV80X_XL_NC_T_2_TAG                 = 0x6,
+    LSM6DSV80X_XL_NC_T_1_TAG                 = 0x7,
+    LSM6DSV80X_XL_2XC_TAG                    = 0x8,
+    LSM6DSV80X_XL_3XC_TAG                    = 0x9,
+    LSM6DSV80X_GY_NC_T_2_TAG                 = 0xA,
+    LSM6DSV80X_GY_NC_T_1_TAG                 = 0xB,
+    LSM6DSV80X_GY_2XC_TAG                    = 0xC,
+    LSM6DSV80X_GY_3XC_TAG                    = 0xD,
+    LSM6DSV80X_SENSORHUB_TARGET0_TAG         = 0xE,
+    LSM6DSV80X_SENSORHUB_TARGET1_TAG         = 0xF,
+    LSM6DSV80X_SENSORHUB_TARGET2_TAG         = 0x10,
+    LSM6DSV80X_SENSORHUB_TARGET3_TAG         = 0x11,
+    LSM6DSV80X_STEP_COUNTER_TAG              = 0x12,
+    LSM6DSV80X_SFLP_GAME_ROTATION_VECTOR_TAG = 0x13,
+    LSM6DSV80X_SFLP_GYROSCOPE_BIAS_TAG       = 0x16,
+    LSM6DSV80X_SFLP_GRAVITY_VECTOR_TAG       = 0x17,
+    LSM6DSV80X_HG_XL_PEAK_TAG                = 0x18,
+    LSM6DSV80X_SENSORHUB_NACK_TAG            = 0x19,
+    LSM6DSV80X_MLC_RESULT_TAG                = 0x1A,
+    LSM6DSV80X_MLC_FILTER                    = 0x1B,
+    LSM6DSV80X_MLC_FEATURE                   = 0x1C,
+    LSM6DSV80X_XL_HG_TAG                     = 0x1D,
+    LSM6DSV80X_FSM_RESULT_TAG                = 0x1F,
+  } tag;
+  uint8_t cnt;
+  uint8_t data[6];
+} lsm6dsv80x_fifo_out_raw_t;
+int32_t lsm6dsv80x_fifo_out_raw_get(const stmdev_ctx_t *ctx,
+                                    lsm6dsv80x_fifo_out_raw_t *val);
+
+int32_t lsm6dsv80x_fifo_stpcnt_batch_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_fifo_stpcnt_batch_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv80x_fifo_fsm_batch_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_fifo_fsm_batch_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv80x_fifo_mlc_batch_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_fifo_mlc_batch_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv80x_fifo_mlc_filt_batch_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_fifo_mlc_filt_batch_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv80x_fifo_sh_batch_target_set(const stmdev_ctx_t *ctx, uint8_t idx, uint8_t val);
+int32_t lsm6dsv80x_fifo_sh_batch_target_get(const stmdev_ctx_t *ctx, uint8_t idx, uint8_t *val);
+
+typedef struct
+{
+  uint8_t game_rotation                : 1;
+  uint8_t gravity                      : 1;
+  uint8_t gbias                        : 1;
+} lsm6dsv80x_fifo_sflp_raw_t;
+int32_t lsm6dsv80x_fifo_sflp_batch_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_fifo_sflp_raw_t val);
+int32_t lsm6dsv80x_fifo_sflp_batch_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_fifo_sflp_raw_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_AUTO          = 0x0,
+  LSM6DSV80X_ALWAYS_ACTIVE = 0x1,
+} lsm6dsv80x_filt_anti_spike_t;
+int32_t lsm6dsv80x_filt_anti_spike_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_filt_anti_spike_t val);
+int32_t lsm6dsv80x_filt_anti_spike_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_filt_anti_spike_t *val);
+
+typedef struct
+{
+  uint8_t drdy                         : 1;
+  uint8_t irq_xl                       : 1;
+  uint8_t irq_xl_hg                    : 1;
+  uint8_t irq_g                        : 1;
+} lsm6dsv80x_filt_settling_mask_t;
+int32_t lsm6dsv80x_filt_settling_mask_set(const stmdev_ctx_t *ctx,
+                                          lsm6dsv80x_filt_settling_mask_t val);
+int32_t lsm6dsv80x_filt_settling_mask_get(const stmdev_ctx_t *ctx,
+                                          lsm6dsv80x_filt_settling_mask_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_GY_ULTRA_LIGHT   = 0x0,
+  LSM6DSV80X_GY_VERY_LIGHT    = 0x1,
+  LSM6DSV80X_GY_LIGHT         = 0x2,
+  LSM6DSV80X_GY_MEDIUM        = 0x3,
+  LSM6DSV80X_GY_STRONG        = 0x4,
+  LSM6DSV80X_GY_VERY_STRONG   = 0x5,
+  LSM6DSV80X_GY_AGGRESSIVE    = 0x6,
+  LSM6DSV80X_GY_XTREME        = 0x7,
+} lsm6dsv80x_filt_gy_lp1_bandwidth_t;
+int32_t lsm6dsv80x_filt_gy_lp1_bandwidth_set(const stmdev_ctx_t *ctx,
+                                             lsm6dsv80x_filt_gy_lp1_bandwidth_t val);
+int32_t lsm6dsv80x_filt_gy_lp1_bandwidth_get(const stmdev_ctx_t *ctx,
+                                             lsm6dsv80x_filt_gy_lp1_bandwidth_t *val);
+
+int32_t lsm6dsv80x_filt_gy_lp1_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_filt_gy_lp1_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_XL_ULTRA_LIGHT = 0x0,
+  LSM6DSV80X_XL_VERY_LIGHT  = 0x1,
+  LSM6DSV80X_XL_LIGHT       = 0x2,
+  LSM6DSV80X_XL_MEDIUM      = 0x3,
+  LSM6DSV80X_XL_STRONG      = 0x4,
+  LSM6DSV80X_XL_VERY_STRONG = 0x5,
+  LSM6DSV80X_XL_AGGRESSIVE  = 0x6,
+  LSM6DSV80X_XL_XTREME      = 0x7,
+} lsm6dsv80x_filt_xl_lp2_bandwidth_t;
+int32_t lsm6dsv80x_filt_xl_lp2_bandwidth_set(const stmdev_ctx_t *ctx,
+                                             lsm6dsv80x_filt_xl_lp2_bandwidth_t val);
+int32_t lsm6dsv80x_filt_xl_lp2_bandwidth_get(const stmdev_ctx_t *ctx,
+                                             lsm6dsv80x_filt_xl_lp2_bandwidth_t *val);
+
+int32_t lsm6dsv80x_filt_xl_lp2_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_filt_xl_lp2_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv80x_filt_xl_hp_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_filt_xl_hp_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv80x_filt_xl_fast_settling_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_filt_xl_fast_settling_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_HP_MD_NORMAL    = 0x0,
+  LSM6DSV80X_HP_MD_REFERENCE = 0x1,
+} lsm6dsv80x_filt_xl_hp_mode_t;
+int32_t lsm6dsv80x_filt_xl_hp_mode_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_filt_xl_hp_mode_t val);
+int32_t lsm6dsv80x_filt_xl_hp_mode_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_filt_xl_hp_mode_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_WK_FEED_SLOPE          = 0x0,
+  LSM6DSV80X_WK_FEED_HIGH_PASS      = 0x1,
+  LSM6DSV80X_WK_FEED_LP_WITH_OFFSET = 0x2,
+} lsm6dsv80x_filt_wkup_act_feed_t;
+int32_t lsm6dsv80x_filt_wkup_act_feed_set(const stmdev_ctx_t *ctx,
+                                          lsm6dsv80x_filt_wkup_act_feed_t val);
+int32_t lsm6dsv80x_filt_wkup_act_feed_get(const stmdev_ctx_t *ctx,
+                                          lsm6dsv80x_filt_wkup_act_feed_t *val);
+
+int32_t lsm6dsv80x_mask_trigger_xl_settl_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_mask_trigger_xl_settl_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_SIXD_FEED_ODR_DIV_2 = 0x0,
+  LSM6DSV80X_SIXD_FEED_LOW_PASS  = 0x1,
+} lsm6dsv80x_filt_sixd_feed_t;
+int32_t lsm6dsv80x_filt_sixd_feed_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_filt_sixd_feed_t val);
+int32_t lsm6dsv80x_filt_sixd_feed_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_filt_sixd_feed_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_PROTECT_CTRL_REGS = 0x0,
+  LSM6DSV80X_WRITE_CTRL_REG    = 0x1,
+} lsm6dsv80x_fsm_permission_t;
+int32_t lsm6dsv80x_fsm_permission_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_fsm_permission_t val);
+int32_t lsm6dsv80x_fsm_permission_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_fsm_permission_t *val);
+int32_t lsm6dsv80x_fsm_permission_status(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef struct
+{
+  uint8_t fsm1_en                      : 1;
+  uint8_t fsm2_en                      : 1;
+  uint8_t fsm3_en                      : 1;
+  uint8_t fsm4_en                      : 1;
+  uint8_t fsm5_en                      : 1;
+  uint8_t fsm6_en                      : 1;
+  uint8_t fsm7_en                      : 1;
+  uint8_t fsm8_en                      : 1;
+} lsm6dsv80x_fsm_mode_t;
+int32_t lsm6dsv80x_fsm_mode_set(const stmdev_ctx_t *ctx, lsm6dsv80x_fsm_mode_t val);
+int32_t lsm6dsv80x_fsm_mode_get(const stmdev_ctx_t *ctx, lsm6dsv80x_fsm_mode_t *val);
+
+int32_t lsm6dsv80x_fsm_long_cnt_set(const stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsv80x_fsm_long_cnt_get(const stmdev_ctx_t *ctx, uint16_t *val);
+
+
+typedef struct
+{
+  uint8_t fsm_outs1;
+  uint8_t fsm_outs2;
+  uint8_t fsm_outs3;
+  uint8_t fsm_outs4;
+  uint8_t fsm_outs5;
+  uint8_t fsm_outs6;
+  uint8_t fsm_outs7;
+  uint8_t fsm_outs8;
+} lsm6dsv80x_fsm_out_t;
+int32_t lsm6dsv80x_fsm_out_get(const stmdev_ctx_t *ctx, lsm6dsv80x_fsm_out_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_FSM_15Hz  = 0x0,
+  LSM6DSV80X_FSM_30Hz  = 0x1,
+  LSM6DSV80X_FSM_60Hz  = 0x2,
+  LSM6DSV80X_FSM_120Hz = 0x3,
+  LSM6DSV80X_FSM_240Hz = 0x4,
+  LSM6DSV80X_FSM_480Hz = 0x5,
+  LSM6DSV80X_FSM_960Hz = 0x6,
+} lsm6dsv80x_fsm_data_rate_t;
+int32_t lsm6dsv80x_fsm_data_rate_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_fsm_data_rate_t val);
+int32_t lsm6dsv80x_fsm_data_rate_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_fsm_data_rate_t *val);
+
+int32_t lsm6dsv80x_fsm_ext_sens_sensitivity_set(const stmdev_ctx_t *ctx,
+                                                uint16_t val);
+int32_t lsm6dsv80x_fsm_ext_sens_sensitivity_get(const stmdev_ctx_t *ctx,
+                                                uint16_t *val);
+
+typedef struct
+{
+  uint16_t z;
+  uint16_t y;
+  uint16_t x;
+} lsm6dsv80x_xl_fsm_ext_sens_offset_t;
+int32_t lsm6dsv80x_fsm_ext_sens_offset_set(const stmdev_ctx_t *ctx,
+                                           lsm6dsv80x_xl_fsm_ext_sens_offset_t val);
+int32_t lsm6dsv80x_fsm_ext_sens_offset_get(const stmdev_ctx_t *ctx,
+                                           lsm6dsv80x_xl_fsm_ext_sens_offset_t *val);
+
+typedef struct
+{
+  uint16_t xx;
+  uint16_t xy;
+  uint16_t xz;
+  uint16_t yy;
+  uint16_t yz;
+  uint16_t zz;
+} lsm6dsv80x_xl_fsm_ext_sens_matrix_t;
+int32_t lsm6dsv80x_fsm_ext_sens_matrix_set(const stmdev_ctx_t *ctx,
+                                           lsm6dsv80x_xl_fsm_ext_sens_matrix_t val);
+int32_t lsm6dsv80x_fsm_ext_sens_matrix_get(const stmdev_ctx_t *ctx,
+                                           lsm6dsv80x_xl_fsm_ext_sens_matrix_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_Z_EQ_Y     = 0x0,
+  LSM6DSV80X_Z_EQ_MIN_Y = 0x1,
+  LSM6DSV80X_Z_EQ_X     = 0x2,
+  LSM6DSV80X_Z_EQ_MIN_X = 0x3,
+  LSM6DSV80X_Z_EQ_MIN_Z = 0x4,
+  LSM6DSV80X_Z_EQ_Z     = 0x5,
+} lsm6dsv80x_fsm_ext_sens_z_orient_t;
+int32_t lsm6dsv80x_fsm_ext_sens_z_orient_set(const stmdev_ctx_t *ctx,
+                                             lsm6dsv80x_fsm_ext_sens_z_orient_t val);
+int32_t lsm6dsv80x_fsm_ext_sens_z_orient_get(const stmdev_ctx_t *ctx,
+                                             lsm6dsv80x_fsm_ext_sens_z_orient_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_Y_EQ_Y     = 0x0,
+  LSM6DSV80X_Y_EQ_MIN_Y = 0x1,
+  LSM6DSV80X_Y_EQ_X     = 0x2,
+  LSM6DSV80X_Y_EQ_MIN_X = 0x3,
+  LSM6DSV80X_Y_EQ_MIN_Z = 0x4,
+  LSM6DSV80X_Y_EQ_Z     = 0x5,
+} lsm6dsv80x_fsm_ext_sens_y_orient_t;
+int32_t lsm6dsv80x_fsm_ext_sens_y_orient_set(const stmdev_ctx_t *ctx,
+                                             lsm6dsv80x_fsm_ext_sens_y_orient_t val);
+int32_t lsm6dsv80x_fsm_ext_sens_y_orient_get(const stmdev_ctx_t *ctx,
+                                             lsm6dsv80x_fsm_ext_sens_y_orient_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_X_EQ_Y     = 0x0,
+  LSM6DSV80X_X_EQ_MIN_Y = 0x1,
+  LSM6DSV80X_X_EQ_X     = 0x2,
+  LSM6DSV80X_X_EQ_MIN_X = 0x3,
+  LSM6DSV80X_X_EQ_MIN_Z = 0x4,
+  LSM6DSV80X_X_EQ_Z     = 0x5,
+} lsm6dsv80x_fsm_ext_sens_x_orient_t;
+int32_t lsm6dsv80x_fsm_ext_sens_x_orient_set(const stmdev_ctx_t *ctx,
+                                             lsm6dsv80x_fsm_ext_sens_x_orient_t val);
+int32_t lsm6dsv80x_fsm_ext_sens_x_orient_get(const stmdev_ctx_t *ctx,
+                                             lsm6dsv80x_fsm_ext_sens_x_orient_t *val);
+
+int32_t lsm6dsv80x_xl_hg_peak_tracking_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_xl_hg_peak_tracking_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv80x_xl_hg_sensitivity_set(const stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsv80x_xl_hg_sensitivity_get(const stmdev_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6dsv80x_fsm_long_cnt_timeout_set(const stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsv80x_fsm_long_cnt_timeout_get(const stmdev_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6dsv80x_fsm_number_of_programs_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_fsm_number_of_programs_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv80x_fsm_start_address_set(const stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsv80x_fsm_start_address_get(const stmdev_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6dsv80x_ff_time_windows_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_ff_time_windows_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_156_mg = 0x0,
+  LSM6DSV80X_219_mg = 0x1,
+  LSM6DSV80X_250_mg = 0x2,
+  LSM6DSV80X_312_mg = 0x3,
+  LSM6DSV80X_344_mg = 0x4,
+  LSM6DSV80X_406_mg = 0x5,
+  LSM6DSV80X_469_mg = 0x6,
+  LSM6DSV80X_500_mg = 0x7,
+} lsm6dsv80x_ff_thresholds_t;
+int32_t lsm6dsv80x_ff_thresholds_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_ff_thresholds_t val);
+int32_t lsm6dsv80x_ff_thresholds_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_ff_thresholds_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_MLC_OFF                             = 0x0,
+  LSM6DSV80X_MLC_ON                              = 0x1,
+  LSM6DSV80X_MLC_ON_BEFORE_FSM                   = 0x2,
+} lsm6dsv80x_mlc_mode_t;
+int32_t lsm6dsv80x_mlc_set(const stmdev_ctx_t *ctx, lsm6dsv80x_mlc_mode_t val);
+int32_t lsm6dsv80x_mlc_get(const stmdev_ctx_t *ctx, lsm6dsv80x_mlc_mode_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_MLC_15Hz  = 0x0,
+  LSM6DSV80X_MLC_30Hz  = 0x1,
+  LSM6DSV80X_MLC_60Hz  = 0x2,
+  LSM6DSV80X_MLC_120Hz = 0x3,
+  LSM6DSV80X_MLC_240Hz = 0x4,
+  LSM6DSV80X_MLC_480Hz = 0x5,
+  LSM6DSV80X_MLC_960Hz = 0x6,
+} lsm6dsv80x_mlc_data_rate_t;
+int32_t lsm6dsv80x_mlc_data_rate_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_mlc_data_rate_t val);
+int32_t lsm6dsv80x_mlc_data_rate_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_mlc_data_rate_t *val);
+
+typedef struct
+{
+  uint8_t mlc1_src;
+  uint8_t mlc2_src;
+  uint8_t mlc3_src;
+  uint8_t mlc4_src;
+  uint8_t mlc5_src;
+  uint8_t mlc6_src;
+  uint8_t mlc7_src;
+  uint8_t mlc8_src;
+} lsm6dsv80x_mlc_out_t;
+int32_t lsm6dsv80x_mlc_out_get(const stmdev_ctx_t *ctx, lsm6dsv80x_mlc_out_t *val);
+
+int32_t lsm6dsv80x_mlc_ext_sens_sensitivity_set(const stmdev_ctx_t *ctx,
+                                                uint16_t val);
+int32_t lsm6dsv80x_mlc_ext_sens_sensitivity_get(const stmdev_ctx_t *ctx,
+                                                uint16_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_DEG_80 = 0x0,
+  LSM6DSV80X_DEG_70 = 0x1,
+  LSM6DSV80X_DEG_60 = 0x2,
+  LSM6DSV80X_DEG_50 = 0x3,
+} lsm6dsv80x_6d_threshold_t;
+int32_t lsm6dsv80x_6d_threshold_set(const stmdev_ctx_t *ctx,
+                                    lsm6dsv80x_6d_threshold_t val);
+int32_t lsm6dsv80x_6d_threshold_get(const stmdev_ctx_t *ctx,
+                                    lsm6dsv80x_6d_threshold_t *val);
+
+int32_t lsm6dsv80x_4d_mode_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_4d_mode_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_I2C_I3C_ENABLE  = 0x0,
+  LSM6DSV80X_I2C_I3C_DISABLE = 0x1,
+} lsm6dsv80x_ui_i2c_i3c_mode_t;
+int32_t lsm6dsv80x_ui_i2c_i3c_mode_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_ui_i2c_i3c_mode_t val);
+int32_t lsm6dsv80x_ui_i2c_i3c_mode_get(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_ui_i2c_i3c_mode_t *val);
+
+typedef struct
+{
+  enum
+  {
+    LSM6DSV80X_SW_RST_DYN_ADDRESS_RST = 0x0,
+    LSM6DSV80X_I3C_GLOBAL_RST         = 0x1,
+  } rst_mode;
+  enum
+  {
+    LSM6DSV80X_IBI_50us = 0x0,
+    LSM6DSV80X_IBI_2us  = 0x1,
+    LSM6DSV80X_IBI_1ms  = 0x2,
+    LSM6DSV80X_IBI_50ms = 0x3,
+  } ibi_time;
+} lsm6dsv80x_i3c_config_t;
+
+int32_t lsm6dsv80x_i3c_config_set(const stmdev_ctx_t *ctx,
+                                  lsm6dsv80x_i3c_config_t val);
+int32_t lsm6dsv80x_i3c_config_get(const stmdev_ctx_t *ctx,
+                                  lsm6dsv80x_i3c_config_t *val);
+
+int32_t lsm6dsv80x_sh_controller_interface_pull_up_set(const stmdev_ctx_t *ctx,
+                                                       uint8_t val);
+int32_t lsm6dsv80x_sh_controller_interface_pull_up_get(const stmdev_ctx_t *ctx,
+                                                       uint8_t *val);
+
+int32_t lsm6dsv80x_sh_read_data_raw_get(const stmdev_ctx_t *ctx, uint8_t *val,
+                                        uint8_t len);
+
+typedef enum
+{
+  LSM6DSV80X_TGT_0       = 0x0,
+  LSM6DSV80X_TGT_0_1     = 0x1,
+  LSM6DSV80X_TGT_0_1_2   = 0x2,
+  LSM6DSV80X_TGT_0_1_2_3 = 0x3,
+} lsm6dsv80x_sh_target_connected_t;
+int32_t lsm6dsv80x_sh_target_connected_set(const stmdev_ctx_t *ctx,
+                                           lsm6dsv80x_sh_target_connected_t val);
+int32_t lsm6dsv80x_sh_target_connected_get(const stmdev_ctx_t *ctx,
+                                           lsm6dsv80x_sh_target_connected_t *val);
+
+int32_t lsm6dsv80x_sh_controller_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_sh_controller_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv80x_sh_pass_through_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_sh_pass_through_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_SH_TRG_XL_GY_DRDY = 0x0,
+  LSM6DSV80X_SH_TRIG_INT2      = 0x1,
+} lsm6dsv80x_sh_syncro_mode_t;
+int32_t lsm6dsv80x_sh_syncro_mode_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_sh_syncro_mode_t val);
+int32_t lsm6dsv80x_sh_syncro_mode_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_sh_syncro_mode_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_EACH_SH_CYCLE    = 0x0,
+  LSM6DSV80X_ONLY_FIRST_CYCLE = 0x1,
+} lsm6dsv80x_sh_write_mode_t;
+int32_t lsm6dsv80x_sh_write_mode_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_sh_write_mode_t val);
+int32_t lsm6dsv80x_sh_write_mode_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_sh_write_mode_t *val);
+
+int32_t lsm6dsv80x_sh_reset_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_sh_reset_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef struct
+{
+  uint8_t   tgt0_add;
+  uint8_t   tgt0_subadd;
+  uint8_t   tgt0_data;
+} lsm6dsv80x_sh_cfg_write_t;
+int32_t lsm6dsv80x_sh_cfg_write(const stmdev_ctx_t *ctx,
+                                lsm6dsv80x_sh_cfg_write_t *val);
+typedef enum
+{
+  LSM6DSV80X_SH_15Hz  = 0x1,
+  LSM6DSV80X_SH_30Hz  = 0x2,
+  LSM6DSV80X_SH_60Hz  = 0x3,
+  LSM6DSV80X_SH_120Hz = 0x4,
+  LSM6DSV80X_SH_240Hz = 0x5,
+  LSM6DSV80X_SH_480Hz = 0x6,
+} lsm6dsv80x_sh_data_rate_t;
+int32_t lsm6dsv80x_sh_data_rate_set(const stmdev_ctx_t *ctx,
+                                    lsm6dsv80x_sh_data_rate_t val);
+int32_t lsm6dsv80x_sh_data_rate_get(const stmdev_ctx_t *ctx,
+                                    lsm6dsv80x_sh_data_rate_t *val);
+
+typedef struct
+{
+  uint8_t   tgt_add;
+  uint8_t   tgt_subadd;
+  uint8_t   tgt_len;
+} lsm6dsv80x_sh_cfg_read_t;
+int32_t lsm6dsv80x_sh_tgt_cfg_read(const stmdev_ctx_t *ctx, uint8_t idx,
+                                   lsm6dsv80x_sh_cfg_read_t *val);
+
+int32_t lsm6dsv80x_sh_status_get(const stmdev_ctx_t *ctx,
+                                 lsm6dsv80x_status_controller_t *val);
+
+int32_t lsm6dsv80x_ui_sdo_pull_up_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_ui_sdo_pull_up_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_PAD_LOW_STRENGTH     = 0x1,
+  LSM6DSV80X_PAD_MIDDLE_STRENGTH  = 0x2,
+  LSM6DSV80X_PAD_HIGH_STRENGTH    = 0x4,
+} lsm6dsv80x_pad_strength_t;
+int32_t lsm6dsv80x_pad_strength_set(const stmdev_ctx_t *ctx, lsm6dsv80x_pad_strength_t val);
+int32_t lsm6dsv80x_pad_strength_get(const stmdev_ctx_t *ctx, lsm6dsv80x_pad_strength_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_SPI_4_WIRE = 0x0,
+  LSM6DSV80X_SPI_3_WIRE = 0x1,
+} lsm6dsv80x_spi_mode_t;
+int32_t lsm6dsv80x_spi_mode_set(const stmdev_ctx_t *ctx, lsm6dsv80x_spi_mode_t val);
+int32_t lsm6dsv80x_spi_mode_get(const stmdev_ctx_t *ctx, lsm6dsv80x_spi_mode_t *val);
+
+int32_t lsm6dsv80x_ui_sda_pull_up_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_ui_sda_pull_up_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv80x_if2_spi_mode_set(const stmdev_ctx_t *ctx, lsm6dsv80x_spi_mode_t val);
+int32_t lsm6dsv80x_if2_spi_mode_get(const stmdev_ctx_t *ctx,
+                                    lsm6dsv80x_spi_mode_t *val);
+
+int32_t lsm6dsv80x_sigmot_mode_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_sigmot_mode_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef struct
+{
+  uint8_t step_counter_enable          : 1;
+  uint8_t false_step_rej               : 1;
+} lsm6dsv80x_stpcnt_mode_t;
+int32_t lsm6dsv80x_stpcnt_mode_set(const stmdev_ctx_t *ctx,
+                                   lsm6dsv80x_stpcnt_mode_t val);
+int32_t lsm6dsv80x_stpcnt_mode_get(const stmdev_ctx_t *ctx,
+                                   lsm6dsv80x_stpcnt_mode_t *val);
+
+int32_t lsm6dsv80x_stpcnt_steps_get(const stmdev_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6dsv80x_stpcnt_rst_step_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_stpcnt_rst_step_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv80x_stpcnt_debounce_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_stpcnt_debounce_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv80x_stpcnt_period_set(const stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsv80x_stpcnt_period_get(const stmdev_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6dsv80x_sflp_game_rotation_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_sflp_game_rotation_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef struct
+{
+  float_t gbias_x; /* dps */
+  float_t gbias_y; /* dps */
+  float_t gbias_z; /* dps */
+} lsm6dsv80x_sflp_gbias_t;
+int32_t lsm6dsv80x_sflp_game_gbias_set(const stmdev_ctx_t *ctx,
+                                       lsm6dsv80x_sflp_gbias_t *val);
+
+typedef struct
+{
+  float_t quat_w;
+  float_t quat_x;
+  float_t quat_y;
+  float_t quat_z;
+} lsm6dsv80x_quaternion_t;
+int32_t lsm6dsv80x_sflp_quaternion_get(const stmdev_ctx_t *ctx, lsm6dsv80x_quaternion_t *quat);
+
+typedef enum
+{
+  LSM6DSV80X_SFLP_15Hz  = 0x0,
+  LSM6DSV80X_SFLP_30Hz  = 0x1,
+  LSM6DSV80X_SFLP_60Hz  = 0x2,
+  LSM6DSV80X_SFLP_120Hz = 0x3,
+  LSM6DSV80X_SFLP_240Hz = 0x4,
+  LSM6DSV80X_SFLP_480Hz = 0x5,
+} lsm6dsv80x_sflp_data_rate_t;
+int32_t lsm6dsv80x_sflp_data_rate_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_sflp_data_rate_t val);
+int32_t lsm6dsv80x_sflp_data_rate_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_sflp_data_rate_t *val);
+
+typedef struct
+{
+  uint8_t tap_x_en                     : 1;
+  uint8_t tap_y_en                     : 1;
+  uint8_t tap_z_en                     : 1;
+} lsm6dsv80x_tap_detection_t;
+int32_t lsm6dsv80x_tap_detection_set(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_tap_detection_t val);
+int32_t lsm6dsv80x_tap_detection_get(const stmdev_ctx_t *ctx,
+                                     lsm6dsv80x_tap_detection_t *val);
+
+typedef struct
+{
+  uint8_t x                            : 5;
+  uint8_t y                            : 5;
+  uint8_t z                            : 5;
+} lsm6dsv80x_tap_thresholds_t;
+int32_t lsm6dsv80x_tap_thresholds_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_tap_thresholds_t val);
+int32_t lsm6dsv80x_tap_thresholds_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_tap_thresholds_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_XYZ  = 0x0,
+  LSM6DSV80X_YXZ  = 0x1,
+  LSM6DSV80X_XZY  = 0x2,
+  LSM6DSV80X_ZYX  = 0x3,
+  LSM6DSV80X_YZX  = 0x5,
+  LSM6DSV80X_ZXY  = 0x6,
+} lsm6dsv80x_tap_axis_priority_t;
+int32_t lsm6dsv80x_tap_axis_priority_set(const stmdev_ctx_t *ctx,
+                                         lsm6dsv80x_tap_axis_priority_t val);
+int32_t lsm6dsv80x_tap_axis_priority_get(const stmdev_ctx_t *ctx,
+                                         lsm6dsv80x_tap_axis_priority_t *val);
+
+typedef struct
+{
+  uint8_t shock                        : 2;
+  uint8_t quiet                        : 2;
+  uint8_t tap_gap                      : 4;
+} lsm6dsv80x_tap_time_windows_t;
+int32_t lsm6dsv80x_tap_time_windows_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv80x_tap_time_windows_t val);
+int32_t lsm6dsv80x_tap_time_windows_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv80x_tap_time_windows_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_ONLY_SINGLE        = 0x0,
+  LSM6DSV80X_BOTH_SINGLE_DOUBLE = 0x1,
+} lsm6dsv80x_tap_mode_t;
+int32_t lsm6dsv80x_tap_mode_set(const stmdev_ctx_t *ctx, lsm6dsv80x_tap_mode_t val);
+int32_t lsm6dsv80x_tap_mode_get(const stmdev_ctx_t *ctx, lsm6dsv80x_tap_mode_t *val);
+
+int32_t lsm6dsv80x_tilt_mode_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_tilt_mode_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsv80x_timestamp_raw_get(const stmdev_ctx_t *ctx, uint32_t *val);
+
+int32_t lsm6dsv80x_timestamp_set(const stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv80x_timestamp_get(const stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_XL_AND_GY_NOT_AFFECTED       = 0x0,
+  LSM6DSV80X_XL_LOW_POWER_GY_NOT_AFFECTED = 0x1,
+  LSM6DSV80X_XL_LOW_POWER_GY_SLEEP        = 0x2,
+  LSM6DSV80X_XL_LOW_POWER_GY_POWER_DOWN   = 0x3,
+} lsm6dsv80x_act_mode_t;
+int32_t lsm6dsv80x_act_mode_set(const stmdev_ctx_t *ctx, lsm6dsv80x_act_mode_t val);
+int32_t lsm6dsv80x_act_mode_get(const stmdev_ctx_t *ctx, lsm6dsv80x_act_mode_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_SLEEP_TO_ACT_AT_1ST_SAMPLE = 0x0,
+  LSM6DSV80X_SLEEP_TO_ACT_AT_2ND_SAMPLE = 0x1,
+  LSM6DSV80X_SLEEP_TO_ACT_AT_3RD_SAMPLE = 0x2,
+  LSM6DSV80X_SLEEP_TO_ACT_AT_4th_SAMPLE = 0x3,
+} lsm6dsv80x_act_from_sleep_to_act_dur_t;
+int32_t lsm6dsv80x_act_from_sleep_to_act_dur_set(const stmdev_ctx_t *ctx,
+                                                 lsm6dsv80x_act_from_sleep_to_act_dur_t val);
+int32_t lsm6dsv80x_act_from_sleep_to_act_dur_get(const stmdev_ctx_t *ctx,
+                                                 lsm6dsv80x_act_from_sleep_to_act_dur_t *val);
+
+typedef enum
+{
+  LSM6DSV80X_1Hz875 = 0x0,
+  LSM6DSV80X_15Hz   = 0x1,
+  LSM6DSV80X_30Hz   = 0x2,
+  LSM6DSV80X_60Hz   = 0x3,
+} lsm6dsv80x_act_sleep_xl_odr_t;
+int32_t lsm6dsv80x_act_sleep_xl_odr_set(const stmdev_ctx_t *ctx,
+                                        lsm6dsv80x_act_sleep_xl_odr_t val);
+int32_t lsm6dsv80x_act_sleep_xl_odr_get(const stmdev_ctx_t *ctx,
+                                        lsm6dsv80x_act_sleep_xl_odr_t *val);
+
+typedef struct
+{
+  lsm6dsv80x_inactivity_dur_t inactivity_cfg;
+  uint8_t inactivity_ths;
+  uint8_t threshold;
+  uint8_t duration;
+} lsm6dsv80x_act_thresholds_t;
+int32_t lsm6dsv80x_act_thresholds_set(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_act_thresholds_t *val);
+int32_t lsm6dsv80x_act_thresholds_get(const stmdev_ctx_t *ctx,
+                                      lsm6dsv80x_act_thresholds_t *val);
+
+typedef struct
+{
+  uint8_t shock                        : 2;
+  uint8_t quiet                        : 4;
+} lsm6dsv80x_act_wkup_time_windows_t;
+int32_t lsm6dsv80x_act_wkup_time_windows_set(const stmdev_ctx_t *ctx,
+                                             lsm6dsv80x_act_wkup_time_windows_t val);
+int32_t lsm6dsv80x_act_wkup_time_windows_get(const stmdev_ctx_t *ctx,
+                                             lsm6dsv80x_act_wkup_time_windows_t *val);
+
+/**
+  * @}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*LSM6DSV80X_DRIVER_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/st1vafe3bx_STdC/driver/st1vafe3bx_reg.c
+++ b/sensor/stmemsc/st1vafe3bx_STdC/driver/st1vafe3bx_reg.c
@@ -46,7 +46,7 @@
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t __weak st1vafe3bx_read_reg(const stmdev_ctx_t *ctx, uint8_t reg,
+int32_t __weak st1vafe3bx_read_reg(const st1vafe3bx_ctx_t *ctx, uint8_t reg,
                                    uint8_t *data, uint16_t len)
 {
   if (ctx == NULL)
@@ -67,7 +67,7 @@ int32_t __weak st1vafe3bx_read_reg(const stmdev_ctx_t *ctx, uint8_t reg,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t __weak st1vafe3bx_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
+int32_t __weak st1vafe3bx_write_reg(const st1vafe3bx_ctx_t *ctx, uint8_t reg,
                                     uint8_t *data, uint16_t len)
 {
   if (ctx == NULL)
@@ -134,7 +134,7 @@ float_t st1vafe3bx_from_lsb_to_mv(int16_t lsb)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_device_id_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t st1vafe3bx_device_id_get(const st1vafe3bx_ctx_t *ctx, uint8_t *val)
 {
   int32_t ret;
 
@@ -151,7 +151,7 @@ int32_t st1vafe3bx_device_id_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_init_set(const stmdev_ctx_t *ctx, st1vafe3bx_init_t val)
+int32_t st1vafe3bx_init_set(const st1vafe3bx_ctx_t *ctx, st1vafe3bx_init_t val)
 {
   st1vafe3bx_ctrl1_t ctrl1;
   st1vafe3bx_ctrl4_t ctrl4;
@@ -315,7 +315,7 @@ int32_t st1vafe3bx_init_set(const stmdev_ctx_t *ctx, st1vafe3bx_init_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_smart_power_set(const stmdev_ctx_t *ctx, st1vafe3bx_smart_power_t val)
+int32_t st1vafe3bx_smart_power_set(const st1vafe3bx_ctx_t *ctx, st1vafe3bx_smart_power_t val)
 {
   st1vafe3bx_ctrl1_t ctrl1;
   st1vafe3bx_smart_power_ctrl_t pwr_ctrl;
@@ -346,7 +346,7 @@ int32_t st1vafe3bx_smart_power_set(const stmdev_ctx_t *ctx, st1vafe3bx_smart_pow
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_smart_power_get(const stmdev_ctx_t *ctx, st1vafe3bx_smart_power_t *val)
+int32_t st1vafe3bx_smart_power_get(const st1vafe3bx_ctx_t *ctx, st1vafe3bx_smart_power_t *val)
 {
   st1vafe3bx_ctrl1_t ctrl1;
   st1vafe3bx_smart_power_ctrl_t pwr_ctrl;
@@ -374,7 +374,7 @@ int32_t st1vafe3bx_smart_power_get(const stmdev_ctx_t *ctx, st1vafe3bx_smart_pow
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_status_get(const stmdev_ctx_t *ctx, st1vafe3bx_status_t *val)
+int32_t st1vafe3bx_status_get(const st1vafe3bx_ctx_t *ctx, st1vafe3bx_status_t *val)
 {
   st1vafe3bx_status_register_t status_register;
   st1vafe3bx_ctrl1_t ctrl1;
@@ -401,7 +401,7 @@ int32_t st1vafe3bx_status_get(const stmdev_ctx_t *ctx, st1vafe3bx_status_t *val)
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_drdy_status_get(const stmdev_ctx_t *ctx, st1vafe3bx_status_t *val)
+int32_t st1vafe3bx_drdy_status_get(const st1vafe3bx_ctx_t *ctx, st1vafe3bx_status_t *val)
 {
   st1vafe3bx_status_register_t status_register;
   int32_t ret;
@@ -420,7 +420,7 @@ int32_t st1vafe3bx_drdy_status_get(const stmdev_ctx_t *ctx, st1vafe3bx_status_t 
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_embedded_status_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_embedded_status_get(const st1vafe3bx_ctx_t *ctx,
                                        st1vafe3bx_embedded_status_t *val)
 {
   st1vafe3bx_emb_func_status_t status;
@@ -447,7 +447,7 @@ int32_t st1vafe3bx_embedded_status_get(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_data_ready_mode_set(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_data_ready_mode_set(const st1vafe3bx_ctx_t *ctx,
                                        st1vafe3bx_data_ready_mode_t val)
 {
   st1vafe3bx_ctrl1_t ctrl1;
@@ -472,7 +472,7 @@ int32_t st1vafe3bx_data_ready_mode_set(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_data_ready_mode_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_data_ready_mode_get(const st1vafe3bx_ctx_t *ctx,
                                        st1vafe3bx_data_ready_mode_t *val)
 {
   st1vafe3bx_ctrl1_t ctrl1;
@@ -505,7 +505,7 @@ int32_t st1vafe3bx_data_ready_mode_get(const stmdev_ctx_t *ctx,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_mode_set(const stmdev_ctx_t *ctx, const st1vafe3bx_md_t *val)
+int32_t st1vafe3bx_mode_set(const st1vafe3bx_ctx_t *ctx, const st1vafe3bx_md_t *val)
 {
   st1vafe3bx_ctrl3_t ctrl3;
   st1vafe3bx_ctrl5_t ctrl5;
@@ -606,7 +606,7 @@ int32_t st1vafe3bx_mode_set(const stmdev_ctx_t *ctx, const st1vafe3bx_md_t *val)
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_mode_get(const stmdev_ctx_t *ctx, st1vafe3bx_md_t *val)
+int32_t st1vafe3bx_mode_get(const st1vafe3bx_ctx_t *ctx, st1vafe3bx_md_t *val)
 {
   st1vafe3bx_ah_bio_cfg2_t ah_bio_cfg2;
   st1vafe3bx_ctrl3_t ctrl3;
@@ -779,7 +779,7 @@ int32_t st1vafe3bx_mode_get(const stmdev_ctx_t *ctx, st1vafe3bx_md_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_exit_deep_power_down(const stmdev_ctx_t *ctx)
+int32_t st1vafe3bx_exit_deep_power_down(const st1vafe3bx_ctx_t *ctx)
 {
   st1vafe3bx_en_device_config_t en_device_config = {0};
   int32_t ret;
@@ -804,7 +804,7 @@ int32_t st1vafe3bx_exit_deep_power_down(const stmdev_ctx_t *ctx)
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_trigger_sw(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_trigger_sw(const st1vafe3bx_ctx_t *ctx,
                               const st1vafe3bx_md_t *md)
 {
   st1vafe3bx_ctrl4_t ctrl4;
@@ -822,7 +822,7 @@ int32_t st1vafe3bx_trigger_sw(const stmdev_ctx_t *ctx,
   return ret;
 }
 
-int32_t st1vafe3bx_all_sources_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_all_sources_get(const st1vafe3bx_ctx_t *ctx,
                                    st1vafe3bx_all_sources_t *val)
 {
   st1vafe3bx_status_register_t status;
@@ -877,7 +877,7 @@ int32_t st1vafe3bx_all_sources_get(const stmdev_ctx_t *ctx,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_xl_data_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_xl_data_get(const st1vafe3bx_ctx_t *ctx,
                                const st1vafe3bx_md_t *md,
                                st1vafe3bx_xl_data_t *data)
 {
@@ -926,18 +926,31 @@ int32_t st1vafe3bx_xl_data_get(const stmdev_ctx_t *ctx,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_ah_bio_data_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_ah_bio_data_get(const st1vafe3bx_ctx_t *ctx,
                                    st1vafe3bx_ah_bio_data_t *data)
 {
-  uint8_t buff[2];
+  uint8_t buff[3];
   int32_t ret;
 
-  ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_OUT_AH_BIO_L, buff, 2);
+  if (ctx->vafe_only == 1)
+  {
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_OUT_AH_BIO_L, buff, 2);
 
-  data->raw = (int16_t)buff[1];
-  data->raw = (data->raw * 256U) + (int16_t)buff[0];
+    data->raw = (int16_t)buff[1];
+    data->raw = (data->raw * 256U) + (int16_t)buff[0];
 
-  data->mv = st1vafe3bx_from_lsb_to_mv(data->raw);
+    data->mv = st1vafe3bx_from_lsb_to_mv(data->raw);
+  }
+  else
+  {
+    /* Read and discard also OUT_Z_H reg to clear drdy */
+    ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_OUT_AH_BIO_L - 1, buff, 3);
+
+    data->raw = (int16_t)buff[2];
+    data->raw = (data->raw * 256U) + (int16_t)buff[1];
+
+    data->mv = st1vafe3bx_from_lsb_to_mv(data->raw);
+  }
 
   return ret;
 }
@@ -950,7 +963,7 @@ int32_t st1vafe3bx_ah_bio_data_get(const stmdev_ctx_t *ctx,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_self_test_sign_set(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_self_test_sign_set(const st1vafe3bx_ctx_t *ctx,
                                       st1vafe3bx_xl_self_test_t val)
 {
   st1vafe3bx_ctrl3_t ctrl3;
@@ -997,7 +1010,7 @@ int32_t st1vafe3bx_self_test_sign_set(const stmdev_ctx_t *ctx,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_self_test_start(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t st1vafe3bx_self_test_start(const st1vafe3bx_ctx_t *ctx, uint8_t val)
 {
   st1vafe3bx_ah_bio_cfg3_t ah_bio_cfg3;
   int32_t ret;
@@ -1025,7 +1038,7 @@ int32_t st1vafe3bx_self_test_start(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_self_test_stop(const stmdev_ctx_t *ctx)
+int32_t st1vafe3bx_self_test_stop(const st1vafe3bx_ctx_t *ctx)
 {
   st1vafe3bx_ah_bio_cfg3_t ah_bio_cfg3;
   int32_t ret;
@@ -1049,7 +1062,7 @@ int32_t st1vafe3bx_self_test_stop(const stmdev_ctx_t *ctx)
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_i3c_configure_set(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_i3c_configure_set(const st1vafe3bx_ctx_t *ctx,
                                      const st1vafe3bx_i3c_cfg_t *val)
 {
   st1vafe3bx_i3c_if_ctrl_t i3c_cfg;
@@ -1077,7 +1090,7 @@ int32_t st1vafe3bx_i3c_configure_set(const stmdev_ctx_t *ctx,
   * @param  val   configuration params
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
-  */int32_t st1vafe3bx_i3c_configure_get(const stmdev_ctx_t *ctx,
+  */int32_t st1vafe3bx_i3c_configure_get(const st1vafe3bx_ctx_t *ctx,
                                          st1vafe3bx_i3c_cfg_t *val)
 {
   st1vafe3bx_i3c_if_ctrl_t i3c_cfg;
@@ -1121,7 +1134,7 @@ int32_t st1vafe3bx_i3c_configure_set(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_mem_bank_set(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_mem_bank_set(const st1vafe3bx_ctx_t *ctx,
                                 st1vafe3bx_mem_bank_t val)
 {
   st1vafe3bx_func_cfg_access_t func_cfg_access;
@@ -1149,7 +1162,7 @@ int32_t st1vafe3bx_mem_bank_set(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_mem_bank_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_mem_bank_get(const st1vafe3bx_ctx_t *ctx,
                                 st1vafe3bx_mem_bank_t *val)
 {
   st1vafe3bx_func_cfg_access_t func_cfg_access;
@@ -1186,7 +1199,7 @@ int32_t st1vafe3bx_mem_bank_get(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t address,
+int32_t st1vafe3bx_ln_pg_write(const st1vafe3bx_ctx_t *ctx, uint16_t address,
                                uint8_t *buf, uint8_t len)
 {
   st1vafe3bx_page_address_t  page_address;
@@ -1272,7 +1285,7 @@ int32_t st1vafe3bx_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t address,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_ln_pg_read(const stmdev_ctx_t *ctx, uint16_t address,
+int32_t st1vafe3bx_ln_pg_read(const st1vafe3bx_ctx_t *ctx, uint16_t address,
                               uint8_t *buf, uint8_t len)
 {
   st1vafe3bx_page_address_t  page_address;
@@ -1367,7 +1380,7 @@ int32_t st1vafe3bx_ln_pg_read(const stmdev_ctx_t *ctx, uint16_t address,
   * @retval      interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_ext_clk_en_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t st1vafe3bx_ext_clk_en_set(const st1vafe3bx_ctx_t *ctx, uint8_t val)
 {
   st1vafe3bx_ext_clk_cfg_t clk;
   int32_t ret;
@@ -1387,7 +1400,7 @@ int32_t st1vafe3bx_ext_clk_en_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval      interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_ext_clk_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t st1vafe3bx_ext_clk_en_get(const st1vafe3bx_ctx_t *ctx, uint8_t *val)
 {
   st1vafe3bx_ext_clk_cfg_t clk;
   int32_t ret;
@@ -1406,7 +1419,7 @@ int32_t st1vafe3bx_ext_clk_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval      interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_pin_conf_set(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_pin_conf_set(const st1vafe3bx_ctx_t *ctx,
                                 const st1vafe3bx_pin_conf_t *val)
 {
   st1vafe3bx_pin_ctrl_t pin_ctrl;
@@ -1436,7 +1449,7 @@ int32_t st1vafe3bx_pin_conf_set(const stmdev_ctx_t *ctx,
   * @retval      interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_pin_conf_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_pin_conf_get(const st1vafe3bx_ctx_t *ctx,
                                 st1vafe3bx_pin_conf_t *val)
 {
   st1vafe3bx_pin_ctrl_t pin_ctrl;
@@ -1460,7 +1473,7 @@ int32_t st1vafe3bx_pin_conf_get(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_int_pin_polarity_set(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_int_pin_polarity_set(const st1vafe3bx_ctx_t *ctx,
                                         st1vafe3bx_int_pin_polarity_t val)
 {
   st1vafe3bx_pin_ctrl_t pin_ctrl;
@@ -1486,7 +1499,7 @@ int32_t st1vafe3bx_int_pin_polarity_set(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_int_pin_polarity_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_int_pin_polarity_get(const st1vafe3bx_ctx_t *ctx,
                                         st1vafe3bx_int_pin_polarity_t *val)
 {
   st1vafe3bx_pin_ctrl_t pin_ctrl;
@@ -1520,7 +1533,7 @@ int32_t st1vafe3bx_int_pin_polarity_get(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_spi_mode_set(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_spi_mode_set(const st1vafe3bx_ctx_t *ctx,
                                 st1vafe3bx_spi_mode val)
 {
   st1vafe3bx_pin_ctrl_t pin_ctrl;
@@ -1546,7 +1559,7 @@ int32_t st1vafe3bx_spi_mode_set(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_spi_mode_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_spi_mode_get(const st1vafe3bx_ctx_t *ctx,
                                 st1vafe3bx_spi_mode *val)
 {
   st1vafe3bx_pin_ctrl_t pin_ctrl;
@@ -1579,7 +1592,7 @@ int32_t st1vafe3bx_spi_mode_get(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_pin_int_route_set(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_pin_int_route_set(const st1vafe3bx_ctx_t *ctx,
                                      const st1vafe3bx_pin_int_route_t *val)
 {
   st1vafe3bx_ctrl1_t ctrl1;
@@ -1637,7 +1650,7 @@ int32_t st1vafe3bx_pin_int_route_set(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_pin_int_route_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_pin_int_route_get(const st1vafe3bx_ctx_t *ctx,
                                      st1vafe3bx_pin_int_route_t *val)
 {
   st1vafe3bx_ctrl2_t ctrl2;
@@ -1675,7 +1688,7 @@ int32_t st1vafe3bx_pin_int_route_get(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_emb_pin_int_route_set(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_emb_pin_int_route_set(const st1vafe3bx_ctx_t *ctx,
                                          const st1vafe3bx_emb_pin_int_route_t *val)
 {
   st1vafe3bx_emb_func_int_t emb_func_int;
@@ -1719,7 +1732,7 @@ int32_t st1vafe3bx_emb_pin_int_route_set(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_emb_pin_int_route_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_emb_pin_int_route_get(const st1vafe3bx_ctx_t *ctx,
                                          st1vafe3bx_emb_pin_int_route_t *val)
 {
   st1vafe3bx_emb_func_int_t emb_func_int;
@@ -1752,7 +1765,7 @@ int32_t st1vafe3bx_emb_pin_int_route_get(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_int_config_set(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_int_config_set(const st1vafe3bx_ctx_t *ctx,
                                   const st1vafe3bx_int_config_t *val)
 {
   st1vafe3bx_interrupt_cfg_t interrupt_cfg;
@@ -1799,7 +1812,7 @@ int32_t st1vafe3bx_int_config_set(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_int_config_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_int_config_get(const st1vafe3bx_ctx_t *ctx,
                                   st1vafe3bx_int_config_t *val)
 {
   st1vafe3bx_interrupt_cfg_t interrupt_cfg;
@@ -1838,7 +1851,7 @@ int32_t st1vafe3bx_int_config_get(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_embedded_int_cfg_set(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_embedded_int_cfg_set(const st1vafe3bx_ctx_t *ctx,
                                         st1vafe3bx_embedded_int_config_t val)
 {
   st1vafe3bx_page_rw_t page_rw;
@@ -1878,7 +1891,7 @@ int32_t st1vafe3bx_embedded_int_cfg_set(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_embedded_int_cfg_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_embedded_int_cfg_get(const st1vafe3bx_ctx_t *ctx,
                                         st1vafe3bx_embedded_int_config_t *val)
 {
   st1vafe3bx_page_rw_t page_rw;
@@ -1925,7 +1938,7 @@ int32_t st1vafe3bx_embedded_int_cfg_get(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_fifo_mode_set(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_fifo_mode_set(const st1vafe3bx_ctx_t *ctx,
                                  st1vafe3bx_fifo_mode_t val)
 {
   st1vafe3bx_ctrl4_t ctrl4;
@@ -1978,11 +1991,8 @@ int32_t st1vafe3bx_fifo_mode_set(const stmdev_ctx_t *ctx,
     fifo_wtm.xl_only_fifo = val.xl_only;
 
     /* set batching info */
-    if (val.batch.dec_ts != ST1VAFE3BX_DEC_TS_OFF)
-    {
-      fifo_batch.dec_ts_batch = (uint8_t)val.batch.dec_ts;
-      fifo_batch.bdr_xl = (uint8_t)val.batch.bdr_xl;
-    }
+    fifo_batch.dec_ts_batch = (uint8_t)val.batch.dec_ts;
+    fifo_batch.bdr_xl = (uint8_t)val.batch.bdr_xl;
 
     fifo_ctrl.cfg_chg_en = val.cfg_change_in_fifo;
 
@@ -2014,7 +2024,7 @@ int32_t st1vafe3bx_fifo_mode_set(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_fifo_mode_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_fifo_mode_get(const st1vafe3bx_ctx_t *ctx,
                                  st1vafe3bx_fifo_mode_t *val)
 {
   st1vafe3bx_ctrl4_t ctrl4;
@@ -2068,7 +2078,7 @@ int32_t st1vafe3bx_fifo_mode_get(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_fifo_data_level_get(const stmdev_ctx_t *ctx, uint16_t *val)
+int32_t st1vafe3bx_fifo_data_level_get(const st1vafe3bx_ctx_t *ctx, uint16_t *val)
 {
   uint8_t buff;
   int32_t ret;
@@ -2080,7 +2090,7 @@ int32_t st1vafe3bx_fifo_data_level_get(const stmdev_ctx_t *ctx, uint16_t *val)
   return ret;
 }
 
-int32_t st1vafe3bx_fifo_wtm_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t st1vafe3bx_fifo_wtm_flag_get(const st1vafe3bx_ctx_t *ctx, uint8_t *val)
 {
   st1vafe3bx_fifo_status1_t fifo_status1;
   int32_t ret;
@@ -2092,7 +2102,7 @@ int32_t st1vafe3bx_fifo_wtm_flag_get(const stmdev_ctx_t *ctx, uint8_t *val)
   return ret;
 }
 
-int32_t st1vafe3bx_fifo_sensor_tag_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_fifo_sensor_tag_get(const st1vafe3bx_ctx_t *ctx,
                                        st1vafe3bx_fifo_sensor_tag_t *val)
 {
   st1vafe3bx_fifo_data_out_tag_t fifo_tag;
@@ -2106,7 +2116,7 @@ int32_t st1vafe3bx_fifo_sensor_tag_get(const stmdev_ctx_t *ctx,
   return ret;
 }
 
-int32_t st1vafe3bx_fifo_out_raw_get(const stmdev_ctx_t *ctx, uint8_t *buff)
+int32_t st1vafe3bx_fifo_out_raw_get(const st1vafe3bx_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -2115,7 +2125,7 @@ int32_t st1vafe3bx_fifo_out_raw_get(const stmdev_ctx_t *ctx, uint8_t *buff)
   return ret;
 }
 
-int32_t st1vafe3bx_fifo_data_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_fifo_data_get(const st1vafe3bx_ctx_t *ctx,
                                  const st1vafe3bx_md_t *md,
                                  const st1vafe3bx_fifo_mode_t *fmd,
                                  st1vafe3bx_fifo_data_t *data)
@@ -2271,7 +2281,7 @@ int32_t st1vafe3bx_fifo_data_get(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_ah_bio_config_set(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_ah_bio_config_set(const st1vafe3bx_ctx_t *ctx,
                                      st1vafe3bx_ah_bio_config_t val)
 {
   st1vafe3bx_ah_bio_cfg1_t cfg1;
@@ -2361,7 +2371,7 @@ int32_t st1vafe3bx_ah_bio_config_set(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_ah_bio_config_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_ah_bio_config_get(const st1vafe3bx_ctx_t *ctx,
                                      st1vafe3bx_ah_bio_config_t *val)
 {
   st1vafe3bx_ah_bio_cfg1_t cfg1;
@@ -2447,7 +2457,7 @@ int32_t st1vafe3bx_ah_bio_config_get(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_enter_vafe_only(const stmdev_ctx_t *ctx)
+int32_t st1vafe3bx_enter_vafe_only(st1vafe3bx_ctx_t *ctx)
 {
   st1vafe3bx_ah_bio_cfg2_t cfg2;
   int32_t ret;
@@ -2455,6 +2465,11 @@ int32_t st1vafe3bx_enter_vafe_only(const stmdev_ctx_t *ctx)
   ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_AH_BIO_CFG2, (uint8_t *)&cfg2, 1);
   cfg2.ah_bio_en = 1;
   ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_AH_BIO_CFG2, (uint8_t *)&cfg2, 1);
+
+  if (ret == 0)
+  {
+    ctx->vafe_only = 1;
+  }
 
   return ret;
 }
@@ -2466,7 +2481,7 @@ int32_t st1vafe3bx_enter_vafe_only(const stmdev_ctx_t *ctx)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_exit_vafe_only(const stmdev_ctx_t *ctx)
+int32_t st1vafe3bx_exit_vafe_only(st1vafe3bx_ctx_t *ctx)
 {
   st1vafe3bx_ah_bio_cfg2_t cfg2;
   int32_t ret;
@@ -2474,6 +2489,11 @@ int32_t st1vafe3bx_exit_vafe_only(const stmdev_ctx_t *ctx)
   ret = st1vafe3bx_read_reg(ctx, ST1VAFE3BX_AH_BIO_CFG2, (uint8_t *)&cfg2, 1);
   cfg2.ah_bio_en = 0;
   ret += st1vafe3bx_write_reg(ctx, ST1VAFE3BX_AH_BIO_CFG2, (uint8_t *)&cfg2, 1);
+
+  if (ret == 0)
+  {
+    ctx->vafe_only = 0;
+  }
 
   return ret;
 }
@@ -2486,7 +2506,7 @@ int32_t st1vafe3bx_exit_vafe_only(const stmdev_ctx_t *ctx)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_ah_bio_active(const stmdev_ctx_t *ctx, uint8_t filter_on)
+int32_t st1vafe3bx_ah_bio_active(const st1vafe3bx_ctx_t *ctx, uint8_t filter_on)
 {
   st1vafe3bx_ah_bio_cfg3_t cfg3;
   st1vafe3bx_ctrl3_t ctrl3;
@@ -2530,7 +2550,7 @@ int32_t st1vafe3bx_ah_bio_active(const stmdev_ctx_t *ctx, uint8_t filter_on)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_stpcnt_mode_set(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_stpcnt_mode_set(const st1vafe3bx_ctx_t *ctx,
                                    st1vafe3bx_stpcnt_mode_t val)
 {
   st1vafe3bx_emb_func_en_a_t emb_func_en_a;
@@ -2586,7 +2606,7 @@ int32_t st1vafe3bx_stpcnt_mode_set(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_stpcnt_mode_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_stpcnt_mode_get(const st1vafe3bx_ctx_t *ctx,
                                    st1vafe3bx_stpcnt_mode_t *val)
 {
   st1vafe3bx_emb_func_en_a_t emb_func_en_a;
@@ -2615,7 +2635,7 @@ int32_t st1vafe3bx_stpcnt_mode_get(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_stpcnt_steps_get(const stmdev_ctx_t *ctx, uint16_t *val)
+int32_t st1vafe3bx_stpcnt_steps_get(const st1vafe3bx_ctx_t *ctx, uint16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -2638,7 +2658,7 @@ int32_t st1vafe3bx_stpcnt_steps_get(const stmdev_ctx_t *ctx, uint16_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_stpcnt_rst_step_set(const stmdev_ctx_t *ctx)
+int32_t st1vafe3bx_stpcnt_rst_step_set(const st1vafe3bx_ctx_t *ctx)
 {
   st1vafe3bx_emb_func_src_t emb_func_src;
   int32_t ret;
@@ -2666,7 +2686,7 @@ int32_t st1vafe3bx_stpcnt_rst_step_set(const stmdev_ctx_t *ctx)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_stpcnt_debounce_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t st1vafe3bx_stpcnt_debounce_set(const st1vafe3bx_ctx_t *ctx, uint8_t val)
 {
   st1vafe3bx_pedo_deb_steps_conf_t pedo_deb_steps_conf;
   int32_t ret;
@@ -2687,7 +2707,7 @@ int32_t st1vafe3bx_stpcnt_debounce_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_stpcnt_debounce_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t st1vafe3bx_stpcnt_debounce_get(const st1vafe3bx_ctx_t *ctx, uint8_t *val)
 {
   st1vafe3bx_pedo_deb_steps_conf_t pedo_deb_steps_conf;
   int32_t ret;
@@ -2708,7 +2728,7 @@ int32_t st1vafe3bx_stpcnt_debounce_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_stpcnt_period_set(const stmdev_ctx_t *ctx, uint16_t val)
+int32_t st1vafe3bx_stpcnt_period_set(const st1vafe3bx_ctx_t *ctx, uint16_t val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -2731,7 +2751,7 @@ int32_t st1vafe3bx_stpcnt_period_set(const stmdev_ctx_t *ctx, uint16_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_stpcnt_period_get(const stmdev_ctx_t *ctx, uint16_t *val)
+int32_t st1vafe3bx_stpcnt_period_get(const st1vafe3bx_ctx_t *ctx, uint16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -2764,7 +2784,7 @@ int32_t st1vafe3bx_stpcnt_period_get(const stmdev_ctx_t *ctx, uint16_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_tilt_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t st1vafe3bx_tilt_mode_set(const st1vafe3bx_ctx_t *ctx, uint8_t val)
 {
   st1vafe3bx_emb_func_en_a_t emb_func_en_a;
   int32_t ret;
@@ -2792,7 +2812,7 @@ int32_t st1vafe3bx_tilt_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_tilt_mode_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t st1vafe3bx_tilt_mode_get(const st1vafe3bx_ctx_t *ctx, uint8_t *val)
 {
   st1vafe3bx_emb_func_en_a_t emb_func_en_a;
   int32_t ret;
@@ -2829,7 +2849,7 @@ int32_t st1vafe3bx_tilt_mode_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_sigmot_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t st1vafe3bx_sigmot_mode_set(const st1vafe3bx_ctx_t *ctx, uint8_t val)
 {
   st1vafe3bx_emb_func_en_a_t emb_func_en_a;
   int32_t ret;
@@ -2857,7 +2877,7 @@ int32_t st1vafe3bx_sigmot_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_sigmot_mode_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t st1vafe3bx_sigmot_mode_get(const st1vafe3bx_ctx_t *ctx, uint8_t *val)
 {
   st1vafe3bx_emb_func_en_a_t emb_func_en_a;
   int32_t ret;
@@ -2897,7 +2917,7 @@ int32_t st1vafe3bx_sigmot_mode_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_ff_duration_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t st1vafe3bx_ff_duration_set(const st1vafe3bx_ctx_t *ctx, uint8_t val)
 {
   st1vafe3bx_wake_up_dur_t wake_up_dur;
   st1vafe3bx_free_fall_t free_fall;
@@ -2935,7 +2955,7 @@ int32_t st1vafe3bx_ff_duration_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_ff_duration_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t st1vafe3bx_ff_duration_get(const st1vafe3bx_ctx_t *ctx, uint8_t *val)
 {
   st1vafe3bx_wake_up_dur_t wake_up_dur;
   st1vafe3bx_free_fall_t free_fall;
@@ -2960,7 +2980,7 @@ int32_t st1vafe3bx_ff_duration_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_ff_thresholds_set(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_ff_thresholds_set(const st1vafe3bx_ctx_t *ctx,
                                      st1vafe3bx_ff_thresholds_t val)
 {
   st1vafe3bx_free_fall_t free_fall;
@@ -2984,7 +3004,7 @@ int32_t st1vafe3bx_ff_thresholds_set(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_ff_thresholds_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_ff_thresholds_get(const st1vafe3bx_ctx_t *ctx,
                                      st1vafe3bx_ff_thresholds_t *val)
 {
   st1vafe3bx_free_fall_t free_fall;
@@ -3055,7 +3075,7 @@ int32_t st1vafe3bx_ff_thresholds_get(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_sixd_config_set(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_sixd_config_set(const st1vafe3bx_ctx_t *ctx,
                                    st1vafe3bx_sixd_config_t val)
 {
   st1vafe3bx_sixd_t sixd;
@@ -3081,7 +3101,7 @@ int32_t st1vafe3bx_sixd_config_set(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_sixd_config_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_sixd_config_get(const st1vafe3bx_ctx_t *ctx,
                                    st1vafe3bx_sixd_config_t *val)
 {
   st1vafe3bx_sixd_t sixd;
@@ -3137,7 +3157,7 @@ int32_t st1vafe3bx_sixd_config_get(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_wakeup_config_set(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_wakeup_config_set(const st1vafe3bx_ctx_t *ctx,
                                      st1vafe3bx_wakeup_config_t val)
 {
   st1vafe3bx_wake_up_ths_t wup_ths;
@@ -3206,7 +3226,7 @@ int32_t st1vafe3bx_wakeup_config_set(const stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t st1vafe3bx_wakeup_config_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_wakeup_config_get(const st1vafe3bx_ctx_t *ctx,
                                      st1vafe3bx_wakeup_config_t *val)
 {
   st1vafe3bx_wake_up_ths_t wup_ths;
@@ -3267,7 +3287,7 @@ int32_t st1vafe3bx_wakeup_config_get(const stmdev_ctx_t *ctx,
   *
   */
 
-int32_t st1vafe3bx_tap_config_set(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_tap_config_set(const st1vafe3bx_ctx_t *ctx,
                                   st1vafe3bx_tap_config_t val)
 {
   st1vafe3bx_tap_cfg0_t tap_cfg0;
@@ -3325,7 +3345,7 @@ int32_t st1vafe3bx_tap_config_set(const stmdev_ctx_t *ctx,
   return ret;
 }
 
-int32_t st1vafe3bx_tap_config_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_tap_config_get(const st1vafe3bx_ctx_t *ctx,
                                   st1vafe3bx_tap_config_t *val)
 {
   st1vafe3bx_tap_cfg0_t tap_cfg0;
@@ -3388,7 +3408,7 @@ int32_t st1vafe3bx_tap_config_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t st1vafe3bx_timestamp_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t st1vafe3bx_timestamp_set(const st1vafe3bx_ctx_t *ctx, uint8_t val)
 {
   st1vafe3bx_interrupt_cfg_t int_cfg;
   int32_t ret;
@@ -3414,7 +3434,7 @@ int32_t st1vafe3bx_timestamp_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t st1vafe3bx_timestamp_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t st1vafe3bx_timestamp_get(const st1vafe3bx_ctx_t *ctx, uint8_t *val)
 {
   st1vafe3bx_interrupt_cfg_t int_cfg;
   int32_t ret;
@@ -3436,7 +3456,7 @@ int32_t st1vafe3bx_timestamp_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t st1vafe3bx_timestamp_raw_get(const stmdev_ctx_t *ctx, uint32_t *val)
+int32_t st1vafe3bx_timestamp_raw_get(const st1vafe3bx_ctx_t *ctx, uint32_t *val)
 {
   uint8_t buff[4];
   int32_t ret;
@@ -3472,7 +3492,7 @@ int32_t st1vafe3bx_timestamp_raw_get(const stmdev_ctx_t *ctx, uint32_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t st1vafe3bx_long_cnt_flag_data_ready_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_long_cnt_flag_data_ready_get(const st1vafe3bx_ctx_t *ctx,
                                                 uint8_t *val)
 {
   st1vafe3bx_emb_func_status_t emb_func_status;
@@ -3501,7 +3521,7 @@ int32_t st1vafe3bx_long_cnt_flag_data_ready_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t st1vafe3bx_emb_fsm_en_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t st1vafe3bx_emb_fsm_en_set(const st1vafe3bx_ctx_t *ctx, uint8_t val)
 {
   int32_t ret;
 
@@ -3532,7 +3552,7 @@ int32_t st1vafe3bx_emb_fsm_en_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t st1vafe3bx_emb_fsm_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t st1vafe3bx_emb_fsm_en_get(const st1vafe3bx_ctx_t *ctx, uint8_t *val)
 {
   int32_t ret;
 
@@ -3563,7 +3583,7 @@ int32_t st1vafe3bx_emb_fsm_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t st1vafe3bx_fsm_enable_set(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_fsm_enable_set(const st1vafe3bx_ctx_t *ctx,
                                   st1vafe3bx_emb_fsm_enable_t *val)
 {
   st1vafe3bx_emb_func_en_b_t emb_func_en_b;
@@ -3615,7 +3635,7 @@ int32_t st1vafe3bx_fsm_enable_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t st1vafe3bx_fsm_enable_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_fsm_enable_get(const st1vafe3bx_ctx_t *ctx,
                                   st1vafe3bx_emb_fsm_enable_t *val)
 {
   int32_t ret;
@@ -3642,7 +3662,7 @@ int32_t st1vafe3bx_fsm_enable_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t st1vafe3bx_long_cnt_set(const stmdev_ctx_t *ctx, uint16_t val)
+int32_t st1vafe3bx_long_cnt_set(const st1vafe3bx_ctx_t *ctx, uint16_t val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -3670,7 +3690,7 @@ int32_t st1vafe3bx_long_cnt_set(const stmdev_ctx_t *ctx, uint16_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t st1vafe3bx_long_cnt_get(const stmdev_ctx_t *ctx, uint16_t *val)
+int32_t st1vafe3bx_long_cnt_get(const st1vafe3bx_ctx_t *ctx, uint16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -3696,7 +3716,7 @@ int32_t st1vafe3bx_long_cnt_get(const stmdev_ctx_t *ctx, uint16_t *val)
   * @param  val      register FSM_STATUS_MAINPAGE
   *
   */
-int32_t st1vafe3bx_fsm_status_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_fsm_status_get(const st1vafe3bx_ctx_t *ctx,
                                   st1vafe3bx_fsm_status_mainpage_t *val)
 {
   return st1vafe3bx_read_reg(ctx, ST1VAFE3BX_FSM_STATUS_MAINPAGE,
@@ -3711,7 +3731,7 @@ int32_t st1vafe3bx_fsm_status_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t st1vafe3bx_fsm_out_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t st1vafe3bx_fsm_out_get(const st1vafe3bx_ctx_t *ctx, uint8_t *val)
 {
   int32_t ret;
 
@@ -3735,7 +3755,7 @@ int32_t st1vafe3bx_fsm_out_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t st1vafe3bx_fsm_data_rate_set(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_fsm_data_rate_set(const st1vafe3bx_ctx_t *ctx,
                                      st1vafe3bx_fsm_val_odr_t val)
 {
   st1vafe3bx_ah_bio_cfg2_t ah_bio_cfg2;
@@ -3770,7 +3790,7 @@ int32_t st1vafe3bx_fsm_data_rate_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t st1vafe3bx_fsm_data_rate_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_fsm_data_rate_get(const st1vafe3bx_ctx_t *ctx,
                                      st1vafe3bx_fsm_val_odr_t *val)
 {
   st1vafe3bx_ah_bio_cfg2_t ah_bio_cfg2;
@@ -3859,7 +3879,7 @@ int32_t st1vafe3bx_fsm_data_rate_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t st1vafe3bx_fsm_init_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t st1vafe3bx_fsm_init_set(const st1vafe3bx_ctx_t *ctx, uint8_t val)
 {
   st1vafe3bx_emb_func_init_b_t emb_func_init_b;
   int32_t ret;
@@ -3890,7 +3910,7 @@ int32_t st1vafe3bx_fsm_init_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t st1vafe3bx_fsm_init_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t st1vafe3bx_fsm_init_get(const st1vafe3bx_ctx_t *ctx, uint8_t *val)
 {
   st1vafe3bx_emb_func_init_b_t emb_func_init_b;
   int32_t ret;
@@ -3918,7 +3938,7 @@ int32_t st1vafe3bx_fsm_init_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t st1vafe3bx_fsm_fifo_en_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t st1vafe3bx_fsm_fifo_en_set(const st1vafe3bx_ctx_t *ctx, uint8_t val)
 {
   st1vafe3bx_emb_func_fifo_en_t fifo_reg;
   int32_t ret;
@@ -3947,7 +3967,7 @@ int32_t st1vafe3bx_fsm_fifo_en_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t st1vafe3bx_fsm_fifo_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t st1vafe3bx_fsm_fifo_en_get(const st1vafe3bx_ctx_t *ctx, uint8_t *val)
 {
   st1vafe3bx_emb_func_fifo_en_t fifo_reg;
   int32_t ret;
@@ -3977,7 +3997,7 @@ int32_t st1vafe3bx_fsm_fifo_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t st1vafe3bx_long_cnt_int_value_set(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_long_cnt_int_value_set(const st1vafe3bx_ctx_t *ctx,
                                           uint16_t val)
 {
   uint8_t buff[2];
@@ -4001,7 +4021,7 @@ int32_t st1vafe3bx_long_cnt_int_value_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t st1vafe3bx_long_cnt_int_value_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_long_cnt_int_value_get(const st1vafe3bx_ctx_t *ctx,
                                           uint16_t *val)
 {
   uint8_t buff[2];
@@ -4022,7 +4042,7 @@ int32_t st1vafe3bx_long_cnt_int_value_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t st1vafe3bx_fsm_programs_num_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t st1vafe3bx_fsm_programs_num_set(const st1vafe3bx_ctx_t *ctx, uint8_t val)
 {
   int32_t ret;
 
@@ -4039,7 +4059,7 @@ int32_t st1vafe3bx_fsm_programs_num_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t st1vafe3bx_fsm_programs_num_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t st1vafe3bx_fsm_programs_num_get(const st1vafe3bx_ctx_t *ctx, uint8_t *val)
 {
   int32_t ret;
 
@@ -4057,7 +4077,7 @@ int32_t st1vafe3bx_fsm_programs_num_get(const stmdev_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t st1vafe3bx_fsm_start_address_set(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_fsm_start_address_set(const st1vafe3bx_ctx_t *ctx,
                                          uint16_t val)
 {
   uint8_t buff[2];
@@ -4079,7 +4099,7 @@ int32_t st1vafe3bx_fsm_start_address_set(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t st1vafe3bx_fsm_start_address_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_fsm_start_address_get(const st1vafe3bx_ctx_t *ctx,
                                          uint16_t *val)
 {
   uint8_t buff[2];
@@ -4114,7 +4134,7 @@ int32_t st1vafe3bx_fsm_start_address_get(const stmdev_ctx_t *ctx,
   *                  in EMB_FUNC_INIT_A
   *
   */
-int32_t st1vafe3bx_mlc_set(const stmdev_ctx_t *ctx, st1vafe3bx_mlc_mode_t val)
+int32_t st1vafe3bx_mlc_set(const st1vafe3bx_ctx_t *ctx, st1vafe3bx_mlc_mode_t val)
 {
   st1vafe3bx_emb_func_en_a_t emb_en_a;
   st1vafe3bx_emb_func_en_b_t emb_en_b;
@@ -4168,7 +4188,7 @@ int32_t st1vafe3bx_mlc_set(const stmdev_ctx_t *ctx, st1vafe3bx_mlc_mode_t val)
   *                  in EMB_FUNC_INIT_A
   *
   */
-int32_t st1vafe3bx_mlc_get(const stmdev_ctx_t *ctx, st1vafe3bx_mlc_mode_t *val)
+int32_t st1vafe3bx_mlc_get(const st1vafe3bx_ctx_t *ctx, st1vafe3bx_mlc_mode_t *val)
 {
   st1vafe3bx_emb_func_en_a_t emb_en_a;
   st1vafe3bx_emb_func_en_b_t emb_en_b;
@@ -4213,7 +4233,7 @@ int32_t st1vafe3bx_mlc_get(const stmdev_ctx_t *ctx, st1vafe3bx_mlc_mode_t *val)
   * @param  val      register MLC_STATUS_MAINPAGE
   *
   */
-int32_t st1vafe3bx_mlc_status_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_mlc_status_get(const st1vafe3bx_ctx_t *ctx,
                                   st1vafe3bx_mlc_status_mainpage_t *val)
 {
   return st1vafe3bx_read_reg(ctx, ST1VAFE3BX_MLC_STATUS_MAINPAGE,
@@ -4227,7 +4247,7 @@ int32_t st1vafe3bx_mlc_status_get(const stmdev_ctx_t *ctx,
   * @param  uint8_t * : buffer that stores data read
   *
   */
-int32_t st1vafe3bx_mlc_out_get(const stmdev_ctx_t *ctx, uint8_t *buff)
+int32_t st1vafe3bx_mlc_out_get(const st1vafe3bx_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -4251,7 +4271,7 @@ int32_t st1vafe3bx_mlc_out_get(const stmdev_ctx_t *ctx, uint8_t *buff)
   *                  reg EMB_FUNC_ODR_CFG_C
   *
   */
-int32_t st1vafe3bx_mlc_data_rate_set(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_mlc_data_rate_set(const st1vafe3bx_ctx_t *ctx,
                                      st1vafe3bx_mlc_odr_val_t val)
 {
   st1vafe3bx_ah_bio_cfg2_t ah_bio_cfg2;
@@ -4283,7 +4303,7 @@ int32_t st1vafe3bx_mlc_data_rate_set(const stmdev_ctx_t *ctx,
   *                  reg EMB_FUNC_ODR_CFG_C
   *
   */
-int32_t st1vafe3bx_mlc_data_rate_get(const stmdev_ctx_t *ctx,
+int32_t st1vafe3bx_mlc_data_rate_get(const st1vafe3bx_ctx_t *ctx,
                                      st1vafe3bx_mlc_odr_val_t *val)
 {
   st1vafe3bx_ah_bio_cfg2_t ah_bio_cfg2;
@@ -4365,7 +4385,7 @@ int32_t st1vafe3bx_mlc_data_rate_get(const stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t st1vafe3bx_mlc_fifo_en_set(const stmdev_ctx_t *ctx, uint8_t val)
+int32_t st1vafe3bx_mlc_fifo_en_set(const st1vafe3bx_ctx_t *ctx, uint8_t val)
 {
   st1vafe3bx_emb_func_fifo_en_t fifo_reg;
   int32_t ret;
@@ -4394,7 +4414,7 @@ int32_t st1vafe3bx_mlc_fifo_en_set(const stmdev_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t st1vafe3bx_mlc_fifo_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
+int32_t st1vafe3bx_mlc_fifo_en_get(const st1vafe3bx_ctx_t *ctx, uint8_t *val)
 {
   st1vafe3bx_emb_func_fifo_en_t fifo_reg;
   int32_t ret;

--- a/sensor/stmemsc/st1vafe6ax_STdC/driver/st1vafe6ax_reg.h
+++ b/sensor/stmemsc/st1vafe6ax_STdC/driver/st1vafe6ax_reg.h
@@ -3112,9 +3112,9 @@ int32_t st1vafe6ax_tap_detection_get(const stmdev_ctx_t *ctx,
 
 typedef struct
 {
-  uint8_t x                             : 1;
-  uint8_t y                             : 1;
-  uint8_t z                             : 1;
+  uint8_t x                             : 5;
+  uint8_t y                             : 5;
+  uint8_t z                             : 5;
 } st1vafe6ax_tap_thresholds_t;
 int32_t st1vafe6ax_tap_thresholds_set(const stmdev_ctx_t *ctx,
                                       st1vafe6ax_tap_thresholds_t val);
@@ -3138,9 +3138,9 @@ int32_t st1vafe6ax_tap_axis_priority_get(const stmdev_ctx_t *ctx,
 
 typedef struct
 {
-  uint8_t shock                         : 1;
-  uint8_t quiet                         : 1;
-  uint8_t tap_gap                       : 1;
+  uint8_t shock                         : 2;
+  uint8_t quiet                         : 2;
+  uint8_t tap_gap                       : 4;
 } st1vafe6ax_tap_time_windows_t;
 int32_t st1vafe6ax_tap_time_windows_set(const stmdev_ctx_t *ctx,
                                         st1vafe6ax_tap_time_windows_t val);

--- a/sensor/stmemsc/stts22h_STdC/driver/stts22h_reg.c
+++ b/sensor/stmemsc/stts22h_STdC/driver/stts22h_reg.c
@@ -52,7 +52,10 @@ int32_t __weak stts22h_read_reg(const stmdev_ctx_t *ctx, uint8_t reg,
 {
   int32_t ret;
 
-  if (ctx == NULL) return -1;
+  if (ctx == NULL)
+  {
+    return -1;
+  }
 
   ret = ctx->read_reg(ctx->handle, reg, data, len);
 
@@ -70,12 +73,15 @@ int32_t __weak stts22h_read_reg(const stmdev_ctx_t *ctx, uint8_t reg,
   *
   */
 int32_t __weak stts22h_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
-                                 uint8_t *data,
+                                 const uint8_t *data,
                                  uint16_t len)
 {
   int32_t ret;
 
-  if (ctx == NULL) return -1;
+  if (ctx == NULL)
+  {
+    return -1;
+  }
 
   ret = ctx->write_reg(ctx->handle, reg, data, len);
 

--- a/sensor/stmemsc/stts22h_STdC/driver/stts22h_reg.h
+++ b/sensor/stmemsc/stts22h_STdC/driver/stts22h_reg.h
@@ -131,33 +131,6 @@ typedef struct
 
 #endif /* MEMS_SHARED_TYPES */
 
-#ifndef MEMS_UCF_SHARED_TYPES
-#define MEMS_UCF_SHARED_TYPES
-
-/** @defgroup    Generic address-data structure definition
-  * @brief       This structure is useful to load a predefined configuration
-  *              of a sensor.
-  *              You can create a sensor configuration by your own or using
-  *              Unico / Unicleo tools available on STMicroelectronics
-  *              web site.
-  *
-  * @{
-  *
-  */
-
-typedef struct
-{
-  uint8_t address;
-  uint8_t data;
-} ucf_line_t;
-
-/**
-  * @}
-  *
-  */
-
-#endif /* MEMS_UCF_SHARED_TYPES */
-
 /**
   * @}
   *
@@ -234,33 +207,6 @@ typedef struct
 #define STTS22H_TEMP_L_OUT                   0x06U
 #define STTS22H_TEMP_H_OUT                   0x07U
 
-/**
-  * @defgroup STTS22H_Register_Union
-  * @brief    This union group all the registers having a bit-field
-  *           description.
-  *           This union is useful but it's not needed by the driver.
-  *
-  *           REMOVING this union you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-typedef union
-{
-  stts22h_temp_h_limit_t      temp_h_limit;
-  stts22h_temp_l_limit_t      temp_l_limit;
-  stts22h_ctrl_t              ctrl;
-  stts22h_status_t            status;
-  bitwise_t                   bitwise;
-  uint8_t                     byte;
-} stts22h_reg_t;
-
-/**
-  * @}
-  *
-  */
-
 #ifndef __weak
 #define __weak __attribute__((weak))
 #endif /* __weak */
@@ -278,7 +224,7 @@ int32_t stts22h_read_reg(const stmdev_ctx_t *ctx, uint8_t reg,
                          uint8_t *data,
                          uint16_t len);
 int32_t stts22h_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
-                          uint8_t *data,
+                          const uint8_t *data,
                           uint16_t len);
 
 float_t stts22h_from_lsb_to_celsius(int16_t lsb);


### PR DESCRIPTION
Align stmemsc HAL i/f to v2.9.1

(see [#89202](https://github.com/zephyrproject-rtos/zephyr/pull/89202))