### PR TITLE
sensor/stmemsc: Align stmemsc i/f to v2.13.2

### DIFF
--- a/sensor/stmemsc/README
+++ b/sensor/stmemsc/README
@@ -6,7 +6,7 @@ Origin:
    https://www.st.com/en/embedded-software/c-driver-mems.html
 
 Status:
-   version v2.13.0
+   version v2.13.2
 
 Purpose:
    ST Microelectronics standard C platform-independent drivers for MEMS
@@ -47,103 +47,21 @@ Description:
        .mdelay = (stmdev_mdelay_ptr) platform_mdelay,
    };
 
-   Driver versions in this package:
+   Driver updated since v2.13.1:
 
-     - a3g4250d_STdC        v3.2.1
-     - ais25ba_STdC         v2.2.1
-     - ais2dw12_STdC        v2.3.1
-     - ais2ih_STdC          v2.3.1
-     - ais328dq_STdC        v2.2.1
-     - ais3624dq_STdC       v2.2.1
-     - asm330lhb_STdC       v2.4.0
-     - asm330lhbg1_STdC     v1.4.0
-     - asm330lhh_STdC       v3.5.0
-     - asm330lhhg1_STdC     v1.1.0
-     - asm330lhhx_STdC      v2.4.0
-     - asm330lhhxg1_STdC    v3.1.0
-     - h3lis100dl_STdC      v2.2.1
-     - h3lis331dl_STdC      v2.2.1
-     - hts221_STdC          v2.3.1
-     - i3g4250d_STdC        v2.2.1
-     - iis2dh_STdC          v2.2.1
-     - iis2dlpc_STdC        v2.2.1
-     - iis2dulpx_STdC       v4.1.1
-     - iis2iclx_STdC        v2.3.0
-     - iis2mdc_STdC         v2.2.1
-     - iis328dq_STdC        v2.2.1
-     - iis3dhhc_STdC        v2.2.1
-     - iis3dwb_STdC         v2.2.1
-     - iis3dwbg1_STdC       v1.0.1
-     - ilps22qs_STdC        v4.0.3
-     - ilps28qsw_STdC       v3.1.0
-     - ism303dac_STdC       v2.2.1
-     - ism330bx_STdC        v3.3.1
-     - ism330dhcx_STdC      v4.0.0
-     - ism330dlc_STdC       v2.2.2
-     - ism330is_STdC        v3.2.2
-     - ism6hg256x_STdC      v4.1.2
-     - l3gd20h_STdC         v2.2.1
-     - lis25ba_STdC         v2.2.1
-     - lis2de12_STdC        v2.2.1
-     - lis2dh12_STdC        v2.2.1
-     - lis2ds12_STdC        v2.2.2
-     - lis2dtw12_STdC       v2.2.1
-     - lis2du12_STdC        v3.0.1
-     - lis2dux12_STdC       v5.1.1
-     - lis2duxs12_STdC      v5.1.1
-     - lis2dw12_STdC        v2.3.1
-     - lis2hh12_STdC        v2.2.1
-     - lis2mdl_STdC         v2.3.2
-     - lis331dlh_STdC       v2.2.1
-     - lis3de_STdC          v2.2.1
-     - lis3dh_STdC          v2.2.1
-     - lis3dhh_STdC         v2.2.1
-     - lis3mdl_STdC         v2.2.1
-     - lps22ch_STdC         v2.2.1
-     - lps22df_STdC         v2.4.3
-     - lps22hb_STdC         v2.2.1
-     - lps22hh_STdC         v3.2.1
-     - lps25hb_STdC         v2.2.1
-     - lps27hhtw_STdC       v2.2.1
-     - lps27hhw_STdC        v2.2.1
-     - lps28dfw_STdC        v3.1.0
-     - lps33k_STdC          v2.2.1
-     - lsm303agr_STdC       v2.2.1
-     - lsm303ah_STdC        v2.2.1
-     - lsm6ds3tr-c_STdC     v2.2.2
-     - lsm6dsl_STdC         v2.2.2
-     - lsm6dsm_STdC         v2.2.2
-     - lsm6dso16is_STdC     v3.2.2
-     - lsm6dso32_STdC       v2.3.1
-     - lsm6dso32x_STdC      v2.3.1
-     - lsm6dso_STdC         v3.2.2
-     - lsm6dsox_STdC        v3.3.1
-     - lsm6dsr_STdC         v4.0.0
-     - lsm6dsrx_STdC        v4.0.1
-     - lsm6dsv16b_STdC      v3.2.1
-     - lsm6dsv16bx_STdC     v5.2.1
-     - lsm6dsv16x_STdC      v6.1.1
-     - lsm6dsv320x_STdC     v5.1.2
-     - lsm6dsv32x_STdC      v4.1.1
-     - lsm6dsv80x_STdC      v5.1.2
-     - lsm6dsv_STdC         v5.1.1
-     - lsm9ds1_STdC         v2.2.1
-     - mis2du12_STdC        v1.0.1
-     - st1vafe3bx_STdC      v2.4.2
-     - st1vafe6ax_STdC      v2.2.1
-     - sths34pf80_STdC      v3.2.1
-     - stts22h_STdC         v2.3.1
-     - stts751_STdC         v2.2.1
+     - ism6hg256x_STdC      v4.3.0
+     - lsm6dsv320x_STdC     v5.3.0
+     - lsm6dsv80x_STdC      v5.3.0
 
 Dependencies:
     None.
 
 URL:
    https://www.st.com/en/embedded-software/c-driver-mems.html
-   https://github.com/STMicroelectronics/STMems_Standard_C_drivers/tree/v2.13.0
+   https://github.com/STMicroelectronics/STMems_Standard_C_drivers/tree/v2.13.2
 
 commit:
-   63a14610 (tag v2.13.0)
+   d72ebacb (tag v2.13.2)
 
 Maintained-by:
    ST Microelectronics

--- a/sensor/stmemsc/ism6hg256x_STdC/driver/ism6hg256x_reg.c
+++ b/sensor/stmemsc/ism6hg256x_STdC/driver/ism6hg256x_reg.c
@@ -50,7 +50,7 @@ int32_t __weak ism6hg256x_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
   return ret;
 }
 
-static void bytecpy(uint8_t *target, uint8_t *source)
+static void bytecpy(uint8_t *target, const uint8_t *source)
 {
   if ((target != NULL) && (source != NULL))
   {
@@ -173,7 +173,7 @@ int32_t ism6hg256x_xl_offset_on_out_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = ism6hg256x_read_reg(ctx, ISM6HG256X_CTRL9, (uint8_t *)&ctrl9, 1);
   if (ret == 0)
   {
-    ctrl9.usr_off_on_out = val;
+    ctrl9.usr_off_on_out = val & 0x01U;
     ret = ism6hg256x_write_reg(ctx, ISM6HG256X_CTRL9, (uint8_t *)&ctrl9, 1);
   }
 
@@ -204,7 +204,7 @@ int32_t ism6hg256x_xl_offset_mg_set(const stmdev_ctx_t *ctx,
   ism6hg256x_x_ofs_usr_t x_ofs_usr = {0};
   ism6hg256x_ctrl9_t ctrl9 = {0};
   int32_t ret = 0;
-  float_t tmp = 0;
+  float_t tmp = 0.0f;
 
   ret = ism6hg256x_read_reg(ctx, ISM6HG256X_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
   ret += ism6hg256x_read_reg(ctx, ISM6HG256X_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
@@ -220,38 +220,38 @@ int32_t ism6hg256x_xl_offset_mg_set(const stmdev_ctx_t *ctx,
       (val.y_mg < (0.0078125f * 127.0f)) && (val.y_mg > (0.0078125f * -127.0f)) &&
       (val.z_mg < (0.0078125f * 127.0f)) && (val.z_mg > (0.0078125f * -127.0f)))
   {
-    ctrl9.usr_off_w = 0;
+    ctrl9.usr_off_w = 0u;
 
     tmp = val.z_mg / 0.0078125f;
-    z_ofs_usr.z_ofs_usr = (uint8_t)tmp;
+    z_ofs_usr.z_ofs_usr = (int8_t)(int32_t)tmp;
 
     tmp = val.y_mg / 0.0078125f;
-    y_ofs_usr.y_ofs_usr = (uint8_t)tmp;
+    y_ofs_usr.y_ofs_usr = (int8_t)(int32_t)tmp;
 
     tmp = val.x_mg / 0.0078125f;
-    x_ofs_usr.x_ofs_usr = (uint8_t)tmp;
+    x_ofs_usr.x_ofs_usr = (int8_t)(int32_t)tmp;
   }
   else if ((val.x_mg < (0.125f * 127.0f)) && (val.x_mg > (0.125f * -127.0f)) &&
            (val.y_mg < (0.125f * 127.0f)) && (val.y_mg > (0.125f * -127.0f)) &&
            (val.z_mg < (0.125f * 127.0f)) && (val.z_mg > (0.125f * -127.0f)))
   {
-    ctrl9.usr_off_w = 1;
+    ctrl9.usr_off_w = 1u;
 
     tmp = val.z_mg / 0.125f;
-    z_ofs_usr.z_ofs_usr = (uint8_t)tmp;
+    z_ofs_usr.z_ofs_usr = (int8_t)(int32_t)tmp;
 
     tmp = val.y_mg / 0.125f;
-    y_ofs_usr.y_ofs_usr = (uint8_t)tmp;
+    y_ofs_usr.y_ofs_usr = (int8_t)(int32_t)tmp;
 
     tmp = val.x_mg / 0.125f;
-    x_ofs_usr.x_ofs_usr = (uint8_t)tmp;
+    x_ofs_usr.x_ofs_usr = (int8_t)(int32_t)tmp;
   }
   else // out of limit
   {
-    ctrl9.usr_off_w = 1;
-    z_ofs_usr.z_ofs_usr = 0xFFU;
-    y_ofs_usr.y_ofs_usr = 0xFFU;
-    x_ofs_usr.x_ofs_usr = 0xFFU;
+    ctrl9.usr_off_w = 1u;
+    z_ofs_usr.z_ofs_usr = 0;
+    y_ofs_usr.y_ofs_usr = 0;
+    x_ofs_usr.x_ofs_usr = 0;
   }
 
   ret = ism6hg256x_write_reg(ctx, ISM6HG256X_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
@@ -306,7 +306,7 @@ int32_t ism6hg256x_hg_xl_offset_mg_set(const stmdev_ctx_t *ctx,
   ism6hg256x_hg_x_ofs_usr_t x_ofs_usr = {0};
   ism6hg256x_ctrl1_xl_hg_t  ctrl1_xl_hg = {0};
   int32_t ret = 0;
-  float_t tmp = 0;
+  float_t tmp = 0.0f;
 
   ret = ism6hg256x_read_reg(ctx, ISM6HG256X_CTRL1_XL_HG, (uint8_t *)&ctrl1_xl_hg, 1);
   if (ret != 0)
@@ -318,23 +318,23 @@ int32_t ism6hg256x_hg_xl_offset_mg_set(const stmdev_ctx_t *ctx,
       (val.y_mg < (0.25f * 127.0f)) && (val.y_mg > (0.25f * -127.0f)) &&
       (val.z_mg < (0.25f * 127.0f)) && (val.z_mg > (0.25f * -127.0f)))
   {
-    ctrl1_xl_hg.hg_usr_off_on_out = 1;
+    ctrl1_xl_hg.hg_usr_off_on_out = 1U;
 
     tmp = val.z_mg / 0.25f;
-    z_ofs_usr.xl_hg_z_ofs_usr = (uint8_t)tmp;
+    z_ofs_usr.xl_hg_z_ofs_usr = (int8_t)tmp;
 
     tmp = val.y_mg / 0.25f;
-    y_ofs_usr.xl_hg_y_ofs_usr = (uint8_t)tmp;
+    y_ofs_usr.xl_hg_y_ofs_usr = (int8_t)tmp;
 
     tmp = val.x_mg / 0.25f;
-    x_ofs_usr.xl_hg_x_ofs_usr = (uint8_t)tmp;
+    x_ofs_usr.xl_hg_x_ofs_usr = (int8_t)tmp;
   }
   else // out of limit
   {
-    ctrl1_xl_hg.hg_usr_off_on_out = 0;
-    z_ofs_usr.xl_hg_z_ofs_usr = 0xFFU;
-    y_ofs_usr.xl_hg_y_ofs_usr = 0xFFU;
-    x_ofs_usr.xl_hg_x_ofs_usr = 0xFFU;
+    ctrl1_xl_hg.hg_usr_off_on_out = 0u;
+    z_ofs_usr.xl_hg_z_ofs_usr = 0;
+    y_ofs_usr.xl_hg_y_ofs_usr = 0;
+    x_ofs_usr.xl_hg_x_ofs_usr = 0;
   }
 
   ret = ism6hg256x_write_reg(ctx, ISM6HG256X_XL_HG_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
@@ -386,12 +386,12 @@ int32_t ism6hg256x_reboot(const stmdev_ctx_t *ctx)
   ism6hg256x_ctrl3_t ctrl3 = {0};
   int32_t ret = 0;
   /* configuration to restore after reboot */
-  ism6hg256x_data_rate_t xl;
-  ism6hg256x_data_rate_t gy;
-  ism6hg256x_hg_xl_data_rate_t hg_xl;
-  ism6hg256x_xl_mode_t xlm;
-  ism6hg256x_gy_mode_t gym;
-  uint8_t reg_out_en;
+  ism6hg256x_data_rate_t xl = ISM6HG256X_ODR_OFF;
+  ism6hg256x_data_rate_t gy = ISM6HG256X_ODR_OFF;
+  ism6hg256x_hg_xl_data_rate_t hg_xl = ISM6HG256X_HG_XL_ODR_OFF;
+  ism6hg256x_xl_mode_t xlm = ISM6HG256X_XL_UNCHANGED_MD;
+  ism6hg256x_gy_mode_t gym = ISM6HG256X_GY_UNCHANGED_MD;
+  uint8_t reg_out_en = 0u;
 
   if (ctx->mdelay == NULL)
   {
@@ -482,7 +482,7 @@ exit:
 int32_t ism6hg256x_sw_reset(const stmdev_ctx_t *ctx)
 {
   ism6hg256x_ctrl3_t ctrl3 = {0};
-  uint8_t retry = 0;
+  uint8_t retry = 0u;
   int32_t ret = 0;
 
   if (ctx->mdelay == NULL)
@@ -514,9 +514,10 @@ int32_t ism6hg256x_sw_reset(const stmdev_ctx_t *ctx)
     }
 
     ctx->mdelay(1);
-  } while (ctrl3.sw_reset == 1 && retry++ < 3);
+    retry++;
+  } while ((ctrl3.sw_reset == 1u) && (retry < 3u));
 
-  return (ctrl3.sw_reset == 0) ? 0 : -1;
+  return (ctrl3.sw_reset == 0u) ? 0 : -1;
 
 exit:
   return ret;
@@ -638,7 +639,7 @@ int32_t ism6hg256x_xl_setup(
   // if odr_xl bits has 4th bit enabled, low-power modes are not allowed
   else if (
     // odr >= 480 and low-power and normal mode
-    ((uint8_t)xl_odr & 0x8) != 0 && ((uint8_t)xl_mode & 0x4) != 0 &&
+    ((uint8_t)xl_odr & 0x8) != 0u && ((uint8_t)xl_mode & 0x4) != 0u &&
     (xl_mode != ISM6HG256X_XL_NORMAL_MD || // normal mode is not allowed for some data rates
      xl_odr == ISM6HG256X_ODR_AT_3840Hz ||
      xl_odr == ISM6HG256X_ODR_AT_7680Hz))
@@ -658,8 +659,8 @@ int32_t ism6hg256x_xl_setup(
   }
 
   // if odr is choosed as high-accuracy value, mode should also be set in HAODR mode
-  if ((xl_ha != 0 && xl_mode != ISM6HG256X_XL_HIGH_ACCURACY_ODR_MD) ||
-      (xl_ha == 0 && xl_mode == ISM6HG256X_XL_HIGH_ACCURACY_ODR_MD))
+  if ((xl_ha != 0u && xl_mode != ISM6HG256X_XL_HIGH_ACCURACY_ODR_MD) ||
+      (xl_ha == 0u && xl_mode == ISM6HG256X_XL_HIGH_ACCURACY_ODR_MD))
   {
     ret = -1;
     goto exit;
@@ -678,17 +679,10 @@ int32_t ism6hg256x_xl_setup(
 
   // cross-checking haodr mode
   both_on = ctrl1.odr_xl != (uint8_t)ISM6HG256X_ODR_OFF &&
-            ctrl2.odr_g != (uint8_t)ISM6HG256X_ODR_OFF ? 1 : 0;
+            ctrl2.odr_g != (uint8_t)ISM6HG256X_ODR_OFF ? 1u : 0u;
 
   // if both on, then haodr_sel is a shared bit. Could be changed through haodr_set API
-  if (both_on == 1 && (xl_ha != haodr.haodr_sel))
-  {
-    ret = -1;
-    goto exit;
-  }
-
-  // if odr is choosed as an high-accuracy value, mode should be set in high-accuracy
-  if ((xl_ha != 0 && xl_mode != ISM6HG256X_XL_HIGH_ACCURACY_ODR_MD))
+  if (both_on == 1u && (xl_ha != haodr.haodr_sel))
   {
     ret = -1;
     goto exit;
@@ -708,9 +702,9 @@ int32_t ism6hg256x_xl_setup(
   else
   {
     // if HAODR switch is not required, just set ctrl1 settings
-    ctrl1.op_mode_xl = (uint8_t)xl_mode;
-    ctrl1.odr_xl = (uint8_t)xl_odr;
-    haodr.haodr_sel = xl_ha;
+    ctrl1.op_mode_xl = (uint8_t)xl_mode & 0x07U;
+    ctrl1.odr_xl = (uint8_t)xl_odr & 0x0FU;
+    haodr.haodr_sel = xl_ha & 0x03U;
     ret += ism6hg256x_write_reg(ctx, ISM6HG256X_CTRL1, (uint8_t *)&ctrl1, 1);
     ret += ism6hg256x_write_reg(ctx, ISM6HG256X_HAODR_CFG, (uint8_t *)&haodr, 1);
   }
@@ -755,7 +749,7 @@ int32_t ism6hg256x_gy_setup(
 
   // Table 13 of AN6353
   // 7.5Hz with HAODR mode enable, is already handled by the enum selection
-  if (((uint8_t)gy_odr & 0x8) != 0 && gy_mode == ISM6HG256X_GY_LOW_POWER_MD)
+  if (((uint8_t)gy_odr & 0x8) != 0u && gy_mode == ISM6HG256X_GY_LOW_POWER_MD)
   {
     ret = -1;
     goto exit;
@@ -771,8 +765,8 @@ int32_t ism6hg256x_gy_setup(
   }
 
   // if odr is choosed as high-accuracy value, mode should also be set in HAODR mode
-  if ((gy_ha != 0 && gy_mode != ISM6HG256X_GY_HIGH_ACCURACY_ODR_MD) ||
-      (gy_ha == 0 && gy_mode == ISM6HG256X_GY_HIGH_ACCURACY_ODR_MD))
+  if ((gy_ha != 0u && gy_mode != ISM6HG256X_GY_HIGH_ACCURACY_ODR_MD) ||
+      (gy_ha == 0u && gy_mode == ISM6HG256X_GY_HIGH_ACCURACY_ODR_MD))
   {
     ret = -1;
     goto exit;
@@ -791,10 +785,10 @@ int32_t ism6hg256x_gy_setup(
 
   // cross-checking haodr mode
   both_on = ctrl1.odr_xl != (uint8_t)ISM6HG256X_ODR_OFF &&
-            ctrl2.odr_g != (uint8_t)ISM6HG256X_ODR_OFF ? 1 : 0;
+            ctrl2.odr_g != (uint8_t)ISM6HG256X_ODR_OFF ? 1u : 0u;
 
   // if both on, then haodr_sel is a shared bit
-  if (both_on == 1 && (gy_ha != haodr.haodr_sel))
+  if (both_on == 1u && (gy_ha != haodr.haodr_sel))
   {
     ret = -1;
     goto exit;
@@ -813,9 +807,9 @@ int32_t ism6hg256x_gy_setup(
   else
   {
     // if HAODR switch is not required, just set ctrl2 settings
-    ctrl2.op_mode_g = (uint8_t)gy_mode;
-    ctrl2.odr_g = (uint8_t)gy_odr;
-    haodr.haodr_sel = gy_ha;
+    ctrl2.op_mode_g = (uint8_t)gy_mode & 0x07U;
+    ctrl2.odr_g = (uint8_t)gy_odr & 0x0FU;
+    haodr.haodr_sel = gy_ha & 0x03U;
     ret += ism6hg256x_write_reg(ctx, ISM6HG256X_CTRL2, (uint8_t *)&ctrl2, 1);
     ret += ism6hg256x_write_reg(ctx, ISM6HG256X_HAODR_CFG, (uint8_t *)&haodr, 1);
   }
@@ -836,7 +830,7 @@ int32_t ism6hg256x_haodr_set(
   ism6hg256x_ctrl2_t ctrl2 = {0};
   ism6hg256x_haodr_cfg_t haodr = {0};
   ism6hg256x_ctrl1_xl_hg_t ctrl1_xl_hg = {0};
-  ism6hg256x_xl_mode_t prev_mode = {0};
+  ism6hg256x_xl_mode_t prev_mode = ISM6HG256X_XL_UNCHANGED_MD;
   ism6hg256x_ctrl1_xl_hg_t ctrl1_xl_hg_prev = {0};
   ism6hg256x_ctrl_eis_t ctrl_eis_prev = {0};
   ism6hg256x_ctrl_eis_t ctrl_eis = {0};
@@ -852,7 +846,7 @@ int32_t ism6hg256x_haodr_set(
     goto exit;
   }
 
-  if (both_on == 1 && (xl_ha != gy_ha))
+  if (both_on == 1u && (xl_ha != gy_ha))
   {
     ret = -1;
     goto exit;
@@ -877,7 +871,7 @@ int32_t ism6hg256x_haodr_set(
   ctrl1.odr_xl = (uint8_t)ISM6HG256X_ODR_OFF;
   ctrl2.odr_g = (uint8_t)ISM6HG256X_ODR_OFF;
   ctrl1_xl_hg.odr_xl_hg = (uint8_t)ISM6HG256X_HG_XL_ODR_OFF;
-  ctrl1_xl_hg.xl_hg_regout_en = 0;
+  ctrl1_xl_hg.xl_hg_regout_en = 0u;
   ctrl_eis.odr_g_eis = (uint8_t)ISM6HG256X_EIS_ODR_OFF;
   ret = ism6hg256x_write_reg(ctx, ISM6HG256X_CTRL1, (uint8_t *)&ctrl1, 1);
   ret += ism6hg256x_write_reg(ctx, ISM6HG256X_CTRL2, (uint8_t *)&ctrl2, 1);
@@ -892,9 +886,9 @@ int32_t ism6hg256x_haodr_set(
   }
 
   // set HAODR
-  haodr.haodr_sel = xl_ha | gy_ha;
-  ctrl1.op_mode_xl = (uint8_t)xl_mode;
-  ctrl2.op_mode_g = (uint8_t)gy_mode;
+  haodr.haodr_sel = (xl_ha | gy_ha) & 0x03U;
+  ctrl1.op_mode_xl = (uint8_t)xl_mode & 0x07U;
+  ctrl2.op_mode_g = (uint8_t)gy_mode & 0x07U;
 
   ret += ism6hg256x_write_reg(ctx, ISM6HG256X_HAODR_CFG, (uint8_t *)&haodr, 1);
   ret += ism6hg256x_write_reg(ctx, ISM6HG256X_CTRL1, (uint8_t *)&ctrl1, 1);
@@ -906,8 +900,8 @@ int32_t ism6hg256x_haodr_set(
   }
 
   // set xl and gy data rates and restore high-g xl and eis to their previous data rates
-  ctrl1.odr_xl = (uint8_t)xl_odr;
-  ctrl2.odr_g = (uint8_t)gy_odr;
+  ctrl1.odr_xl = (uint8_t)xl_odr & 0x0FU;
+  ctrl2.odr_g = (uint8_t)gy_odr & 0x0FU;
   ret += ism6hg256x_write_reg(ctx, ISM6HG256X_CTRL1, (uint8_t *)&ctrl1, 1);
   ret += ism6hg256x_write_reg(ctx, ISM6HG256X_CTRL2, (uint8_t *)&ctrl2, 1);
   // if off, there is no need to turn them on
@@ -954,7 +948,7 @@ int32_t ism6hg256x_xl_data_rate_set(const stmdev_ctx_t *ctx,
     {
       return ret;
     }
-    haodr.haodr_sel = sel;
+    haodr.haodr_sel = sel & 0x03U;
     ret += ism6hg256x_write_reg(ctx, ISM6HG256X_HAODR_CFG, (uint8_t *)&haodr, 1);
   }
 
@@ -996,7 +990,6 @@ int32_t ism6hg256x_xl_data_rate_get(const stmdev_ctx_t *ctx,
     case (uint8_t)ISM6HG256X_ODR_AT_15Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = ISM6HG256X_ODR_AT_15Hz;
           break;
@@ -1009,13 +1002,15 @@ int32_t ism6hg256x_xl_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = ISM6HG256X_ODR_HA03_AT_13Hz;
           break;
+        default:
+          *val = ISM6HG256X_ODR_AT_15Hz;
+          break;
       }
       break;
 
     case (uint8_t)ISM6HG256X_ODR_AT_30Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = ISM6HG256X_ODR_AT_30Hz;
           break;
@@ -1028,13 +1023,15 @@ int32_t ism6hg256x_xl_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = ISM6HG256X_ODR_HA03_AT_26Hz;
           break;
+        default:
+          *val = ISM6HG256X_ODR_AT_30Hz;
+          break;
       }
       break;
 
     case (uint8_t)ISM6HG256X_ODR_AT_60Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = ISM6HG256X_ODR_AT_60Hz;
           break;
@@ -1047,13 +1044,15 @@ int32_t ism6hg256x_xl_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = ISM6HG256X_ODR_HA03_AT_52Hz;
           break;
+        default:
+          *val = ISM6HG256X_ODR_AT_60Hz;
+          break;
       }
       break;
 
     case (uint8_t)ISM6HG256X_ODR_AT_120Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = ISM6HG256X_ODR_AT_120Hz;
           break;
@@ -1066,13 +1065,15 @@ int32_t ism6hg256x_xl_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = ISM6HG256X_ODR_HA03_AT_104Hz;
           break;
+        default:
+          *val = ISM6HG256X_ODR_AT_120Hz;
+          break;
       }
       break;
 
     case (uint8_t)ISM6HG256X_ODR_AT_240Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = ISM6HG256X_ODR_AT_240Hz;
           break;
@@ -1085,13 +1086,15 @@ int32_t ism6hg256x_xl_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = ISM6HG256X_ODR_HA03_AT_208Hz;
           break;
+        default:
+          *val = ISM6HG256X_ODR_AT_240Hz;
+          break;
       }
       break;
 
     case (uint8_t)ISM6HG256X_ODR_AT_480Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = ISM6HG256X_ODR_AT_480Hz;
           break;
@@ -1104,13 +1107,15 @@ int32_t ism6hg256x_xl_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = ISM6HG256X_ODR_HA03_AT_417Hz;
           break;
+        default:
+          *val = ISM6HG256X_ODR_AT_480Hz;
+          break;
       }
       break;
 
     case (uint8_t)ISM6HG256X_ODR_AT_960Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = ISM6HG256X_ODR_AT_960Hz;
           break;
@@ -1123,13 +1128,15 @@ int32_t ism6hg256x_xl_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = ISM6HG256X_ODR_HA03_AT_833Hz;
           break;
+        default:
+          *val = ISM6HG256X_ODR_AT_960Hz;
+          break;
       }
       break;
 
     case (uint8_t)ISM6HG256X_ODR_AT_1920Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = ISM6HG256X_ODR_AT_1920Hz;
           break;
@@ -1142,13 +1149,15 @@ int32_t ism6hg256x_xl_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = ISM6HG256X_ODR_HA03_AT_1667Hz;
           break;
+        default:
+          *val = ISM6HG256X_ODR_AT_1920Hz;
+          break;
       }
       break;
 
     case (uint8_t)ISM6HG256X_ODR_AT_3840Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = ISM6HG256X_ODR_AT_3840Hz;
           break;
@@ -1161,13 +1170,15 @@ int32_t ism6hg256x_xl_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = ISM6HG256X_ODR_HA03_AT_3333Hz;
           break;
+        default:
+          *val = ISM6HG256X_ODR_AT_3840Hz;
+          break;
       }
       break;
 
     case (uint8_t)ISM6HG256X_ODR_AT_7680Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = ISM6HG256X_ODR_AT_7680Hz;
           break;
@@ -1179,6 +1190,9 @@ int32_t ism6hg256x_xl_data_rate_get(const stmdev_ctx_t *ctx,
           break;
         case 3:
           *val = ISM6HG256X_ODR_HA03_AT_6667Hz;
+          break;
+        default:
+          *val = ISM6HG256X_ODR_AT_7680Hz;
           break;
       }
       break;
@@ -1387,7 +1401,7 @@ int32_t ism6hg256x_gy_data_rate_set(const stmdev_ctx_t *ctx,
     {
       return ret;
     }
-    haodr.haodr_sel = sel;
+    haodr.haodr_sel = sel & 0x03U;
     ret += ism6hg256x_write_reg(ctx, ISM6HG256X_HAODR_CFG, (uint8_t *)&haodr, 1);
   }
 
@@ -1429,7 +1443,6 @@ int32_t ism6hg256x_gy_data_rate_get(const stmdev_ctx_t *ctx,
     case (uint8_t)ISM6HG256X_ODR_AT_15Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = ISM6HG256X_ODR_AT_15Hz;
           break;
@@ -1442,13 +1455,15 @@ int32_t ism6hg256x_gy_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = ISM6HG256X_ODR_HA03_AT_13Hz;
           break;
+        default:
+          *val = ISM6HG256X_ODR_AT_15Hz;
+          break;
       }
       break;
 
     case (uint8_t)ISM6HG256X_ODR_AT_30Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = ISM6HG256X_ODR_AT_30Hz;
           break;
@@ -1461,13 +1476,15 @@ int32_t ism6hg256x_gy_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = ISM6HG256X_ODR_HA03_AT_26Hz;
           break;
+        default:
+          *val = ISM6HG256X_ODR_AT_30Hz;
+          break;
       }
       break;
 
     case (uint8_t)ISM6HG256X_ODR_AT_60Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = ISM6HG256X_ODR_AT_60Hz;
           break;
@@ -1480,13 +1497,15 @@ int32_t ism6hg256x_gy_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = ISM6HG256X_ODR_HA03_AT_52Hz;
           break;
+        default:
+          *val = ISM6HG256X_ODR_AT_60Hz;
+          break;
       }
       break;
 
     case (uint8_t)ISM6HG256X_ODR_AT_120Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = ISM6HG256X_ODR_AT_120Hz;
           break;
@@ -1499,13 +1518,15 @@ int32_t ism6hg256x_gy_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = ISM6HG256X_ODR_HA03_AT_104Hz;
           break;
+        default:
+          *val = ISM6HG256X_ODR_AT_120Hz;
+          break;
       }
       break;
 
     case (uint8_t)ISM6HG256X_ODR_AT_240Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = ISM6HG256X_ODR_AT_240Hz;
           break;
@@ -1518,13 +1539,15 @@ int32_t ism6hg256x_gy_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = ISM6HG256X_ODR_HA03_AT_208Hz;
           break;
+        default:
+          *val = ISM6HG256X_ODR_AT_240Hz;
+          break;
       }
       break;
 
     case (uint8_t)ISM6HG256X_ODR_AT_480Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = ISM6HG256X_ODR_AT_480Hz;
           break;
@@ -1537,13 +1560,15 @@ int32_t ism6hg256x_gy_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = ISM6HG256X_ODR_HA03_AT_417Hz;
           break;
+        default:
+          *val = ISM6HG256X_ODR_AT_480Hz;
+          break;
       }
       break;
 
     case (uint8_t)ISM6HG256X_ODR_AT_960Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = ISM6HG256X_ODR_AT_960Hz;
           break;
@@ -1556,13 +1581,15 @@ int32_t ism6hg256x_gy_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = ISM6HG256X_ODR_HA03_AT_833Hz;
           break;
+        default:
+          *val = ISM6HG256X_ODR_AT_960Hz;
+          break;
       }
       break;
 
     case (uint8_t)ISM6HG256X_ODR_AT_1920Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = ISM6HG256X_ODR_AT_1920Hz;
           break;
@@ -1575,13 +1602,15 @@ int32_t ism6hg256x_gy_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = ISM6HG256X_ODR_HA03_AT_1667Hz;
           break;
+        default:
+          *val = ISM6HG256X_ODR_AT_1920Hz;
+          break;
       }
       break;
 
     case (uint8_t)ISM6HG256X_ODR_AT_3840Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = ISM6HG256X_ODR_AT_3840Hz;
           break;
@@ -1594,13 +1623,15 @@ int32_t ism6hg256x_gy_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = ISM6HG256X_ODR_HA03_AT_3333Hz;
           break;
+        default:
+          *val = ISM6HG256X_ODR_AT_3840Hz;
+          break;
       }
       break;
 
     case (uint8_t)ISM6HG256X_ODR_AT_7680Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = ISM6HG256X_ODR_AT_7680Hz;
           break;
@@ -1612,6 +1643,9 @@ int32_t ism6hg256x_gy_data_rate_get(const stmdev_ctx_t *ctx,
           break;
         case 3:
           *val = ISM6HG256X_ODR_HA03_AT_6667Hz;
+          break;
+        default:
+          *val = ISM6HG256X_ODR_AT_7680Hz;
           break;
       }
       break;
@@ -1691,7 +1725,7 @@ int32_t ism6hg256x_auto_increment_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = ism6hg256x_read_reg(ctx, ISM6HG256X_CTRL3, (uint8_t *)&ctrl3, 1);
   if (ret == 0)
   {
-    ctrl3.if_inc = val;
+    ctrl3.if_inc = val & 0x01U;
     ret = ism6hg256x_write_reg(ctx, ISM6HG256X_CTRL3, (uint8_t *)&ctrl3, 1);
   }
 
@@ -1724,7 +1758,7 @@ int32_t ism6hg256x_block_data_update_set(const stmdev_ctx_t *ctx, uint8_t val)
 
   if (ret == 0)
   {
-    ctrl3.bdu = val;
+    ctrl3.bdu = val & 0x01U;
     ret = ism6hg256x_write_reg(ctx, ISM6HG256X_CTRL3, (uint8_t *)&ctrl3, 1);
   }
 
@@ -1910,7 +1944,7 @@ int32_t ism6hg256x_gy_full_scale_set(const stmdev_ctx_t *ctx,
     ret += ism6hg256x_write_reg(ctx, ISM6HG256X_CTRL2, (uint8_t *)&ctrl2, 1);
   }
 
-  ctrl6.fs_g = (uint8_t)val & 0xfu;
+  ctrl6.fs_g = (uint8_t)val & 0x07u;
   ret += ism6hg256x_write_reg(ctx, ISM6HG256X_CTRL6, (uint8_t *)&ctrl6, 1);
 
   // restore previous odr set
@@ -3440,8 +3474,7 @@ int32_t ism6hg256x_temperature_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
     return ret;
   }
 
-  *val = (int16_t)buff[1];
-  *val = (*val * 256) + (int16_t)buff[0];
+  *val = (int16_t)((uint16_t)buff[0] | ((uint16_t)buff[1] << 8));
 
   return ret;
 }
@@ -3458,12 +3491,9 @@ int32_t ism6hg256x_angular_rate_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
     return ret;
   }
 
-  val[0] = (int16_t)buff[1];
-  val[0] = (val[0] * 256) + (int16_t)buff[0];
-  val[1] = (int16_t)buff[3];
-  val[1] = (val[1] * 256) + (int16_t)buff[2];
-  val[2] = (int16_t)buff[5];
-  val[2] = (val[2] * 256) + (int16_t)buff[4];
+  val[0] = (int16_t)((uint16_t)buff[0] | ((uint16_t)buff[1] << 8));
+  val[1] = (int16_t)((uint16_t)buff[2] | ((uint16_t)buff[3] << 8));
+  val[2] = (int16_t)((uint16_t)buff[4] | ((uint16_t)buff[5] << 8));
 
   return ret;
 }
@@ -3479,12 +3509,9 @@ int32_t ism6hg256x_ois_angular_rate_raw_get(const stmdev_ctx_t *ctx, int16_t *va
     return ret;
   }
 
-  val[0] = (int16_t)buff[1];
-  val[0] = (*val * 256) + (int16_t)buff[0];
-  val[1] = (int16_t)buff[3];
-  val[1] = (*val * 256) + (int16_t)buff[2];
-  val[2] = (int16_t)buff[5];
-  val[2] = (*val * 256) + (int16_t)buff[4];
+  val[0] = (int16_t)((uint16_t)buff[0] | ((uint16_t)buff[1] << 8));
+  val[1] = (int16_t)((uint16_t)buff[2] | ((uint16_t)buff[3] << 8));
+  val[2] = (int16_t)((uint16_t)buff[4] | ((uint16_t)buff[5] << 8));
 
   return ret;
 }
@@ -3501,9 +3528,9 @@ int32_t ism6hg256x_ois_eis_angular_rate_raw_get(const stmdev_ctx_t *ctx, int16_t
     return ret;
   }
 
-  val[0] = (int16_t)((uint16_t)buff[1] << 8 | (uint16_t)buff[0]);
-  val[1] = (int16_t)((uint16_t)buff[3] << 8 | (uint16_t)buff[2]);
-  val[2] = (int16_t)((uint16_t)buff[5] << 8 | (uint16_t)buff[4]);
+  val[0] = (int16_t)buff[0] | (int16_t)((uint16_t)buff[1] << 8);
+  val[1] = (int16_t)buff[2] | (int16_t)((uint16_t)buff[3] << 8);
+  val[2] = (int16_t)buff[4] | (int16_t)((uint16_t)buff[5] << 8);
 
   return ret;
 }
@@ -3520,12 +3547,9 @@ int32_t ism6hg256x_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
     return ret;
   }
 
-  val[0] = (int16_t)buff[1];
-  val[0] = (val[0] * 256) + (int16_t)buff[0];
-  val[1] = (int16_t)buff[3];
-  val[1] = (val[1] * 256) + (int16_t)buff[2];
-  val[2] = (int16_t)buff[5];
-  val[2] = (val[2] * 256) + (int16_t)buff[4];
+  val[0] = (int16_t)((uint16_t)buff[0] | ((uint16_t)buff[1] << 8));
+  val[1] = (int16_t)((uint16_t)buff[2] | ((uint16_t)buff[3] << 8));
+  val[2] = (int16_t)((uint16_t)buff[4] | ((uint16_t)buff[5] << 8));
 
   return ret;
 }
@@ -3542,12 +3566,9 @@ int32_t ism6hg256x_hg_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *val
     return ret;
   }
 
-  val[0] = (int16_t)buff[1];
-  val[0] = (val[0] * 256) + (int16_t)buff[0];
-  val[1] = (int16_t)buff[3];
-  val[1] = (val[1] * 256) + (int16_t)buff[2];
-  val[2] = (int16_t)buff[5];
-  val[2] = (val[2] * 256) + (int16_t)buff[4];
+  val[0] = (int16_t)((uint16_t)buff[0] | ((uint16_t)buff[1] << 8));
+  val[1] = (int16_t)((uint16_t)buff[2] | ((uint16_t)buff[3] << 8));
+  val[2] = (int16_t)((uint16_t)buff[4] | ((uint16_t)buff[5] << 8));
 
   return ret;
 }
@@ -3563,12 +3584,9 @@ int32_t ism6hg256x_ois_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *va
     return ret;
   }
 
-  val[0] = (int16_t)buff[1];
-  val[0] = (val[0] * 256) + (int16_t)buff[0];
-  val[1] = (int16_t)buff[3];
-  val[1] = (val[1] * 256) + (int16_t)buff[2];
-  val[2] = (int16_t)buff[5];
-  val[2] = (val[2] * 256) + (int16_t)buff[4];
+  val[0] = (int16_t)((uint16_t)buff[0] | ((uint16_t)buff[1] << 8));
+  val[1] = (int16_t)((uint16_t)buff[2] | ((uint16_t)buff[3] << 8));
+  val[2] = (int16_t)((uint16_t)buff[4] | ((uint16_t)buff[5] << 8));
 
   return ret;
 }
@@ -3587,12 +3605,9 @@ int32_t ism6hg256x_sflp_gbias_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
     return ret;
   }
 
-  val[0] = (int16_t)buff[1];
-  val[0] = (val[0] * 256) + (int16_t)buff[0];
-  val[1] = (int16_t)buff[3];
-  val[1] = (val[1] * 256) + (int16_t)buff[2];
-  val[2] = (int16_t)buff[5];
-  val[2] = (val[2] * 256) + (int16_t)buff[4];
+  val[0] = (int16_t)((uint16_t)buff[0] | ((uint16_t)buff[1] << 8));
+  val[1] = (int16_t)((uint16_t)buff[2] | ((uint16_t)buff[3] << 8));
+  val[2] = (int16_t)((uint16_t)buff[4] | ((uint16_t)buff[5] << 8));
 
   return ret;
 }
@@ -3611,12 +3626,9 @@ int32_t ism6hg256x_sflp_gravity_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
     return ret;
   }
 
-  val[0] = (int16_t)buff[1];
-  val[0] = (val[0] * 256) + (int16_t)buff[0];
-  val[1] = (int16_t)buff[3];
-  val[1] = (val[1] * 256) + (int16_t)buff[2];
-  val[2] = (int16_t)buff[5];
-  val[2] = (val[2] * 256) + (int16_t)buff[4];
+  val[0] = (int16_t)((uint16_t)buff[0] | ((uint16_t)buff[1] << 8));
+  val[1] = (int16_t)((uint16_t)buff[2] | ((uint16_t)buff[3] << 8));
+  val[2] = (int16_t)((uint16_t)buff[4] | ((uint16_t)buff[5] << 8));
 
   return ret;
 }
@@ -3808,7 +3820,7 @@ int32_t ism6hg256x_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t address,
   {
     goto exit;
   }
-  page_sel.page_sel = msb;
+  page_sel.page_sel = msb & 0x0FU;
   page_sel.not_used0 = 1; // Default value
   ret += ism6hg256x_write_reg(ctx, ISM6HG256X_PAGE_SEL, (uint8_t *)&page_sel, 1);
   if (ret != 0)
@@ -3845,7 +3857,7 @@ int32_t ism6hg256x_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t address,
         goto exit;
       }
 
-      page_sel.page_sel = msb;
+      page_sel.page_sel = msb & 0x0FU;
       page_sel.not_used0 = 1; // Default value
       ret += ism6hg256x_write_reg(ctx, ISM6HG256X_PAGE_SEL, (uint8_t *)&page_sel, 1);
       if (ret != 0)
@@ -3855,8 +3867,8 @@ int32_t ism6hg256x_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t address,
     }
   }
 
-  page_sel.page_sel = 0;
-  page_sel.not_used0 = 1;// Default value
+  page_sel.page_sel = 0U;
+  page_sel.not_used0 = 1U;// Default value
   ret += ism6hg256x_write_reg(ctx, ISM6HG256X_PAGE_SEL, (uint8_t *)&page_sel, 1);
   if (ret != 0)
   {
@@ -3920,8 +3932,8 @@ int32_t ism6hg256x_ln_pg_read(const stmdev_ctx_t *ctx, uint16_t address, uint8_t
   {
     goto exit;
   }
-  page_sel.page_sel = msb;
-  page_sel.not_used0 = 1; // Default value
+  page_sel.page_sel = msb & 0x0FU;
+  page_sel.not_used0 = 1U; // Default value
   ret += ism6hg256x_write_reg(ctx, ISM6HG256X_PAGE_SEL, (uint8_t *)&page_sel, 1);
   if (ret != 0)
   {
@@ -3957,8 +3969,8 @@ int32_t ism6hg256x_ln_pg_read(const stmdev_ctx_t *ctx, uint16_t address, uint8_t
         goto exit;
       }
 
-      page_sel.page_sel = msb;
-      page_sel.not_used0 = 1; // Default value
+      page_sel.page_sel = msb & 0x0FU;
+      page_sel.not_used0 = 1U; // Default value
       ret += ism6hg256x_write_reg(ctx, ISM6HG256X_PAGE_SEL, (uint8_t *)&page_sel, 1);
       if (ret != 0)
       {
@@ -3967,8 +3979,8 @@ int32_t ism6hg256x_ln_pg_read(const stmdev_ctx_t *ctx, uint16_t address, uint8_t
     }
   }
 
-  page_sel.page_sel = 0;
-  page_sel.not_used0 = 1;// Default value
+  page_sel.page_sel = 0U;
+  page_sel.not_used0 = 1U;// Default value
   ret += ism6hg256x_write_reg(ctx, ISM6HG256X_PAGE_SEL, (uint8_t *)&page_sel, 1);
   if (ret != 0)
   {
@@ -4001,7 +4013,7 @@ int32_t ism6hg256x_emb_function_dbg_set(const stmdev_ctx_t *ctx, uint8_t val)
 
   if (ret == 0)
   {
-    ctrl10.emb_func_debug = val;
+    ctrl10.emb_func_debug = val & 0x01U;
     ret = ism6hg256x_write_reg(ctx, ISM6HG256X_CTRL10, (uint8_t *)&ctrl10, 1);
   }
 
@@ -4093,9 +4105,9 @@ int32_t ism6hg256x_eis_gy_full_scale_set(const stmdev_ctx_t *ctx,
 
   // For the correct operation of the device, the user must set a
   // configuration from 001 to 101 when the gyroscope is in power-down mode.
-  if (ctrl2.odr_g != ISM6HG256X_ODR_OFF)
+  if (ctrl2.odr_g != (uint8_t)ISM6HG256X_ODR_OFF)
   {
-    ctrl2.odr_g = ISM6HG256X_ODR_OFF;
+    ctrl2.odr_g = (uint8_t)ISM6HG256X_ODR_OFF;
     ret += ism6hg256x_write_reg(ctx, ISM6HG256X_CTRL2, (uint8_t *)&ctrl2, 1);
   }
 
@@ -4164,7 +4176,7 @@ int32_t ism6hg256x_eis_gy_on_if2_set(const stmdev_ctx_t *ctx, uint8_t val)
 
   if (ret == 0)
   {
-    ctrl_eis.g_eis_on_g_ois_out_reg = val;
+    ctrl_eis.g_eis_on_g_ois_out_reg = val & 0x01U;
     ret = ism6hg256x_write_reg(ctx, ISM6HG256X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
   }
 
@@ -4359,7 +4371,7 @@ int32_t ism6hg256x_fifo_virtual_sens_odr_chg_set(const stmdev_ctx_t *ctx, uint8_
   ret = ism6hg256x_read_reg(ctx, ISM6HG256X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
   if (ret == 0)
   {
-    fifo_ctrl2.odr_chg_en = val;
+    fifo_ctrl2.odr_chg_en = val & 0x01U;
     ret = ism6hg256x_write_reg(ctx, ISM6HG256X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
   }
 
@@ -4398,7 +4410,7 @@ int32_t ism6hg256x_fifo_compress_algo_real_time_set(const stmdev_ctx_t *ctx,
   {
     return ret;
   }
-  fifo_ctrl2.fifo_compr_rt_en = val;
+  fifo_ctrl2.fifo_compr_rt_en = val & 0x01U;
   ret += ism6hg256x_write_reg(ctx, ISM6HG256X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
   if (ret != 0)
   {
@@ -4415,7 +4427,7 @@ int32_t ism6hg256x_fifo_compress_algo_real_time_set(const stmdev_ctx_t *ctx,
   {
     goto exit;
   }
-  emb_func_en_b.fifo_compr_en = val;
+  emb_func_en_b.fifo_compr_en = val & 0x01U;
   ret += ism6hg256x_write_reg(ctx, ISM6HG256X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
 exit:
   ret += ism6hg256x_mem_bank_set(ctx, ISM6HG256X_MAIN_MEM_BANK);
@@ -4761,7 +4773,7 @@ int32_t ism6hg256x_fifo_gy_eis_batch_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = ism6hg256x_read_reg(ctx, ISM6HG256X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
   if (ret == 0)
   {
-    fifo_ctrl4.g_eis_fifo_en = val;
+    fifo_ctrl4.g_eis_fifo_en = val & 0x01U;
     ret = ism6hg256x_write_reg(ctx, ISM6HG256X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
   }
 
@@ -4931,8 +4943,7 @@ int32_t ism6hg256x_fifo_batch_counter_threshold_get(const stmdev_ctx_t *ctx,
     return ret;
   }
 
-  *val = (uint16_t)buff[0] & 0x3U;
-  *val = (*val * 256U) + (uint16_t)buff[1];
+  *val = (uint16_t)(buff[1] | ((uint16_t)(buff[0] & 0x3U) << 8));
 
   return ret;
 }
@@ -5012,8 +5023,7 @@ int32_t ism6hg256x_fifo_status_get(const stmdev_ctx_t *ctx,
   val->fifo_full = status.fifo_full_ia;
   val->fifo_th = status.fifo_wtm_ia;
 
-  val->fifo_level = (uint16_t)buff[1] & 0x01U;
-  val->fifo_level = (val->fifo_level * 256U) + buff[0];
+  val->fifo_level = (uint16_t)(buff[0] | ((uint16_t)(buff[1] & 0x01U) << 8));
 
   return ret;
 }
@@ -5191,7 +5201,7 @@ int32_t ism6hg256x_fifo_stpcnt_batch_set(const stmdev_ctx_t *ctx, uint8_t val)
   {
     goto exit;
   }
-  emb_func_fifo_en_a.step_counter_fifo_en = val;
+  emb_func_fifo_en_a.step_counter_fifo_en = val & 0x01U;
   ret += ism6hg256x_write_reg(ctx, ISM6HG256X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
 
 exit:
@@ -5217,7 +5227,7 @@ int32_t ism6hg256x_fifo_stpcnt_batch_get(const stmdev_ctx_t *ctx, uint8_t *val)
   {
     goto exit;
   }
-  *val = emb_func_fifo_en_a.step_counter_fifo_en;
+  *val = emb_func_fifo_en_a.step_counter_fifo_en & 0x01U;
 
 exit:
   ret += ism6hg256x_mem_bank_set(ctx, ISM6HG256X_MAIN_MEM_BANK);
@@ -5242,7 +5252,7 @@ int32_t ism6hg256x_fifo_fsm_batch_set(const stmdev_ctx_t *ctx, uint8_t val)
   {
     goto exit;
   }
-  emb_func_fifo_en_b.fsm_fifo_en = val;
+  emb_func_fifo_en_b.fsm_fifo_en = val & 0x01U;
   ret += ism6hg256x_write_reg(ctx, ISM6HG256X_EMB_FUNC_FIFO_EN_B, (uint8_t *)&emb_func_fifo_en_b, 1);
 
 exit:
@@ -5293,7 +5303,7 @@ int32_t ism6hg256x_fifo_mlc_batch_set(const stmdev_ctx_t *ctx, uint8_t val)
   {
     goto exit;
   }
-  emb_func_fifo_en_a.mlc_fifo_en = val;
+  emb_func_fifo_en_a.mlc_fifo_en = val & 0x01U;
   ret += ism6hg256x_write_reg(ctx, ISM6HG256X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
 
 exit:
@@ -5344,7 +5354,7 @@ int32_t ism6hg256x_fifo_mlc_filt_batch_set(const stmdev_ctx_t *ctx, uint8_t val)
   {
     goto exit;
   }
-  emb_func_fifo_en_b.mlc_filter_feature_fifo_en = val;
+  emb_func_fifo_en_b.mlc_filter_feature_fifo_en = val & 0x01U;
   ret += ism6hg256x_write_reg(ctx, ISM6HG256X_EMB_FUNC_FIFO_EN_B, (uint8_t *)&emb_func_fifo_en_b, 1);
 
 exit:
@@ -5395,13 +5405,15 @@ int32_t ism6hg256x_fifo_sh_batch_target_set(const stmdev_ctx_t *ctx, uint8_t idx
     goto exit;
   }
 
-  ret = ism6hg256x_read_reg(ctx, ISM6HG256X_TGT0_CONFIG + idx * 3U, (uint8_t *)&tgt_config, 1);
+  ret = ism6hg256x_read_reg(ctx, ISM6HG256X_TGT0_CONFIG + (uint8_t)(idx * 3U), (uint8_t *)&tgt_config,
+                            1);
   if (ret != 0)
   {
     goto exit;
   }
-  tgt_config.batch_ext_sens_0_en = val;
-  ret += ism6hg256x_write_reg(ctx, ISM6HG256X_TGT0_CONFIG + idx * 3U, (uint8_t *)&tgt_config, 1);
+  tgt_config.batch_ext_sens_0_en = val & 0x01U;
+  ret += ism6hg256x_write_reg(ctx, ISM6HG256X_TGT0_CONFIG + (uint8_t)(idx * 3U),
+                              (uint8_t *)&tgt_config, 1);
 
 exit:
   ret += ism6hg256x_mem_bank_set(ctx, ISM6HG256X_MAIN_MEM_BANK);
@@ -5426,7 +5438,8 @@ int32_t ism6hg256x_fifo_sh_batch_target_get(const stmdev_ctx_t *ctx, uint8_t idx
     goto exit;
   }
 
-  ret = ism6hg256x_read_reg(ctx, ISM6HG256X_TGT0_CONFIG + idx * 3U, (uint8_t *)&tgt_config, 1);
+  ret = ism6hg256x_read_reg(ctx, ISM6HG256X_TGT0_CONFIG + (uint8_t)(idx * 3U), (uint8_t *)&tgt_config,
+                            1);
   if (ret != 0)
   {
     goto exit;
@@ -5663,7 +5676,7 @@ int32_t ism6hg256x_filt_gy_lp1_bandwidth_set(const stmdev_ctx_t *ctx,
   ret = ism6hg256x_read_reg(ctx, ISM6HG256X_CTRL6, (uint8_t *)&ctrl6, 1);
   if (ret == 0)
   {
-    ctrl6.lpf1_g_bw = (uint8_t)val & 0x0Fu;
+    ctrl6.lpf1_g_bw = (uint8_t)val & 0x07u;
     ret = ism6hg256x_write_reg(ctx, ISM6HG256X_CTRL6, (uint8_t *)&ctrl6, 1);
   }
 
@@ -5734,7 +5747,7 @@ int32_t ism6hg256x_filt_gy_lp1_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = ism6hg256x_read_reg(ctx, ISM6HG256X_CTRL7, (uint8_t *)&ctrl7, 1);
   if (ret == 0)
   {
-    ctrl7.lpf1_g_en = val;
+    ctrl7.lpf1_g_en = val & 0x01U;
     ret = ism6hg256x_write_reg(ctx, ISM6HG256X_CTRL7, (uint8_t *)&ctrl7, 1);
   }
 
@@ -5786,23 +5799,23 @@ int32_t ism6hg256x_filt_xl_setup(const stmdev_ctx_t *ctx, ism6hg256x_xl_filter f
 
   if (filter == ISM6HG256X_XL_FILT_LP_LPF2)
   {
-    ctrl9.hp_slope_xl_en = 0;
-    ctrl9.lpf2_xl_en = 1;
+    ctrl9.hp_slope_xl_en = 0U;
+    ctrl9.lpf2_xl_en = 1U;
   }
   else if (filter == ISM6HG256X_XL_FILT_LP_LPF1)
   {
-    ctrl9.hp_slope_xl_en = 0;
-    ctrl9.lpf2_xl_en = 0;
+    ctrl9.hp_slope_xl_en = 0U;
+    ctrl9.lpf2_xl_en = 0U;
   }
   else if (filter == ISM6HG256X_XL_FILT_HP)
   {
-    ctrl9.hp_slope_xl_en = 1;
-    ctrl9.lpf2_xl_en = 0;
+    ctrl9.hp_slope_xl_en = 1U;
+    ctrl9.lpf2_xl_en = 0U;
   }
   else if (filter == ISM6HG256X_XL_FILT_HP_SLOPE)
   {
-    ctrl9.hp_slope_xl_en = 1;
-    ctrl9.lpf2_xl_en = 0;
+    ctrl9.hp_slope_xl_en = 1U;
+    ctrl9.lpf2_xl_en = 0U;
   }
   else
   {
@@ -5811,7 +5824,7 @@ int32_t ism6hg256x_filt_xl_setup(const stmdev_ctx_t *ctx, ism6hg256x_xl_filter f
   }
 
   ctrl8.hp_lpf2_xl_bw = (uint8_t)bw & 0x07U;
-  ctrl9.hp_ref_mode_xl = hp_ref_mode_xl;
+  ctrl9.hp_ref_mode_xl = hp_ref_mode_xl & 0x01U;
 
   ret = ism6hg256x_write_reg(ctx, ISM6HG256X_CTRL8, (uint8_t *)&ctrl8, 1);
   ret += ism6hg256x_write_reg(ctx, ISM6HG256X_CTRL9, (uint8_t *)&ctrl9, 1);
@@ -5901,7 +5914,7 @@ int32_t ism6hg256x_filt_xl_lp2_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = ism6hg256x_read_reg(ctx, ISM6HG256X_CTRL9, (uint8_t *)&ctrl9, 1);
   if (ret == 0)
   {
-    ctrl9.lpf2_xl_en = val;
+    ctrl9.lpf2_xl_en = val & 0x01U;
     ret = ism6hg256x_write_reg(ctx, ISM6HG256X_CTRL9, (uint8_t *)&ctrl9, 1);
   }
 
@@ -5933,7 +5946,7 @@ int32_t ism6hg256x_filt_xl_hp_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = ism6hg256x_read_reg(ctx, ISM6HG256X_CTRL9, (uint8_t *)&ctrl9, 1);
   if (ret == 0)
   {
-    ctrl9.hp_slope_xl_en = val;
+    ctrl9.hp_slope_xl_en = val & 0x01U;
     ret = ism6hg256x_write_reg(ctx, ISM6HG256X_CTRL9, (uint8_t *)&ctrl9, 1);
   }
 
@@ -5965,7 +5978,7 @@ int32_t ism6hg256x_filt_xl_fast_settling_set(const stmdev_ctx_t *ctx, uint8_t va
   ret = ism6hg256x_read_reg(ctx, ISM6HG256X_CTRL9, (uint8_t *)&ctrl9, 1);
   if (ret == 0)
   {
-    ctrl9.xl_fastsettl_mode = val;
+    ctrl9.xl_fastsettl_mode = val & 0x01U;
     ret = ism6hg256x_write_reg(ctx, ISM6HG256X_CTRL9, (uint8_t *)&ctrl9, 1);
   }
 
@@ -5999,7 +6012,7 @@ int32_t ism6hg256x_filt_xl_hp_mode_set(const stmdev_ctx_t *ctx,
   if (ret == 0)
   {
     ctrl9.hp_ref_mode_xl = (uint8_t)val & 0x01U;
-    ctrl9.hp_slope_xl_en = ((uint8_t)val & 0x02U) >> 1;
+    ctrl9.hp_slope_xl_en = ((uint8_t)val >> 1) & 0x01U;
     ret = ism6hg256x_write_reg(ctx, ISM6HG256X_CTRL9, (uint8_t *)&ctrl9, 1);
   }
 
@@ -6560,8 +6573,7 @@ exit:
     return ret;
   }
 
-  *val = buff[1];
-  *val = (*val * 256U) + buff[0];
+  *val = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
 
   return ret;
 }
@@ -6692,12 +6704,6 @@ exit:
 #ifndef NPY_HALF_ROUND_TIES_TO_EVEN
 #define NPY_HALF_ROUND_TIES_TO_EVEN 1
 #endif
-
-typedef union
-{
-  float_t f;
-  uint32_t fbits;
-} hf_conv_t;
 
 static uint16_t npy_floatbits_to_halfbits(uint32_t f)
 {
@@ -6831,18 +6837,19 @@ static uint16_t npy_floatbits_to_halfbits(uint32_t f)
   {
     npy_set_floatstatus_overflow();
   }
-  return h_sgn + h_sig;
+  return (uint16_t)(h_sgn + h_sig);
 #else
-  return h_sgn + h_exp + h_sig;
+  return (uint16_t)(h_sgn + h_exp + h_sig);
 #endif
 }
 
 static uint16_t npy_float_to_half(float_t f)
 {
-  hf_conv_t conv;
+  uint32_t bits;
 
-  conv.f = f;
-  return npy_floatbits_to_halfbits(conv.fbits);
+  (void)memcpy(&bits, &f, sizeof(bits));
+
+  return npy_floatbits_to_halfbits(bits);
 }
 
 static uint32_t npy_halfbits_to_floatbits(uint16_t h)
@@ -6857,19 +6864,19 @@ static uint32_t npy_halfbits_to_floatbits(uint16_t h)
     {
       uint16_t h_sig = (uint16_t)(h & 0x03ffu);
       // Signed zero
-      if (h_sig == 0)
+      if (h_sig == 0u)
       {
         result = f_sgn;
         break;
       }
       // Subnormal
       h_sig <<= 1;
-      while ((h_sig & 0x0400u) == 0)
+      while ((h_sig & 0x0400u) == 0u)
       {
         h_sig <<= 1;
         h_exp++;
       }
-      uint32_t f_exp = ((uint32_t)(127 - 15 - h_exp)) << 23;
+      uint32_t f_exp = ((uint32_t)(127u - 15u - h_exp)) << 23;
       uint32_t f_sig = ((uint32_t)h_sig & 0x03ffu) << 13;
       result = f_sgn + f_exp + f_sig;
       break;
@@ -6889,18 +6896,20 @@ static uint32_t npy_halfbits_to_floatbits(uint16_t h)
 
 static float_t npy_half_to_float(uint16_t h)
 {
-  hf_conv_t conv;
+  float_t f = 0;
 
-  conv.fbits = npy_halfbits_to_floatbits(h);
+  uint32_t bits = npy_halfbits_to_floatbits(h);
 
-  return conv.f;
+  (void)memcpy(&f, &bits, sizeof(bits));
+
+  return f;
 }
 
 
 int32_t ism6hg256x_sflp_game_gbias_set(const stmdev_ctx_t *ctx,
                                        const ism6hg256x_sflp_gbias_t *val)
 {
-  ism6hg256x_sflp_data_rate_t sflp_odr = {0};
+  ism6hg256x_sflp_data_rate_t sflp_odr = ISM6HG256X_SFLP_15Hz;
   uint16_t gbias_hf[3] = {0};
   float_t k = 0.005f;
   int32_t ret = 0;
@@ -6979,8 +6988,7 @@ int32_t ism6hg256x_fsm_ext_sens_sensitivity_get(const stmdev_ctx_t *ctx,
     return ret;
   }
 
-  *val = buff[1];
-  *val = (*val * 256U) + buff[0];
+  *val = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
 
   return ret;
 }
@@ -7016,12 +7024,9 @@ int32_t ism6hg256x_fsm_ext_sens_offset_get(const stmdev_ctx_t *ctx,
     return ret;
   }
 
-  val->x = buff[1];
-  val->x = (val->x * 256U) + buff[0];
-  val->y = buff[3];
-  val->y = (val->y * 256U) + buff[2];
-  val->z = buff[5];
-  val->z = (val->z * 256U) + buff[4];
+  val->x = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
+  val->y = (uint16_t)(buff[2] | ((uint16_t)buff[3] << 8));
+  val->z = (uint16_t)(buff[4] | ((uint16_t)buff[5] << 8));
 
   return ret;
 }
@@ -7062,18 +7067,12 @@ int32_t ism6hg256x_fsm_ext_sens_matrix_get(const stmdev_ctx_t *ctx,
     return ret;
   }
 
-  val->xx = buff[1];
-  val->xx = (val->xx * 256U) + buff[0];
-  val->xy = buff[3];
-  val->xy = (val->xy * 256U) + buff[2];
-  val->xz = buff[5];
-  val->xz = (val->xz * 256U) + buff[4];
-  val->yy = buff[7];
-  val->yy = (val->yy * 256U) + buff[6];
-  val->yz = buff[9];
-  val->yz = (val->yz * 256U) + buff[8];
-  val->zz = buff[11];
-  val->zz = (val->zz * 256U) + buff[10];
+  val->xx = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
+  val->xy = (uint16_t)(buff[2] | ((uint16_t)buff[3] << 8));
+  val->xz = (uint16_t)(buff[4] | ((uint16_t)buff[5] << 8));
+  val->yy = (uint16_t)(buff[6] | ((uint16_t)buff[7] << 8));
+  val->yz = (uint16_t)(buff[8] | ((uint16_t)buff[9] << 8));
+  val->zz = (uint16_t)(buff[10] | ((uint16_t)buff[11] << 8));
 
   return ret;
 }
@@ -7288,7 +7287,7 @@ int32_t ism6hg256x_xl_hg_peak_tracking_set(const stmdev_ctx_t *ctx, uint8_t val)
   {
     goto exit;
   }
-  emb_func_init_b.pt_init = val;
+  emb_func_init_b.pt_init = val & 0x01U;
   ret += ism6hg256x_write_reg(ctx, ISM6HG256X_EMB_FUNC_INIT_B, (uint8_t *)&emb_func_init_b, 1);
 
 exit:
@@ -7314,7 +7313,7 @@ int32_t ism6hg256x_xl_hg_peak_tracking_get(const stmdev_ctx_t *ctx, uint8_t *val
   {
     goto exit;
   }
-  *val = emb_func_init_b.pt_init;
+  *val = emb_func_init_b.pt_init & 0x01U;
 
 exit:
   ret += ism6hg256x_mem_bank_set(ctx, ISM6HG256X_MAIN_MEM_BANK);
@@ -7349,8 +7348,7 @@ int32_t ism6hg256x_xl_hg_sensitivity_get(const stmdev_ctx_t *ctx, uint16_t *val)
     return ret;
   }
 
-  *val = buff[1];
-  *val = (*val * 256U) + buff[0];
+  *val = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
 
   return ret;
 }
@@ -7381,8 +7379,7 @@ int32_t ism6hg256x_fsm_long_cnt_timeout_get(const stmdev_ctx_t *ctx, uint16_t *v
     return ret;
   }
 
-  *val = buff[1];
-  *val = (*val * 256U) + buff[0];
+  *val = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
 
   return ret;
 }
@@ -7447,8 +7444,7 @@ int32_t ism6hg256x_fsm_start_address_get(const stmdev_ctx_t *ctx, uint16_t *val)
     return ret;
   }
 
-  *val = buff[1];
-  *val = (*val * 256U) + buff[0];
+  *val = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
 
   return ret;
 }
@@ -7497,7 +7493,7 @@ int32_t ism6hg256x_ff_time_windows_get(const stmdev_ctx_t *ctx, uint8_t *val)
     return ret;
   }
 
-  *val = (wake_up_dur.ff_dur << 5) + free_fall.ff_dur;
+  *val = (uint8_t)(wake_up_dur.ff_dur << 5) | free_fall.ff_dur;
 
   return ret;
 }
@@ -7608,6 +7604,9 @@ int32_t ism6hg256x_mlc_set(const stmdev_ctx_t *ctx, ism6hg256x_mlc_mode_t val)
       emb_en_b.mlc_en = 0;
       break;
     default:
+      // default used: MLC_OFF
+      emb_en_a.mlc_before_fsm_en = 0;
+      emb_en_b.mlc_en = 0;
       break;
   }
 
@@ -7785,8 +7784,7 @@ int32_t ism6hg256x_mlc_ext_sens_sensitivity_get(const stmdev_ctx_t *ctx,
     return ret;
   }
 
-  *val = buff[1];
-  *val = (*val * 256U) + buff[0];
+  *val = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
 
   return ret;
 }
@@ -7847,7 +7845,7 @@ int32_t ism6hg256x_ois_reset_set(const stmdev_ctx_t *ctx, int8_t val)
   ret = ism6hg256x_read_reg(ctx, ISM6HG256X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
   if (ret == 0)
   {
-    func_cfg_access.if2_reset = (uint8_t)val;
+    func_cfg_access.if2_reset = (uint8_t)val & 0x01U;
     ret = ism6hg256x_write_reg(ctx, ISM6HG256X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
   }
 
@@ -7879,7 +7877,7 @@ int32_t ism6hg256x_ois_interface_pull_up_set(const stmdev_ctx_t *ctx, uint8_t va
   ret = ism6hg256x_read_reg(ctx, ISM6HG256X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
   if (ret == 0)
   {
-    pin_ctrl.ois_pu_dis = val;
+    pin_ctrl.ois_pu_dis = val & 0x01U;
     ret = ism6hg256x_write_reg(ctx, ISM6HG256X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
   }
 
@@ -8002,7 +8000,7 @@ int32_t ism6hg256x_ois_on_if2_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = ism6hg256x_read_reg(ctx, ISM6HG256X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
   if (ret == 0)
   {
-    ui_ctrl1_ois.if2_spi_read_en = val;
+    ui_ctrl1_ois.if2_spi_read_en = val & 0x01U;
     ret = ism6hg256x_write_reg(ctx, ISM6HG256X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
   }
 
@@ -8236,7 +8234,7 @@ int32_t ism6hg256x_4d_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = ism6hg256x_read_reg(ctx, ISM6HG256X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
   if (ret == 0)
   {
-    tap_ths_6d.d4d_en = val;
+    tap_ths_6d.d4d_en = val & 0x01U;
     ret = ism6hg256x_write_reg(ctx, ISM6HG256X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
   }
 
@@ -8356,7 +8354,7 @@ int32_t ism6hg256x_sh_controller_interface_pull_up_set(const stmdev_ctx_t *ctx,
   ret = ism6hg256x_read_reg(ctx, ISM6HG256X_IF_CFG, (uint8_t *)&if_cfg, 1);
   if (ret == 0)
   {
-    if_cfg.shub_pu_en = val;
+    if_cfg.shub_pu_en = val & 0x01U;
     ret = ism6hg256x_write_reg(ctx, ISM6HG256X_IF_CFG, (uint8_t *)&if_cfg, 1);
   }
 
@@ -8480,7 +8478,7 @@ int32_t ism6hg256x_sh_controller_set(const stmdev_ctx_t *ctx, uint8_t val)
     goto exit;
   }
 
-  controller_config.controller_on = val;
+  controller_config.controller_on = val & 0x01U;
   ret = ism6hg256x_write_reg(ctx, ISM6HG256X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
 
 exit:
@@ -8527,7 +8525,7 @@ int32_t ism6hg256x_sh_pass_through_set(const stmdev_ctx_t *ctx, uint8_t val)
     goto exit;
   }
 
-  controller_config.pass_through_mode = val;
+  controller_config.pass_through_mode = val & 0x01U;
   ret = ism6hg256x_write_reg(ctx, ISM6HG256X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
 
 exit:
@@ -8684,7 +8682,7 @@ int32_t ism6hg256x_sh_reset_set(const stmdev_ctx_t *ctx, uint8_t val)
     goto exit;
   }
 
-  controller_config.rst_controller_regs = val;
+  controller_config.rst_controller_regs = val & 0x01U;
   ret = ism6hg256x_write_reg(ctx, ISM6HG256X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
 
 exit:
@@ -8727,7 +8725,7 @@ int32_t ism6hg256x_sh_cfg_write(const stmdev_ctx_t *ctx,
     goto exit;
   }
 
-  reg.target0_add = (uint8_t)(val->tgt0_add >> 1);
+  reg.target0_add = (val->tgt0_add >> 1) & 0x07U;
   reg.rw_0 = 0;
   ret = ism6hg256x_write_reg(ctx, ISM6HG256X_TGT0_ADD, (uint8_t *)&reg, 1);
   if (ret != 0)
@@ -8845,31 +8843,31 @@ int32_t ism6hg256x_sh_tgt_cfg_read(const stmdev_ctx_t *ctx, uint8_t idx,
     return ret;
   }
 
-  tgt_add.target0_add = (uint8_t)(val->tgt_add >> 1);
+  tgt_add.target0_add = (val->tgt_add >> 1) & 0x07U;
   tgt_add.rw_0 = 1;
-  ret = ism6hg256x_write_reg(ctx, ISM6HG256X_TGT0_ADD + idx * 3U,
+  ret = ism6hg256x_write_reg(ctx, ISM6HG256X_TGT0_ADD + (uint8_t)(idx * 3U),
                              (uint8_t *)&tgt_add, 1);
   if (ret != 0)
   {
     goto exit;
   }
 
-  ret = ism6hg256x_write_reg(ctx, ISM6HG256X_TGT0_SUBADD + idx * 3U,
+  ret = ism6hg256x_write_reg(ctx, ISM6HG256X_TGT0_SUBADD + (uint8_t)(idx * 3U),
                              &(val->tgt_subadd), 1);
   if (ret != 0)
   {
     goto exit;
   }
 
-  ret = ism6hg256x_read_reg(ctx, ISM6HG256X_TGT0_CONFIG + idx * 3U,
+  ret = ism6hg256x_read_reg(ctx, ISM6HG256X_TGT0_CONFIG + (uint8_t)(idx * 3U),
                             (uint8_t *)&tgt_config, 1);
   if (ret != 0)
   {
     goto exit;
   }
 
-  tgt_config.target0_numop = val->tgt_len;
-  ret = ism6hg256x_write_reg(ctx, ISM6HG256X_TGT0_CONFIG + idx * 3U,
+  tgt_config.target0_numop = val->tgt_len & 0x07U;
+  ret = ism6hg256x_write_reg(ctx, ISM6HG256X_TGT0_CONFIG + (uint8_t)(idx * 3U),
                              (uint8_t *)&tgt_config, 1);
 
 exit:
@@ -8898,7 +8896,7 @@ int32_t ism6hg256x_ui_sdo_pull_up_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = ism6hg256x_read_reg(ctx, ISM6HG256X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
   if (ret == 0)
   {
-    pin_ctrl.sdo_pu_en = val;
+    pin_ctrl.sdo_pu_en = val & 0x01U;
     ret = ism6hg256x_write_reg(ctx, ISM6HG256X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
   }
 
@@ -8930,7 +8928,7 @@ int32_t ism6hg256x_pad_strength_set(const stmdev_ctx_t *ctx, ism6hg256x_pad_stre
   ret = ism6hg256x_read_reg(ctx, ISM6HG256X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
   if (ret == 0)
   {
-    pin_ctrl.io_pad_strength = val;
+    pin_ctrl.io_pad_strength = val & 0x03U;
     ret = ism6hg256x_write_reg(ctx, ISM6HG256X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
   }
 
@@ -9071,7 +9069,7 @@ int32_t ism6hg256x_ui_sda_pull_up_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = ism6hg256x_read_reg(ctx, ISM6HG256X_IF_CFG, (uint8_t *)&if_cfg, 1);
   if (ret == 0)
   {
-    if_cfg.sda_pu_en = val;
+    if_cfg.sda_pu_en = val & 0x01U;
     ret = ism6hg256x_write_reg(ctx, ISM6HG256X_IF_CFG, (uint8_t *)&if_cfg, 1);
   }
 
@@ -9157,7 +9155,7 @@ int32_t ism6hg256x_sigmot_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
   {
     goto exit;
   }
-  emb_func_en_a.sign_motion_en = val;
+  emb_func_en_a.sign_motion_en = val & 0x01U;
   ret += ism6hg256x_write_reg(ctx, ISM6HG256X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
 
 exit:
@@ -9285,8 +9283,7 @@ int32_t ism6hg256x_stpcnt_steps_get(const stmdev_ctx_t *ctx, uint16_t *val)
     return ret;
   }
 
-  *val = buff[1];
-  *val = (*val * 256U) + buff[0];
+  *val = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
 
   return ret;
 }
@@ -9309,7 +9306,7 @@ int32_t ism6hg256x_stpcnt_rst_step_set(const stmdev_ctx_t *ctx, uint8_t val)
     goto exit;
   }
 
-  emb_func_src.pedo_rst_step = val;
+  emb_func_src.pedo_rst_step = val & 0x01U;
   ret = ism6hg256x_write_reg(ctx, ISM6HG256X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
 
 exit:
@@ -9405,8 +9402,7 @@ int32_t ism6hg256x_stpcnt_period_get(const stmdev_ctx_t *ctx, uint16_t *val)
     return ret;
   }
 
-  *val = buff[1];
-  *val = (*val * 256U) + buff[0];
+  *val = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
 
   return ret;
 }
@@ -9429,7 +9425,7 @@ int32_t ism6hg256x_sflp_game_rotation_set(const stmdev_ctx_t *ctx, uint8_t val)
     goto exit;
   }
 
-  emb_func_en_a.sflp_game_en = val;
+  emb_func_en_a.sflp_game_en = val & 0x01U;
   ret += ism6hg256x_write_reg(ctx, ISM6HG256X_EMB_FUNC_EN_A,
                               (uint8_t *)&emb_func_en_a, 1);
 
@@ -9481,7 +9477,7 @@ int32_t ism6hg256x_sflp_game_rotation_reset(const stmdev_ctx_t *ctx, uint8_t val
   {
     goto exit;
   }
-  emb_func_init_a.sflp_game_init = val;
+  emb_func_init_a.sflp_game_init = val & 0x01U;
   ret += ism6hg256x_write_reg(ctx, ISM6HG256X_EMB_FUNC_INIT_A, (uint8_t *)&emb_func_init_a, 1);
 
 exit:
@@ -9819,7 +9815,7 @@ int32_t ism6hg256x_tilt_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
   }
 
   ret = ism6hg256x_read_reg(ctx, ISM6HG256X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
-  emb_func_en_a.tilt_en = val;
+  emb_func_en_a.tilt_en = val & 0x01U;
   ret += ism6hg256x_write_reg(ctx, ISM6HG256X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
 
   ret += ism6hg256x_mem_bank_set(ctx, ISM6HG256X_MAIN_MEM_BANK);
@@ -9859,10 +9855,10 @@ int32_t ism6hg256x_timestamp_raw_get(const stmdev_ctx_t *ctx, uint32_t *val)
     return ret;
   }
 
-  *val = buff[3];
-  *val = (*val * 256U) + buff[2];
-  *val = (*val * 256U) + buff[1];
-  *val = (*val * 256U) + buff[0];
+  *val = (uint32_t)buff[3] << 8;
+  *val = (*val | (uint32_t)buff[2]) << 8;
+  *val = (*val | (uint32_t)buff[1]) << 8;
+  *val = (*val | (uint32_t)buff[0]) << 8;
 
   return ret;
 }
@@ -9876,7 +9872,7 @@ int32_t ism6hg256x_timestamp_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = ism6hg256x_read_reg(ctx, ISM6HG256X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
   if (ret == 0)
   {
-    functions_enable.timestamp_en = val;
+    functions_enable.timestamp_en = val & 0x01U;
     ret = ism6hg256x_write_reg(ctx, ISM6HG256X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
   }
 
@@ -10085,13 +10081,13 @@ int32_t ism6hg256x_act_thresholds_set(const stmdev_ctx_t *ctx,
     return ret;
   }
 
-  inactivity_dur.wu_inact_ths_w = val->inactivity_cfg.wu_inact_ths_w;
-  inactivity_dur.xl_inact_odr = val->inactivity_cfg.xl_inact_odr;
-  inactivity_dur.inact_dur = val->inactivity_cfg.inact_dur;
+  inactivity_dur.wu_inact_ths_w = val->inactivity_cfg.wu_inact_ths_w & 0x07U;
+  inactivity_dur.xl_inact_odr = val->inactivity_cfg.xl_inact_odr & 0x03U;
+  inactivity_dur.inact_dur = val->inactivity_cfg.inact_dur & 0x03U;
 
-  inactivity_ths.inact_ths = val->inactivity_ths;
-  wake_up_ths.wk_ths = val->threshold;
-  wake_up_dur.wake_dur = val->duration;
+  inactivity_ths.inact_ths = val->inactivity_ths & 0x3FU;
+  wake_up_ths.wk_ths = val->threshold & 0x3FU;
+  wake_up_dur.wake_dur = val->duration & 0x03U;
 
   ret += ism6hg256x_write_reg(ctx, ISM6HG256X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
   ret += ism6hg256x_write_reg(ctx, ISM6HG256X_INACTIVITY_THS, (uint8_t *)&inactivity_ths, 1);

--- a/sensor/stmemsc/ism6hg256x_STdC/driver/ism6hg256x_reg.h
+++ b/sensor/stmemsc/ism6hg256x_STdC/driver/ism6hg256x_reg.h
@@ -29,6 +29,7 @@ extern "C" {
 #include <stdint.h>
 #include <stddef.h>
 #include <math.h>
+#include <string.h>
 
 /** @addtogroup ISM6HG256X
   * @{

--- a/sensor/stmemsc/lsm6dsv320x_STdC/driver/lsm6dsv320x_reg.c
+++ b/sensor/stmemsc/lsm6dsv320x_STdC/driver/lsm6dsv320x_reg.c
@@ -50,7 +50,7 @@ int32_t __weak lsm6dsv320x_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
   return ret;
 }
 
-static void bytecpy(uint8_t *target, uint8_t *source)
+static void bytecpy(uint8_t *target, const uint8_t *source)
 {
   if ((target != NULL) && (source != NULL))
   {
@@ -178,7 +178,7 @@ int32_t lsm6dsv320x_xl_offset_on_out_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL9, (uint8_t *)&ctrl9, 1);
   if (ret == 0)
   {
-    ctrl9.usr_off_on_out = val;
+    ctrl9.usr_off_on_out = val & 0x01U;
     ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL9, (uint8_t *)&ctrl9, 1);
   }
 
@@ -209,7 +209,7 @@ int32_t lsm6dsv320x_xl_offset_mg_set(const stmdev_ctx_t *ctx,
   lsm6dsv320x_x_ofs_usr_t x_ofs_usr = {0};
   lsm6dsv320x_ctrl9_t ctrl9 = {0};
   int32_t ret = 0;
-  float_t tmp = 0;
+  float_t tmp = 0.0f;
 
   ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
   ret += lsm6dsv320x_read_reg(ctx, LSM6DSV320X_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
@@ -225,38 +225,38 @@ int32_t lsm6dsv320x_xl_offset_mg_set(const stmdev_ctx_t *ctx,
       (val.y_mg < (0.0078125f * 127.0f)) && (val.y_mg > (0.0078125f * -127.0f)) &&
       (val.z_mg < (0.0078125f * 127.0f)) && (val.z_mg > (0.0078125f * -127.0f)))
   {
-    ctrl9.usr_off_w = 0;
+    ctrl9.usr_off_w = 0u;
 
     tmp = val.z_mg / 0.0078125f;
-    z_ofs_usr.z_ofs_usr = (uint8_t)tmp;
+    z_ofs_usr.z_ofs_usr = (int8_t)(int32_t)tmp;
 
     tmp = val.y_mg / 0.0078125f;
-    y_ofs_usr.y_ofs_usr = (uint8_t)tmp;
+    y_ofs_usr.y_ofs_usr = (int8_t)(int32_t)tmp;
 
     tmp = val.x_mg / 0.0078125f;
-    x_ofs_usr.x_ofs_usr = (uint8_t)tmp;
+    x_ofs_usr.x_ofs_usr = (int8_t)(int32_t)tmp;
   }
   else if ((val.x_mg < (0.125f * 127.0f)) && (val.x_mg > (0.125f * -127.0f)) &&
            (val.y_mg < (0.125f * 127.0f)) && (val.y_mg > (0.125f * -127.0f)) &&
            (val.z_mg < (0.125f * 127.0f)) && (val.z_mg > (0.125f * -127.0f)))
   {
-    ctrl9.usr_off_w = 1;
+    ctrl9.usr_off_w = 1u;
 
     tmp = val.z_mg / 0.125f;
-    z_ofs_usr.z_ofs_usr = (uint8_t)tmp;
+    z_ofs_usr.z_ofs_usr = (int8_t)(int32_t)tmp;
 
     tmp = val.y_mg / 0.125f;
-    y_ofs_usr.y_ofs_usr = (uint8_t)tmp;
+    y_ofs_usr.y_ofs_usr = (int8_t)(int32_t)tmp;
 
     tmp = val.x_mg / 0.125f;
-    x_ofs_usr.x_ofs_usr = (uint8_t)tmp;
+    x_ofs_usr.x_ofs_usr = (int8_t)(int32_t)tmp;
   }
   else // out of limit
   {
-    ctrl9.usr_off_w = 1;
-    z_ofs_usr.z_ofs_usr = 0xFFU;
-    y_ofs_usr.y_ofs_usr = 0xFFU;
-    x_ofs_usr.x_ofs_usr = 0xFFU;
+    ctrl9.usr_off_w = 1u;
+    z_ofs_usr.z_ofs_usr = 0;
+    y_ofs_usr.y_ofs_usr = 0;
+    x_ofs_usr.x_ofs_usr = 0;
   }
 
   ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
@@ -311,7 +311,7 @@ int32_t lsm6dsv320x_hg_xl_offset_mg_set(const stmdev_ctx_t *ctx,
   lsm6dsv320x_hg_x_ofs_usr_t x_ofs_usr = {0};
   lsm6dsv320x_ctrl1_xl_hg_t  ctrl1_xl_hg = {0};
   int32_t ret = 0;
-  float_t tmp = 0;
+  float_t tmp = 0.0f;
 
   ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL1_XL_HG, (uint8_t *)&ctrl1_xl_hg, 1);
   if (ret != 0)
@@ -323,23 +323,23 @@ int32_t lsm6dsv320x_hg_xl_offset_mg_set(const stmdev_ctx_t *ctx,
       (val.y_mg < (0.25f * 127.0f)) && (val.y_mg > (0.25f * -127.0f)) &&
       (val.z_mg < (0.25f * 127.0f)) && (val.z_mg > (0.25f * -127.0f)))
   {
-    ctrl1_xl_hg.hg_usr_off_on_out = 1;
+    ctrl1_xl_hg.hg_usr_off_on_out = 1U;
 
     tmp = val.z_mg / 0.25f;
-    z_ofs_usr.xl_hg_z_ofs_usr = (uint8_t)tmp;
+    z_ofs_usr.xl_hg_z_ofs_usr = (int8_t)tmp;
 
     tmp = val.y_mg / 0.25f;
-    y_ofs_usr.xl_hg_y_ofs_usr = (uint8_t)tmp;
+    y_ofs_usr.xl_hg_y_ofs_usr = (int8_t)tmp;
 
     tmp = val.x_mg / 0.25f;
-    x_ofs_usr.xl_hg_x_ofs_usr = (uint8_t)tmp;
+    x_ofs_usr.xl_hg_x_ofs_usr = (int8_t)tmp;
   }
   else // out of limit
   {
-    ctrl1_xl_hg.hg_usr_off_on_out = 0;
-    z_ofs_usr.xl_hg_z_ofs_usr = 0xFFU;
-    y_ofs_usr.xl_hg_y_ofs_usr = 0xFFU;
-    x_ofs_usr.xl_hg_x_ofs_usr = 0xFFU;
+    ctrl1_xl_hg.hg_usr_off_on_out = 0u;
+    z_ofs_usr.xl_hg_z_ofs_usr = 0;
+    y_ofs_usr.xl_hg_y_ofs_usr = 0;
+    x_ofs_usr.xl_hg_x_ofs_usr = 0;
   }
 
   ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_XL_HG_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
@@ -391,12 +391,12 @@ int32_t lsm6dsv320x_reboot(const stmdev_ctx_t *ctx)
   lsm6dsv320x_ctrl3_t ctrl3 = {0};
   int32_t ret = 0;
   /* configuration to restore after reboot */
-  lsm6dsv320x_data_rate_t xl;
-  lsm6dsv320x_data_rate_t gy;
-  lsm6dsv320x_hg_xl_data_rate_t hg_xl;
-  lsm6dsv320x_xl_mode_t xlm;
-  lsm6dsv320x_gy_mode_t gym;
-  uint8_t reg_out_en;
+  lsm6dsv320x_data_rate_t xl = LSM6DSV320X_ODR_OFF;
+  lsm6dsv320x_data_rate_t gy = LSM6DSV320X_ODR_OFF;
+  lsm6dsv320x_hg_xl_data_rate_t hg_xl = LSM6DSV320X_HG_XL_ODR_OFF;
+  lsm6dsv320x_xl_mode_t xlm = LSM6DSV320X_XL_UNCHANGED_MD;
+  lsm6dsv320x_gy_mode_t gym = LSM6DSV320X_GY_UNCHANGED_MD;
+  uint8_t reg_out_en = 0u;
 
   if (ctx->mdelay == NULL)
   {
@@ -487,7 +487,7 @@ exit:
 int32_t lsm6dsv320x_sw_reset(const stmdev_ctx_t *ctx)
 {
   lsm6dsv320x_ctrl3_t ctrl3 = {0};
-  uint8_t retry = 0;
+  uint8_t retry = 0u;
   int32_t ret = 0;
 
   if (ctx->mdelay == NULL)
@@ -519,9 +519,10 @@ int32_t lsm6dsv320x_sw_reset(const stmdev_ctx_t *ctx)
     }
 
     ctx->mdelay(1);
-  } while (ctrl3.sw_reset == 1 && retry++ < 3);
+    retry++;
+  } while ((ctrl3.sw_reset == 1u) && (retry < 3u));
 
-  return (ctrl3.sw_reset == 0) ? 0 : -1;
+  return (ctrl3.sw_reset == 0u) ? 0 : -1;
 
 exit:
   return ret;
@@ -643,7 +644,7 @@ int32_t lsm6dsv320x_xl_setup(
   // if odr_xl bits has 4th bit enabled, low-power modes are not allowed
   else if (
     // odr >= 480 and low-power and normal mode
-    ((uint8_t)xl_odr & 0x8) != 0 && ((uint8_t)xl_mode & 0x4) != 0 &&
+    ((uint8_t)xl_odr & 0x8) != 0u && ((uint8_t)xl_mode & 0x4) != 0u &&
     (xl_mode != LSM6DSV320X_XL_NORMAL_MD || // normal mode is not allowed for some data rates
      xl_odr == LSM6DSV320X_ODR_AT_3840Hz ||
      xl_odr == LSM6DSV320X_ODR_AT_7680Hz))
@@ -663,8 +664,8 @@ int32_t lsm6dsv320x_xl_setup(
   }
 
   // if odr is choosed as high-accuracy value, mode should also be set in HAODR mode
-  if ((xl_ha != 0 && xl_mode != LSM6DSV320X_XL_HIGH_ACCURACY_ODR_MD) ||
-      (xl_ha == 0 && xl_mode == LSM6DSV320X_XL_HIGH_ACCURACY_ODR_MD))
+  if ((xl_ha != 0u && xl_mode != LSM6DSV320X_XL_HIGH_ACCURACY_ODR_MD) ||
+      (xl_ha == 0u && xl_mode == LSM6DSV320X_XL_HIGH_ACCURACY_ODR_MD))
   {
     ret = -1;
     goto exit;
@@ -683,17 +684,10 @@ int32_t lsm6dsv320x_xl_setup(
 
   // cross-checking haodr mode
   both_on = ctrl1.odr_xl != (uint8_t)LSM6DSV320X_ODR_OFF &&
-            ctrl2.odr_g != (uint8_t)LSM6DSV320X_ODR_OFF ? 1 : 0;
+            ctrl2.odr_g != (uint8_t)LSM6DSV320X_ODR_OFF ? 1u : 0u;
 
   // if both on, then haodr_sel is a shared bit. Could be changed through haodr_set API
-  if (both_on == 1 && (xl_ha != haodr.haodr_sel))
-  {
-    ret = -1;
-    goto exit;
-  }
-
-  // if odr is choosed as an high-accuracy value, mode should be set in high-accuracy
-  if ((xl_ha != 0 && xl_mode != LSM6DSV320X_XL_HIGH_ACCURACY_ODR_MD))
+  if (both_on == 1u && (xl_ha != haodr.haodr_sel))
   {
     ret = -1;
     goto exit;
@@ -713,9 +707,9 @@ int32_t lsm6dsv320x_xl_setup(
   else
   {
     // if HAODR switch is not required, just set ctrl1 settings
-    ctrl1.op_mode_xl = (uint8_t)xl_mode;
-    ctrl1.odr_xl = (uint8_t)xl_odr;
-    haodr.haodr_sel = xl_ha;
+    ctrl1.op_mode_xl = (uint8_t)xl_mode & 0x07U;
+    ctrl1.odr_xl = (uint8_t)xl_odr & 0x0FU;
+    haodr.haodr_sel = xl_ha & 0x03U;
     ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL1, (uint8_t *)&ctrl1, 1);
     ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_HAODR_CFG, (uint8_t *)&haodr, 1);
   }
@@ -760,7 +754,7 @@ int32_t lsm6dsv320x_gy_setup(
 
   // Table 13 of AN6119
   // 7.5Hz with HAODR mode enable, is already handled by the enum selection
-  if (((uint8_t)gy_odr & 0x8) != 0 && gy_mode == LSM6DSV320X_GY_LOW_POWER_MD)
+  if (((uint8_t)gy_odr & 0x8) != 0u && gy_mode == LSM6DSV320X_GY_LOW_POWER_MD)
   {
     ret = -1;
     goto exit;
@@ -776,8 +770,8 @@ int32_t lsm6dsv320x_gy_setup(
   }
 
   // if odr is choosed as high-accuracy value, mode should also be set in HAODR mode
-  if ((gy_ha != 0 && gy_mode != LSM6DSV320X_GY_HIGH_ACCURACY_ODR_MD) ||
-      (gy_ha == 0 && gy_mode == LSM6DSV320X_GY_HIGH_ACCURACY_ODR_MD))
+  if ((gy_ha != 0u && gy_mode != LSM6DSV320X_GY_HIGH_ACCURACY_ODR_MD) ||
+      (gy_ha == 0u && gy_mode == LSM6DSV320X_GY_HIGH_ACCURACY_ODR_MD))
   {
     ret = -1;
     goto exit;
@@ -796,10 +790,10 @@ int32_t lsm6dsv320x_gy_setup(
 
   // cross-checking haodr mode
   both_on = ctrl1.odr_xl != (uint8_t)LSM6DSV320X_ODR_OFF &&
-            ctrl2.odr_g != (uint8_t)LSM6DSV320X_ODR_OFF ? 1 : 0;
+            ctrl2.odr_g != (uint8_t)LSM6DSV320X_ODR_OFF ? 1u : 0u;
 
   // if both on, then haodr_sel is a shared bit
-  if (both_on == 1 && (gy_ha != haodr.haodr_sel))
+  if (both_on == 1u && (gy_ha != haodr.haodr_sel))
   {
     ret = -1;
     goto exit;
@@ -819,9 +813,9 @@ int32_t lsm6dsv320x_gy_setup(
   else
   {
     // if HAODR switch is not required, just set ctrl2 settings
-    ctrl2.op_mode_g = (uint8_t)gy_mode;
-    ctrl2.odr_g = (uint8_t)gy_odr;
-    haodr.haodr_sel = gy_ha;
+    ctrl2.op_mode_g = (uint8_t)gy_mode & 0x07U;
+    ctrl2.odr_g = (uint8_t)gy_odr & 0x0FU;
+    haodr.haodr_sel = gy_ha & 0x03U;
     ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL2, (uint8_t *)&ctrl2, 1);
     ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_HAODR_CFG, (uint8_t *)&haodr, 1);
   }
@@ -842,7 +836,7 @@ int32_t lsm6dsv320x_haodr_set(
   lsm6dsv320x_ctrl2_t ctrl2 = {0};
   lsm6dsv320x_haodr_cfg_t haodr = {0};
   lsm6dsv320x_ctrl1_xl_hg_t ctrl1_xl_hg = {0};
-  lsm6dsv320x_xl_mode_t prev_mode = {0};
+  lsm6dsv320x_xl_mode_t prev_mode = LSM6DSV320X_XL_UNCHANGED_MD;
   lsm6dsv320x_ctrl1_xl_hg_t ctrl1_xl_hg_prev = {0};
   lsm6dsv320x_ctrl_eis_t ctrl_eis_prev = {0};
   lsm6dsv320x_ctrl_eis_t ctrl_eis = {0};
@@ -858,7 +852,7 @@ int32_t lsm6dsv320x_haodr_set(
     goto exit;
   }
 
-  if (both_on == 1 && (xl_ha != gy_ha))
+  if (both_on == 1u && (xl_ha != gy_ha))
   {
     ret = -1;
     goto exit;
@@ -883,7 +877,7 @@ int32_t lsm6dsv320x_haodr_set(
   ctrl1.odr_xl = (uint8_t)LSM6DSV320X_ODR_OFF;
   ctrl2.odr_g = (uint8_t)LSM6DSV320X_ODR_OFF;
   ctrl1_xl_hg.odr_xl_hg = (uint8_t)LSM6DSV320X_HG_XL_ODR_OFF;
-  ctrl1_xl_hg.xl_hg_regout_en = 0;
+  ctrl1_xl_hg.xl_hg_regout_en = 0u;
   ctrl_eis.odr_g_eis = (uint8_t)LSM6DSV320X_EIS_ODR_OFF;
   ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL1, (uint8_t *)&ctrl1, 1);
   ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL2, (uint8_t *)&ctrl2, 1);
@@ -898,9 +892,9 @@ int32_t lsm6dsv320x_haodr_set(
   }
 
   // set HAODR
-  haodr.haodr_sel = xl_ha | gy_ha;
-  ctrl1.op_mode_xl = (uint8_t)xl_mode;
-  ctrl2.op_mode_g = (uint8_t)gy_mode;
+  haodr.haodr_sel = (xl_ha | gy_ha) & 0x03U;
+  ctrl1.op_mode_xl = (uint8_t)xl_mode & 0x07U;
+  ctrl2.op_mode_g = (uint8_t)gy_mode & 0x07U;
 
   ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_HAODR_CFG, (uint8_t *)&haodr, 1);
   ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL1, (uint8_t *)&ctrl1, 1);
@@ -912,8 +906,8 @@ int32_t lsm6dsv320x_haodr_set(
   }
 
   // set xl and gy data rates and restore high-g xl and eis to their previous data rates
-  ctrl1.odr_xl = (uint8_t)xl_odr;
-  ctrl2.odr_g = (uint8_t)gy_odr;
+  ctrl1.odr_xl = (uint8_t)xl_odr & 0x0FU;
+  ctrl2.odr_g = (uint8_t)gy_odr & 0x0FU;
   ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL1, (uint8_t *)&ctrl1, 1);
   ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL2, (uint8_t *)&ctrl2, 1);
   // if off, there is no need to turn them on
@@ -960,7 +954,7 @@ int32_t lsm6dsv320x_xl_data_rate_set(const stmdev_ctx_t *ctx,
     {
       return ret;
     }
-    haodr.haodr_sel = sel;
+    haodr.haodr_sel = sel & 0x03U;
     ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_HAODR_CFG, (uint8_t *)&haodr, 1);
   }
 
@@ -1002,7 +996,6 @@ int32_t lsm6dsv320x_xl_data_rate_get(const stmdev_ctx_t *ctx,
     case (uint8_t)LSM6DSV320X_ODR_AT_15Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV320X_ODR_AT_15Hz;
           break;
@@ -1015,13 +1008,15 @@ int32_t lsm6dsv320x_xl_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV320X_ODR_HA03_AT_13Hz;
           break;
+        default:
+          *val = LSM6DSV320X_ODR_AT_15Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV320X_ODR_AT_30Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV320X_ODR_AT_30Hz;
           break;
@@ -1034,13 +1029,15 @@ int32_t lsm6dsv320x_xl_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV320X_ODR_HA03_AT_26Hz;
           break;
+        default:
+          *val = LSM6DSV320X_ODR_AT_30Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV320X_ODR_AT_60Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV320X_ODR_AT_60Hz;
           break;
@@ -1053,13 +1050,15 @@ int32_t lsm6dsv320x_xl_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV320X_ODR_HA03_AT_52Hz;
           break;
+        default:
+          *val = LSM6DSV320X_ODR_AT_60Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV320X_ODR_AT_120Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV320X_ODR_AT_120Hz;
           break;
@@ -1072,13 +1071,15 @@ int32_t lsm6dsv320x_xl_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV320X_ODR_HA03_AT_104Hz;
           break;
+        default:
+          *val = LSM6DSV320X_ODR_AT_120Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV320X_ODR_AT_240Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV320X_ODR_AT_240Hz;
           break;
@@ -1091,13 +1092,15 @@ int32_t lsm6dsv320x_xl_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV320X_ODR_HA03_AT_208Hz;
           break;
+        default:
+          *val = LSM6DSV320X_ODR_AT_240Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV320X_ODR_AT_480Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV320X_ODR_AT_480Hz;
           break;
@@ -1110,13 +1113,15 @@ int32_t lsm6dsv320x_xl_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV320X_ODR_HA03_AT_417Hz;
           break;
+        default:
+          *val = LSM6DSV320X_ODR_AT_480Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV320X_ODR_AT_960Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV320X_ODR_AT_960Hz;
           break;
@@ -1129,13 +1134,15 @@ int32_t lsm6dsv320x_xl_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV320X_ODR_HA03_AT_833Hz;
           break;
+        default:
+          *val = LSM6DSV320X_ODR_AT_960Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV320X_ODR_AT_1920Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV320X_ODR_AT_1920Hz;
           break;
@@ -1148,13 +1155,15 @@ int32_t lsm6dsv320x_xl_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV320X_ODR_HA03_AT_1667Hz;
           break;
+        default:
+          *val = LSM6DSV320X_ODR_AT_1920Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV320X_ODR_AT_3840Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV320X_ODR_AT_3840Hz;
           break;
@@ -1167,13 +1176,15 @@ int32_t lsm6dsv320x_xl_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV320X_ODR_HA03_AT_3333Hz;
           break;
+        default:
+          *val = LSM6DSV320X_ODR_AT_3840Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV320X_ODR_AT_7680Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV320X_ODR_AT_7680Hz;
           break;
@@ -1185,6 +1196,9 @@ int32_t lsm6dsv320x_xl_data_rate_get(const stmdev_ctx_t *ctx,
           break;
         case 3:
           *val = LSM6DSV320X_ODR_HA03_AT_6667Hz;
+          break;
+        default:
+          *val = LSM6DSV320X_ODR_AT_7680Hz;
           break;
       }
       break;
@@ -1393,7 +1407,7 @@ int32_t lsm6dsv320x_gy_data_rate_set(const stmdev_ctx_t *ctx,
     {
       return ret;
     }
-    haodr.haodr_sel = sel;
+    haodr.haodr_sel = sel & 0x03U;
     ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_HAODR_CFG, (uint8_t *)&haodr, 1);
   }
 
@@ -1435,7 +1449,6 @@ int32_t lsm6dsv320x_gy_data_rate_get(const stmdev_ctx_t *ctx,
     case (uint8_t)LSM6DSV320X_ODR_AT_15Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV320X_ODR_AT_15Hz;
           break;
@@ -1448,13 +1461,15 @@ int32_t lsm6dsv320x_gy_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV320X_ODR_HA03_AT_13Hz;
           break;
+        default:
+          *val = LSM6DSV320X_ODR_AT_15Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV320X_ODR_AT_30Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV320X_ODR_AT_30Hz;
           break;
@@ -1467,13 +1482,15 @@ int32_t lsm6dsv320x_gy_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV320X_ODR_HA03_AT_26Hz;
           break;
+        default:
+          *val = LSM6DSV320X_ODR_AT_30Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV320X_ODR_AT_60Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV320X_ODR_AT_60Hz;
           break;
@@ -1486,13 +1503,15 @@ int32_t lsm6dsv320x_gy_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV320X_ODR_HA03_AT_52Hz;
           break;
+        default:
+          *val = LSM6DSV320X_ODR_AT_60Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV320X_ODR_AT_120Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV320X_ODR_AT_120Hz;
           break;
@@ -1505,13 +1524,15 @@ int32_t lsm6dsv320x_gy_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV320X_ODR_HA03_AT_104Hz;
           break;
+        default:
+          *val = LSM6DSV320X_ODR_AT_120Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV320X_ODR_AT_240Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV320X_ODR_AT_240Hz;
           break;
@@ -1524,13 +1545,15 @@ int32_t lsm6dsv320x_gy_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV320X_ODR_HA03_AT_208Hz;
           break;
+        default:
+          *val = LSM6DSV320X_ODR_AT_240Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV320X_ODR_AT_480Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV320X_ODR_AT_480Hz;
           break;
@@ -1543,13 +1566,15 @@ int32_t lsm6dsv320x_gy_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV320X_ODR_HA03_AT_417Hz;
           break;
+        default:
+          *val = LSM6DSV320X_ODR_AT_480Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV320X_ODR_AT_960Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV320X_ODR_AT_960Hz;
           break;
@@ -1562,13 +1587,15 @@ int32_t lsm6dsv320x_gy_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV320X_ODR_HA03_AT_833Hz;
           break;
+        default:
+          *val = LSM6DSV320X_ODR_AT_960Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV320X_ODR_AT_1920Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV320X_ODR_AT_1920Hz;
           break;
@@ -1581,13 +1608,15 @@ int32_t lsm6dsv320x_gy_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV320X_ODR_HA03_AT_1667Hz;
           break;
+        default:
+          *val = LSM6DSV320X_ODR_AT_1920Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV320X_ODR_AT_3840Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV320X_ODR_AT_3840Hz;
           break;
@@ -1600,13 +1629,15 @@ int32_t lsm6dsv320x_gy_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV320X_ODR_HA03_AT_3333Hz;
           break;
+        default:
+          *val = LSM6DSV320X_ODR_AT_3840Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV320X_ODR_AT_7680Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV320X_ODR_AT_7680Hz;
           break;
@@ -1618,6 +1649,9 @@ int32_t lsm6dsv320x_gy_data_rate_get(const stmdev_ctx_t *ctx,
           break;
         case 3:
           *val = LSM6DSV320X_ODR_HA03_AT_6667Hz;
+          break;
+        default:
+          *val = LSM6DSV320X_ODR_AT_7680Hz;
           break;
       }
       break;
@@ -1697,7 +1731,7 @@ int32_t lsm6dsv320x_auto_increment_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL3, (uint8_t *)&ctrl3, 1);
   if (ret == 0)
   {
-    ctrl3.if_inc = val;
+    ctrl3.if_inc = val & 0x01U;
     ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL3, (uint8_t *)&ctrl3, 1);
   }
 
@@ -1730,7 +1764,7 @@ int32_t lsm6dsv320x_block_data_update_set(const stmdev_ctx_t *ctx, uint8_t val)
 
   if (ret == 0)
   {
-    ctrl3.bdu = val;
+    ctrl3.bdu = val & 0x01U;
     ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL3, (uint8_t *)&ctrl3, 1);
   }
 
@@ -1916,7 +1950,7 @@ int32_t lsm6dsv320x_gy_full_scale_set(const stmdev_ctx_t *ctx,
     ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL2, (uint8_t *)&ctrl2, 1);
   }
 
-  ctrl6.fs_g = (uint8_t)val & 0xfu;
+  ctrl6.fs_g = (uint8_t)val & 0x07u;
   ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL6, (uint8_t *)&ctrl6, 1);
 
   // restore previous odr set
@@ -3450,8 +3484,7 @@ int32_t lsm6dsv320x_temperature_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
     return ret;
   }
 
-  *val = (int16_t)buff[1];
-  *val = (*val * 256) + (int16_t)buff[0];
+  *val = (int16_t)((uint16_t)buff[0] | ((uint16_t)buff[1] << 8));
 
   return ret;
 }
@@ -3468,12 +3501,9 @@ int32_t lsm6dsv320x_angular_rate_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
     return ret;
   }
 
-  val[0] = (int16_t)buff[1];
-  val[0] = (val[0] * 256) + (int16_t)buff[0];
-  val[1] = (int16_t)buff[3];
-  val[1] = (val[1] * 256) + (int16_t)buff[2];
-  val[2] = (int16_t)buff[5];
-  val[2] = (val[2] * 256) + (int16_t)buff[4];
+  val[0] = (int16_t)((uint16_t)buff[0] | ((uint16_t)buff[1] << 8));
+  val[1] = (int16_t)((uint16_t)buff[2] | ((uint16_t)buff[3] << 8));
+  val[2] = (int16_t)((uint16_t)buff[4] | ((uint16_t)buff[5] << 8));
 
   return ret;
 }
@@ -3489,12 +3519,9 @@ int32_t lsm6dsv320x_ois_angular_rate_raw_get(const stmdev_ctx_t *ctx, int16_t *v
     return ret;
   }
 
-  val[0] = (int16_t)buff[1];
-  val[0] = (*val * 256) + (int16_t)buff[0];
-  val[1] = (int16_t)buff[3];
-  val[1] = (*val * 256) + (int16_t)buff[2];
-  val[2] = (int16_t)buff[5];
-  val[2] = (*val * 256) + (int16_t)buff[4];
+  val[0] = (int16_t)((uint16_t)buff[0] | ((uint16_t)buff[1] << 8));
+  val[1] = (int16_t)((uint16_t)buff[2] | ((uint16_t)buff[3] << 8));
+  val[2] = (int16_t)((uint16_t)buff[4] | ((uint16_t)buff[5] << 8));
 
   return ret;
 }
@@ -3511,9 +3538,9 @@ int32_t lsm6dsv320x_ois_eis_angular_rate_raw_get(const stmdev_ctx_t *ctx, int16_
     return ret;
   }
 
-  val[0] = (int16_t)((uint16_t)buff[1] << 8 | (uint16_t)buff[0]);
-  val[1] = (int16_t)((uint16_t)buff[3] << 8 | (uint16_t)buff[2]);
-  val[2] = (int16_t)((uint16_t)buff[5] << 8 | (uint16_t)buff[4]);
+  val[0] = (int16_t)buff[0] | (int16_t)((uint16_t)buff[1] << 8);
+  val[1] = (int16_t)buff[2] | (int16_t)((uint16_t)buff[3] << 8);
+  val[2] = (int16_t)buff[4] | (int16_t)((uint16_t)buff[5] << 8);
 
   return ret;
 }
@@ -3530,12 +3557,9 @@ int32_t lsm6dsv320x_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
     return ret;
   }
 
-  val[0] = (int16_t)buff[1];
-  val[0] = (val[0] * 256) + (int16_t)buff[0];
-  val[1] = (int16_t)buff[3];
-  val[1] = (val[1] * 256) + (int16_t)buff[2];
-  val[2] = (int16_t)buff[5];
-  val[2] = (val[2] * 256) + (int16_t)buff[4];
+  val[0] = (int16_t)((uint16_t)buff[0] | ((uint16_t)buff[1] << 8));
+  val[1] = (int16_t)((uint16_t)buff[2] | ((uint16_t)buff[3] << 8));
+  val[2] = (int16_t)((uint16_t)buff[4] | ((uint16_t)buff[5] << 8));
 
   return ret;
 }
@@ -3552,12 +3576,9 @@ int32_t lsm6dsv320x_hg_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *va
     return ret;
   }
 
-  val[0] = (int16_t)buff[1];
-  val[0] = (val[0] * 256) + (int16_t)buff[0];
-  val[1] = (int16_t)buff[3];
-  val[1] = (val[1] * 256) + (int16_t)buff[2];
-  val[2] = (int16_t)buff[5];
-  val[2] = (val[2] * 256) + (int16_t)buff[4];
+  val[0] = (int16_t)((uint16_t)buff[0] | ((uint16_t)buff[1] << 8));
+  val[1] = (int16_t)((uint16_t)buff[2] | ((uint16_t)buff[3] << 8));
+  val[2] = (int16_t)((uint16_t)buff[4] | ((uint16_t)buff[5] << 8));
 
   return ret;
 }
@@ -3573,12 +3594,9 @@ int32_t lsm6dsv320x_ois_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *v
     return ret;
   }
 
-  val[0] = (int16_t)buff[1];
-  val[0] = (val[0] * 256) + (int16_t)buff[0];
-  val[1] = (int16_t)buff[3];
-  val[1] = (val[1] * 256) + (int16_t)buff[2];
-  val[2] = (int16_t)buff[5];
-  val[2] = (val[2] * 256) + (int16_t)buff[4];
+  val[0] = (int16_t)((uint16_t)buff[0] | ((uint16_t)buff[1] << 8));
+  val[1] = (int16_t)((uint16_t)buff[2] | ((uint16_t)buff[3] << 8));
+  val[2] = (int16_t)((uint16_t)buff[4] | ((uint16_t)buff[5] << 8));
 
   return ret;
 }
@@ -3597,12 +3615,9 @@ int32_t lsm6dsv320x_sflp_gbias_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
     return ret;
   }
 
-  val[0] = (int16_t)buff[1];
-  val[0] = (val[0] * 256) + (int16_t)buff[0];
-  val[1] = (int16_t)buff[3];
-  val[1] = (val[1] * 256) + (int16_t)buff[2];
-  val[2] = (int16_t)buff[5];
-  val[2] = (val[2] * 256) + (int16_t)buff[4];
+  val[0] = (int16_t)((uint16_t)buff[0] | ((uint16_t)buff[1] << 8));
+  val[1] = (int16_t)((uint16_t)buff[2] | ((uint16_t)buff[3] << 8));
+  val[2] = (int16_t)((uint16_t)buff[4] | ((uint16_t)buff[5] << 8));
 
   return ret;
 }
@@ -3621,12 +3636,9 @@ int32_t lsm6dsv320x_sflp_gravity_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
     return ret;
   }
 
-  val[0] = (int16_t)buff[1];
-  val[0] = (val[0] * 256) + (int16_t)buff[0];
-  val[1] = (int16_t)buff[3];
-  val[1] = (val[1] * 256) + (int16_t)buff[2];
-  val[2] = (int16_t)buff[5];
-  val[2] = (val[2] * 256) + (int16_t)buff[4];
+  val[0] = (int16_t)((uint16_t)buff[0] | ((uint16_t)buff[1] << 8));
+  val[1] = (int16_t)((uint16_t)buff[2] | ((uint16_t)buff[3] << 8));
+  val[2] = (int16_t)((uint16_t)buff[4] | ((uint16_t)buff[5] << 8));
 
   return ret;
 }
@@ -3818,7 +3830,7 @@ int32_t lsm6dsv320x_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t address,
   {
     goto exit;
   }
-  page_sel.page_sel = msb;
+  page_sel.page_sel = msb & 0x0FU;
   page_sel.not_used0 = 1; // Default value
   ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_PAGE_SEL, (uint8_t *)&page_sel, 1);
   if (ret != 0)
@@ -3855,7 +3867,7 @@ int32_t lsm6dsv320x_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t address,
         goto exit;
       }
 
-      page_sel.page_sel = msb;
+      page_sel.page_sel = msb & 0x0FU;
       page_sel.not_used0 = 1; // Default value
       ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_PAGE_SEL, (uint8_t *)&page_sel, 1);
       if (ret != 0)
@@ -3865,8 +3877,8 @@ int32_t lsm6dsv320x_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t address,
     }
   }
 
-  page_sel.page_sel = 0;
-  page_sel.not_used0 = 1;// Default value
+  page_sel.page_sel = 0U;
+  page_sel.not_used0 = 1U;// Default value
   ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_PAGE_SEL, (uint8_t *)&page_sel, 1);
   if (ret != 0)
   {
@@ -3930,8 +3942,8 @@ int32_t lsm6dsv320x_ln_pg_read(const stmdev_ctx_t *ctx, uint16_t address, uint8_
   {
     goto exit;
   }
-  page_sel.page_sel = msb;
-  page_sel.not_used0 = 1; // Default value
+  page_sel.page_sel = msb & 0x0FU;
+  page_sel.not_used0 = 1U; // Default value
   ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_PAGE_SEL, (uint8_t *)&page_sel, 1);
   if (ret != 0)
   {
@@ -3967,8 +3979,8 @@ int32_t lsm6dsv320x_ln_pg_read(const stmdev_ctx_t *ctx, uint16_t address, uint8_
         goto exit;
       }
 
-      page_sel.page_sel = msb;
-      page_sel.not_used0 = 1; // Default value
+      page_sel.page_sel = msb & 0x0FU;
+      page_sel.not_used0 = 1U; // Default value
       ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_PAGE_SEL, (uint8_t *)&page_sel, 1);
       if (ret != 0)
       {
@@ -3977,8 +3989,8 @@ int32_t lsm6dsv320x_ln_pg_read(const stmdev_ctx_t *ctx, uint16_t address, uint8_
     }
   }
 
-  page_sel.page_sel = 0;
-  page_sel.not_used0 = 1;// Default value
+  page_sel.page_sel = 0U;
+  page_sel.not_used0 = 1U;// Default value
   ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_PAGE_SEL, (uint8_t *)&page_sel, 1);
   if (ret != 0)
   {
@@ -4011,7 +4023,7 @@ int32_t lsm6dsv320x_emb_function_dbg_set(const stmdev_ctx_t *ctx, uint8_t val)
 
   if (ret == 0)
   {
-    ctrl10.emb_func_debug = val;
+    ctrl10.emb_func_debug = val & 0x01U;
     ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL10, (uint8_t *)&ctrl10, 1);
   }
 
@@ -4103,9 +4115,9 @@ int32_t lsm6dsv320x_eis_gy_full_scale_set(const stmdev_ctx_t *ctx,
 
   // For the correct operation of the device, the user must set a
   // configuration from 001 to 101 when the gyroscope is in power-down mode.
-  if (ctrl2.odr_g != LSM6DSV320X_ODR_OFF)
+  if (ctrl2.odr_g != (uint8_t)LSM6DSV320X_ODR_OFF)
   {
-    ctrl2.odr_g = LSM6DSV320X_ODR_OFF;
+    ctrl2.odr_g = (uint8_t)LSM6DSV320X_ODR_OFF;
     ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL2, (uint8_t *)&ctrl2, 1);
   }
 
@@ -4174,7 +4186,7 @@ int32_t lsm6dsv320x_eis_gy_on_if2_set(const stmdev_ctx_t *ctx, uint8_t val)
 
   if (ret == 0)
   {
-    ctrl_eis.g_eis_on_g_ois_out_reg = val;
+    ctrl_eis.g_eis_on_g_ois_out_reg = val & 0x01U;
     ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
   }
 
@@ -4369,7 +4381,7 @@ int32_t lsm6dsv320x_fifo_virtual_sens_odr_chg_set(const stmdev_ctx_t *ctx, uint8
   ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
   if (ret == 0)
   {
-    fifo_ctrl2.odr_chg_en = val;
+    fifo_ctrl2.odr_chg_en = val & 0x01U;
     ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
   }
 
@@ -4408,7 +4420,7 @@ int32_t lsm6dsv320x_fifo_compress_algo_real_time_set(const stmdev_ctx_t *ctx,
   {
     return ret;
   }
-  fifo_ctrl2.fifo_compr_rt_en = val;
+  fifo_ctrl2.fifo_compr_rt_en = val & 0x01U;
   ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
   if (ret != 0)
   {
@@ -4425,7 +4437,7 @@ int32_t lsm6dsv320x_fifo_compress_algo_real_time_set(const stmdev_ctx_t *ctx,
   {
     goto exit;
   }
-  emb_func_en_b.fifo_compr_en = val;
+  emb_func_en_b.fifo_compr_en = val & 0x01U;
   ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
 exit:
   ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
@@ -4771,7 +4783,7 @@ int32_t lsm6dsv320x_fifo_gy_eis_batch_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
   if (ret == 0)
   {
-    fifo_ctrl4.g_eis_fifo_en = val;
+    fifo_ctrl4.g_eis_fifo_en = val & 0x01U;
     ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
   }
 
@@ -4941,8 +4953,7 @@ int32_t lsm6dsv320x_fifo_batch_counter_threshold_get(const stmdev_ctx_t *ctx,
     return ret;
   }
 
-  *val = (uint16_t)buff[0] & 0x3U;
-  *val = (*val * 256U) + (uint16_t)buff[1];
+  *val = (uint16_t)(buff[1] | ((uint16_t)(buff[0] & 0x3U) << 8));
 
   return ret;
 }
@@ -5022,8 +5033,7 @@ int32_t lsm6dsv320x_fifo_status_get(const stmdev_ctx_t *ctx,
   val->fifo_full = status.fifo_full_ia;
   val->fifo_th = status.fifo_wtm_ia;
 
-  val->fifo_level = (uint16_t)buff[1] & 0x01U;
-  val->fifo_level = (val->fifo_level * 256U) + buff[0];
+  val->fifo_level = (uint16_t)(buff[0] | ((uint16_t)(buff[1] & 0x01U) << 8));
 
   return ret;
 }
@@ -5201,7 +5211,7 @@ int32_t lsm6dsv320x_fifo_stpcnt_batch_set(const stmdev_ctx_t *ctx, uint8_t val)
   {
     goto exit;
   }
-  emb_func_fifo_en_a.step_counter_fifo_en = val;
+  emb_func_fifo_en_a.step_counter_fifo_en = val & 0x01U;
   ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a,
                                1);
 
@@ -5228,7 +5238,7 @@ int32_t lsm6dsv320x_fifo_stpcnt_batch_get(const stmdev_ctx_t *ctx, uint8_t *val)
   {
     goto exit;
   }
-  *val = emb_func_fifo_en_a.step_counter_fifo_en;
+  *val = emb_func_fifo_en_a.step_counter_fifo_en & 0x01U;
 
 exit:
   ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
@@ -5253,7 +5263,7 @@ int32_t lsm6dsv320x_fifo_fsm_batch_set(const stmdev_ctx_t *ctx, uint8_t val)
   {
     goto exit;
   }
-  emb_func_fifo_en_b.fsm_fifo_en = val;
+  emb_func_fifo_en_b.fsm_fifo_en = val & 0x01U;
   ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_FIFO_EN_B, (uint8_t *)&emb_func_fifo_en_b,
                                1);
 
@@ -5305,7 +5315,7 @@ int32_t lsm6dsv320x_fifo_mlc_batch_set(const stmdev_ctx_t *ctx, uint8_t val)
   {
     goto exit;
   }
-  emb_func_fifo_en_a.mlc_fifo_en = val;
+  emb_func_fifo_en_a.mlc_fifo_en = val & 0x01U;
   ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a,
                                1);
 
@@ -5357,7 +5367,7 @@ int32_t lsm6dsv320x_fifo_mlc_filt_batch_set(const stmdev_ctx_t *ctx, uint8_t val
   {
     goto exit;
   }
-  emb_func_fifo_en_b.mlc_filter_feature_fifo_en = val;
+  emb_func_fifo_en_b.mlc_filter_feature_fifo_en = val & 0x01U;
   ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_FIFO_EN_B, (uint8_t *)&emb_func_fifo_en_b,
                                1);
 
@@ -5409,13 +5419,15 @@ int32_t lsm6dsv320x_fifo_sh_batch_target_set(const stmdev_ctx_t *ctx, uint8_t id
     goto exit;
   }
 
-  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TGT0_CONFIG + idx * 3U, (uint8_t *)&tgt_config, 1);
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TGT0_CONFIG + (uint8_t)(idx * 3U),
+                             (uint8_t *)&tgt_config, 1);
   if (ret != 0)
   {
     goto exit;
   }
-  tgt_config.batch_ext_sens_0_en = val;
-  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TGT0_CONFIG + idx * 3U, (uint8_t *)&tgt_config, 1);
+  tgt_config.batch_ext_sens_0_en = val & 0x01U;
+  ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TGT0_CONFIG + (uint8_t)(idx * 3U),
+                               (uint8_t *)&tgt_config, 1);
 
 exit:
   ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
@@ -5440,7 +5452,8 @@ int32_t lsm6dsv320x_fifo_sh_batch_target_get(const stmdev_ctx_t *ctx, uint8_t id
     goto exit;
   }
 
-  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TGT0_CONFIG + idx * 3U, (uint8_t *)&tgt_config, 1);
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TGT0_CONFIG + (uint8_t)(idx * 3U),
+                             (uint8_t *)&tgt_config, 1);
   if (ret != 0)
   {
     goto exit;
@@ -5677,7 +5690,7 @@ int32_t lsm6dsv320x_filt_gy_lp1_bandwidth_set(const stmdev_ctx_t *ctx,
   ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL6, (uint8_t *)&ctrl6, 1);
   if (ret == 0)
   {
-    ctrl6.lpf1_g_bw = (uint8_t)val & 0x0Fu;
+    ctrl6.lpf1_g_bw = (uint8_t)val & 0x07u;
     ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL6, (uint8_t *)&ctrl6, 1);
   }
 
@@ -5748,7 +5761,7 @@ int32_t lsm6dsv320x_filt_gy_lp1_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL7, (uint8_t *)&ctrl7, 1);
   if (ret == 0)
   {
-    ctrl7.lpf1_g_en = val;
+    ctrl7.lpf1_g_en = val & 0x01U;
     ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL7, (uint8_t *)&ctrl7, 1);
   }
 
@@ -5800,23 +5813,23 @@ int32_t lsm6dsv320x_filt_xl_setup(const stmdev_ctx_t *ctx, lsm6dsv320x_xl_filter
 
   if (filter == LSM6DSV320X_XL_FILT_LP_LPF2)
   {
-    ctrl9.hp_slope_xl_en = 0;
-    ctrl9.lpf2_xl_en = 1;
+    ctrl9.hp_slope_xl_en = 0U;
+    ctrl9.lpf2_xl_en = 1U;
   }
   else if (filter == LSM6DSV320X_XL_FILT_LP_LPF1)
   {
-    ctrl9.hp_slope_xl_en = 0;
-    ctrl9.lpf2_xl_en = 0;
+    ctrl9.hp_slope_xl_en = 0U;
+    ctrl9.lpf2_xl_en = 0U;
   }
   else if (filter == LSM6DSV320X_XL_FILT_HP)
   {
-    ctrl9.hp_slope_xl_en = 1;
-    ctrl9.lpf2_xl_en = 0;
+    ctrl9.hp_slope_xl_en = 1U;
+    ctrl9.lpf2_xl_en = 0U;
   }
   else if (filter == LSM6DSV320X_XL_FILT_HP_SLOPE)
   {
-    ctrl9.hp_slope_xl_en = 1;
-    ctrl9.lpf2_xl_en = 0;
+    ctrl9.hp_slope_xl_en = 1U;
+    ctrl9.lpf2_xl_en = 0U;
   }
   else
   {
@@ -5825,7 +5838,7 @@ int32_t lsm6dsv320x_filt_xl_setup(const stmdev_ctx_t *ctx, lsm6dsv320x_xl_filter
   }
 
   ctrl8.hp_lpf2_xl_bw = (uint8_t)bw & 0x07U;
-  ctrl9.hp_ref_mode_xl = hp_ref_mode_xl;
+  ctrl9.hp_ref_mode_xl = hp_ref_mode_xl & 0x01U;
 
   ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL8, (uint8_t *)&ctrl8, 1);
   ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL9, (uint8_t *)&ctrl9, 1);
@@ -5915,7 +5928,7 @@ int32_t lsm6dsv320x_filt_xl_lp2_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL9, (uint8_t *)&ctrl9, 1);
   if (ret == 0)
   {
-    ctrl9.lpf2_xl_en = val;
+    ctrl9.lpf2_xl_en = val & 0x01U;
     ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL9, (uint8_t *)&ctrl9, 1);
   }
 
@@ -5947,7 +5960,7 @@ int32_t lsm6dsv320x_filt_xl_hp_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL9, (uint8_t *)&ctrl9, 1);
   if (ret == 0)
   {
-    ctrl9.hp_slope_xl_en = val;
+    ctrl9.hp_slope_xl_en = val & 0x01U;
     ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL9, (uint8_t *)&ctrl9, 1);
   }
 
@@ -5979,7 +5992,7 @@ int32_t lsm6dsv320x_filt_xl_fast_settling_set(const stmdev_ctx_t *ctx, uint8_t v
   ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_CTRL9, (uint8_t *)&ctrl9, 1);
   if (ret == 0)
   {
-    ctrl9.xl_fastsettl_mode = val;
+    ctrl9.xl_fastsettl_mode = val & 0x01U;
     ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL9, (uint8_t *)&ctrl9, 1);
   }
 
@@ -6013,7 +6026,7 @@ int32_t lsm6dsv320x_filt_xl_hp_mode_set(const stmdev_ctx_t *ctx,
   if (ret == 0)
   {
     ctrl9.hp_ref_mode_xl = (uint8_t)val & 0x01U;
-    ctrl9.hp_slope_xl_en = ((uint8_t)val & 0x02U) >> 1;
+    ctrl9.hp_slope_xl_en = ((uint8_t)val >> 1) & 0x01U;
     ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CTRL9, (uint8_t *)&ctrl9, 1);
   }
 
@@ -6574,8 +6587,7 @@ exit:
     return ret;
   }
 
-  *val = buff[1];
-  *val = (*val * 256U) + buff[0];
+  *val = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
 
   return ret;
 }
@@ -6706,12 +6718,6 @@ exit:
 #ifndef NPY_HALF_ROUND_TIES_TO_EVEN
 #define NPY_HALF_ROUND_TIES_TO_EVEN 1
 #endif
-
-typedef union
-{
-  float_t f;
-  uint32_t fbits;
-} hf_conv_t;
 
 static uint16_t npy_floatbits_to_halfbits(uint32_t f)
 {
@@ -6845,18 +6851,19 @@ static uint16_t npy_floatbits_to_halfbits(uint32_t f)
   {
     npy_set_floatstatus_overflow();
   }
-  return h_sgn + h_sig;
+  return (uint16_t)(h_sgn + h_sig);
 #else
-  return h_sgn + h_exp + h_sig;
+  return (uint16_t)(h_sgn + h_exp + h_sig);
 #endif
 }
 
 static uint16_t npy_float_to_half(float_t f)
 {
-  hf_conv_t conv;
+  uint32_t bits;
 
-  conv.f = f;
-  return npy_floatbits_to_halfbits(conv.fbits);
+  (void)memcpy(&bits, &f, sizeof(bits));
+
+  return npy_floatbits_to_halfbits(bits);
 }
 
 static uint32_t npy_halfbits_to_floatbits(uint16_t h)
@@ -6871,19 +6878,19 @@ static uint32_t npy_halfbits_to_floatbits(uint16_t h)
     {
       uint16_t h_sig = (uint16_t)(h & 0x03ffu);
       // Signed zero
-      if (h_sig == 0)
+      if (h_sig == 0u)
       {
         result = f_sgn;
         break;
       }
       // Subnormal
       h_sig <<= 1;
-      while ((h_sig & 0x0400u) == 0)
+      while ((h_sig & 0x0400u) == 0u)
       {
         h_sig <<= 1;
         h_exp++;
       }
-      uint32_t f_exp = ((uint32_t)(127 - 15 - h_exp)) << 23;
+      uint32_t f_exp = ((uint32_t)(127u - 15u - h_exp)) << 23;
       uint32_t f_sig = ((uint32_t)h_sig & 0x03ffu) << 13;
       result = f_sgn + f_exp + f_sig;
       break;
@@ -6903,18 +6910,20 @@ static uint32_t npy_halfbits_to_floatbits(uint16_t h)
 
 static float_t npy_half_to_float(uint16_t h)
 {
-  hf_conv_t conv;
+  float_t f = 0;
 
-  conv.fbits = npy_halfbits_to_floatbits(h);
+  uint32_t bits = npy_halfbits_to_floatbits(h);
 
-  return conv.f;
+  (void)memcpy(&f, &bits, sizeof(bits));
+
+  return f;
 }
 
 
 int32_t lsm6dsv320x_sflp_game_gbias_set(const stmdev_ctx_t *ctx,
                                         const lsm6dsv320x_sflp_gbias_t *val)
 {
-  lsm6dsv320x_sflp_data_rate_t sflp_odr = {0};
+  lsm6dsv320x_sflp_data_rate_t sflp_odr = LSM6DSV320X_SFLP_15Hz;
   uint16_t gbias_hf[3] = {0};
   float_t k = 0.005f;
   int32_t ret = 0;
@@ -6993,8 +7002,7 @@ int32_t lsm6dsv320x_fsm_ext_sens_sensitivity_get(const stmdev_ctx_t *ctx,
     return ret;
   }
 
-  *val = buff[1];
-  *val = (*val * 256U) + buff[0];
+  *val = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
 
   return ret;
 }
@@ -7030,12 +7038,9 @@ int32_t lsm6dsv320x_fsm_ext_sens_offset_get(const stmdev_ctx_t *ctx,
     return ret;
   }
 
-  val->x = buff[1];
-  val->x = (val->x * 256U) + buff[0];
-  val->y = buff[3];
-  val->y = (val->y * 256U) + buff[2];
-  val->z = buff[5];
-  val->z = (val->z * 256U) + buff[4];
+  val->x = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
+  val->y = (uint16_t)(buff[2] | ((uint16_t)buff[3] << 8));
+  val->z = (uint16_t)(buff[4] | ((uint16_t)buff[5] << 8));
 
   return ret;
 }
@@ -7076,18 +7081,12 @@ int32_t lsm6dsv320x_fsm_ext_sens_matrix_get(const stmdev_ctx_t *ctx,
     return ret;
   }
 
-  val->xx = buff[1];
-  val->xx = (val->xx * 256U) + buff[0];
-  val->xy = buff[3];
-  val->xy = (val->xy * 256U) + buff[2];
-  val->xz = buff[5];
-  val->xz = (val->xz * 256U) + buff[4];
-  val->yy = buff[7];
-  val->yy = (val->yy * 256U) + buff[6];
-  val->yz = buff[9];
-  val->yz = (val->yz * 256U) + buff[8];
-  val->zz = buff[11];
-  val->zz = (val->zz * 256U) + buff[10];
+  val->xx = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
+  val->xy = (uint16_t)(buff[2] | ((uint16_t)buff[3] << 8));
+  val->xz = (uint16_t)(buff[4] | ((uint16_t)buff[5] << 8));
+  val->yy = (uint16_t)(buff[6] | ((uint16_t)buff[7] << 8));
+  val->yz = (uint16_t)(buff[8] | ((uint16_t)buff[9] << 8));
+  val->zz = (uint16_t)(buff[10] | ((uint16_t)buff[11] << 8));
 
   return ret;
 }
@@ -7302,7 +7301,7 @@ int32_t lsm6dsv320x_xl_hg_peak_tracking_set(const stmdev_ctx_t *ctx, uint8_t val
   {
     goto exit;
   }
-  emb_func_init_b.pt_init = val;
+  emb_func_init_b.pt_init = val & 0x01U;
   ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_INIT_B, (uint8_t *)&emb_func_init_b, 1);
 
 exit:
@@ -7328,7 +7327,7 @@ int32_t lsm6dsv320x_xl_hg_peak_tracking_get(const stmdev_ctx_t *ctx, uint8_t *va
   {
     goto exit;
   }
-  *val = emb_func_init_b.pt_init;
+  *val = emb_func_init_b.pt_init & 0x01U;
 
 exit:
   ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
@@ -7363,8 +7362,7 @@ int32_t lsm6dsv320x_xl_hg_sensitivity_get(const stmdev_ctx_t *ctx, uint16_t *val
     return ret;
   }
 
-  *val = buff[1];
-  *val = (*val * 256U) + buff[0];
+  *val = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
 
   return ret;
 }
@@ -7395,8 +7393,7 @@ int32_t lsm6dsv320x_fsm_long_cnt_timeout_get(const stmdev_ctx_t *ctx, uint16_t *
     return ret;
   }
 
-  *val = buff[1];
-  *val = (*val * 256U) + buff[0];
+  *val = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
 
   return ret;
 }
@@ -7462,8 +7459,7 @@ int32_t lsm6dsv320x_fsm_start_address_get(const stmdev_ctx_t *ctx, uint16_t *val
     return ret;
   }
 
-  *val = buff[1];
-  *val = (*val * 256U) + buff[0];
+  *val = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
 
   return ret;
 }
@@ -7512,7 +7508,7 @@ int32_t lsm6dsv320x_ff_time_windows_get(const stmdev_ctx_t *ctx, uint8_t *val)
     return ret;
   }
 
-  *val = (wake_up_dur.ff_dur << 5) + free_fall.ff_dur;
+  *val = (uint8_t)(wake_up_dur.ff_dur << 5) | free_fall.ff_dur;
 
   return ret;
 }
@@ -7623,6 +7619,9 @@ int32_t lsm6dsv320x_mlc_set(const stmdev_ctx_t *ctx, lsm6dsv320x_mlc_mode_t val)
       emb_en_b.mlc_en = 0;
       break;
     default:
+      // default used: MLC_OFF
+      emb_en_a.mlc_before_fsm_en = 0;
+      emb_en_b.mlc_en = 0;
       break;
   }
 
@@ -7800,8 +7799,7 @@ int32_t lsm6dsv320x_mlc_ext_sens_sensitivity_get(const stmdev_ctx_t *ctx,
     return ret;
   }
 
-  *val = buff[1];
-  *val = (*val * 256U) + buff[0];
+  *val = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
 
   return ret;
 }
@@ -7862,7 +7860,7 @@ int32_t lsm6dsv320x_ois_reset_set(const stmdev_ctx_t *ctx, int8_t val)
   ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
   if (ret == 0)
   {
-    func_cfg_access.if2_reset = (uint8_t)val;
+    func_cfg_access.if2_reset = (uint8_t)val & 0x01U;
     ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
   }
 
@@ -7894,7 +7892,7 @@ int32_t lsm6dsv320x_ois_interface_pull_up_set(const stmdev_ctx_t *ctx, uint8_t v
   ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
   if (ret == 0)
   {
-    pin_ctrl.ois_pu_dis = val;
+    pin_ctrl.ois_pu_dis = val & 0x01U;
     ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
   }
 
@@ -8017,7 +8015,7 @@ int32_t lsm6dsv320x_ois_on_if2_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
   if (ret == 0)
   {
-    ui_ctrl1_ois.if2_spi_read_en = val;
+    ui_ctrl1_ois.if2_spi_read_en = val & 0x01U;
     ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
   }
 
@@ -8251,7 +8249,7 @@ int32_t lsm6dsv320x_4d_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
   if (ret == 0)
   {
-    tap_ths_6d.d4d_en = val;
+    tap_ths_6d.d4d_en = val & 0x01U;
     ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
   }
 
@@ -8371,7 +8369,7 @@ int32_t lsm6dsv320x_sh_controller_interface_pull_up_set(const stmdev_ctx_t *ctx,
   ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_IF_CFG, (uint8_t *)&if_cfg, 1);
   if (ret == 0)
   {
-    if_cfg.shub_pu_en = val;
+    if_cfg.shub_pu_en = val & 0x01U;
     ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_IF_CFG, (uint8_t *)&if_cfg, 1);
   }
 
@@ -8495,7 +8493,7 @@ int32_t lsm6dsv320x_sh_controller_set(const stmdev_ctx_t *ctx, uint8_t val)
     goto exit;
   }
 
-  controller_config.controller_on = val;
+  controller_config.controller_on = val & 0x01U;
   ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
 
 exit:
@@ -8542,7 +8540,7 @@ int32_t lsm6dsv320x_sh_pass_through_set(const stmdev_ctx_t *ctx, uint8_t val)
     goto exit;
   }
 
-  controller_config.pass_through_mode = val;
+  controller_config.pass_through_mode = val & 0x01U;
   ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
 
 exit:
@@ -8699,7 +8697,7 @@ int32_t lsm6dsv320x_sh_reset_set(const stmdev_ctx_t *ctx, uint8_t val)
     goto exit;
   }
 
-  controller_config.rst_controller_regs = val;
+  controller_config.rst_controller_regs = val & 0x01U;
   ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
 
 exit:
@@ -8742,7 +8740,7 @@ int32_t lsm6dsv320x_sh_cfg_write(const stmdev_ctx_t *ctx,
     goto exit;
   }
 
-  reg.target0_add = (uint8_t)(val->tgt0_add >> 1);
+  reg.target0_add = (val->tgt0_add >> 1) & 0x07U;
   reg.rw_0 = 0;
   ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TGT0_ADD, (uint8_t *)&reg, 1);
   if (ret != 0)
@@ -8860,31 +8858,31 @@ int32_t lsm6dsv320x_sh_tgt_cfg_read(const stmdev_ctx_t *ctx, uint8_t idx,
     return ret;
   }
 
-  tgt_add.target0_add = (uint8_t)(val->tgt_add >> 1);
+  tgt_add.target0_add = (val->tgt_add >> 1) & 0x07U;
   tgt_add.rw_0 = 1;
-  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TGT0_ADD + idx * 3U,
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TGT0_ADD + (uint8_t)(idx * 3U),
                               (uint8_t *)&tgt_add, 1);
   if (ret != 0)
   {
     goto exit;
   }
 
-  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TGT0_SUBADD + idx * 3U,
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TGT0_SUBADD + (uint8_t)(idx * 3U),
                               &(val->tgt_subadd), 1);
   if (ret != 0)
   {
     goto exit;
   }
 
-  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TGT0_CONFIG + idx * 3U,
+  ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_TGT0_CONFIG + (uint8_t)(idx * 3U),
                              (uint8_t *)&tgt_config, 1);
   if (ret != 0)
   {
     goto exit;
   }
 
-  tgt_config.target0_numop = val->tgt_len;
-  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TGT0_CONFIG + idx * 3U,
+  tgt_config.target0_numop = val->tgt_len & 0x07U;
+  ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_TGT0_CONFIG + (uint8_t)(idx * 3U),
                               (uint8_t *)&tgt_config, 1);
 
 exit:
@@ -8913,7 +8911,7 @@ int32_t lsm6dsv320x_ui_sdo_pull_up_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
   if (ret == 0)
   {
-    pin_ctrl.sdo_pu_en = val;
+    pin_ctrl.sdo_pu_en = val & 0x01U;
     ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
   }
 
@@ -8945,7 +8943,7 @@ int32_t lsm6dsv320x_pad_strength_set(const stmdev_ctx_t *ctx, lsm6dsv320x_pad_st
   ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
   if (ret == 0)
   {
-    pin_ctrl.io_pad_strength = val;
+    pin_ctrl.io_pad_strength = val & 0x03U;
     ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
   }
 
@@ -9086,7 +9084,7 @@ int32_t lsm6dsv320x_ui_sda_pull_up_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_IF_CFG, (uint8_t *)&if_cfg, 1);
   if (ret == 0)
   {
-    if_cfg.sda_pu_en = val;
+    if_cfg.sda_pu_en = val & 0x01U;
     ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_IF_CFG, (uint8_t *)&if_cfg, 1);
   }
 
@@ -9172,7 +9170,7 @@ int32_t lsm6dsv320x_sigmot_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
   {
     goto exit;
   }
-  emb_func_en_a.sign_motion_en = val;
+  emb_func_en_a.sign_motion_en = val & 0x01U;
   ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
 
 exit:
@@ -9300,8 +9298,7 @@ int32_t lsm6dsv320x_stpcnt_steps_get(const stmdev_ctx_t *ctx, uint16_t *val)
     return ret;
   }
 
-  *val = buff[1];
-  *val = (*val * 256U) + buff[0];
+  *val = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
 
   return ret;
 }
@@ -9324,7 +9321,7 @@ int32_t lsm6dsv320x_stpcnt_rst_step_set(const stmdev_ctx_t *ctx, uint8_t val)
     goto exit;
   }
 
-  emb_func_src.pedo_rst_step = val;
+  emb_func_src.pedo_rst_step = val & 0x01U;
   ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
 
 exit:
@@ -9420,8 +9417,7 @@ int32_t lsm6dsv320x_stpcnt_period_get(const stmdev_ctx_t *ctx, uint16_t *val)
     return ret;
   }
 
-  *val = buff[1];
-  *val = (*val * 256U) + buff[0];
+  *val = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
 
   return ret;
 }
@@ -9444,7 +9440,7 @@ int32_t lsm6dsv320x_sflp_game_rotation_set(const stmdev_ctx_t *ctx, uint8_t val)
     goto exit;
   }
 
-  emb_func_en_a.sflp_game_en = val;
+  emb_func_en_a.sflp_game_en = val & 0x01U;
   ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_EN_A,
                                (uint8_t *)&emb_func_en_a, 1);
 
@@ -9496,7 +9492,7 @@ int32_t lsm6dsv320x_sflp_game_rotation_reset(const stmdev_ctx_t *ctx, uint8_t va
   {
     goto exit;
   }
-  emb_func_init_a.sflp_game_init = val;
+  emb_func_init_a.sflp_game_init = val & 0x01U;
   ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_INIT_A, (uint8_t *)&emb_func_init_a, 1);
 
 exit:
@@ -9834,7 +9830,7 @@ int32_t lsm6dsv320x_tilt_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
   }
 
   ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
-  emb_func_en_a.tilt_en = val;
+  emb_func_en_a.tilt_en = val & 0x01U;
   ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
 
   ret += lsm6dsv320x_mem_bank_set(ctx, LSM6DSV320X_MAIN_MEM_BANK);
@@ -9874,10 +9870,10 @@ int32_t lsm6dsv320x_timestamp_raw_get(const stmdev_ctx_t *ctx, uint32_t *val)
     return ret;
   }
 
-  *val = buff[3];
-  *val = (*val * 256U) + buff[2];
-  *val = (*val * 256U) + buff[1];
-  *val = (*val * 256U) + buff[0];
+  *val = (uint32_t)buff[3] << 8;
+  *val = (*val | (uint32_t)buff[2]) << 8;
+  *val = (*val | (uint32_t)buff[1]) << 8;
+  *val = (*val | (uint32_t)buff[0]) << 8;
 
   return ret;
 }
@@ -9891,7 +9887,7 @@ int32_t lsm6dsv320x_timestamp_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = lsm6dsv320x_read_reg(ctx, LSM6DSV320X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
   if (ret == 0)
   {
-    functions_enable.timestamp_en = val;
+    functions_enable.timestamp_en = val & 0x01U;
     ret = lsm6dsv320x_write_reg(ctx, LSM6DSV320X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
   }
 
@@ -10100,13 +10096,13 @@ int32_t lsm6dsv320x_act_thresholds_set(const stmdev_ctx_t *ctx,
     return ret;
   }
 
-  inactivity_dur.wu_inact_ths_w = val->inactivity_cfg.wu_inact_ths_w;
-  inactivity_dur.xl_inact_odr = val->inactivity_cfg.xl_inact_odr;
-  inactivity_dur.inact_dur = val->inactivity_cfg.inact_dur;
+  inactivity_dur.wu_inact_ths_w = val->inactivity_cfg.wu_inact_ths_w & 0x07U;
+  inactivity_dur.xl_inact_odr = val->inactivity_cfg.xl_inact_odr & 0x03U;
+  inactivity_dur.inact_dur = val->inactivity_cfg.inact_dur & 0x03U;
 
-  inactivity_ths.inact_ths = val->inactivity_ths;
-  wake_up_ths.wk_ths = val->threshold;
-  wake_up_dur.wake_dur = val->duration;
+  inactivity_ths.inact_ths = val->inactivity_ths & 0x3FU;
+  wake_up_ths.wk_ths = val->threshold & 0x3FU;
+  wake_up_dur.wake_dur = val->duration & 0x03U;
 
   ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
   ret += lsm6dsv320x_write_reg(ctx, LSM6DSV320X_INACTIVITY_THS, (uint8_t *)&inactivity_ths, 1);

--- a/sensor/stmemsc/lsm6dsv320x_STdC/driver/lsm6dsv320x_reg.h
+++ b/sensor/stmemsc/lsm6dsv320x_STdC/driver/lsm6dsv320x_reg.h
@@ -29,6 +29,7 @@ extern "C" {
 #include <stdint.h>
 #include <stddef.h>
 #include <math.h>
+#include <string.h>
 
 /** @addtogroup LSM6DSV320X
   * @{

--- a/sensor/stmemsc/lsm6dsv80x_STdC/driver/lsm6dsv80x_reg.c
+++ b/sensor/stmemsc/lsm6dsv80x_STdC/driver/lsm6dsv80x_reg.c
@@ -50,7 +50,7 @@ int32_t __weak lsm6dsv80x_write_reg(const stmdev_ctx_t *ctx, uint8_t reg,
   return ret;
 }
 
-static void bytecpy(uint8_t *target, uint8_t *source)
+static void bytecpy(uint8_t *target, const uint8_t *source)
 {
   if ((target != NULL) && (source != NULL))
   {
@@ -168,7 +168,7 @@ int32_t lsm6dsv80x_xl_offset_on_out_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL9, (uint8_t *)&ctrl9, 1);
   if (ret == 0)
   {
-    ctrl9.usr_off_on_out = val;
+    ctrl9.usr_off_on_out = val & 0x01U;
     ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL9, (uint8_t *)&ctrl9, 1);
   }
 
@@ -199,7 +199,7 @@ int32_t lsm6dsv80x_xl_offset_mg_set(const stmdev_ctx_t *ctx,
   lsm6dsv80x_x_ofs_usr_t x_ofs_usr = {0};
   lsm6dsv80x_ctrl9_t ctrl9 = {0};
   int32_t ret = 0;
-  float_t tmp = 0;
+  float_t tmp = 0.0f;
 
   ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
   ret += lsm6dsv80x_read_reg(ctx, LSM6DSV80X_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
@@ -215,38 +215,38 @@ int32_t lsm6dsv80x_xl_offset_mg_set(const stmdev_ctx_t *ctx,
       (val.y_mg < (0.0078125f * 127.0f)) && (val.y_mg > (0.0078125f * -127.0f)) &&
       (val.z_mg < (0.0078125f * 127.0f)) && (val.z_mg > (0.0078125f * -127.0f)))
   {
-    ctrl9.usr_off_w = 0;
+    ctrl9.usr_off_w = 0u;
 
     tmp = val.z_mg / 0.0078125f;
-    z_ofs_usr.z_ofs_usr = (uint8_t)tmp;
+    z_ofs_usr.z_ofs_usr = (int8_t)(int32_t)tmp;
 
     tmp = val.y_mg / 0.0078125f;
-    y_ofs_usr.y_ofs_usr = (uint8_t)tmp;
+    y_ofs_usr.y_ofs_usr = (int8_t)(int32_t)tmp;
 
     tmp = val.x_mg / 0.0078125f;
-    x_ofs_usr.x_ofs_usr = (uint8_t)tmp;
+    x_ofs_usr.x_ofs_usr = (int8_t)(int32_t)tmp;
   }
   else if ((val.x_mg < (0.125f * 127.0f)) && (val.x_mg > (0.125f * -127.0f)) &&
            (val.y_mg < (0.125f * 127.0f)) && (val.y_mg > (0.125f * -127.0f)) &&
            (val.z_mg < (0.125f * 127.0f)) && (val.z_mg > (0.125f * -127.0f)))
   {
-    ctrl9.usr_off_w = 1;
+    ctrl9.usr_off_w = 1u;
 
     tmp = val.z_mg / 0.125f;
-    z_ofs_usr.z_ofs_usr = (uint8_t)tmp;
+    z_ofs_usr.z_ofs_usr = (int8_t)(int32_t)tmp;
 
     tmp = val.y_mg / 0.125f;
-    y_ofs_usr.y_ofs_usr = (uint8_t)tmp;
+    y_ofs_usr.y_ofs_usr = (int8_t)(int32_t)tmp;
 
     tmp = val.x_mg / 0.125f;
-    x_ofs_usr.x_ofs_usr = (uint8_t)tmp;
+    x_ofs_usr.x_ofs_usr = (int8_t)(int32_t)tmp;
   }
   else // out of limit
   {
-    ctrl9.usr_off_w = 1;
-    z_ofs_usr.z_ofs_usr = 0xFFU;
-    y_ofs_usr.y_ofs_usr = 0xFFU;
-    x_ofs_usr.x_ofs_usr = 0xFFU;
+    ctrl9.usr_off_w = 1u;
+    z_ofs_usr.z_ofs_usr = 0;
+    y_ofs_usr.y_ofs_usr = 0;
+    x_ofs_usr.x_ofs_usr = 0;
   }
 
   ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
@@ -301,7 +301,7 @@ int32_t lsm6dsv80x_hg_xl_offset_mg_set(const stmdev_ctx_t *ctx,
   lsm6dsv80x_hg_x_ofs_usr_t x_ofs_usr = {0};
   lsm6dsv80x_ctrl1_xl_hg_t  ctrl1_xl_hg = {0};
   int32_t ret = 0;
-  float_t tmp = 0;
+  float_t tmp = 0.0f;
 
   ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL1_XL_HG, (uint8_t *)&ctrl1_xl_hg, 1);
   if (ret != 0)
@@ -313,23 +313,23 @@ int32_t lsm6dsv80x_hg_xl_offset_mg_set(const stmdev_ctx_t *ctx,
       (val.y_mg < (0.25f * 127.0f)) && (val.y_mg > (0.25f * -127.0f)) &&
       (val.z_mg < (0.25f * 127.0f)) && (val.z_mg > (0.25f * -127.0f)))
   {
-    ctrl1_xl_hg.hg_usr_off_on_out = 1;
+    ctrl1_xl_hg.hg_usr_off_on_out = 1U;
 
     tmp = val.z_mg / 0.25f;
-    z_ofs_usr.xl_hg_z_ofs_usr = (uint8_t)tmp;
+    z_ofs_usr.xl_hg_z_ofs_usr = (int8_t)tmp;
 
     tmp = val.y_mg / 0.25f;
-    y_ofs_usr.xl_hg_y_ofs_usr = (uint8_t)tmp;
+    y_ofs_usr.xl_hg_y_ofs_usr = (int8_t)tmp;
 
     tmp = val.x_mg / 0.25f;
-    x_ofs_usr.xl_hg_x_ofs_usr = (uint8_t)tmp;
+    x_ofs_usr.xl_hg_x_ofs_usr = (int8_t)tmp;
   }
   else // out of limit
   {
-    ctrl1_xl_hg.hg_usr_off_on_out = 0;
-    z_ofs_usr.xl_hg_z_ofs_usr = 0xFFU;
-    y_ofs_usr.xl_hg_y_ofs_usr = 0xFFU;
-    x_ofs_usr.xl_hg_x_ofs_usr = 0xFFU;
+    ctrl1_xl_hg.hg_usr_off_on_out = 0u;
+    z_ofs_usr.xl_hg_z_ofs_usr = 0;
+    y_ofs_usr.xl_hg_y_ofs_usr = 0;
+    x_ofs_usr.xl_hg_x_ofs_usr = 0;
   }
 
   ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_XL_HG_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
@@ -381,12 +381,12 @@ int32_t lsm6dsv80x_reboot(const stmdev_ctx_t *ctx)
   lsm6dsv80x_ctrl3_t ctrl3 = {0};
   int32_t ret = 0;
   /* configuration to restore after reboot */
-  lsm6dsv80x_data_rate_t xl;
-  lsm6dsv80x_data_rate_t gy;
-  lsm6dsv80x_hg_xl_data_rate_t hg_xl;
-  lsm6dsv80x_xl_mode_t xlm;
-  lsm6dsv80x_gy_mode_t gym;
-  uint8_t reg_out_en;
+  lsm6dsv80x_data_rate_t xl = LSM6DSV80X_ODR_OFF;
+  lsm6dsv80x_data_rate_t gy = LSM6DSV80X_ODR_OFF;
+  lsm6dsv80x_hg_xl_data_rate_t hg_xl = LSM6DSV80X_HG_XL_ODR_OFF;
+  lsm6dsv80x_xl_mode_t xlm = LSM6DSV80X_XL_UNCHANGED_MD;
+  lsm6dsv80x_gy_mode_t gym = LSM6DSV80X_GY_UNCHANGED_MD;
+  uint8_t reg_out_en = 0u;
 
   if (ctx->mdelay == NULL)
   {
@@ -477,7 +477,7 @@ exit:
 int32_t lsm6dsv80x_sw_reset(const stmdev_ctx_t *ctx)
 {
   lsm6dsv80x_ctrl3_t ctrl3 = {0};
-  uint8_t retry = 0;
+  uint8_t retry = 0u;
   int32_t ret = 0;
 
   if (ctx->mdelay == NULL)
@@ -509,9 +509,10 @@ int32_t lsm6dsv80x_sw_reset(const stmdev_ctx_t *ctx)
     }
 
     ctx->mdelay(1);
-  } while (ctrl3.sw_reset == 1 && retry++ < 3);
+    retry++;
+  } while ((ctrl3.sw_reset == 1u) && (retry < 3u));
 
-  return (ctrl3.sw_reset == 0) ? 0 : -1;
+  return (ctrl3.sw_reset == 0u) ? 0 : -1;
 
 exit:
   return ret;
@@ -633,7 +634,7 @@ int32_t lsm6dsv80x_xl_setup(
   // if odr_xl bits has 4th bit enabled, low-power modes are not allowed
   else if (
     // odr >= 480 and low-power and normal mode
-    ((uint8_t)xl_odr & 0x8) != 0 && ((uint8_t)xl_mode & 0x4) != 0 &&
+    ((uint8_t)xl_odr & 0x8) != 0u && ((uint8_t)xl_mode & 0x4) != 0u &&
     (xl_mode != LSM6DSV80X_XL_NORMAL_MD || // normal mode is not allowed for some data rates
      xl_odr == LSM6DSV80X_ODR_AT_3840Hz ||
      xl_odr == LSM6DSV80X_ODR_AT_7680Hz))
@@ -653,8 +654,8 @@ int32_t lsm6dsv80x_xl_setup(
   }
 
   // if odr is choosed as high-accuracy value, mode should also be set in HAODR mode
-  if ((xl_ha != 0 && xl_mode != LSM6DSV80X_XL_HIGH_ACCURACY_ODR_MD) ||
-      (xl_ha == 0 && xl_mode == LSM6DSV80X_XL_HIGH_ACCURACY_ODR_MD))
+  if ((xl_ha != 0u && xl_mode != LSM6DSV80X_XL_HIGH_ACCURACY_ODR_MD) ||
+      (xl_ha == 0u && xl_mode == LSM6DSV80X_XL_HIGH_ACCURACY_ODR_MD))
   {
     ret = -1;
     goto exit;
@@ -673,17 +674,10 @@ int32_t lsm6dsv80x_xl_setup(
 
   // cross-checking haodr mode
   both_on = ctrl1.odr_xl != (uint8_t)LSM6DSV80X_ODR_OFF &&
-            ctrl2.odr_g != (uint8_t)LSM6DSV80X_ODR_OFF ? 1 : 0;
+            ctrl2.odr_g != (uint8_t)LSM6DSV80X_ODR_OFF ? 1u : 0u;
 
   // if both on, then haodr_sel is a shared bit. Could be changed through haodr_set API
-  if (both_on == 1 && (xl_ha != haodr.haodr_sel))
-  {
-    ret = -1;
-    goto exit;
-  }
-
-  // if odr is choosed as an high-accuracy value, mode should be set in high-accuracy
-  if ((xl_ha != 0 && xl_mode != LSM6DSV80X_XL_HIGH_ACCURACY_ODR_MD))
+  if (both_on == 1u && (xl_ha != haodr.haodr_sel))
   {
     ret = -1;
     goto exit;
@@ -703,9 +697,9 @@ int32_t lsm6dsv80x_xl_setup(
   else
   {
     // if HAODR switch is not required, just set ctrl1 settings
-    ctrl1.op_mode_xl = (uint8_t)xl_mode;
-    ctrl1.odr_xl = (uint8_t)xl_odr;
-    haodr.haodr_sel = xl_ha;
+    ctrl1.op_mode_xl = (uint8_t)xl_mode & 0x07U;
+    ctrl1.odr_xl = (uint8_t)xl_odr & 0x0FU;
+    haodr.haodr_sel = xl_ha & 0x03U;
     ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL1, (uint8_t *)&ctrl1, 1);
     ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_HAODR_CFG, (uint8_t *)&haodr, 1);
   }
@@ -750,7 +744,7 @@ int32_t lsm6dsv80x_gy_setup(
 
   // Table 12 of AN6281
   // 7.5Hz with HAODR mode enable, is already handled by the enum selection
-  if (((uint8_t)gy_odr & 0x8) != 0 && gy_mode == LSM6DSV80X_GY_LOW_POWER_MD)
+  if (((uint8_t)gy_odr & 0x8) != 0u && gy_mode == LSM6DSV80X_GY_LOW_POWER_MD)
   {
     ret = -1;
     goto exit;
@@ -766,8 +760,8 @@ int32_t lsm6dsv80x_gy_setup(
   }
 
   // if odr is choosed as high-accuracy value, mode should also be set in HAODR mode
-  if ((gy_ha != 0 && gy_mode != LSM6DSV80X_GY_HIGH_ACCURACY_ODR_MD) ||
-      (gy_ha == 0 && gy_mode == LSM6DSV80X_GY_HIGH_ACCURACY_ODR_MD))
+  if ((gy_ha != 0u && gy_mode != LSM6DSV80X_GY_HIGH_ACCURACY_ODR_MD) ||
+      (gy_ha == 0u && gy_mode == LSM6DSV80X_GY_HIGH_ACCURACY_ODR_MD))
   {
     ret = -1;
     goto exit;
@@ -786,10 +780,10 @@ int32_t lsm6dsv80x_gy_setup(
 
   // cross-checking haodr mode
   both_on = ctrl1.odr_xl != (uint8_t)LSM6DSV80X_ODR_OFF &&
-            ctrl2.odr_g != (uint8_t)LSM6DSV80X_ODR_OFF ? 1 : 0;
+            ctrl2.odr_g != (uint8_t)LSM6DSV80X_ODR_OFF ? 1u : 0u;
 
   // if both on, then haodr_sel is a shared bit
-  if (both_on == 1 && (gy_ha != haodr.haodr_sel))
+  if (both_on == 1u && (gy_ha != haodr.haodr_sel))
   {
     ret = -1;
     goto exit;
@@ -808,9 +802,9 @@ int32_t lsm6dsv80x_gy_setup(
   else
   {
     // if HAODR switch is not required, just set ctrl2 settings
-    ctrl2.op_mode_g = (uint8_t)gy_mode;
-    ctrl2.odr_g = (uint8_t)gy_odr;
-    haodr.haodr_sel = gy_ha;
+    ctrl2.op_mode_g = (uint8_t)gy_mode & 0x07U;
+    ctrl2.odr_g = (uint8_t)gy_odr & 0x0FU;
+    haodr.haodr_sel = gy_ha & 0x03U;
     ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL2, (uint8_t *)&ctrl2, 1);
     ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_HAODR_CFG, (uint8_t *)&haodr, 1);
   }
@@ -831,7 +825,7 @@ int32_t lsm6dsv80x_haodr_set(
   lsm6dsv80x_ctrl2_t ctrl2 = {0};
   lsm6dsv80x_haodr_cfg_t haodr = {0};
   lsm6dsv80x_ctrl1_xl_hg_t ctrl1_xl_hg = {0};
-  lsm6dsv80x_xl_mode_t prev_mode = {0};
+  lsm6dsv80x_xl_mode_t prev_mode = LSM6DSV80X_XL_UNCHANGED_MD;
   lsm6dsv80x_ctrl1_xl_hg_t ctrl1_xl_hg_prev = {0};
   int32_t ret = 0;
 
@@ -845,7 +839,7 @@ int32_t lsm6dsv80x_haodr_set(
     goto exit;
   }
 
-  if (both_on == 1 && (xl_ha != gy_ha))
+  if (both_on == 1u && (xl_ha != gy_ha))
   {
     ret = -1;
     goto exit;
@@ -868,7 +862,7 @@ int32_t lsm6dsv80x_haodr_set(
   ctrl1.odr_xl = (uint8_t)LSM6DSV80X_ODR_OFF;
   ctrl2.odr_g = (uint8_t)LSM6DSV80X_ODR_OFF;
   ctrl1_xl_hg.odr_xl_hg = (uint8_t)LSM6DSV80X_HG_XL_ODR_OFF;
-  ctrl1_xl_hg.xl_hg_regout_en = 0;
+  ctrl1_xl_hg.xl_hg_regout_en = 0u;
   ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL1, (uint8_t *)&ctrl1, 1);
   ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL2, (uint8_t *)&ctrl2, 1);
   // avoid turning off if already off
@@ -878,9 +872,9 @@ int32_t lsm6dsv80x_haodr_set(
   }
 
   // set HAODR
-  haodr.haodr_sel = xl_ha | gy_ha;
-  ctrl1.op_mode_xl = (uint8_t)xl_mode;
-  ctrl2.op_mode_g = (uint8_t)gy_mode;
+  haodr.haodr_sel = (xl_ha | gy_ha) & 0x03U;
+  ctrl1.op_mode_xl = (uint8_t)xl_mode & 0x07U;
+  ctrl2.op_mode_g = (uint8_t)gy_mode & 0x07U;
 
   ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_HAODR_CFG, (uint8_t *)&haodr, 1);
   ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL1, (uint8_t *)&ctrl1, 1);
@@ -892,8 +886,8 @@ int32_t lsm6dsv80x_haodr_set(
   }
 
   // set xl and gy data rates and restore high-g xl and eis to their previous data rates
-  ctrl1.odr_xl = (uint8_t)xl_odr;
-  ctrl2.odr_g = (uint8_t)gy_odr;
+  ctrl1.odr_xl = (uint8_t)xl_odr & 0x0FU;
+  ctrl2.odr_g = (uint8_t)gy_odr & 0x0FU;
   ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL1, (uint8_t *)&ctrl1, 1);
   ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL2, (uint8_t *)&ctrl2, 1);
   // if off, there is no need to turn them on
@@ -936,7 +930,7 @@ int32_t lsm6dsv80x_xl_data_rate_set(const stmdev_ctx_t *ctx,
     {
       return ret;
     }
-    haodr.haodr_sel = sel;
+    haodr.haodr_sel = sel & 0x03U;
     ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_HAODR_CFG, (uint8_t *)&haodr, 1);
   }
 
@@ -978,7 +972,6 @@ int32_t lsm6dsv80x_xl_data_rate_get(const stmdev_ctx_t *ctx,
     case (uint8_t)LSM6DSV80X_ODR_AT_15Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV80X_ODR_AT_15Hz;
           break;
@@ -991,13 +984,15 @@ int32_t lsm6dsv80x_xl_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV80X_ODR_HA03_AT_13Hz;
           break;
+        default:
+          *val = LSM6DSV80X_ODR_AT_15Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV80X_ODR_AT_30Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV80X_ODR_AT_30Hz;
           break;
@@ -1010,13 +1005,15 @@ int32_t lsm6dsv80x_xl_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV80X_ODR_HA03_AT_26Hz;
           break;
+        default:
+          *val = LSM6DSV80X_ODR_AT_30Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV80X_ODR_AT_60Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV80X_ODR_AT_60Hz;
           break;
@@ -1029,13 +1026,15 @@ int32_t lsm6dsv80x_xl_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV80X_ODR_HA03_AT_52Hz;
           break;
+        default:
+          *val = LSM6DSV80X_ODR_AT_60Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV80X_ODR_AT_120Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV80X_ODR_AT_120Hz;
           break;
@@ -1048,13 +1047,15 @@ int32_t lsm6dsv80x_xl_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV80X_ODR_HA03_AT_104Hz;
           break;
+        default:
+          *val = LSM6DSV80X_ODR_AT_120Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV80X_ODR_AT_240Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV80X_ODR_AT_240Hz;
           break;
@@ -1067,13 +1068,15 @@ int32_t lsm6dsv80x_xl_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV80X_ODR_HA03_AT_208Hz;
           break;
+        default:
+          *val = LSM6DSV80X_ODR_AT_240Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV80X_ODR_AT_480Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV80X_ODR_AT_480Hz;
           break;
@@ -1086,13 +1089,15 @@ int32_t lsm6dsv80x_xl_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV80X_ODR_HA03_AT_417Hz;
           break;
+        default:
+          *val = LSM6DSV80X_ODR_AT_480Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV80X_ODR_AT_960Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV80X_ODR_AT_960Hz;
           break;
@@ -1105,13 +1110,15 @@ int32_t lsm6dsv80x_xl_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV80X_ODR_HA03_AT_833Hz;
           break;
+        default:
+          *val = LSM6DSV80X_ODR_AT_960Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV80X_ODR_AT_1920Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV80X_ODR_AT_1920Hz;
           break;
@@ -1124,13 +1131,15 @@ int32_t lsm6dsv80x_xl_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV80X_ODR_HA03_AT_1667Hz;
           break;
+        default:
+          *val = LSM6DSV80X_ODR_AT_1920Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV80X_ODR_AT_3840Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV80X_ODR_AT_3840Hz;
           break;
@@ -1143,13 +1152,15 @@ int32_t lsm6dsv80x_xl_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV80X_ODR_HA03_AT_3333Hz;
           break;
+        default:
+          *val = LSM6DSV80X_ODR_AT_3840Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV80X_ODR_AT_7680Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV80X_ODR_AT_7680Hz;
           break;
@@ -1161,6 +1172,9 @@ int32_t lsm6dsv80x_xl_data_rate_get(const stmdev_ctx_t *ctx,
           break;
         case 3:
           *val = LSM6DSV80X_ODR_HA03_AT_6667Hz;
+          break;
+        default:
+          *val = LSM6DSV80X_ODR_AT_7680Hz;
           break;
       }
       break;
@@ -1369,7 +1383,7 @@ int32_t lsm6dsv80x_gy_data_rate_set(const stmdev_ctx_t *ctx,
     {
       return ret;
     }
-    haodr.haodr_sel = sel;
+    haodr.haodr_sel = sel & 0x03U;
     ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_HAODR_CFG, (uint8_t *)&haodr, 1);
   }
 
@@ -1411,7 +1425,6 @@ int32_t lsm6dsv80x_gy_data_rate_get(const stmdev_ctx_t *ctx,
     case (uint8_t)LSM6DSV80X_ODR_AT_15Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV80X_ODR_AT_15Hz;
           break;
@@ -1424,13 +1437,15 @@ int32_t lsm6dsv80x_gy_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV80X_ODR_HA03_AT_13Hz;
           break;
+        default:
+          *val = LSM6DSV80X_ODR_AT_15Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV80X_ODR_AT_30Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV80X_ODR_AT_30Hz;
           break;
@@ -1443,13 +1458,15 @@ int32_t lsm6dsv80x_gy_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV80X_ODR_HA03_AT_26Hz;
           break;
+        default:
+          *val = LSM6DSV80X_ODR_AT_30Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV80X_ODR_AT_60Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV80X_ODR_AT_60Hz;
           break;
@@ -1462,13 +1479,15 @@ int32_t lsm6dsv80x_gy_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV80X_ODR_HA03_AT_52Hz;
           break;
+        default:
+          *val = LSM6DSV80X_ODR_AT_60Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV80X_ODR_AT_120Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV80X_ODR_AT_120Hz;
           break;
@@ -1481,13 +1500,15 @@ int32_t lsm6dsv80x_gy_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV80X_ODR_HA03_AT_104Hz;
           break;
+        default:
+          *val = LSM6DSV80X_ODR_AT_120Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV80X_ODR_AT_240Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV80X_ODR_AT_240Hz;
           break;
@@ -1500,13 +1521,15 @@ int32_t lsm6dsv80x_gy_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV80X_ODR_HA03_AT_208Hz;
           break;
+        default:
+          *val = LSM6DSV80X_ODR_AT_240Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV80X_ODR_AT_480Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV80X_ODR_AT_480Hz;
           break;
@@ -1519,13 +1542,15 @@ int32_t lsm6dsv80x_gy_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV80X_ODR_HA03_AT_417Hz;
           break;
+        default:
+          *val = LSM6DSV80X_ODR_AT_480Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV80X_ODR_AT_960Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV80X_ODR_AT_960Hz;
           break;
@@ -1538,13 +1563,15 @@ int32_t lsm6dsv80x_gy_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV80X_ODR_HA03_AT_833Hz;
           break;
+        default:
+          *val = LSM6DSV80X_ODR_AT_960Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV80X_ODR_AT_1920Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV80X_ODR_AT_1920Hz;
           break;
@@ -1557,13 +1584,15 @@ int32_t lsm6dsv80x_gy_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV80X_ODR_HA03_AT_1667Hz;
           break;
+        default:
+          *val = LSM6DSV80X_ODR_AT_1920Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV80X_ODR_AT_3840Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV80X_ODR_AT_3840Hz;
           break;
@@ -1576,13 +1605,15 @@ int32_t lsm6dsv80x_gy_data_rate_get(const stmdev_ctx_t *ctx,
         case 3:
           *val = LSM6DSV80X_ODR_HA03_AT_3333Hz;
           break;
+        default:
+          *val = LSM6DSV80X_ODR_AT_3840Hz;
+          break;
       }
       break;
 
     case (uint8_t)LSM6DSV80X_ODR_AT_7680Hz:
       switch (sel)
       {
-        default:
         case 0:
           *val = LSM6DSV80X_ODR_AT_7680Hz;
           break;
@@ -1594,6 +1625,9 @@ int32_t lsm6dsv80x_gy_data_rate_get(const stmdev_ctx_t *ctx,
           break;
         case 3:
           *val = LSM6DSV80X_ODR_HA03_AT_6667Hz;
+          break;
+        default:
+          *val = LSM6DSV80X_ODR_AT_7680Hz;
           break;
       }
       break;
@@ -1673,7 +1707,7 @@ int32_t lsm6dsv80x_auto_increment_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL3, (uint8_t *)&ctrl3, 1);
   if (ret == 0)
   {
-    ctrl3.if_inc = val;
+    ctrl3.if_inc = val & 0x01U;
     ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL3, (uint8_t *)&ctrl3, 1);
   }
 
@@ -1706,7 +1740,7 @@ int32_t lsm6dsv80x_block_data_update_set(const stmdev_ctx_t *ctx, uint8_t val)
 
   if (ret == 0)
   {
-    ctrl3.bdu = val;
+    ctrl3.bdu = val & 0x01U;
     ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL3, (uint8_t *)&ctrl3, 1);
   }
 
@@ -1892,7 +1926,7 @@ int32_t lsm6dsv80x_gy_full_scale_set(const stmdev_ctx_t *ctx,
     ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL2, (uint8_t *)&ctrl2, 1);
   }
 
-  ctrl6.fs_g = (uint8_t)val & 0xfu;
+  ctrl6.fs_g = (uint8_t)val & 0x07u;
   ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL6, (uint8_t *)&ctrl6, 1);
 
   // restore previous odr set
@@ -3305,8 +3339,7 @@ int32_t lsm6dsv80x_temperature_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
     return ret;
   }
 
-  *val = (int16_t)buff[1];
-  *val = (*val * 256) + (int16_t)buff[0];
+  *val = (int16_t)((uint16_t)buff[0] | ((uint16_t)buff[1] << 8));
 
   return ret;
 }
@@ -3323,12 +3356,9 @@ int32_t lsm6dsv80x_angular_rate_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
     return ret;
   }
 
-  val[0] = (int16_t)buff[1];
-  val[0] = (val[0] * 256) + (int16_t)buff[0];
-  val[1] = (int16_t)buff[3];
-  val[1] = (val[1] * 256) + (int16_t)buff[2];
-  val[2] = (int16_t)buff[5];
-  val[2] = (val[2] * 256) + (int16_t)buff[4];
+  val[0] = (int16_t)((uint16_t)buff[0] | ((uint16_t)buff[1] << 8));
+  val[1] = (int16_t)((uint16_t)buff[2] | ((uint16_t)buff[3] << 8));
+  val[2] = (int16_t)((uint16_t)buff[4] | ((uint16_t)buff[5] << 8));
 
   return ret;
 }
@@ -3345,12 +3375,9 @@ int32_t lsm6dsv80x_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
     return ret;
   }
 
-  val[0] = (int16_t)buff[1];
-  val[0] = (val[0] * 256) + (int16_t)buff[0];
-  val[1] = (int16_t)buff[3];
-  val[1] = (val[1] * 256) + (int16_t)buff[2];
-  val[2] = (int16_t)buff[5];
-  val[2] = (val[2] * 256) + (int16_t)buff[4];
+  val[0] = (int16_t)((uint16_t)buff[0] | ((uint16_t)buff[1] << 8));
+  val[1] = (int16_t)((uint16_t)buff[2] | ((uint16_t)buff[3] << 8));
+  val[2] = (int16_t)((uint16_t)buff[4] | ((uint16_t)buff[5] << 8));
 
   return ret;
 }
@@ -3367,12 +3394,9 @@ int32_t lsm6dsv80x_hg_acceleration_raw_get(const stmdev_ctx_t *ctx, int16_t *val
     return ret;
   }
 
-  val[0] = (int16_t)buff[1];
-  val[0] = (val[0] * 256) + (int16_t)buff[0];
-  val[1] = (int16_t)buff[3];
-  val[1] = (val[1] * 256) + (int16_t)buff[2];
-  val[2] = (int16_t)buff[5];
-  val[2] = (val[2] * 256) + (int16_t)buff[4];
+  val[0] = (int16_t)((uint16_t)buff[0] | ((uint16_t)buff[1] << 8));
+  val[1] = (int16_t)((uint16_t)buff[2] | ((uint16_t)buff[3] << 8));
+  val[2] = (int16_t)((uint16_t)buff[4] | ((uint16_t)buff[5] << 8));
 
   return ret;
 }
@@ -3391,12 +3415,9 @@ int32_t lsm6dsv80x_sflp_gbias_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
     return ret;
   }
 
-  val[0] = (int16_t)buff[1];
-  val[0] = (val[0] * 256) + (int16_t)buff[0];
-  val[1] = (int16_t)buff[3];
-  val[1] = (val[1] * 256) + (int16_t)buff[2];
-  val[2] = (int16_t)buff[5];
-  val[2] = (val[2] * 256) + (int16_t)buff[4];
+  val[0] = (int16_t)((uint16_t)buff[0] | ((uint16_t)buff[1] << 8));
+  val[1] = (int16_t)((uint16_t)buff[2] | ((uint16_t)buff[3] << 8));
+  val[2] = (int16_t)((uint16_t)buff[4] | ((uint16_t)buff[5] << 8));
 
   return ret;
 }
@@ -3415,12 +3436,9 @@ int32_t lsm6dsv80x_sflp_gravity_raw_get(const stmdev_ctx_t *ctx, int16_t *val)
     return ret;
   }
 
-  val[0] = (int16_t)buff[1];
-  val[0] = (val[0] * 256) + (int16_t)buff[0];
-  val[1] = (int16_t)buff[3];
-  val[1] = (val[1] * 256) + (int16_t)buff[2];
-  val[2] = (int16_t)buff[5];
-  val[2] = (val[2] * 256) + (int16_t)buff[4];
+  val[0] = (int16_t)((uint16_t)buff[0] | ((uint16_t)buff[1] << 8));
+  val[1] = (int16_t)((uint16_t)buff[2] | ((uint16_t)buff[3] << 8));
+  val[2] = (int16_t)((uint16_t)buff[4] | ((uint16_t)buff[5] << 8));
 
   return ret;
 }
@@ -3612,7 +3630,7 @@ int32_t lsm6dsv80x_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t address,
   {
     goto exit;
   }
-  page_sel.page_sel = msb;
+  page_sel.page_sel = msb & 0x0FU;
   page_sel.not_used0 = 1; // Default value
   ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_PAGE_SEL, (uint8_t *)&page_sel, 1);
   if (ret != 0)
@@ -3649,7 +3667,7 @@ int32_t lsm6dsv80x_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t address,
         goto exit;
       }
 
-      page_sel.page_sel = msb;
+      page_sel.page_sel = msb & 0x0FU;
       page_sel.not_used0 = 1; // Default value
       ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_PAGE_SEL, (uint8_t *)&page_sel, 1);
       if (ret != 0)
@@ -3659,8 +3677,8 @@ int32_t lsm6dsv80x_ln_pg_write(const stmdev_ctx_t *ctx, uint16_t address,
     }
   }
 
-  page_sel.page_sel = 0;
-  page_sel.not_used0 = 1;// Default value
+  page_sel.page_sel = 0U;
+  page_sel.not_used0 = 1U;// Default value
   ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_PAGE_SEL, (uint8_t *)&page_sel, 1);
   if (ret != 0)
   {
@@ -3724,8 +3742,8 @@ int32_t lsm6dsv80x_ln_pg_read(const stmdev_ctx_t *ctx, uint16_t address, uint8_t
   {
     goto exit;
   }
-  page_sel.page_sel = msb;
-  page_sel.not_used0 = 1; // Default value
+  page_sel.page_sel = msb & 0x0FU;
+  page_sel.not_used0 = 1U; // Default value
   ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_PAGE_SEL, (uint8_t *)&page_sel, 1);
   if (ret != 0)
   {
@@ -3761,8 +3779,8 @@ int32_t lsm6dsv80x_ln_pg_read(const stmdev_ctx_t *ctx, uint16_t address, uint8_t
         goto exit;
       }
 
-      page_sel.page_sel = msb;
-      page_sel.not_used0 = 1; // Default value
+      page_sel.page_sel = msb & 0x0FU;
+      page_sel.not_used0 = 1U; // Default value
       ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_PAGE_SEL, (uint8_t *)&page_sel, 1);
       if (ret != 0)
       {
@@ -3771,8 +3789,8 @@ int32_t lsm6dsv80x_ln_pg_read(const stmdev_ctx_t *ctx, uint16_t address, uint8_t
     }
   }
 
-  page_sel.page_sel = 0;
-  page_sel.not_used0 = 1;// Default value
+  page_sel.page_sel = 0U;
+  page_sel.not_used0 = 1U;// Default value
   ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_PAGE_SEL, (uint8_t *)&page_sel, 1);
   if (ret != 0)
   {
@@ -3805,7 +3823,7 @@ int32_t lsm6dsv80x_emb_function_dbg_set(const stmdev_ctx_t *ctx, uint8_t val)
 
   if (ret == 0)
   {
-    ctrl10.emb_func_debug = val;
+    ctrl10.emb_func_debug = val & 0x01U;
     ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL10, (uint8_t *)&ctrl10, 1);
   }
 
@@ -3975,7 +3993,7 @@ int32_t lsm6dsv80x_fifo_virtual_sens_odr_chg_set(const stmdev_ctx_t *ctx, uint8_
   ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
   if (ret == 0)
   {
-    fifo_ctrl2.odr_chg_en = val;
+    fifo_ctrl2.odr_chg_en = val & 0x01U;
     ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
   }
 
@@ -4014,7 +4032,7 @@ int32_t lsm6dsv80x_fifo_compress_algo_real_time_set(const stmdev_ctx_t *ctx,
   {
     return ret;
   }
-  fifo_ctrl2.fifo_compr_rt_en = val;
+  fifo_ctrl2.fifo_compr_rt_en = val & 0x01U;
   ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
   if (ret != 0)
   {
@@ -4031,7 +4049,7 @@ int32_t lsm6dsv80x_fifo_compress_algo_real_time_set(const stmdev_ctx_t *ctx,
   {
     goto exit;
   }
-  emb_func_en_b.fifo_compr_en = val;
+  emb_func_en_b.fifo_compr_en = val & 0x01U;
   ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
 exit:
   ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
@@ -4515,8 +4533,7 @@ int32_t lsm6dsv80x_fifo_batch_counter_threshold_get(const stmdev_ctx_t *ctx,
     return ret;
   }
 
-  *val = (uint16_t)buff[0] & 0x3U;
-  *val = (*val * 256U) + (uint16_t)buff[1];
+  *val = (uint16_t)(buff[1] | ((uint16_t)(buff[0] & 0x3U) << 8));
 
   return ret;
 }
@@ -4592,8 +4609,7 @@ int32_t lsm6dsv80x_fifo_status_get(const stmdev_ctx_t *ctx,
   val->fifo_full = status.fifo_full_ia;
   val->fifo_th = status.fifo_wtm_ia;
 
-  val->fifo_level = (uint16_t)buff[1] & 0x01U;
-  val->fifo_level = (val->fifo_level * 256U) + buff[0];
+  val->fifo_level = (uint16_t)(buff[0] | ((uint16_t)(buff[1] & 0x01U) << 8));
 
   return ret;
 }
@@ -4767,7 +4783,7 @@ int32_t lsm6dsv80x_fifo_stpcnt_batch_set(const stmdev_ctx_t *ctx, uint8_t val)
   {
     goto exit;
   }
-  emb_func_fifo_en_a.step_counter_fifo_en = val;
+  emb_func_fifo_en_a.step_counter_fifo_en = val & 0x01U;
   ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
 
 exit:
@@ -4793,7 +4809,7 @@ int32_t lsm6dsv80x_fifo_stpcnt_batch_get(const stmdev_ctx_t *ctx, uint8_t *val)
   {
     goto exit;
   }
-  *val = emb_func_fifo_en_a.step_counter_fifo_en;
+  *val = emb_func_fifo_en_a.step_counter_fifo_en & 0x01U;
 
 exit:
   ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
@@ -4818,7 +4834,7 @@ int32_t lsm6dsv80x_fifo_fsm_batch_set(const stmdev_ctx_t *ctx, uint8_t val)
   {
     goto exit;
   }
-  emb_func_fifo_en_b.fsm_fifo_en = val;
+  emb_func_fifo_en_b.fsm_fifo_en = val & 0x01U;
   ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_FIFO_EN_B, (uint8_t *)&emb_func_fifo_en_b, 1);
 
 exit:
@@ -4869,7 +4885,7 @@ int32_t lsm6dsv80x_fifo_mlc_batch_set(const stmdev_ctx_t *ctx, uint8_t val)
   {
     goto exit;
   }
-  emb_func_fifo_en_a.mlc_fifo_en = val;
+  emb_func_fifo_en_a.mlc_fifo_en = val & 0x01U;
   ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
 
 exit:
@@ -4920,7 +4936,7 @@ int32_t lsm6dsv80x_fifo_mlc_filt_batch_set(const stmdev_ctx_t *ctx, uint8_t val)
   {
     goto exit;
   }
-  emb_func_fifo_en_b.mlc_filter_feature_fifo_en = val;
+  emb_func_fifo_en_b.mlc_filter_feature_fifo_en = val & 0x01U;
   ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_FIFO_EN_B, (uint8_t *)&emb_func_fifo_en_b, 1);
 
 exit:
@@ -4971,13 +4987,15 @@ int32_t lsm6dsv80x_fifo_sh_batch_target_set(const stmdev_ctx_t *ctx, uint8_t idx
     goto exit;
   }
 
-  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TGT0_CONFIG + idx * 3U, (uint8_t *)&tgt_config, 1);
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TGT0_CONFIG + (uint8_t)(idx * 3U), (uint8_t *)&tgt_config,
+                            1);
   if (ret != 0)
   {
     goto exit;
   }
-  tgt_config.batch_ext_sens_0_en = val;
-  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TGT0_CONFIG + idx * 3U, (uint8_t *)&tgt_config, 1);
+  tgt_config.batch_ext_sens_0_en = val & 0x01U;
+  ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TGT0_CONFIG + (uint8_t)(idx * 3U),
+                              (uint8_t *)&tgt_config, 1);
 
 exit:
   ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
@@ -5002,7 +5020,8 @@ int32_t lsm6dsv80x_fifo_sh_batch_target_get(const stmdev_ctx_t *ctx, uint8_t idx
     goto exit;
   }
 
-  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TGT0_CONFIG + idx * 3U, (uint8_t *)&tgt_config, 1);
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TGT0_CONFIG + (uint8_t)(idx * 3U), (uint8_t *)&tgt_config,
+                            1);
   if (ret != 0)
   {
     goto exit;
@@ -5191,7 +5210,7 @@ int32_t lsm6dsv80x_filt_gy_lp1_bandwidth_set(const stmdev_ctx_t *ctx,
   ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL6, (uint8_t *)&ctrl6, 1);
   if (ret == 0)
   {
-    ctrl6.lpf1_g_bw = (uint8_t)val & 0x0Fu;
+    ctrl6.lpf1_g_bw = (uint8_t)val & 0x07u;
     ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL6, (uint8_t *)&ctrl6, 1);
   }
 
@@ -5262,7 +5281,7 @@ int32_t lsm6dsv80x_filt_gy_lp1_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL7, (uint8_t *)&ctrl7, 1);
   if (ret == 0)
   {
-    ctrl7.lpf1_g_en = val;
+    ctrl7.lpf1_g_en = val & 0x01U;
     ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL7, (uint8_t *)&ctrl7, 1);
   }
 
@@ -5314,23 +5333,23 @@ int32_t lsm6dsv80x_filt_xl_setup(const stmdev_ctx_t *ctx, lsm6dsv80x_xl_filter f
 
   if (filter == LSM6DSV80X_XL_FILT_LP_LPF2)
   {
-    ctrl9.hp_slope_xl_en = 0;
-    ctrl9.lpf2_xl_en = 1;
+    ctrl9.hp_slope_xl_en = 0U;
+    ctrl9.lpf2_xl_en = 1U;
   }
   else if (filter == LSM6DSV80X_XL_FILT_LP_LPF1)
   {
-    ctrl9.hp_slope_xl_en = 0;
-    ctrl9.lpf2_xl_en = 0;
+    ctrl9.hp_slope_xl_en = 0U;
+    ctrl9.lpf2_xl_en = 0U;
   }
   else if (filter == LSM6DSV80X_XL_FILT_HP)
   {
-    ctrl9.hp_slope_xl_en = 1;
-    ctrl9.lpf2_xl_en = 0;
+    ctrl9.hp_slope_xl_en = 1U;
+    ctrl9.lpf2_xl_en = 0U;
   }
   else if (filter == LSM6DSV80X_XL_FILT_HP_SLOPE)
   {
-    ctrl9.hp_slope_xl_en = 1;
-    ctrl9.lpf2_xl_en = 0;
+    ctrl9.hp_slope_xl_en = 1U;
+    ctrl9.lpf2_xl_en = 0U;
   }
   else
   {
@@ -5339,7 +5358,7 @@ int32_t lsm6dsv80x_filt_xl_setup(const stmdev_ctx_t *ctx, lsm6dsv80x_xl_filter f
   }
 
   ctrl8.hp_lpf2_xl_bw = (uint8_t)bw & 0x07U;
-  ctrl9.hp_ref_mode_xl = hp_ref_mode_xl;
+  ctrl9.hp_ref_mode_xl = hp_ref_mode_xl & 0x01U;
 
   ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL8, (uint8_t *)&ctrl8, 1);
   ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL9, (uint8_t *)&ctrl9, 1);
@@ -5429,7 +5448,7 @@ int32_t lsm6dsv80x_filt_xl_lp2_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL9, (uint8_t *)&ctrl9, 1);
   if (ret == 0)
   {
-    ctrl9.lpf2_xl_en = val;
+    ctrl9.lpf2_xl_en = val & 0x01U;
     ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL9, (uint8_t *)&ctrl9, 1);
   }
 
@@ -5461,7 +5480,7 @@ int32_t lsm6dsv80x_filt_xl_hp_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL9, (uint8_t *)&ctrl9, 1);
   if (ret == 0)
   {
-    ctrl9.hp_slope_xl_en = val;
+    ctrl9.hp_slope_xl_en = val & 0x01U;
     ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL9, (uint8_t *)&ctrl9, 1);
   }
 
@@ -5493,7 +5512,7 @@ int32_t lsm6dsv80x_filt_xl_fast_settling_set(const stmdev_ctx_t *ctx, uint8_t va
   ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_CTRL9, (uint8_t *)&ctrl9, 1);
   if (ret == 0)
   {
-    ctrl9.xl_fastsettl_mode = val;
+    ctrl9.xl_fastsettl_mode = val & 0x01U;
     ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL9, (uint8_t *)&ctrl9, 1);
   }
 
@@ -5527,7 +5546,7 @@ int32_t lsm6dsv80x_filt_xl_hp_mode_set(const stmdev_ctx_t *ctx,
   if (ret == 0)
   {
     ctrl9.hp_ref_mode_xl = (uint8_t)val & 0x01U;
-    ctrl9.hp_slope_xl_en = ((uint8_t)val & 0x02U) >> 1;
+    ctrl9.hp_slope_xl_en = ((uint8_t)val >> 1) & 0x01U;
     ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CTRL9, (uint8_t *)&ctrl9, 1);
   }
 
@@ -5909,8 +5928,7 @@ exit:
     return ret;
   }
 
-  *val = buff[1];
-  *val = (*val * 256U) + buff[0];
+  *val = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
 
   return ret;
 }
@@ -6041,12 +6059,6 @@ exit:
 #ifndef NPY_HALF_ROUND_TIES_TO_EVEN
 #define NPY_HALF_ROUND_TIES_TO_EVEN 1
 #endif
-
-typedef union
-{
-  float_t f;
-  uint32_t fbits;
-} hf_conv_t;
 
 static uint16_t npy_floatbits_to_halfbits(uint32_t f)
 {
@@ -6180,18 +6192,19 @@ static uint16_t npy_floatbits_to_halfbits(uint32_t f)
   {
     npy_set_floatstatus_overflow();
   }
-  return h_sgn + h_sig;
+  return (uint16_t)(h_sgn + h_sig);
 #else
-  return h_sgn + h_exp + h_sig;
+  return (uint16_t)(h_sgn + h_exp + h_sig);
 #endif
 }
 
 static uint16_t npy_float_to_half(float_t f)
 {
-  hf_conv_t conv;
+  uint32_t bits;
 
-  conv.f = f;
-  return npy_floatbits_to_halfbits(conv.fbits);
+  (void)memcpy(&bits, &f, sizeof(bits));
+
+  return npy_floatbits_to_halfbits(bits);
 }
 
 static uint32_t npy_halfbits_to_floatbits(uint16_t h)
@@ -6206,19 +6219,19 @@ static uint32_t npy_halfbits_to_floatbits(uint16_t h)
     {
       uint16_t h_sig = (uint16_t)(h & 0x03ffu);
       // Signed zero
-      if (h_sig == 0)
+      if (h_sig == 0u)
       {
         result = f_sgn;
         break;
       }
       // Subnormal
       h_sig <<= 1;
-      while ((h_sig & 0x0400u) == 0)
+      while ((h_sig & 0x0400u) == 0u)
       {
         h_sig <<= 1;
         h_exp++;
       }
-      uint32_t f_exp = ((uint32_t)(127 - 15 - h_exp)) << 23;
+      uint32_t f_exp = ((uint32_t)(127u - 15u - h_exp)) << 23;
       uint32_t f_sig = ((uint32_t)h_sig & 0x03ffu) << 13;
       result = f_sgn + f_exp + f_sig;
       break;
@@ -6238,18 +6251,20 @@ static uint32_t npy_halfbits_to_floatbits(uint16_t h)
 
 static float_t npy_half_to_float(uint16_t h)
 {
-  hf_conv_t conv;
+  float_t f = 0;
 
-  conv.fbits = npy_halfbits_to_floatbits(h);
+  uint32_t bits = npy_halfbits_to_floatbits(h);
 
-  return conv.f;
+  (void)memcpy(&f, &bits, sizeof(bits));
+
+  return f;
 }
 
 
 int32_t lsm6dsv80x_sflp_game_gbias_set(const stmdev_ctx_t *ctx,
                                        const lsm6dsv80x_sflp_gbias_t *val)
 {
-  lsm6dsv80x_sflp_data_rate_t sflp_odr = {0};
+  lsm6dsv80x_sflp_data_rate_t sflp_odr = LSM6DSV80X_SFLP_15Hz;
   uint16_t gbias_hf[3] = {0};
   float_t k = 0.005f;
   int32_t ret = 0;
@@ -6328,8 +6343,7 @@ int32_t lsm6dsv80x_fsm_ext_sens_sensitivity_get(const stmdev_ctx_t *ctx,
     return ret;
   }
 
-  *val = buff[1];
-  *val = (*val * 256U) + buff[0];
+  *val = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
 
   return ret;
 }
@@ -6365,12 +6379,9 @@ int32_t lsm6dsv80x_fsm_ext_sens_offset_get(const stmdev_ctx_t *ctx,
     return ret;
   }
 
-  val->x = buff[1];
-  val->x = (val->x * 256U) + buff[0];
-  val->y = buff[3];
-  val->y = (val->y * 256U) + buff[2];
-  val->z = buff[5];
-  val->z = (val->z * 256U) + buff[4];
+  val->x = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
+  val->y = (uint16_t)(buff[2] | ((uint16_t)buff[3] << 8));
+  val->z = (uint16_t)(buff[4] | ((uint16_t)buff[5] << 8));
 
   return ret;
 }
@@ -6411,18 +6422,12 @@ int32_t lsm6dsv80x_fsm_ext_sens_matrix_get(const stmdev_ctx_t *ctx,
     return ret;
   }
 
-  val->xx = buff[1];
-  val->xx = (val->xx * 256U) + buff[0];
-  val->xy = buff[3];
-  val->xy = (val->xy * 256U) + buff[2];
-  val->xz = buff[5];
-  val->xz = (val->xz * 256U) + buff[4];
-  val->yy = buff[7];
-  val->yy = (val->yy * 256U) + buff[6];
-  val->yz = buff[9];
-  val->yz = (val->yz * 256U) + buff[8];
-  val->zz = buff[11];
-  val->zz = (val->zz * 256U) + buff[10];
+  val->xx = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
+  val->xy = (uint16_t)(buff[2] | ((uint16_t)buff[3] << 8));
+  val->xz = (uint16_t)(buff[4] | ((uint16_t)buff[5] << 8));
+  val->yy = (uint16_t)(buff[6] | ((uint16_t)buff[7] << 8));
+  val->yz = (uint16_t)(buff[8] | ((uint16_t)buff[9] << 8));
+  val->zz = (uint16_t)(buff[10] | ((uint16_t)buff[11] << 8));
 
   return ret;
 }
@@ -6637,7 +6642,7 @@ int32_t lsm6dsv80x_xl_hg_peak_tracking_set(const stmdev_ctx_t *ctx, uint8_t val)
   {
     goto exit;
   }
-  emb_func_init_b.pt_init = val;
+  emb_func_init_b.pt_init = val & 0x01U;
   ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_INIT_B, (uint8_t *)&emb_func_init_b, 1);
 
 exit:
@@ -6663,7 +6668,7 @@ int32_t lsm6dsv80x_xl_hg_peak_tracking_get(const stmdev_ctx_t *ctx, uint8_t *val
   {
     goto exit;
   }
-  *val = emb_func_init_b.pt_init;
+  *val = emb_func_init_b.pt_init & 0x01U;
 
 exit:
   ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
@@ -6698,8 +6703,7 @@ int32_t lsm6dsv80x_xl_hg_sensitivity_get(const stmdev_ctx_t *ctx, uint16_t *val)
     return ret;
   }
 
-  *val = buff[1];
-  *val = (*val * 256U) + buff[0];
+  *val = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
 
   return ret;
 }
@@ -6730,8 +6734,7 @@ int32_t lsm6dsv80x_fsm_long_cnt_timeout_get(const stmdev_ctx_t *ctx, uint16_t *v
     return ret;
   }
 
-  *val = buff[1];
-  *val = (*val * 256U) + buff[0];
+  *val = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
 
   return ret;
 }
@@ -6796,8 +6799,7 @@ int32_t lsm6dsv80x_fsm_start_address_get(const stmdev_ctx_t *ctx, uint16_t *val)
     return ret;
   }
 
-  *val = buff[1];
-  *val = (*val * 256U) + buff[0];
+  *val = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
 
   return ret;
 }
@@ -6846,7 +6848,7 @@ int32_t lsm6dsv80x_ff_time_windows_get(const stmdev_ctx_t *ctx, uint8_t *val)
     return ret;
   }
 
-  *val = (wake_up_dur.ff_dur << 5) + free_fall.ff_dur;
+  *val = (uint8_t)(wake_up_dur.ff_dur << 5) | free_fall.ff_dur;
 
   return ret;
 }
@@ -6957,6 +6959,9 @@ int32_t lsm6dsv80x_mlc_set(const stmdev_ctx_t *ctx, lsm6dsv80x_mlc_mode_t val)
       emb_en_b.mlc_en = 0;
       break;
     default:
+      // default used: MLC_OFF
+      emb_en_a.mlc_before_fsm_en = 0;
+      emb_en_b.mlc_en = 0;
       break;
   }
 
@@ -7134,8 +7139,7 @@ int32_t lsm6dsv80x_mlc_ext_sens_sensitivity_get(const stmdev_ctx_t *ctx,
     return ret;
   }
 
-  *val = buff[1];
-  *val = (*val * 256U) + buff[0];
+  *val = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
 
   return ret;
 }
@@ -7205,7 +7209,7 @@ int32_t lsm6dsv80x_4d_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
   if (ret == 0)
   {
-    tap_ths_6d.d4d_en = val;
+    tap_ths_6d.d4d_en = val & 0x01U;
     ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
   }
 
@@ -7322,7 +7326,7 @@ int32_t lsm6dsv80x_sh_controller_interface_pull_up_set(const stmdev_ctx_t *ctx,
   ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_IF_CFG, (uint8_t *)&if_cfg, 1);
   if (ret == 0)
   {
-    if_cfg.shub_pu_en = val;
+    if_cfg.shub_pu_en = val & 0x01U;
     ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_IF_CFG, (uint8_t *)&if_cfg, 1);
   }
 
@@ -7446,7 +7450,7 @@ int32_t lsm6dsv80x_sh_controller_set(const stmdev_ctx_t *ctx, uint8_t val)
     goto exit;
   }
 
-  controller_config.controller_on = val;
+  controller_config.controller_on = val & 0x01U;
   ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
 
 exit:
@@ -7493,7 +7497,7 @@ int32_t lsm6dsv80x_sh_pass_through_set(const stmdev_ctx_t *ctx, uint8_t val)
     goto exit;
   }
 
-  controller_config.pass_through_mode = val;
+  controller_config.pass_through_mode = val & 0x01U;
   ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
 
 exit:
@@ -7650,7 +7654,7 @@ int32_t lsm6dsv80x_sh_reset_set(const stmdev_ctx_t *ctx, uint8_t val)
     goto exit;
   }
 
-  controller_config.rst_controller_regs = val;
+  controller_config.rst_controller_regs = val & 0x01U;
   ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_CONTROLLER_CONFIG, (uint8_t *)&controller_config, 1);
 
 exit:
@@ -7693,7 +7697,7 @@ int32_t lsm6dsv80x_sh_cfg_write(const stmdev_ctx_t *ctx,
     goto exit;
   }
 
-  reg.target0_add = (uint8_t)(val->tgt0_add >> 1);
+  reg.target0_add = (val->tgt0_add >> 1) & 0x07U;
   reg.rw_0 = 0;
   ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TGT0_ADD, (uint8_t *)&reg, 1);
   if (ret != 0)
@@ -7811,31 +7815,31 @@ int32_t lsm6dsv80x_sh_tgt_cfg_read(const stmdev_ctx_t *ctx, uint8_t idx,
     return ret;
   }
 
-  tgt_add.target0_add = (uint8_t)(val->tgt_add >> 1);
+  tgt_add.target0_add = (val->tgt_add >> 1) & 0x07U;
   tgt_add.rw_0 = 1;
-  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TGT0_ADD + idx * 3U,
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TGT0_ADD + (uint8_t)(idx * 3U),
                              (uint8_t *)&tgt_add, 1);
   if (ret != 0)
   {
     goto exit;
   }
 
-  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TGT0_SUBADD + idx * 3U,
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TGT0_SUBADD + (uint8_t)(idx * 3U),
                              &(val->tgt_subadd), 1);
   if (ret != 0)
   {
     goto exit;
   }
 
-  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TGT0_CONFIG + idx * 3U,
+  ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_TGT0_CONFIG + (uint8_t)(idx * 3U),
                             (uint8_t *)&tgt_config, 1);
   if (ret != 0)
   {
     goto exit;
   }
 
-  tgt_config.target0_numop = val->tgt_len;
-  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TGT0_CONFIG + idx * 3U,
+  tgt_config.target0_numop = val->tgt_len & 0x07U;
+  ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_TGT0_CONFIG + (uint8_t)(idx * 3U),
                              (uint8_t *)&tgt_config, 1);
 
 exit:
@@ -7864,7 +7868,7 @@ int32_t lsm6dsv80x_ui_sdo_pull_up_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
   if (ret == 0)
   {
-    pin_ctrl.sdo_pu_en = val;
+    pin_ctrl.sdo_pu_en = val & 0x01U;
     ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
   }
 
@@ -7896,7 +7900,7 @@ int32_t lsm6dsv80x_pad_strength_set(const stmdev_ctx_t *ctx, lsm6dsv80x_pad_stre
   ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
   if (ret == 0)
   {
-    pin_ctrl.io_pad_strength = val;
+    pin_ctrl.io_pad_strength = val & 0x03U;
     ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
   }
 
@@ -8037,7 +8041,7 @@ int32_t lsm6dsv80x_ui_sda_pull_up_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_IF_CFG, (uint8_t *)&if_cfg, 1);
   if (ret == 0)
   {
-    if_cfg.sda_pu_en = val;
+    if_cfg.sda_pu_en = val & 0x01U;
     ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_IF_CFG, (uint8_t *)&if_cfg, 1);
   }
 
@@ -8078,7 +8082,7 @@ int32_t lsm6dsv80x_sigmot_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
   {
     goto exit;
   }
-  emb_func_en_a.sign_motion_en = val;
+  emb_func_en_a.sign_motion_en = val & 0x01U;
   ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
 
 exit:
@@ -8206,8 +8210,7 @@ int32_t lsm6dsv80x_stpcnt_steps_get(const stmdev_ctx_t *ctx, uint16_t *val)
     return ret;
   }
 
-  *val = buff[1];
-  *val = (*val * 256U) + buff[0];
+  *val = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
 
   return ret;
 }
@@ -8230,7 +8233,7 @@ int32_t lsm6dsv80x_stpcnt_rst_step_set(const stmdev_ctx_t *ctx, uint8_t val)
     goto exit;
   }
 
-  emb_func_src.pedo_rst_step = val;
+  emb_func_src.pedo_rst_step = val & 0x01U;
   ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
 
 exit:
@@ -8326,8 +8329,7 @@ int32_t lsm6dsv80x_stpcnt_period_get(const stmdev_ctx_t *ctx, uint16_t *val)
     return ret;
   }
 
-  *val = buff[1];
-  *val = (*val * 256U) + buff[0];
+  *val = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8));
 
   return ret;
 }
@@ -8350,7 +8352,7 @@ int32_t lsm6dsv80x_sflp_game_rotation_set(const stmdev_ctx_t *ctx, uint8_t val)
     goto exit;
   }
 
-  emb_func_en_a.sflp_game_en = val;
+  emb_func_en_a.sflp_game_en = val & 0x01U;
   ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_EN_A,
                               (uint8_t *)&emb_func_en_a, 1);
 
@@ -8402,7 +8404,7 @@ int32_t lsm6dsv80x_sflp_game_rotation_reset(const stmdev_ctx_t *ctx, uint8_t val
   {
     goto exit;
   }
-  emb_func_init_a.sflp_game_init = val;
+  emb_func_init_a.sflp_game_init = val & 0x01U;
   ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_INIT_A, (uint8_t *)&emb_func_init_a, 1);
 
 exit:
@@ -8740,7 +8742,7 @@ int32_t lsm6dsv80x_tilt_mode_set(const stmdev_ctx_t *ctx, uint8_t val)
   }
 
   ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
-  emb_func_en_a.tilt_en = val;
+  emb_func_en_a.tilt_en = val & 0x01U;
   ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
 
   ret += lsm6dsv80x_mem_bank_set(ctx, LSM6DSV80X_MAIN_MEM_BANK);
@@ -8780,10 +8782,10 @@ int32_t lsm6dsv80x_timestamp_raw_get(const stmdev_ctx_t *ctx, uint32_t *val)
     return ret;
   }
 
-  *val = buff[3];
-  *val = (*val * 256U) + buff[2];
-  *val = (*val * 256U) + buff[1];
-  *val = (*val * 256U) + buff[0];
+  *val = (uint32_t)buff[3] << 8;
+  *val = (*val | (uint32_t)buff[2]) << 8;
+  *val = (*val | (uint32_t)buff[1]) << 8;
+  *val = (*val | (uint32_t)buff[0]) << 8;
 
   return ret;
 }
@@ -8797,7 +8799,7 @@ int32_t lsm6dsv80x_timestamp_set(const stmdev_ctx_t *ctx, uint8_t val)
   ret = lsm6dsv80x_read_reg(ctx, LSM6DSV80X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
   if (ret == 0)
   {
-    functions_enable.timestamp_en = val;
+    functions_enable.timestamp_en = val & 0x01U;
     ret = lsm6dsv80x_write_reg(ctx, LSM6DSV80X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
   }
 
@@ -9006,13 +9008,13 @@ int32_t lsm6dsv80x_act_thresholds_set(const stmdev_ctx_t *ctx,
     return ret;
   }
 
-  inactivity_dur.wu_inact_ths_w = val->inactivity_cfg.wu_inact_ths_w;
-  inactivity_dur.xl_inact_odr = val->inactivity_cfg.xl_inact_odr;
-  inactivity_dur.inact_dur = val->inactivity_cfg.inact_dur;
+  inactivity_dur.wu_inact_ths_w = val->inactivity_cfg.wu_inact_ths_w & 0x07U;
+  inactivity_dur.xl_inact_odr = val->inactivity_cfg.xl_inact_odr & 0x03U;
+  inactivity_dur.inact_dur = val->inactivity_cfg.inact_dur & 0x03U;
 
-  inactivity_ths.inact_ths = val->inactivity_ths;
-  wake_up_ths.wk_ths = val->threshold;
-  wake_up_dur.wake_dur = val->duration;
+  inactivity_ths.inact_ths = val->inactivity_ths & 0x3FU;
+  wake_up_ths.wk_ths = val->threshold & 0x3FU;
+  wake_up_dur.wake_dur = val->duration & 0x03U;
 
   ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
   ret += lsm6dsv80x_write_reg(ctx, LSM6DSV80X_INACTIVITY_THS, (uint8_t *)&inactivity_ths, 1);

--- a/sensor/stmemsc/lsm6dsv80x_STdC/driver/lsm6dsv80x_reg.h
+++ b/sensor/stmemsc/lsm6dsv80x_STdC/driver/lsm6dsv80x_reg.h
@@ -29,6 +29,7 @@ extern "C" {
 #include <stdint.h>
 #include <stddef.h>
 #include <math.h>
+#include <string.h>
 
 /** @addtogroup LSM6DSV80X
   * @{


### PR DESCRIPTION
Align stmemsc HAL i/f to v2.13.2

This is necessary to fix clang issues reported here:
https://github.com/zephyrproject-rtos/zephyr/pull/106907#issuecomment-4290226726

And to avoid this revert:
https://github.com/zephyrproject-rtos/zephyr/pull/107734

USed in https://github.com/zephyrproject-rtos/zephyr/pull/107746